### PR TITLE
chore(docs): add deny missing docs to package streaming

### DIFF
--- a/crates/rattler_package_streaming/src/fs.rs
+++ b/crates/rattler_package_streaming/src/fs.rs
@@ -1,3 +1,5 @@
+//! Functions to extracting or stream a Conda package from a file on disk.
+
 use crate::{ArchiveType, ExtractError};
 use std::fs::File;
 use std::path::Path;

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -1,4 +1,6 @@
-//! This crate provides the ability to extract a package archive or specific parts of it.
+#![deny(missing_docs)]
+
+//! This crate provides the ability to extract a Conda package archive or specific parts of it.
 
 use std::path::Path;
 
@@ -14,6 +16,7 @@ pub mod tokio;
 
 /// An error that can occur when extracting a package archive.
 #[derive(thiserror::Error, Debug)]
+#[allow(missing_docs)]
 pub enum ExtractError {
     #[error("an io error occurred")]
     IoError(#[from] std::io::Error),

--- a/crates/rattler_package_streaming/src/read.rs
+++ b/crates/rattler_package_streaming/src/read.rs
@@ -1,3 +1,6 @@
+//! Functions that enable extracting or streaming a Conda package for objects that implement the
+//! [`std::io::Read`] trait.
+
 use super::ExtractError;
 use std::ffi::OsStr;
 use std::{io::Read, path::Path};

--- a/crates/rattler_package_streaming/src/reqwest/mod.rs
+++ b/crates/rattler_package_streaming/src/reqwest/mod.rs
@@ -1,3 +1,5 @@
+//! Functionality to stream and extract packages directly from a [`reqwest::Url`].
+
 #[cfg(feature = "tokio")]
 pub mod tokio;
 

--- a/crates/rattler_package_streaming/src/reqwest/tokio.rs
+++ b/crates/rattler_package_streaming/src/reqwest/tokio.rs
@@ -1,3 +1,6 @@
+//! Functionality to stream and extract packages directly from a [`reqwest::Url`] within a [`tokio`]
+//! async context.
+
 use crate::{ArchiveType, ExtractError};
 use futures_util::stream::TryStreamExt;
 use reqwest::IntoUrl;

--- a/crates/rattler_package_streaming/src/seek.rs
+++ b/crates/rattler_package_streaming/src/seek.rs
@@ -1,3 +1,6 @@
+//! Functionality to stream parts of a `.conda` archive for objects that implement both
+//! [`std::io::Read`] and [`std::io::Seek`] like a [`std::fs::File`] or a [`std::io::Cursor<T>`].
+
 use crate::read::stream_tar_zst;
 use crate::ExtractError;
 use std::io::{Read, Seek, SeekFrom};
@@ -23,7 +26,7 @@ fn stream_conda_zip_entry<'a>(
     let mut reader = archive.into_inner();
     reader.seek(SeekFrom::Start(offset))?;
 
-    // Open the info entry for reading
+    // Given the bytes in the zip archive of the file, decode it as a zst compressed tar file.
     stream_tar_zst(reader.take(size))
 }
 

--- a/crates/rattler_package_streaming/src/tokio/async_read.rs
+++ b/crates/rattler_package_streaming/src/tokio/async_read.rs
@@ -1,3 +1,6 @@
+//! Functions that enable extracting or streaming a Conda package for objects that implement the
+//! [`tokio::io::AsyncRead`] trait.
+
 use crate::ExtractError;
 use std::path::Path;
 use tokio::io::AsyncRead;

--- a/crates/rattler_package_streaming/src/tokio/fs.rs
+++ b/crates/rattler_package_streaming/src/tokio/fs.rs
@@ -1,3 +1,5 @@
+//! Functions to extracting or stream a Conda package from a file on disk.
+
 use crate::{ArchiveType, ExtractError};
 use std::path::Path;
 

--- a/crates/rattler_package_streaming/src/tokio/mod.rs
+++ b/crates/rattler_package_streaming/src/tokio/mod.rs
@@ -1,2 +1,4 @@
+//! Functionality to stream and extract packages in an [`tokio`] async context.
+
 pub mod async_read;
 pub mod fs;


### PR DESCRIPTION
Adds documentation to `rattler_package_streaming` and denies undocumented public members.

One step closer to #61 