### PR TITLE
fix: repodata cache was always out of date

### DIFF
--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -15,6 +15,7 @@ blake2 = "0.10.6"
 cache_control = "0.2.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std", "serde", "alloc", "clock"] }
 humansize = "2.1.3"
+humantime = "2.1.0"
 futures = "0.3.17"
 reqwest = { version = "0.11.6", default-features = false, features = ["stream"] }
 tokio-util = { version = "0.7.3", features = ["codec", "io"] }

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -628,7 +628,7 @@ fn validate_cached_state(cache_path: &Path, subdir_url: &Url) -> ValidatedCacheS
     let cache_state = match RepoDataState::from_path(&cache_state_path) {
         Err(e) if e.kind() == ErrorKind::NotFound => {
             // Ignore, the cache just doesnt exist
-            tracing::info!("repodata cache state is missing. Ignoring cached files...");
+            tracing::debug!("repodata cache state is missing. Ignoring cached files...");
             return ValidatedCacheState::InvalidOrMissing;
         }
         Err(e) => {
@@ -722,13 +722,17 @@ fn validate_cached_state(cache_path: &Path, subdir_url: &Url) -> ValidatedCacheS
                 max_age: Some(duration),
                 ..
             }) => {
-                if duration > cache_age {
-                    tracing::info!("Cache is out of date. Assuming out of date...");
+                if cache_age > duration {
+                    tracing::debug!(
+                        "Cache is {} old but can at most be {} old. Assuming out of date...",
+                        humantime::format_duration(cache_age),
+                        humantime::format_duration(duration),
+                    );
                     return ValidatedCacheState::OutOfDate(cache_state);
                 }
             }
             Some(_) => {
-                tracing::info!(
+                tracing::debug!(
                     "Unsupported cache-control value '{}'. Assuming out of date...",
                     cache_control
                 );


### PR DESCRIPTION
Fixes an issue where the cache was always out of date because the check was reversed. 🙈 

Code taken from https://github.com/mamba-org/rattler/pull/72 to split it up a bit.