### PR TITLE
Docs for all the conda types in crate

### DIFF
--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -190,13 +190,17 @@ impl Channel {
 }
 
 #[derive(Debug, Error, Clone, Eq, PartialEq)]
+/// Error that can occur when parsing a channel.
 pub enum ParseChannelError {
+    /// Error when the platform could not be parsed.
     #[error("could not parse the platforms")]
     ParsePlatformError(#[source] ParsePlatformError),
 
+    /// Error when the url could not be parsed.
     #[error("could not parse url")]
     ParseUrlError(#[source] url::ParseError),
 
+    /// Error when the path is invalid.
     #[error("invalid path '{0}")]
     InvalidPath(PathBuf),
 }

--- a/crates/rattler_conda_types/src/channel_data.rs
+++ b/crates/rattler_conda_types/src/channel_data.rs
@@ -4,7 +4,10 @@
 //!
 //! The [`ChannelData`] struct represents the data found within the `channeldata.json` file. The
 //! [`ChannelDataPackage`] contains information about a package.
-
+//!
+//! Note that certain aspects of `ChannelData` are broken (e.g. run_exports is only available for a single package variant) and therefore the
+//! `ChannelData` struct is not really used much more.
+//!
 use crate::{
     utils::serde::{LossyUrl, VecSkipNone},
     Version,
@@ -25,6 +28,7 @@ pub struct ChannelData {
     /// A mapping of all packages in the channel
     pub packages: HashMap<String, ChannelDataPackage>,
 
+    /// The availalble subdirs for this channel
     #[serde(default)]
     pub subdirs: Vec<String>,
 }

--- a/crates/rattler_conda_types/src/conda_lock/mod.rs
+++ b/crates/rattler_conda_types/src/conda_lock/mod.rs
@@ -28,14 +28,19 @@ const fn default_version() -> u32 {
 pub struct CondaLock {
     /// Metadata for the lock file
     pub metadata: LockMeta,
+
     /// Locked packages
     pub package: Vec<LockedDependency>,
+
+    /// Version of the conda-lock file format
     #[serde(default = "default_version")]
     pub version: u32,
 }
 
+#[allow(missing_docs)]
 #[derive(Debug, thiserror::Error)]
 pub enum ParseCondaLockError {
+    /// The platform could not be parsed
     #[error(transparent)]
     InvalidPlatform(#[from] ParsePlatformError),
 
@@ -123,7 +128,9 @@ pub struct GitMeta {
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Manager {
+    /// The "conda" manager
     Conda,
+    /// The pip manager
     Pip,
 }
 
@@ -137,13 +144,13 @@ impl Display for VersionConstraint {
     }
 }
 
-// This implementation of the `Deserialize` trait for the `PackageHashes` struct
-//
-// It expects the input to have either a `md5` field, a `sha256` field, or both.
-// If both fields are present, it constructs a `Md5Sha256` instance with their values.
-// If only the `md5` field is present, it constructs a `Md5` instance with its value.
-// If only the `sha256` field is present, it constructs a `Sha256` instance with its value.
-// If neither field is present it returns an error
+/// This implementation of the `Deserialize` trait for the `PackageHashes` struct
+///
+/// It expects the input to have either a `md5` field, a `sha256` field, or both.
+/// If both fields are present, it constructs a `Md5Sha256` instance with their values.
+/// If only the `md5` field is present, it constructs a `Md5` instance with its value.
+/// If only the `sha256` field is present, it constructs a `Sha256` instance with its value.
+/// If neither field is present it returns an error
 pub enum PackageHashes {
     /// Contains an MD5 hash
     Md5(Output<md5::Md5>),
@@ -209,6 +216,7 @@ fn default_category() -> String {
     "main".to_string()
 }
 
+/// A locked single dependency / package
 #[derive(Serialize, Deserialize)]
 pub struct LockedDependency {
     /// Package name of dependency
@@ -236,6 +244,7 @@ pub struct LockedDependency {
     pub build: Option<String>,
 }
 
+/// The URL for the dependency (currently only used for pip packages)
 #[derive(Serialize, Deserialize)]
 pub struct DependencySource {
     // According to:
@@ -246,10 +255,12 @@ pub struct DependencySource {
     pub url: Url,
 }
 
+/// The conda channel that was used for the dependency
 #[derive(Serialize, Deserialize)]
 pub struct Channel {
     /// Called `url` but can also be the name of the channel e.g. `conda-forge`
     pub url: String,
+    /// Used env vars for the channel (e.g. hints for passwords or other secrets)
     pub used_env_vars: Vec<String>,
 }
 

--- a/crates/rattler_conda_types/src/explicit_environment_spec.rs
+++ b/crates/rattler_conda_types/src/explicit_environment_spec.rs
@@ -45,15 +45,20 @@ pub struct ExplicitEnvironmentEntry {
 /// package archive. See [`ExplicitEnvironmentEntry::package_archive_hash`].
 #[derive(Debug, Clone)]
 pub enum PackageArchiveHash {
+    /// An MD5 hash for a given package
     Md5(md5::digest::Output<md5::Md5>),
+    /// A SHA256 hash for a given package
     Sha256(sha2::digest::Output<sha2::Sha256>),
 }
 
+/// An error that can occur when parsing a [`PackageArchiveHash`] from a string
 #[derive(Debug, thiserror::Error)]
 pub enum ParsePackageArchiveHashError {
+    /// The hash is not a valid SHA256 hex string
     #[error("invalid sha256 hash")]
     InvalidSha256Hash(#[source] hex::FromHexError),
 
+    /// The hash is not a valid MD5 hex string
     #[error("invalid md5 hash")]
     InvalidMd5Hash(#[source] hex::FromHexError),
 }
@@ -113,17 +118,22 @@ impl From<ExplicitEnvironmentEntry> for Url {
     }
 }
 
+/// An error that can occur when parsing an [`ExplicitEnvironmentSpec`] from a string
 #[derive(Debug, thiserror::Error)]
 pub enum ParseExplicitEnvironmentSpecError {
+    /// The @EXPLICIT tag is missing
     #[error("the @EXPLICIT tag is missing")]
     MissingExplicitTag,
 
+    /// A invalid URL was present in the text file and could not be parsed
     #[error("failed to parse url '{0}'")]
     InvalidUrl(String, #[source] url::ParseError),
 
+    /// The platform string could not be parsed
     #[error(transparent)]
     InvalidPlatform(#[from] ParsePlatformError),
 
+    /// An IO error occurred
     #[error(transparent)]
     IoError(#[from] std::io::Error),
 }

--- a/crates/rattler_conda_types/src/lib.rs
+++ b/crates/rattler_conda_types/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(missing_docs)]
 //! `rattler-conda-types` contains data models for types commonly found within the Conda ecosystem.
 //! The library itself doesnt provide any functionality besides parsing the data types.
 

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -10,12 +10,19 @@ mod parse;
 #[skip_serializing_none]
 #[derive(Debug, Default, Clone, Serialize, Eq, PartialEq)]
 pub struct MatchSpec {
+    /// The name of the package
     pub name: Option<String>,
+    /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`)
     pub version: Option<VersionSpec>,
+    /// The build string of the package (e.g. `py37_0`, `py37h6de7cb9_0`, `py*`)
     pub build: Option<String>,
+    /// The build number of the package
     pub build_number: Option<usize>,
+    /// Match the specific filename of the package
     pub filename: Option<String>,
+    /// The channel of the package
     pub channel: Option<Channel>,
+    /// The namespace of the package (currently not used)
     pub namespace: Option<String>,
 }
 

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -47,6 +47,7 @@ pub enum ParseMatchSpecError {
 }
 
 impl MatchSpec {
+    /// Parses a matchspec from a string.
     pub fn from_str(
         input: &str,
         channel_config: &ChannelConfig,

--- a/crates/rattler_conda_types/src/package/about.rs
+++ b/crates/rattler_conda_types/src/package/about.rs
@@ -9,6 +9,7 @@ use serde_with::{serde_as, skip_serializing_none, OneOrMany, Same};
 
 use url::Url;
 
+/// The `about.json` file contains metadata about the package
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq)]

--- a/crates/rattler_conda_types/src/package/archive_identifier.rs
+++ b/crates/rattler_conda_types/src/package/archive_identifier.rs
@@ -9,9 +9,13 @@ use url::Url;
 /// the [`ArchiveIdentifier::try_from_filename`] and [`ArchiveIdentifier::try_from_url`] functions.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct ArchiveIdentifier {
+    /// The name of the package.
     pub name: String,
+    /// The version of the package.
     pub version: String,
+    /// The build string of the package.
     pub build_string: String,
+    /// The archive type of the package (tar.bz2 or conda)
     pub archive_type: ArchiveType,
 }
 

--- a/crates/rattler_conda_types/src/package/files.rs
+++ b/crates/rattler_conda_types/src/package/files.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 /// Representation of the `info/files` file in older package archives.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Files {
+    /// A list of files in the package.
     pub files: Vec<PathBuf>,
 }
 

--- a/crates/rattler_conda_types/src/package/has_prefix.rs
+++ b/crates/rattler_conda_types/src/package/has_prefix.rs
@@ -24,6 +24,7 @@ pub struct HasPrefixEntry {
 /// Representation of the `info/has_prefix` file in older package archives.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HasPrefix {
+    /// A list of files in the package that contain the `prefix` (and need prefix replacement).
     pub files: Vec<HasPrefixEntry>,
 }
 

--- a/crates/rattler_conda_types/src/package/no_link.rs
+++ b/crates/rattler_conda_types/src/package/no_link.rs
@@ -2,9 +2,10 @@ use super::PackageFile;
 use std::path::{Path, PathBuf};
 
 /// Representation of the `info/no_link` file in older package archives. This file contains a list
-/// of all files that should not be "linked".
+/// of all files that should not be "linked" (i.e. hard linked) but copied.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NoLink {
+    /// A list of files in the package that should not be "linked" (i.e. hard linked) but copied.
     pub files: Vec<PathBuf>,
 }
 

--- a/crates/rattler_conda_types/src/package/no_softlink.rs
+++ b/crates/rattler_conda_types/src/package/no_softlink.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 /// of all files that should not be "softlinked".
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NoSoftlink {
+    /// A list of files in the package that should not be "softlinked".
     pub files: Vec<PathBuf>,
 }
 

--- a/crates/rattler_conda_types/src/package/paths.rs
+++ b/crates/rattler_conda_types/src/package/paths.rs
@@ -155,6 +155,7 @@ impl PathsJson {
     }
 }
 
+/// A single entry in the `paths.json` file.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct PathsEntry {
     /// The relative path from the root of the package
@@ -191,18 +192,25 @@ pub struct PathsEntry {
     pub size_in_bytes: Option<u64>,
 }
 
+/// The file mode of the entry
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum FileMode {
+    /// The file is a binary file (needs binary prefix replacement)
     Binary,
+    /// The file is a text file (needs text prefix replacement)
     Text,
 }
 
+/// The path type of the path entry
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "lowercase")]
 pub enum PathType {
+    /// The path should be hard linked (the default)
     HardLink,
+    /// The path should be soft linked
     SoftLink,
+    /// This should explicitly create an empty directory
     Directory,
 }
 

--- a/crates/rattler_conda_types/src/package/run_exports.rs
+++ b/crates/rattler_conda_types/src/package/run_exports.rs
@@ -11,21 +11,21 @@ use serde_with::{serde_as, skip_serializing_none};
 #[skip_serializing_none]
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
 pub struct RunExportsJson {
-    // weak run exports apply a dependency from host to run
+    /// weak run exports apply a dependency from host to run
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub weak: Vec<String>,
-    // strong run exports apply a dependency from build to host and run
+    /// strong run exports apply a dependency from build to host and run
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub strong: Vec<String>,
-    // noarch run exports apply a run export only to noarch packages (other run exports are ignored)
-    // for example, python uses this to apply a dependency on python to all noarch packages, but not to
-    // the python_abi package
+    /// noarch run exports apply a run export only to noarch packages (other run exports are ignored)
+    /// for example, python uses this to apply a dependency on python to all noarch packages, but not to
+    /// the python_abi package
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub noarch: Vec<String>,
-    // weak constrains apply a constrain dependency from host to build, or run to host
+    /// weak constrains apply a constrain dependency from host to build, or run to host
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub weak_constrains: Vec<String>,
-    // strong constrains apply a constrain dependency from build to host and run
+    /// strong constrains apply a constrain dependency from build to host and run
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub strong_constrains: Vec<String>,
 }

--- a/crates/rattler_conda_types/src/platform.rs
+++ b/crates/rattler_conda_types/src/platform.rs
@@ -4,6 +4,7 @@ use strum::{EnumIter, IntoEnumIterator};
 use thiserror::Error;
 
 /// A platform supported by Conda.
+#[allow(missing_docs)]
 #[derive(EnumIter, Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum Platform {
     NoArch,
@@ -108,6 +109,7 @@ impl Platform {
 #[derive(Debug, Error, Clone, Eq, PartialEq)]
 #[error("'{string}' is not a known platform")]
 pub struct ParsePlatformError {
+    /// The platform string that could not be parsed.
     pub string: String,
 }
 

--- a/crates/rattler_conda_types/src/prefix_record.rs
+++ b/crates/rattler_conda_types/src/prefix_record.rs
@@ -101,7 +101,7 @@ pub enum PathType {
     /// This file is a Python entry point executable for Unix (a `<entrypoint>` Python script file)
     /// Entry points are created in the `bin/...` directory when installing Python noarch packages
     UnixPythonEntryPoint,
-    /// Not used
+    /// NOT USED - path to the package's .json file in conda-meta
     LinkedPackageRecord,
 }
 

--- a/crates/rattler_conda_types/src/prefix_record.rs
+++ b/crates/rattler_conda_types/src/prefix_record.rs
@@ -83,15 +83,25 @@ pub struct PathsEntry {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum PathType {
+    /// The file was installed as a hard link (i.e. a file that points to another file in the package cache)
     #[serde(rename = "hardlink")]
     HardLink,
     #[serde(rename = "softlink")]
+    /// The file was installed as a soft link (i.e. a soft link to a file in the package cache)
     SoftLink,
+    /// An empty directory was created at installation time here
     Directory,
+    /// This is a file that was automatically "compiled" from Python source code when a `noarch` package
+    /// was installed
     PycFile,
+    /// This file is a Python entry point script for Windows (a `<entrypoint>-script.py` Python script file)
     WindowsPythonEntryPointScript,
+    /// This file is a Python entry point executable for Windows (a `<entrypoint>.exe` file)
     WindowsPythonEntryPointExe,
+    /// This file is a Python entry point executable for Unix (a `<entrypoint>` Python script file)
+    /// Entry points are created in the `bin/...` directory when installing Python noarch packages
     UnixPythonEntryPoint,
+    /// Not used
     LinkedPackageRecord,
 }
 
@@ -178,20 +188,29 @@ impl FromStr for PrefixRecord {
     }
 }
 
+/// A record of a single file that was installed into the prefix
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
 pub struct Link {
+    /// The path to the file source that was installed
     pub source: String,
+
+    /// The link type that was used to install the file
     #[serde(rename = "type")]
     pub link_type: Option<LinkType>,
 }
 
+/// The different link types that are used
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize_repr, Deserialize_repr, Hash)]
 #[serde(rename_all = "lowercase")]
 #[repr(u8)]
 pub enum LinkType {
+    /// Hard link refers to the same inode as the source file
     HardLink = 1,
+    /// Soft link is a soft link to the source file
     SoftLink = 2,
+    /// Copy is a proper copy of the source file (duplicated data on hard disk)
     Copy = 3,
+    /// Directory is a (empty) directory
     Directory = 4,
 }
 

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -13,12 +13,22 @@ use crate::{Channel, NoArchType, RepoDataRecord, Version};
 /// [`RepoData`] is an index of package binaries available on in a subdirectory of a Conda channel.
 #[derive(Debug, Deserialize, Eq, PartialEq)]
 pub struct RepoData {
+    /// The version of the repodata format
     #[serde(rename = "repodata_version")]
     pub version: Option<usize>,
+
+    /// The channel information contained in the repodata.json file
     pub info: Option<ChannelInfo>,
+
+    /// The tar.bz2 packages contained in the repodata.json file
     pub packages: FxHashMap<String, PackageRecord>,
+
+    /// The conda packages contained in the repodata.json file (under a different key for
+    /// backwards compatibility with previous conda versions)
     #[serde(rename = "packages.conda")]
     pub conda_packages: FxHashMap<String, PackageRecord>,
+
+    /// removed packages (files are still accessible, but they are not installable like regular packages)
     #[serde(default)]
     pub removed: FxHashSet<String>,
 }
@@ -79,10 +89,16 @@ pub struct PackageRecord {
     #[serde(default)]
     pub constrains: Vec<String>,
 
+    /// Track features are nowadays only used to downweight packages (ie. give them less priority). To
+    /// that effect, the number of track features is counted (number of commas) and the package is downweighted
+    /// by the number of track_features.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[serde_as(as = "OneOrMany<_>")]
     pub track_features: Vec<String>,
 
+    /// Features are a deprecated way to specify different feature sets for the conda solver. This is not
+    /// supported anymore and should not be used. Instead, `mutex` packages should be used to specify
+    /// mutually exclusive features.
     pub features: Option<String>,
 
     /// If this package is independent of architecture this field specifies in what way. See

--- a/crates/rattler_conda_types/src/run_export.rs
+++ b/crates/rattler_conda_types/src/run_export.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 /// Type of runtime export.
 /// See more info in [the conda docs](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#export-runtime-requirements)
 /// [`crate::package::RunExportsJson`]
+#[allow(missing_docs)]
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum RunExportKind {
     Weak,

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -19,10 +19,17 @@ mod parse;
 /// optional epoch number - an integer followed by '!' - can precede the actual version string (this
 /// is useful to indicate a change in the versioning scheme itself). Version comparison is
 /// case-insensitive.
+/// A local version is an optional string that can be used to indicate a local version of a package.
+/// A local version is indicated by a '+' followed by the local version string.
 #[derive(Clone, Debug)]
 pub struct Version {
+    /// The epoch of this version. This is an optional number that can be used to indicate a change
+    /// in the versioning scheme.
     norm: String,
+    /// The version of this version. This is the actual version string.
     version: VersionComponent,
+    /// The local version of this version (everything following a `+`).
+    /// This is an optional string that can be used to indicate a local version of a package.
     local: VersionComponent,
 }
 
@@ -62,6 +69,7 @@ impl Version {
         })
     }
 
+    /// Check if this version version and local strings start with the same as other.
     pub fn starts_with(&self, other: &Self) -> bool {
         self.version.starts_with(&other.version) && self.local.starts_with(&other.local)
     }

--- a/crates/rattler_conda_types/src/version/parse.rs
+++ b/crates/rattler_conda_types/src/version/parse.rs
@@ -44,6 +44,7 @@ impl Display for ParseVersionError {
 impl Error for ParseVersionError {}
 
 impl ParseVersionError {
+    /// Create a new parse error
     pub fn new(text: impl Into<String>, kind: ParseVersionErrorKind) -> Self {
         Self {
             version: text.into(),
@@ -52,14 +53,22 @@ impl ParseVersionError {
     }
 }
 
+/// The type of parse error that occurred when parsing a version string.
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum ParseVersionErrorKind {
+    /// The string was empty
     Empty,
+    /// The string contained invalid characters
     InvalidCharacters,
+    /// The epoch was not an integer value
     EpochMustBeInteger(ParseIntError),
+    /// The string contained an invalid numeral
     InvalidNumeral(ParseIntError),
+    /// The string contained multiple epoch separators
     DuplicateEpochSeparator,
+    /// The string contained multiple local version separators
     DuplicateLocalVersionSeparator,
+    /// The string contained an empty version component
     EmptyVersionComponent,
 }
 

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -59,12 +59,17 @@ impl LogicalOperator {
     }
 }
 
+/// A version specification.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub enum VersionSpec {
+    /// No version specified
     None,
+    /// Any version
     Any,
+    /// A specific version
     Operator(VersionOperator, Version),
+    /// A group of version specifications
     Group(LogicalOperator, Vec<VersionSpec>),
 }
 


### PR DESCRIPTION
Apply `#![deny(docs_missing)]` and add all the missing docs.