### PR TITLE
Link json

### DIFF
--- a/crates/rattler_conda_types/src/package/entry_point.rs
+++ b/crates/rattler_conda_types/src/package/entry_point.rs
@@ -1,0 +1,97 @@
+//! A struct for a single Python entry point.
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt::Display;
+use std::str::FromStr;
+
+/// A struct for a single Python entry point. An entry point is a command that
+/// runs a function in a Python module. For example, the entry point
+/// `jlpm = jupyterlab.jlpmapp:main` will run the `main` function in the
+/// `jupyterlab.jlpmapp` module when the command `jlpm` is run on the command line.
+/// The main usage for entry points is in `noarch: python` packages.
+///
+/// The entry point is represented as a string in the format
+/// `<command> = <module>:<function>`. The command is the name of the command that
+/// will be run on the command line. The module is the name of the Python module
+/// that contains the function. The function is the name of the function to run.
+///
+/// The entry point is parsed from a string using the [`FromStr`] trait. The
+/// [`Display`] trait is implemented for the entry point to convert it back to a
+/// string.
+#[derive(Debug, Clone)]
+pub struct EntryPoint {
+    /// The name of the command that will be available on the command line.
+    pub command: String,
+
+    /// The name of the Python module that contains the function.
+    pub module: String,
+
+    /// The name of the function to run.
+    pub function: String,
+}
+
+impl FromStr for EntryPoint {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.splitn(2, "=");
+        let command = parts.next().ok_or("missing command")?.trim();
+        let module_and_function = parts.next().ok_or("missing module")?;
+
+        let mut parts = module_and_function.splitn(2, ":");
+        let module = parts.next().ok_or("missing module")?.trim();
+        let function = parts.next().ok_or("missing function")?.trim();
+
+        Ok(EntryPoint {
+            command: command.to_string(),
+            module: module.to_string(),
+            function: function.to_string(),
+        })
+    }
+}
+
+impl Display for EntryPoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} = {}:{}", self.command, self.module, self.function)
+    }
+}
+
+impl<'de> Deserialize<'de> for EntryPoint {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for EntryPoint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::EntryPoint;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_entry_point() {
+        let entry_point = EntryPoint::from_str("jlpm = jupyterlab.jlpmapp:main").unwrap();
+        assert_eq!(entry_point.command, "jlpm");
+        assert_eq!(entry_point.module, "jupyterlab.jlpmapp");
+        assert_eq!(entry_point.function, "main");
+
+        let entry_point = EntryPoint::from_str("jupyter=jupyterlab.jupyterapp:main").unwrap();
+        assert_eq!(entry_point.command, "jupyter");
+        assert_eq!(entry_point.module, "jupyterlab.jupyterapp");
+        assert_eq!(entry_point.function, "main");
+
+        insta::assert_yaml_snapshot!(entry_point);
+    }
+}

