### PR TITLE
fix: validate index.json file

### DIFF
--- a/crates/rattler/src/package_cache.rs
+++ b/crates/rattler/src/package_cache.rs
@@ -263,7 +263,7 @@ mod test {
             .unwrap();
 
         // Validate the contents of the package
-        let current_paths = validate_package_directory(&package_dir).unwrap();
+        let (_, current_paths) = validate_package_directory(&package_dir).unwrap();
 
         // Make sure that the paths are the same as what we would expect from the original tar
         // archive.


### PR DESCRIPTION
Updates package cache validation code to also check that a valid `index.json` file exists. The parsed files are also returned so you don't have to reparse them.

Code taken from #72 to split it up a bit.