### PR TITLE
feat: adds the PackageFile trait for consistency

### DIFF
--- a/crates/rattler/src/package_cache.rs
+++ b/crates/rattler/src/package_cache.rs
@@ -269,7 +269,7 @@ where
 mod test {
     use super::{PackageCache, PackageInfo};
     use crate::{get_test_data_dir, validation::validate_package_directory};
-    use rattler_conda_types::package::PathsJson;
+    use rattler_conda_types::package::{PackageFile, PathsJson};
     use std::{fs::File, path::Path};
     use tempfile::tempdir;
 

--- a/crates/rattler/src/validation.rs
+++ b/crates/rattler/src/validation.rs
@@ -11,7 +11,7 @@
 //! [`PathsJson`] object. See [`PathsJson::from_deprecated_package_directory`] for more information.
 
 use crate::{utils, utils::parse_sha256_from_hex};
-use rattler_conda_types::package::{PathType, PathsEntry, PathsJson};
+use rattler_conda_types::package::{PackageFile, PathType, PathsEntry, PathsJson};
 use std::{
     fs::Metadata,
     io::ErrorKind,
@@ -214,7 +214,7 @@ mod test {
         PackageEntryValidationError, PackageValidationError,
     };
     use assert_matches::assert_matches;
-    use rattler_conda_types::package::{PathType, PathsJson};
+    use rattler_conda_types::package::{PackageFile, PathType, PathsJson};
     use rstest::*;
     use std::{
         io::Write,

--- a/crates/rattler_conda_types/src/channel_data.rs
+++ b/crates/rattler_conda_types/src/channel_data.rs
@@ -14,7 +14,7 @@ use serde_with::{serde_as, skip_serializing_none, DisplayFromStr, OneOrMany, Sam
 use std::collections::HashMap;
 use url::Url;
 
-use crate::package::RunExports;
+use crate::package::RunExportsJson;
 
 /// [`ChannelData`] is an index of subdirectories and packages stored within a Channel.
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]
@@ -99,7 +99,7 @@ pub struct ChannelDataPackage {
     /// Any run_exports contained within the package.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     #[serde_as(as = "HashMap<DisplayFromStr, _>")]
-    pub run_exports: HashMap<Version, RunExports>,
+    pub run_exports: HashMap<Version, RunExportsJson>,
 
     /// Which architectures does the package support
     pub subdirs: Vec<String>,

--- a/crates/rattler_conda_types/src/package/files.rs
+++ b/crates/rattler_conda_types/src/package/files.rs
@@ -1,9 +1,5 @@
-use std::{
-    fs::File,
-    io::Read,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use crate::package::PackageFile;
+use std::path::{Path, PathBuf};
 
 /// Representation of the `info/files` file in older package archives.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -11,39 +7,22 @@ pub struct Files {
     pub files: Vec<PathBuf>,
 }
 
-impl Files {
-    /// Parses a `files` file from a reader.
-    pub fn from_reader(mut reader: impl Read) -> Result<Self, std::io::Error> {
-        let mut str = String::new();
-        reader.read_to_string(&mut str)?;
-        Self::from_str(&str)
+impl PackageFile for Files {
+    fn package_path() -> &'static Path {
+        Path::new("info/files")
     }
 
-    /// Parses a `files` file from a file.
-    pub fn from_path(path: &Path) -> Result<Self, std::io::Error> {
-        Self::from_reader(File::open(path)?)
-    }
-
-    /// Reads the file from a package archive directory
-    pub fn from_package_directory(path: &Path) -> Result<Self, std::io::Error> {
-        Self::from_path(&path.join("info/files"))
-    }
-}
-
-impl FromStr for Files {
-    type Err = std::io::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(str: &str) -> Result<Self, std::io::Error> {
         Ok(Self {
-            files: s.lines().map(PathBuf::from).collect(),
+            files: str.lines().map(PathBuf::from).collect(),
         })
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::Files;
-    use std::{path::PathBuf, str::FromStr};
+    use super::{Files, PackageFile};
+    use std::path::PathBuf;
 
     #[test]
     pub fn test_parse_files() {

--- a/crates/rattler_conda_types/src/package/has_prefix.rs
+++ b/crates/rattler_conda_types/src/package/has_prefix.rs
@@ -1,4 +1,5 @@
 use crate::package::paths::FileMode;
+use crate::package::PackageFile;
 use nom::{
     branch::alt,
     bytes::complete::{tag, tag_no_case, take_till1},
@@ -9,8 +10,6 @@ use nom::{
 };
 use std::{
     borrow::Cow,
-    fs::File,
-    io::Read,
     path::{Path, PathBuf},
     str::FromStr,
 };
@@ -28,31 +27,14 @@ pub struct HasPrefix {
     pub files: Vec<HasPrefixEntry>,
 }
 
-impl HasPrefix {
-    /// Parses a `has_prefix` file from a reader.
-    pub fn from_reader(mut reader: impl Read) -> Result<Self, std::io::Error> {
-        let mut str = String::new();
-        reader.read_to_string(&mut str)?;
-        Self::from_str(&str)
+impl PackageFile for HasPrefix {
+    fn package_path() -> &'static Path {
+        Path::new("info/has_prefix")
     }
 
-    /// Parses a `has_prefix` file from a file.
-    pub fn from_path(path: &Path) -> Result<Self, std::io::Error> {
-        Self::from_reader(File::open(path)?)
-    }
-
-    /// Reads the file from a package archive directory
-    pub fn from_package_directory(path: &Path) -> Result<Self, std::io::Error> {
-        Self::from_path(&path.join("info/has_prefix"))
-    }
-}
-
-impl FromStr for HasPrefix {
-    type Err = std::io::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(str: &str) -> Result<Self, std::io::Error> {
         Ok(Self {
-            files: s
+            files: str
                 .lines()
                 .map(HasPrefixEntry::from_str)
                 .collect::<Result<_, _>>()?,
@@ -139,7 +121,8 @@ impl FromStr for HasPrefixEntry {
 mod test {
     use super::HasPrefixEntry;
     use crate::package::FileMode;
-    use std::{borrow::Cow, path::PathBuf, str::FromStr};
+    use std::str::FromStr;
+    use std::{borrow::Cow, path::PathBuf};
 
     #[test]
     pub fn test_parse_has_prefix() {

--- a/crates/rattler_conda_types/src/package/mod.rs
+++ b/crates/rattler_conda_types/src/package/mod.rs
@@ -9,13 +9,67 @@ mod no_softlink;
 mod paths;
 mod run_exports;
 
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
 pub use {
-    about::About,
+    about::AboutJson,
     files::Files,
     has_prefix::HasPrefix,
-    index::Index,
+    index::IndexJson,
     no_link::NoLink,
     no_softlink::NoSoftlink,
     paths::{FileMode, PathType, PathsEntry, PathsJson},
-    run_exports::RunExports,
+    run_exports::RunExportsJson,
 };
+
+/// A trait implemented for structs that represent specific files in a Conda archive.
+///
+/// This trait provides a standardised interface for accessing the contents of known files in a
+/// Conda package, such as the `index.json` (see [`IndexJson`]) or `about.json` (see [`AboutJson`])
+/// files. Structs that represent these files should implement this trait in order to ensure that
+/// they can be easily accessed and manipulated by other code that expects a consistent interface.
+pub trait PackageFile: Sized {
+    /// Returns the path to the file within the Conda archive.
+    ///
+    /// The path is relative to the root of the archive and include any necessary directories.
+    fn package_path() -> &'static Path;
+
+    /// Parses the object from a string, using a format appropriate for the file type.
+    ///
+    /// For example, if the file is in JSON format, this function parses the JSON string and returns
+    /// the resulting object. If the file is not in a parsable format, this function returns an
+    /// error.
+    fn from_str(str: &str) -> Result<Self, std::io::Error>;
+
+    /// Parses the object from a `Read` trait object, using a format appropriate for the file type.
+    ///
+    /// For example, if the file is in JSON format, this function reads the data from the `Read`
+    /// object, parse the JSON string and return the resulting object. If the file is not in a
+    /// parsable format, this function returns an error.
+    fn from_reader(mut reader: impl Read) -> Result<Self, std::io::Error> {
+        let mut str = String::new();
+        reader.read_to_string(&mut str)?;
+        Self::from_str(&str)
+    }
+
+    /// Parses the object from a file specified by a `path`, using a format appropriate for the file
+    /// type.
+    ///
+    /// For example, if the file is in JSON format, this function reads the data from the file at
+    /// the specified path, parse the JSON string and return the resulting object. If the file is
+    /// not in a parsable format or if the file could not read, this function returns an error.
+    fn from_path(path: &Path) -> Result<Self, std::io::Error> {
+        Self::from_reader(File::open(path)?)
+    }
+
+    /// Parses the object by looking up the appropriate file from the root of the specified Conda
+    /// archive directory, using a format appropriate for the file type.
+    ///
+    /// For example, if the file is in JSON format, this function reads the appropriate file from
+    /// the archive, parse the JSON string and return the resulting object. If the file is not in a
+    /// parsable format or if the file could not be read, this function returns an error.
+    fn from_package_directory(path: &Path) -> Result<Self, std::io::Error> {
+        Self::from_path(&path.join(Self::package_path()))
+    }
+}

--- a/crates/rattler_conda_types/src/package/no_link.rs
+++ b/crates/rattler_conda_types/src/package/no_link.rs
@@ -1,9 +1,5 @@
-use std::{
-    fs::File,
-    io::Read,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use super::PackageFile;
+use std::path::{Path, PathBuf};
 
 /// Representation of the `info/no_link` file in older package archives. This file contains a list
 /// of all files that should not be "linked".
@@ -12,39 +8,22 @@ pub struct NoLink {
     pub files: Vec<PathBuf>,
 }
 
-impl NoLink {
-    /// Parses a `no_link` file from a reader.
-    pub fn from_reader(mut reader: impl Read) -> Result<Self, std::io::Error> {
-        let mut str = String::new();
-        reader.read_to_string(&mut str)?;
-        Self::from_str(&str)
+impl PackageFile for NoLink {
+    fn package_path() -> &'static Path {
+        Path::new("info/no_link")
     }
 
-    /// Parses a `files` file from a file.
-    pub fn from_path(path: &Path) -> Result<Self, std::io::Error> {
-        Self::from_reader(File::open(path)?)
-    }
-
-    /// Reads the file from a package archive directory
-    pub fn from_package_directory(path: &Path) -> Result<Self, std::io::Error> {
-        Self::from_path(&path.join("info/no_link"))
-    }
-}
-
-impl FromStr for NoLink {
-    type Err = std::io::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(str: &str) -> Result<Self, std::io::Error> {
         Ok(Self {
-            files: s.lines().map(PathBuf::from).collect(),
+            files: str.lines().map(PathBuf::from).collect(),
         })
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::NoLink;
-    use std::{path::PathBuf, str::FromStr};
+    use super::{NoLink, PackageFile};
+    use std::path::PathBuf;
 
     #[test]
     pub fn test_parse_no_link() {

--- a/crates/rattler_conda_types/src/package/no_softlink.rs
+++ b/crates/rattler_conda_types/src/package/no_softlink.rs
@@ -1,9 +1,5 @@
-use std::{
-    fs::File,
-    io::Read,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use crate::package::PackageFile;
+use std::path::{Path, PathBuf};
 
 /// Representation of the `info/no_softlink` file in older package archives. This file contains a list
 /// of all files that should not be "softlinked".
@@ -12,39 +8,22 @@ pub struct NoSoftlink {
     pub files: Vec<PathBuf>,
 }
 
-impl NoSoftlink {
-    /// Parses a `no_softlink` file from a reader.
-    pub fn from_reader(mut reader: impl Read) -> Result<Self, std::io::Error> {
-        let mut str = String::new();
-        reader.read_to_string(&mut str)?;
-        Self::from_str(&str)
+impl PackageFile for NoSoftlink {
+    fn package_path() -> &'static Path {
+        Path::new("info/no_softlink")
     }
 
-    /// Parses a `no_softlink` file from a file.
-    pub fn from_path(path: &Path) -> Result<Self, std::io::Error> {
-        Self::from_reader(File::open(path)?)
-    }
-
-    /// Reads the file from a package archive directory
-    pub fn from_package_directory(path: &Path) -> Result<Self, std::io::Error> {
-        Self::from_path(&path.join("info/no_softlink"))
-    }
-}
-
-impl FromStr for NoSoftlink {
-    type Err = std::io::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(str: &str) -> Result<Self, std::io::Error> {
         Ok(Self {
-            files: s.lines().map(PathBuf::from).collect(),
+            files: str.lines().map(PathBuf::from).collect(),
         })
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::NoSoftlink;
-    use std::{path::PathBuf, str::FromStr};
+    use super::{NoSoftlink, PackageFile};
+    use std::path::PathBuf;
 
     #[test]
     pub fn test_parse_no_link() {

--- a/crates/rattler_conda_types/src/package/paths.rs
+++ b/crates/rattler_conda_types/src/package/paths.rs
@@ -1,14 +1,10 @@
+use super::PackageFile;
 use crate::package::has_prefix::HasPrefixEntry;
 use crate::package::{Files, HasPrefix, NoLink, NoSoftlink};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::io::ErrorKind;
-use std::{
-    fs::File,
-    io::Read,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::path::{Path, PathBuf};
 
 /// A representation of the `paths.json` file found in package archives.
 ///
@@ -22,24 +18,17 @@ pub struct PathsJson {
     pub paths: Vec<PathsEntry>,
 }
 
+impl PackageFile for PathsJson {
+    fn package_path() -> &'static Path {
+        Path::new("info/paths.json")
+    }
+
+    fn from_str(str: &str) -> Result<Self, std::io::Error> {
+        serde_json::from_str(str).map_err(Into::into)
+    }
+}
+
 impl PathsJson {
-    /// Parses a `paths.json` file from a reader.
-    pub fn from_reader(mut reader: impl Read) -> Result<Self, std::io::Error> {
-        let mut str = String::new();
-        reader.read_to_string(&mut str)?;
-        Self::from_str(&str)
-    }
-
-    /// Parses a `paths.json` file from a file.
-    pub fn from_path(path: &Path) -> Result<Self, std::io::Error> {
-        Self::from_reader(File::open(path)?)
-    }
-
-    /// Reads the file from a package archive directory
-    pub fn from_package_directory(path: &Path) -> Result<Self, std::io::Error> {
-        Self::from_path(&path.join("info/paths.json"))
-    }
-
     /// Reads the file from a package archive directory. If the `paths.json` file could not be found
     /// use the [`Self::from_deprecated_package_directory`] method as a fallback.
     pub fn from_package_directory_with_deprecated_fallback(
@@ -163,14 +152,6 @@ impl PathsJson {
                 }
             })
         })
-    }
-}
-
-impl FromStr for PathsJson {
-    type Err = std::io::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_json::from_str(s).map_err(Into::into)
     }
 }
 

--- a/crates/rattler_conda_types/src/run_export.rs
+++ b/crates/rattler_conda_types/src/run_export.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// Type of runtime export.
 /// See more info in [the conda docs](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#export-runtime-requirements)
-/// [`crate::package::RunExports`]
+/// [`crate::package::RunExportsJson`]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum RunExportKind {
     Weak,


### PR DESCRIPTION
Adds `PackageFile` trait that implements common functionality for files that are commonly found in a package archive like the `index.json` or `about.json`. 

The `PackageFile` trait implements most of the deserialization functions out of the box. You only need to provide the `from_str` and  `package_path` functions.

This PR also renames types that are represented by `.json` files to include the `Json` suffix. This is to indicate that they represent the structure of these json files and are not per se generic data structures.