### PR TITLE
feat: package cache

### DIFF
--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -27,7 +27,7 @@ nom = "7.1.0"
 once_cell = "1.8.0"
 pin-project-lite = "0.2.9"
 rattler_conda_types = { version = "0.1.0", path = "../rattler_conda_types" }
-rattler_package_streaming = { version = "0.1.0", path = "../rattler_package_streaming" }
+rattler_package_streaming = { version = "0.1.0", path = "../rattler_package_streaming", features = ["reqwest", "tokio"] }
 regex = "1.5.4"
 reqwest = { version = "0.11.6", default-features = false, features = ["stream", "json", "gzip"] }
 serde = { version = "1.0.130", features = ["derive"] }

--- a/crates/rattler/src/lib.rs
+++ b/crates/rattler/src/lib.rs
@@ -10,7 +10,7 @@
 //! candidate for a reimplementation.
 
 mod package_archive;
-mod package_store;
+pub mod package_cache;
 pub mod repo_data;
 pub mod solver;
 pub(crate) mod utils;
@@ -29,4 +29,12 @@ pub fn empty_channel() -> rattler_conda_types::Channel {
         &rattler_conda_types::ChannelConfig::default(),
     )
     .unwrap()
+}
+
+#[cfg(test)]
+use std::path::{Path, PathBuf};
+
+#[cfg(test)]
+pub(crate) fn get_test_data_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data")
 }

--- a/crates/rattler/src/lib.rs
+++ b/crates/rattler/src/lib.rs
@@ -10,6 +10,7 @@
 //! candidate for a reimplementation.
 
 mod package_archive;
+mod package_store;
 pub mod repo_data;
 pub mod solver;
 pub(crate) mod utils;

--- a/crates/rattler/src/package_cache.rs
+++ b/crates/rattler/src/package_cache.rs
@@ -1,10 +1,14 @@
+//! This module provides functionality to cache extracted Conda packages. See [`PackageCache`].
+
 use crate::validation::validate_package_directory;
 use fxhash::FxHashMap;
 use reqwest::Client;
