### PR TITLE
chore(docs): add deny missing docs to virtual packages

### DIFF
--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -1,3 +1,13 @@
+//! Provides functionality to detect the CUDA version present on the current system.
+//!
+//! Two methods are provided:
+//!
+//! * [`detect_cuda_version_via_nvml`]
+//! * [`detect_cuda_version_via_libcuda`]
+//!
+//! Both will detect the current supported CUDA version but the first method has less edge cases.
+//! See the function documentation for more information.
+
 use libloading::Symbol;
 use once_cell::sync::OnceCell;
 use rattler_conda_types::Version;
@@ -120,7 +130,6 @@ fn nvml_library_paths() -> &'static [&'static str] {
 ///
 /// Therefore you should use the function [`detect_cuda_version_via_nvml`] instead which does not
 /// have this limitation.
-#[allow(dead_code)]
 pub fn detect_cuda_version_via_libcuda() -> Option<Version> {
     // Try to open the library
     let cuda_library = cuda_library_paths()

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_docs)]
+
 //! A library to detect Conda virtual packages present on a system.
 //!
 //! A virtual package represents a package that is injected into the solver to provide system
@@ -43,8 +45,13 @@ use linux::ParseLinuxVersionError;
 /// `version` and a `build_string`. See [`VirtualPackage`] for available virtual packages.
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct GenericVirtualPackage {
+    /// The name of the package
     pub name: String,
+
+    /// The version of the package
     pub version: Version,
+
+    /// The build identifier of the package.
     pub build_string: String,
 }
 
@@ -96,6 +103,8 @@ impl From<VirtualPackage> for GenericVirtualPackage {
 }
 
 impl VirtualPackage {
+    /// Returns virtual packages detected for the current system or an error if the versions could
+    /// not be properly detected.
     pub fn current() -> Result<&'static [Self], DetectVirtualPackageError> {
         static DETECED_VIRTUAL_PACKAGES: OnceCell<Vec<VirtualPackage>> = OnceCell::new();
         DETECED_VIRTUAL_PACKAGES
@@ -104,7 +113,9 @@ impl VirtualPackage {
     }
 }
 
+/// An error that might be returned by [`VirtualPackage::current`].
 #[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum DetectVirtualPackageError {
     #[error(transparent)]
     ParseLinuxVersion(#[from] ParseLinuxVersionError),
@@ -158,6 +169,7 @@ fn try_detect_virtual_packages() -> Result<Vec<VirtualPackage>, DetectVirtualPac
 /// Linux virtual package description
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Linux {
+    /// The version of linux
     pub version: Version,
 }
 
@@ -190,7 +202,10 @@ impl From<Linux> for VirtualPackage {
 /// LibC virtual package description
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct LibC {
+    /// The family of LibC. This could be glibc for instance.
     pub family: String,
+
+    /// The version of the libc distribution.
     pub version: Version,
 }
 
@@ -223,6 +238,7 @@ impl From<LibC> for VirtualPackage {
 /// Cuda virtual package description
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Cuda {
+    /// The maximum supported Cuda version.
     pub version: Version,
 }
 
@@ -252,6 +268,8 @@ impl From<Cuda> for VirtualPackage {
 /// Archspec describes the CPU architecture
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Archspec {
+    /// A specification of the architecture family. This could be `x86_64` but it could also include
+    /// the full CPU family.
     pub spec: String,
 }
 
@@ -301,6 +319,7 @@ impl From<Archspec> for VirtualPackage {
 /// OSX virtual package description
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct Osx {
+    /// The OSX version
     pub version: Version,
 }
 

--- a/crates/rattler_virtual_packages/src/libc.rs
+++ b/crates/rattler_virtual_packages/src/libc.rs
@@ -1,3 +1,5 @@
+//! Low-level functions to detect the LibC family and version. See [`libc_family_and_version`].
+
 use once_cell::sync::OnceCell;
 use rattler_conda_types::{ParseVersionError, Version};
 use std::ffi::{FromVecWithNulError, IntoStringError};
@@ -28,6 +30,7 @@ mod ffi {
 
 /// An error that could occur when trying to detect to libc version
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+#[allow(missing_docs)]
 pub enum DetectLibCError {
     #[error("failed to parse libc version returned by the system")]
     ParseLibCVersion(#[from] ParseVersionError),

--- a/crates/rattler_virtual_packages/src/linux.rs
+++ b/crates/rattler_virtual_packages/src/linux.rs
@@ -1,3 +1,5 @@
+//! Low-level functions to dect the linux version on the system. See [`linux_version`].
+
 use once_cell::sync::OnceCell;
 use rattler_conda_types::{ParseVersionError, Version};
 use std::str::FromStr;
@@ -56,6 +58,7 @@ const fn try_detect_linux_version() -> Result<Option<Version>, ParseLinuxVersion
 }
 
 #[derive(Debug, Clone, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum ParseLinuxVersionError {
     #[error("error parsing linux version")]
     ParseError,

--- a/crates/rattler_virtual_packages/src/osx.rs
+++ b/crates/rattler_virtual_packages/src/osx.rs
@@ -1,3 +1,5 @@
+//! Low-level functions to detect the OSX version of the system. See [`osx_version`].
+
 use once_cell::sync::OnceCell;
 use rattler_conda_types::{ParseVersionError, Version};
 
@@ -40,6 +42,7 @@ const fn try_detect_osx_version() -> Result<Option<Version>, ParseOsxVersionErro
 }
 
 #[derive(Debug, thiserror::Error)]
+#[allow(missing_docs)]
 pub enum ParseOsxVersionError {
     #[error("failed to read `/System/Library/CoreServices/SystemVersion.plist`")]
     FailedToReadSystemVersion(#[source] std::io::Error),


### PR DESCRIPTION
Adds documentation to `rattler_virtual_packages` and denies undocumented public members.

One step closer to #61 