### PR TITLE
move index to its own file, add helper functions and simple test

### DIFF
--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, fs::File, path::Path, str::FromStr};
+use std::{fs::File, io::Read, path::Path, str::FromStr};
 
-use crate::{RunExports, Version};
+use crate::Version;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 
@@ -45,11 +45,6 @@ pub struct Index {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub constrains: Vec<String>,
 
-    /// Any run_exports contained within the package.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
-    pub run_exports: HashMap<Version, RunExports>,
-
     /// The timestamp when this package was created
     pub timestamp: Option<u64>,
 
@@ -59,8 +54,10 @@ pub struct Index {
 
 impl Index {
     /// Parses a `index.json` file from a reader.
-    pub fn from_reader(reader: impl std::io::Read) -> Result<Self, std::io::Error> {
-        serde_json::from_reader(reader).map_err(Into::into)
+    pub fn from_reader(mut reader: impl Read) -> Result<Self, std::io::Error> {
+        let mut str = String::new();
+        reader.read_to_string(&mut str)?;
+        Self::from_str(&str)
     }
 
     /// Parses a `index.json` file from a file.

--- a/crates/rattler_conda_types/src/package/index.rs
+++ b/crates/rattler_conda_types/src/package/index.rs
@@ -1,0 +1,116 @@
+use std::{collections::HashMap, fs::File, path::Path, str::FromStr};
+
+use crate::{RunExports, Version};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
+
+/// A representation of the `index.json` file found in package archives.
+///
+/// The `index.json` file contains information about the package build and dependencies of the package.
+/// This data makes up the repodata.json file in the repository.
+#[serde_as]
+#[skip_serializing_none]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct Index {
+    /// The lowercase name of the package
+    pub name: String,
+
+    /// The version of the package
+    #[serde_as(as = "DisplayFromStr")]
+    pub version: Version,
+
+    /// The build string of the package.
+    pub build: String,
+
+    /// The build number of the package. This is also included in the build string.
+    pub build_number: usize,
+
+    /// Optionally, the architecture the package is build for.
+    pub arch: Option<String>,
+
+    /// Optionally, the OS the package is build for.
+    pub platform: Option<String>,
+
+    /// Optionally, the license
+    pub license: Option<String>,
+
+    /// Optionally, the license family
+    pub license_family: Option<String>,
+
+    /// The dependencies of the package
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub depends: Vec<String>,
+
+    /// The package constraints of the package
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub constrains: Vec<String>,
+
+    /// Any run_exports contained within the package.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
+    pub run_exports: HashMap<Version, RunExports>,
+
+    /// The timestamp when this package was created
+    pub timestamp: Option<u64>,
+
+    /// The subdirectory that contains this package
+    pub subdir: Option<String>,
+}
+
+impl Index {
+    /// Parses a `index.json` file from a reader.
+    pub fn from_reader(reader: impl std::io::Read) -> Result<Self, std::io::Error> {
+        serde_json::from_reader(reader).map_err(Into::into)
+    }
+
+    /// Parses a `index.json` file from a file.
+    pub fn from_path(path: &Path) -> Result<Self, std::io::Error> {
+        Self::from_reader(File::open(path)?)
+    }
+
+    /// Reads the file from a package archive directory
+    pub fn from_package_directory(path: &Path) -> Result<Self, std::io::Error> {
+        Self::from_path(&path.join("info/index.json"))
+    }
+}
+
+impl FromStr for Index {
+    type Err = std::io::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s).map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Index;
+
+    #[test]
+    pub fn test_reconstruct_index_json() {
+        let package_dir = tempfile::tempdir().unwrap();
+        rattler_package_streaming::fs::extract(
+            &crate::get_test_data_dir().join("zlib-1.2.8-vc10_0.tar.bz2"),
+            package_dir.path(),
+        )
+        .unwrap();
+
+        insta::assert_yaml_snapshot!(Index::from_package_directory(package_dir.path()).unwrap());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    pub fn test_reconstruct_index_json_with_symlinks() {
+        let package_dir = tempfile::tempdir().unwrap();
+        rattler_package_streaming::fs::extract(
+            &crate::get_test_data_dir().join("with-symlinks/zlib-1.2.8-3.tar.bz2"),
+            package_dir.path(),
+        )
+        .unwrap();
+
+        let package_dir = package_dir.into_path();
+        println!("{}", package_dir.display());
+
+        insta::assert_yaml_snapshot!(Index::from_package_directory(&package_dir).unwrap());
+    }
+}

--- a/crates/rattler_conda_types/src/package/mod.rs
+++ b/crates/rattler_conda_types/src/package/mod.rs
@@ -1,16 +1,13 @@
 //! Contains models of files that are found in the `info/` directory of a package.
 
-use crate::{
-    utils::serde::{LossyUrl, MultiLineString, VecSkipNone},
-    RunExports, Version,
-};
+use crate::utils::serde::{LossyUrl, MultiLineString, VecSkipNone};
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, skip_serializing_none, DisplayFromStr, OneOrMany, Same};
-use std::collections::HashMap;
+use serde_with::{serde_as, skip_serializing_none, OneOrMany, Same};
 use url::Url;
 
 mod files;
 mod has_prefix;
+mod index;
 mod no_link;
 mod no_softlink;
 mod paths;
@@ -18,59 +15,11 @@ mod paths;
 pub use {
     files::Files,
     has_prefix::HasPrefix,
+    index::Index,
     no_link::NoLink,
     no_softlink::NoSoftlink,
     paths::{FileMode, PathType, PathsEntry, PathsJson},
 };
-
-#[serde_as]
-#[skip_serializing_none]
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
-pub struct Index {
-    /// The lowercase name of the package
-    pub name: String,
-
-    /// The version of the package
-    #[serde_as(as = "DisplayFromStr")]
-    pub version: Version,
-
-    /// The build string of the package.
-    pub build: String,
-
-    /// The build number of the package. This is also included in the build string.
-    pub build_number: usize,
-
-    /// Optionally, the architecture the package is build for.
-    pub arch: Option<String>,
-
-    /// Optionally, the OS the package is build for.
-    pub platform: Option<String>,
-
-    /// Optionally, the license
-    pub license: Option<String>,
-
-    /// Optionally, the license family
-    pub license_family: Option<String>,
-
-    /// The dependencies of the package
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub depends: Vec<String>,
-
-    /// The package constraints of the package
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub constrains: Vec<String>,
-
-    /// Any run_exports contained within the package.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
-    pub run_exports: HashMap<Version, RunExports>,
-
-    /// The timestamp when this package was created
-    pub timestamp: Option<u64>,
-
-    /// The subdirectory that contains this package
-    pub subdir: Option<String>,
-}
 
 #[serde_as]
 #[skip_serializing_none]

--- a/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__index__test__reconstruct_index_json.snap
+++ b/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__index__test__reconstruct_index_json.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rattler_conda_types/src/package/index.rs
+expression: "Index::from_package_directory(package_dir.path()).unwrap()"
+---
+name: zlib
+version: 1.2.8
+build: vc10_0
+build_number: 0
+arch: x86_64
+platform: win
+license: "zlib (http://zlib.net/zlib_license.html)"
+license_family: Other
+subdir: win-64
+

--- a/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__index__test__reconstruct_index_json_with_symlinks.snap
+++ b/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__index__test__reconstruct_index_json_with_symlinks.snap
@@ -1,0 +1,14 @@
+---
+source: crates/rattler_conda_types/src/package/index.rs
+expression: "Index::from_package_directory(&package_dir).unwrap()"
+---
+name: zlib
+version: 1.2.8
+build: "3"
+build_number: 3
+arch: x86_64
+platform: linux
+license: "zlib (http://zlib.net/zlib_license.html)"
+license_family: Other
+subdir: linux-64
+


### PR DESCRIPTION
Two things I found while writing / adjusting this code:

- to my knowledge, run_exports are defined in a seperate file (`info/run_exports.json`) so I was surprised to see this in the index.json definition. Did you encounter a package where run_exports were added to the index? Otherwise I would suggest we remove that for now?
- The `paths.json` object is called `PathsJson` while the `index.json` object is called `Index`. Should we make them both the same?

Also, I've used `serde_json::from_reader(...)` instead of going via reading a string and reusing the FromStr functions. That means we have two `.map_err(Into::into)`. Let me know if you prefer the `FromStr` way.