-use std::fmt::{Display, Formatter};
-use std::future::Future;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::{
+    fmt::{Display, Formatter},
+    future::Future,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
 use tokio::sync::broadcast;
 use url::Url;
 

--- a/crates/rattler/src/package_store.rs
+++ b/crates/rattler/src/package_store.rs
@@ -1,0 +1,216 @@
+use fxhash::FxHashMap;
+use reqwest::Client;
+use std::fmt::{Display, Formatter};
+use std::future::Future;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tokio::sync::broadcast;
+use url::Url;
+
+/// A [`PackageCache`] manages a cache of extracted Conda packages on disk.
+///
+/// The store does not provide an implementation to get the data into the store. Instead this is
+/// left up to the user when the package is requested. If the package is found in the cache it is
+/// returned immediately. However, if the cache is stale a user defined function is called to
+/// populate the cache. This separates the corners between caching and fetching of the content.
+#[derive(Clone)]
+pub struct PackageCache {
+    inner: Arc<Mutex<PackageCacheInner>>,
+}
+
+/// Provides a unique identifier for packages in the cache.
+/// TODO: This could not be unique over multiple subdir. How to handle?
+/// TODO: Wouldn't it be better to cache based on hashes?
+#[derive(Debug, Hash, Clone, Eq, PartialEq)]
+struct CacheKey {
+    name: String,
+    version: String,
+    build_string: String,
+}
+
+impl From<&PackageInfo> for CacheKey {
+    fn from(pkg: &PackageInfo) -> Self {
+        CacheKey {
+            name: pkg.name.clone(),
+            version: pkg.version.clone(),
+            build_string: pkg.build_string.clone(),
+        }
+    }
+}
+
+impl Display for CacheKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-{}-{}", &self.name, &self.version, &self.build_string)
+    }
+}
+
+#[derive(Default)]
+struct PackageCacheInner {
+    path: PathBuf,
+    packages: FxHashMap<CacheKey, Arc<Mutex<Package>>>,
+}
+
+#[derive(Default)]
+struct Package {
+    path: Option<PathBuf>,
+    inflight: Option<broadcast::Sender<Result<PathBuf, PackageCacheError>>>,
+}
+
+/// Required information about a package we want to retrieve or store in the cache.
+#[derive(Debug)]
+pub struct PackageInfo {
+    pub name: String,
+    pub version: String,
+    pub build_string: String,
+}
+
+/// An error that might be returned from one of the caching function of the [`PackageCache`].
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum PackageCacheError {
+    #[error(transparent)]
+    FetchError(#[from] Arc<dyn std::error::Error + Send + Sync + 'static>),
+}
+
+impl PackageCache {
+    /// Constructs a new [`PackageCache`] located at the specified path.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(PackageCacheInner {
+                path: path.into(),
+                packages: Default::default(),
+            })),
+        }
+    }
+
+    /// Returns the directory that contains the specified package.
+    ///
+    /// If the package was previously successfully fetched and stored in the cache the directory
+    /// containing the data is returned immediately. If the package was not previously fetch the
+    /// filesystem is checked to see if a directory with valid package content exists. Otherwise,
+    /// the user provided `fetch` function is called to populate the cache.
+    ///
+    /// If the package is already being fetched by another task/thread the request is coalesced. No
+    /// duplicate fetch is performed.
+    pub async fn get_or_fetch<F, Fut, E>(
+        &self,
+        pkg: PackageInfo,
+        fetch: F,
+    ) -> Result<PathBuf, PackageCacheError>
+    where
+        F: (FnOnce(PathBuf) -> Fut) + Send + 'static,
+        Fut: Future<Output = Result<(), E>> + Send + 'static,
+        E: std::error::Error + Send + Sync + 'static,
+    {
+        let cache_key = CacheKey::from(&pkg);
+
+        // Get the package entry
+        let (package, pkg_cache_dir) = {
+            let mut inner = self.inner.lock().unwrap();
+            let destination = inner.path.join(cache_key.to_string());
+            let package = inner.packages.entry(cache_key).or_default().clone();
+            (package, destination)
+        };
+
+        let mut rx = {
+            // Only sync code in this block
+            let mut inner = package.lock().unwrap();
+
+            // If there exists an existing value in our cache, we can return that.
+            if let Some(path) = inner.path.as_ref() {
+                return Ok(path.clone());
+            }
+
+            // Is there an in-flight requests for the package?
+            if let Some(inflight) = inner.inflight.as_ref() {
+                inflight.subscribe()
+            } else {
+                // There is no in-flight requests so we start one!
+                let (tx, rx) = broadcast::channel(1);
+                inner.inflight = Some(tx.clone());
+
+                let package = package.clone();
+                tokio::spawn(async move {
+                    let result = validate_or_fetch_to_cache(pkg_cache_dir.clone(), fetch).await;
+
+                    {
+                        // only sync code in this block
+                        let mut package = package.lock().unwrap();
+                        package.inflight = None;
+
+                        match result {
+                            Ok(_) => {
+                                package.path.replace(pkg_cache_dir.clone());
+                                let _ = tx.send(Ok(pkg_cache_dir));
+                            }
+                            Err(e) => {
+                                let _ = tx.send(Err(e));
+                            }
+                        }
+                    }
+                });
+
+                rx
+            }
+        };
+
+        Ok(rx.recv().await.expect("in-flight request has died")?)
+    }
+
+    /// Returns the directory that contains the specified package.
+    ///
+    /// This is a convenience wrapper around `get_or_fetch` which fetches the package from the given
+    /// URL if the package could not be found in the cache.
+    pub async fn get_or_fetch_from_url(
+        &self,
+        pkg: PackageInfo,
+        url: Url,
+        client: Client,
+    ) -> Result<PathBuf, PackageCacheError> {
+        self.get_or_fetch(pkg, move |destination| async move {
+            rattler_package_streaming::reqwest::tokio::extract(client, url, &destination).await
+        })
+        .await
+    }
+}
+
+/// Validates that the package that is currently stored is a valid package and otherwise calls the
+/// `fetch` method to populate the cache.
+async fn validate_or_fetch_to_cache<F, Fut, E>(
+    path: PathBuf,
+    fetch: F,
+) -> Result<(), PackageCacheError>
+where
+    F: FnOnce(PathBuf) -> Fut + Send,
+    Fut: Future<Output = Result<(), E>> + 'static,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    // TODO: Validate the contents of the directory
+
+    // Otherwise, defer to populate method to fill our cache.
+    fetch(path)
+        .await
+        .map_err(|e| PackageCacheError::FetchError(Arc::new(e)))
+}
+
+#[cfg(test)]
+mod test {
+    use crate::package_store::{PackageCache, PackageInfo};
+    use tempfile::tempdir;
+    use url::Url;
+
+    #[tokio::test]
+    pub async fn test_package_cache() {
+        let packages_dir = tempdir().unwrap();
+        let cache = PackageCache::new(packages_dir.path());
+
+        cache.get_or_fetch_from_url(PackageInfo {
+            name: "python".to_string(),
+            version: "3.11.0".to_string(),
+            build_string: "h9a09f29_0_cpython".to_string(),
+        },
+                                    Url::parse("https://conda.anaconda.org/conda-forge/win-64/python-3.11.0-h9a09f29_0_cpython.tar.bz2").unwrap(),
+                                    Default::default())
+            .await
+            .unwrap();
+    }
+}

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -22,7 +22,7 @@ tokio-util = { version = "0.7", optional = true }
 futures-util = { version = "0.3.25", optional = true }
 
 [features]
-tokio = ["dep:tokio", "bzip2/tokio", "tokio/fs", "tokio-util/io", "tokio-util/io-util", "reqwest?/stream"]
+tokio = ["dep:tokio", "bzip2/tokio", "tokio/fs", "tokio-util/io", "tokio-util/io-util", "reqwest?/stream", "futures-util"]
 reqwest = ["reqwest/blocking"]
 
 [dev-dependencies]