--- a/crates/rattler_conda_types/src/package/entry_point.rs
+++ b/crates/rattler_conda_types/src/package/entry_point.rs
@@ -34,13 +34,11 @@ impl FromStr for EntryPoint {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let mut parts = s.splitn(2, "=");
-        let command = parts.next().ok_or("missing command")?.trim();
-        let module_and_function = parts.next().ok_or("missing module")?;
-
-        let mut parts = module_and_function.splitn(2, ":");
-        let module = parts.next().ok_or("missing module")?.trim();
-        let function = parts.next().ok_or("missing function")?.trim();
+        let (command, module_and_function) =
+            s.split_once('=').ok_or("missing entry point separator")?;
+        let (module, function) = module_and_function
+            .split_once(':')
+            .ok_or("missing module and function separator")?;
 
         Ok(EntryPoint {
             command: command.to_string(),

--- a/crates/rattler_conda_types/src/package/entry_point.rs
+++ b/crates/rattler_conda_types/src/package/entry_point.rs
@@ -41,9 +41,9 @@ impl FromStr for EntryPoint {
             .ok_or("missing module and function separator")?;
 
         Ok(EntryPoint {
-            command: command.to_string(),
-            module: module.to_string(),
-            function: function.to_string(),
+            command: command.trim().to_string(),
+            module: module.trim().to_string(),
+            function: function.trim().to_string(),
         })
     }
 }

--- a/crates/rattler_conda_types/src/package/link.rs
+++ b/crates/rattler_conda_types/src/package/link.rs
@@ -1,0 +1,50 @@
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::{EntryPoint, PackageFile};
+
+#[derive(Serialize, Clone, Debug, Deserialize)]
+struct NoarchPython {
+    entry_points: Vec<EntryPoint>,
+}
+
+#[derive(Serialize, Clone, Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum Noarch {
+    Python(NoarchPython),
+}
+
+/// A representation of the `link.json` file found in noarch package archives.
+///
+/// The `link.json` file contains information about entrypoints that need to be installed for the package.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct LinkJson {
+    noarch: Noarch,
+
+    /// The version of the package metadata file
+    pub package_metadata_version: usize,
+}
+
+impl PackageFile for LinkJson {
+    fn package_path() -> &'static Path {
+        Path::new("info/link.json")
+    }
+
+    fn from_str(str: &str) -> Result<Self, std::io::Error> {
+        serde_json::from_str(str).map_err(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::LinkJson;
+
+    #[test]
+    fn test_link_json() {
+        let test_file = &crate::get_test_data_dir().join("link-json/jupyterlab-link.json");
+        let link_json: LinkJson =
+            serde_json::from_reader(std::fs::File::open(test_file).unwrap()).unwrap();
+        insta::assert_yaml_snapshot!(link_json);
+    }
+}

--- a/crates/rattler_conda_types/src/package/mod.rs
+++ b/crates/rattler_conda_types/src/package/mod.rs
@@ -3,9 +3,11 @@
 mod about;
 mod archive_identifier;
 mod archive_type;
+mod entry_point;
 mod files;
 mod has_prefix;
 mod index;
+mod link;
 mod no_link;
 mod no_softlink;
 mod paths;
@@ -18,9 +20,11 @@ pub use {
     about::AboutJson,
     archive_identifier::ArchiveIdentifier,
     archive_type::ArchiveType,
+    entry_point::EntryPoint,
     files::Files,
     has_prefix::HasPrefix,
     index::IndexJson,
+    link::LinkJson,
     no_link::NoLink,
     no_softlink::NoSoftlink,
     paths::{FileMode, PathType, PathsEntry, PathsJson},

--- a/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__entry_point__test__entry_point.snap
+++ b/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__entry_point__test__entry_point.snap
@@ -1,0 +1,6 @@
+---
+source: crates/rattler_conda_types/src/package/entry_point.rs
+expression: entry_point
+---
+"jupyter = jupyterlab.jupyterapp:main"
+

--- a/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__link__test__link_json.snap
+++ b/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__link__test__link_json.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rattler_conda_types/src/package/link.rs
+expression: link_json
+---
+noarch:
+  type: python
+  entry_points:
+    - "jlpm = jupyterlab.jlpmapp:main"
+    - "jupyter-lab = jupyterlab.labapp:main"
+    - "jupyter-labextension = jupyterlab.labextensions:main"
+    - "jupyter-labhub = jupyterlab.labhubapp:main"
+package_metadata_version: 1
+

--- a/test-data/link-json/jupyterlab-link.json
+++ b/test-data/link-json/jupyterlab-link.json
@@ -1,0 +1,12 @@
+{
+    "noarch": {
+      "entry_points": [
+        "jlpm = jupyterlab.jlpmapp:main",
+        "jupyter-lab = jupyterlab.labapp:main",
+        "jupyter-labextension = jupyterlab.labextensions:main",
+        "jupyter-labhub = jupyterlab.labhubapp:main"
+      ],
+      "type": "python"
+    },
+    "package_metadata_version": 1
+}                                                                                                                


### PR DESCRIPTION
Turns out we were missing `link.json` parsing and are also currently not creating entry points for `noarch`-Python packages. That will come in another PR! :)