### PR TITLE
Polish libsolv ffi wrapper

### DIFF
--- a/crates/rattler/src/solver/libsolv/mod.rs
+++ b/crates/rattler/src/solver/libsolv/mod.rs
@@ -49,8 +49,8 @@ mod test {
     #[test]
     fn test_conda_read_repodata() {
         let json_file = conda_json_path();
-        let mut pool = Pool::default();
-        let mut repo = pool.create_repo("conda-forge");
+        let pool = Pool::default();
+        let repo = pool.create_repo("conda-forge");
         repo.add_conda_json(json_file)
             .expect("could not add repodata to Repo");
     }
@@ -62,7 +62,7 @@ mod test {
         let mut pool = Pool::default();
         pool.set_debug_callback(|msg, _level| eprintln!("{}", msg.trim()));
         pool.set_debug_level(Verbosity::Low);
-        let mut repo = pool.create_repo("conda-forge");
+        let repo = pool.create_repo("conda-forge");
         repo.add_repodata(
             &serde_json::from_str(&std::fs::read_to_string(json_file).expect("couldnt read"))
                 .expect("couldnt parse"),

--- a/crates/rattler/src/solver/mod.rs
+++ b/crates/rattler/src/solver/mod.rs
@@ -36,7 +36,7 @@ pub struct SolverProblem<'c> {
 impl<'c> SolverProblem<'c> {
     pub fn solve(self) -> Result<Vec<Entry>, SolveError> {
         // Construct a default libsolv pool
-        let mut pool = Pool::default();
+        let pool = Pool::default();
 
         // Setup proper logging for the pool
         pool.set_debug_callback(|msg, flags| {
@@ -47,7 +47,7 @@ impl<'c> SolverProblem<'c> {
         // Create repos for all channels
         let mut channel_mapping = HashMap::new();
         for (channel, repodata) in self.channels.iter() {
-            let mut repo = pool.create_repo(channel);
+            let repo = pool.create_repo(channel);
             repo.add_repodata(repodata)
                 .map_err(SolveError::ErrorAddingRepodata)?;
             channel_mapping.insert(repo.id(), channel);
@@ -62,7 +62,7 @@ impl<'c> SolverProblem<'c> {
         // Add matchspec to the queue
         let mut queue = Queue::default();
         for spec in self.specs {
-            let id = spec.intern(&mut pool);
+            let id = spec.intern(&pool);
             queue.push_id_with_flags(id, (SOLVER_INSTALL | SOLVER_SOLVABLE_PROVIDES) as i32);
         }
 


### PR DESCRIPTION
This commit makes sure we allow calling libsolv functions from shared references, instead of requiring mutability, because otherwise legitimate use cases of the library (like multiple repos for a single pool) are impossible to express.