--- a/crates/rattler_package_streaming/src/fs.rs
+++ b/crates/rattler_package_streaming/src/fs.rs
@@ -37,8 +37,8 @@ pub fn extract_conda(archive: &Path, destination: &Path) -> Result<(), ExtractEr
 ///
 /// ```rust,no_run
 /// # use std::path::Path;
-/// use rattler_package_streaming::fs::extract_conda;
-/// let _ = extract_conda(
+/// use rattler_package_streaming::fs::extract;
+/// let _ = extract(
 ///     Path::new("conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.conda"),
 ///     Path::new("/tmp"))
 ///     .unwrap();

--- a/crates/rattler_package_streaming/src/tokio/fs.rs
+++ b/crates/rattler_package_streaming/src/tokio/fs.rs
@@ -1,0 +1,86 @@
+use crate::{ArchiveType, ExtractError};
+use std::path::Path;
+
+/// Extracts the contents a `.tar.bz2` package archive at the specified path to a directory.
+///
+/// ```rust,no_run
+/// # #[tokio::main]
+/// # async fn main() {
+/// # use std::path::Path;
+/// use rattler_package_streaming::tokio::fs::extract_tar_bz2;
+/// let _ = extract_tar_bz2(
+///     Path::new("conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.tar.bz2"),
+///     Path::new("/tmp"))
+///     .await
+///     .unwrap();
+/// # }
+/// ```
+pub async fn extract_tar_bz2(archive: &Path, destination: &Path) -> Result<(), ExtractError> {
+    // Spawn a block task to perform the extraction
+    let destination = destination.to_owned();
+    let archive = archive.to_owned();
+    match tokio::task::spawn_blocking(move || crate::fs::extract_tar_bz2(&archive, &destination))
+        .await
+    {
+        Ok(result) => result,
+        Err(err) => {
+            if let Ok(reason) = err.try_into_panic() {
+                std::panic::resume_unwind(reason);
+            }
+            Err(ExtractError::Cancelled)
+        }
+    }
+}
+
+/// Extracts the contents a `.conda` package archive at the specified path to a directory.
+///
+/// ```rust,no_run
+/// # use std::path::Path;
+/// # #[tokio::main]
+/// # async fn main() {
+/// use rattler_package_streaming::tokio::fs::extract_conda;
+/// let _ = extract_conda(
+///     Path::new("conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.conda"),
+///     Path::new("/tmp"))
+///     .await
+///     .unwrap();
+/// # }
+/// ```
+pub async fn extract_conda(archive: &Path, destination: &Path) -> Result<(), ExtractError> {
+    // Spawn a block task to perform the extraction
+    let destination = destination.to_owned();
+    let archive = archive.to_owned();
+    match tokio::task::spawn_blocking(move || crate::fs::extract_conda(&archive, &destination))
+        .await
+    {
+        Ok(result) => result,
+        Err(err) => {
+            if let Ok(reason) = err.try_into_panic() {
+                std::panic::resume_unwind(reason);
+            }
+            Err(ExtractError::Cancelled)
+        }
+    }
+}
+
+/// Extracts the contents a package archive at the specified path to a directory. The type of
+/// package is determined based on the file extension of the archive path.
+///
+/// ```rust,no_run
+/// # #[tokio::main]
+/// # async fn main() {
+/// # use std::path::Path;
+/// use rattler_package_streaming::tokio::fs::extract;
+/// let _ = extract(
+///     Path::new("conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.conda"),
+///     Path::new("/tmp"))
+///     .await
+///     .unwrap();
+/// # }
+/// ```
+pub async fn extract(archive: &Path, destination: &Path) -> Result<(), ExtractError> {
+    match ArchiveType::try_from(archive).ok_or(ExtractError::UnsupportedArchiveType)? {
+        ArchiveType::TarBz2 => extract_tar_bz2(archive, destination).await,
+        ArchiveType::Conda => extract_conda(archive, destination).await,
+    }
+}

--- a/crates/rattler_package_streaming/src/tokio/mod.rs
+++ b/crates/rattler_package_streaming/src/tokio/mod.rs
@@ -1,1 +1,2 @@
 pub mod async_read;
+pub mod fs;


### PR DESCRIPTION
Provides functionality to cache extracted Conda packages in a directory. The cache object holds an in-memory cache of which valid packages exist. It checks the filesystem if an entry doesn't exist in memory yet. Validation (from #39 ) is used to determine whether the cache is corrupt. If the filesystem also doesn't provide the requested package it is fetched into the cache.

The cache does not provide a method to download and extract package archives but instead relies on a `populate` function. The goal is to decouple "caching" and "download/extract". This makes it easier to test, provide different downloading functionalities, queueing, etc.

Builds on #39 which should be merged first!