### PR TITLE
matchspec & version docs

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -20,7 +20,7 @@ use std::{
     future::ready,
     io::ErrorKind,
     path::{Path, PathBuf},
-    time::Duration,
+    time::Duration, str::FromStr,
 };
 use tokio::task::JoinHandle;
 

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -20,7 +20,8 @@ use std::{
     future::ready,
     io::ErrorKind,
     path::{Path, PathBuf},
-    time::Duration, str::FromStr,
+    str::FromStr,
+    time::Duration,
 };
 use tokio::task::JoinHandle;
 

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -45,7 +45,7 @@ pub async fn create(opt: Opt) -> anyhow::Result<()> {
     let specs = opt
         .specs
         .iter()
-        .map(|spec| MatchSpec::from_str(spec, &channel_config))
+        .map(|spec| MatchSpec::from_str(spec))
         .collect::<Result<Vec<_>, _>>()?;
 
     // Find the default cache directory. Create it if it doesnt exist yet.

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -433,7 +433,7 @@ mod test {
     #[tokio::test]
     pub async fn test_conda_lock() {
         // Load a prepared explicit environment file for the current platform.
-        let lock_path = get_test_data_dir().join(format!("conda-lock/python-conda-lock.yml"));
+        let lock_path = get_test_data_dir().join("conda-lock/python-conda-lock.yml".to_string());
         let lock = CondaLock::from_path(&lock_path).unwrap();
 
         let current_platform = Platform::current();

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Channel, VersionSpec};
+use crate::{VersionSpec};
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 use std::fmt::{Debug, Display, Formatter};

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -7,28 +7,28 @@ mod parse;
 
 /// A [`MatchSpec`] is, fundamentally, a query language for conda packages. Any of the fields that
 /// comprise a [`crate::PackageRecord`] can be used to compose a [`MatchSpec`].
-/// 
+///
 /// [`MatchSpec`] can be composed with keyword arguments, where keys are any of the
 /// attributes of [`PackageRecord`]. Values for keyword arguments are the exact values the
 /// attribute should match against. Many fields can also be matched against non-exact values--by
 /// including wildcard `*` and `>`/`<` ranges--where supported. Any non-specified field is
 /// the equivalent of a full wildcard match.
-/// 
+///
 /// MatchSpecs can also be composed using a single positional argument, with optional
 /// keyword arguments. Keyword arguments also override any conflicting information provided in
 /// the positional argument. Conda has historically had several string representations for equivalent
 /// MatchSpecs.
-/// 
+///
 /// A series of rules are now followed for creating the canonical string representation of a
 /// MatchSpec instance. The canonical string representation can generically be
 /// represented by
-/// 
+///
 /// (channel(/subdir):(namespace):)name(version(build))[key1=value1,key2=value2]
-/// 
-/// where `()` indicate optional fields. 
-/// 
+///
+/// where `()` indicate optional fields.
+///
 /// The rules for constructing a canonical string representation are:
-/// 
+///
 /// 1. `name` (i.e. "package name") is required, but its value can be '*'. Its position is always
 ///    outside the key-value brackets.
 /// 2. If `version` is an exact version, it goes outside the key-value brackets and is prepended
@@ -49,26 +49,26 @@ mod parse;
 ///    space, or equal sign.  The canonical format uses comma delimiters and single quotes.
 /// 8. When constructing a `MatchSpec` instance from a string, any key-value pair given
 ///    inside the key-value brackets overrides any matching parameter given outside the brackets.
-/// 
+///
 /// When `MatchSpec` attribute values are simple strings, the are interpreted using the
 /// following conventions:
 ///   - If the string begins with `^` and ends with `$`, it is converted to a regex.
 ///   - If the string contains an asterisk (`*`), it is transformed from a glob to a regex.
 ///   - Otherwise, an exact match to the string is sought.
-/// 
+///
 /// # Examples:
-/// 
+///
 /// ```rust
 /// use rattler_conda_types::{MatchSpec, VersionSpec, ChannelConfig};
 /// use std::str::FromStr;
-/// 
+///
 /// let channel_config = ChannelConfig::default();
-/// 
+///
 /// let spec = MatchSpec::from_str("foo 1.0 py27_0", &channel_config).unwrap();
 /// assert_eq!(spec.name, Some("foo".to_string()));
 /// assert_eq!(spec.version, Some(VersionSpec::from_str("1.0").unwrap()));
 /// assert_eq!(spec.build, Some("py27_0".to_string()));
-/// 
+///
 /// let spec = MatchSpec::from_str("foo=1.0=py27_0", &channel_config).unwrap();
 /// assert_eq!(spec.name, Some("foo".to_string()));
 /// assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
@@ -78,33 +78,33 @@ mod parse;
 /// //assert_eq!(spec.name, Some("foo".to_string()));
 /// //assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
 /// // assert_eq!(spec.channel, Some("conda-forge".to_string()));
-/// 
+///
 /// let spec = MatchSpec::from_str("conda-forge/linux-64::foo>=1.0", &channel_config).unwrap();
 /// assert_eq!(spec.name, Some("foo".to_string()));
 /// assert_eq!(spec.version, Some(VersionSpec::from_str(">=1.0").unwrap()));
 /// //assert_eq!(spec.channel.unwrap().name, "conda-forge"));
 /// //assert_eq!(spec.subdir, Some("linux-64".to_string()));
-/// 
+///
 /// let spec = MatchSpec::from_str("*/linux-64::foo>=1.0", &channel_config).unwrap();
 /// assert_eq!(spec.name, Some("foo".to_string()));
 /// assert_eq!(spec.version, Some(VersionSpec::from_str(">=1.0").unwrap()));
 /// // assert_eq!(spec.subdir, Some("linux-64".to_string()));
-/// 
+///
 /// //let spec = MatchSpec::from_str("foo[build=py2*]", &channel_config).unwrap();
 /// //assert_eq!(spec.name, Some("foo".to_string()));
 /// //assert_eq!(spec.build, Some("py2*".to_string()));
 /// ```
-/// 
+///
 /// To fully-specify a package with a full, exact spec, the following fields must be given as exact values:
-/// 
+///
 ///   - channel
 ///   - subdir
 ///   - name
 ///   - version
 ///   - build
-/// 
+///
 /// In the future, the namespace field might be added to this list.
-/// 
+///
 /// Alternatively, an exact spec is given by '*[sha256=01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b]'.
 #[skip_serializing_none]
 #[derive(Debug, Default, Clone, Serialize, Eq, PartialEq)]

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -59,7 +59,7 @@ mod parse;
 /// # Examples:
 ///
 /// ```rust
-/// use crate::{MatchSpec, VersionSpec};
+/// use rattler_conda_types::{MatchSpec, VersionSpec};
 /// use std::str::FromStr;
 /// 
 /// let spec = MatchSpec::from_str("foo 1.0 py27_0").unwrap();

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -7,6 +7,105 @@ mod parse;
 
 /// A [`MatchSpec`] is, fundamentally, a query language for conda packages. Any of the fields that
 /// comprise a [`crate::PackageRecord`] can be used to compose a [`MatchSpec`].
+/// 
+/// [`MatchSpec`] can be composed with keyword arguments, where keys are any of the
+/// attributes of [`PackageRecord`]. Values for keyword arguments are the exact values the
+/// attribute should match against. Many fields can also be matched against non-exact values--by
+/// including wildcard `*` and `>`/`<` ranges--where supported. Any non-specified field is
+/// the equivalent of a full wildcard match.
+/// 
+/// MatchSpecs can also be composed using a single positional argument, with optional
+/// keyword arguments. Keyword arguments also override any conflicting information provided in
+/// the positional argument. Conda has historically had several string representations for equivalent
+/// MatchSpecs.
+/// 
+/// A series of rules are now followed for creating the canonical string representation of a
+/// MatchSpec instance. The canonical string representation can generically be
+/// represented by
+/// 
+/// (channel(/subdir):(namespace):)name(version(build))[key1=value1,key2=value2]
+/// 
+/// where `()` indicate optional fields. 
+/// 
+/// The rules for constructing a canonical string representation are:
+/// 
+/// 1. `name` (i.e. "package name") is required, but its value can be '*'. Its position is always
+///    outside the key-value brackets.
+/// 2. If `version` is an exact version, it goes outside the key-value brackets and is prepended
+///    by `==`. If `version` is a "fuzzy" value (e.g. `1.11.*`), it goes outside the key-value
+///    brackets with the `.*` left off and is prepended by `=`. Otherwise `version` is included
+///    inside key-value brackets.
+/// 3. If `version` is an exact version, and `build` is an exact value, `build` goes outside
+///    key-value brackets prepended by a `=`.  Otherwise, `build` goes inside key-value brackets.
+///    `build_string` is an alias for `build`.
+/// 4. The `namespace` position is being held for a future feature. It is currently ignored.
+/// 5. If `channel` is included and is an exact value, a `::` separator is used between `channel`
+///    and `name`.  `channel` can either be a canonical channel name or a channel url.  In the
+///    canonical string representation, the canonical channel name will always be used.
+/// 6. If `channel` is an exact value and `subdir` is an exact value, `subdir` is appended to
+///    `channel` with a `/` separator.  Otherwise, `subdir` is included in the key-value brackets.
+/// 7. Key-value brackets can be delimited by comma, space, or comma+space.  Value can optionally
+///    be wrapped in single or double quotes, but must be wrapped if `value` contains a comma,
+///    space, or equal sign.  The canonical format uses comma delimiters and single quotes.
+/// 8. When constructing a `MatchSpec` instance from a string, any key-value pair given
+///    inside the key-value brackets overrides any matching parameter given outside the brackets.
+/// 
+/// When `MatchSpec` attribute values are simple strings, the are interpreted using the
+/// following conventions:
+///   - If the string begins with `^` and ends with `$`, it is converted to a regex.
+///   - If the string contains an asterisk (`*`), it is transformed from a glob to a regex.
+///   - Otherwise, an exact match to the string is sought.
+/// 
+/// # Examples:
+/// 
+/// ```rust
+/// use rattler_conda_types::{MatchSpec, VersionSpec, ChannelConfig};
+/// use std::str::FromStr;
+/// 
+/// let channel_config = ChannelConfig::default();
+/// 
+/// let spec = MatchSpec::from_str("foo 1.0 py27_0", &channel_config).unwrap();
+/// assert_eq!(spec.name, Some("foo".to_string()));
+/// assert_eq!(spec.version, Some(VersionSpec::from_str("1.0").unwrap()));
+/// assert_eq!(spec.build, Some("py27_0".to_string()));
+/// 
+/// let spec = MatchSpec::from_str("foo=1.0=py27_0", &channel_config).unwrap();
+/// assert_eq!(spec.name, Some("foo".to_string()));
+/// assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
+/// assert_eq!(spec.build, Some("py27_0".to_string()));
+///
+/// //let spec = MatchSpec::from_str("conda-forge::foo[version=1.0.*]", &channel_config).unwrap();
+/// //assert_eq!(spec.name, Some("foo".to_string()));
+/// //assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
+/// // assert_eq!(spec.channel, Some("conda-forge".to_string()));
+/// 
+/// let spec = MatchSpec::from_str("conda-forge/linux-64::foo>=1.0", &channel_config).unwrap();
+/// assert_eq!(spec.name, Some("foo".to_string()));
+/// assert_eq!(spec.version, Some(VersionSpec::from_str(">=1.0").unwrap()));
+/// //assert_eq!(spec.channel.unwrap().name, "conda-forge"));
+/// //assert_eq!(spec.subdir, Some("linux-64".to_string()));
+/// 
+/// let spec = MatchSpec::from_str("*/linux-64::foo>=1.0", &channel_config).unwrap();
+/// assert_eq!(spec.name, Some("foo".to_string()));
+/// assert_eq!(spec.version, Some(VersionSpec::from_str(">=1.0").unwrap()));
+/// // assert_eq!(spec.subdir, Some("linux-64".to_string()));
+/// 
+/// //let spec = MatchSpec::from_str("foo[build=py2*]", &channel_config).unwrap();
+/// //assert_eq!(spec.name, Some("foo".to_string()));
+/// //assert_eq!(spec.build, Some("py2*".to_string()));
+/// ```
+/// 
+/// To fully-specify a package with a full, exact spec, the following fields must be given as exact values:
+/// 
+///   - channel
+///   - subdir
+///   - name
+///   - version
+///   - build
+/// 
+/// In the future, the namespace field might be added to this list.
+/// 
+/// Alternatively, an exact spec is given by '*[sha256=01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b]'.
 #[skip_serializing_none]
 #[derive(Debug, Default, Clone, Serialize, Eq, PartialEq)]
 pub struct MatchSpec {

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -118,7 +118,7 @@ pub struct MatchSpec {
     /// The build number of the package
     pub build_number: Option<usize>,
     /// Match the specific filename of the package
-    pub filename: Option<String>,
+    pub file_name: Option<String>,
     /// The channel of the package
     pub channel: Option<Channel>,
     /// The namespace of the package (currently not used)

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -1,4 +1,4 @@
-use crate::{VersionSpec};
+use crate::VersionSpec;
 use serde::Serialize;
 use serde_with::skip_serializing_none;
 use std::fmt::{Debug, Display, Formatter};
@@ -61,7 +61,7 @@ mod parse;
 /// ```rust
 /// use rattler_conda_types::{MatchSpec, VersionSpec};
 /// use std::str::FromStr;
-/// 
+///
 /// let spec = MatchSpec::from_str("foo 1.0 py27_0").unwrap();
 /// assert_eq!(spec.name, Some("foo".to_string()));
 /// assert_eq!(spec.version, Some(VersionSpec::from_str("1.0").unwrap()));

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -1,6 +1,6 @@
 use super::MatchSpec;
 use crate::version_spec::{is_start_of_version_constraint, ParseVersionSpecError};
-use crate::{Channel, ChannelConfig, ParseChannelError, VersionSpec};
+use crate::{ParseChannelError, VersionSpec};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till1, take_until, take_while, take_while1};
 use nom::character::complete::{char, multispace0, one_of};
@@ -164,12 +164,12 @@ fn parse_bracket_vec_into_components(
     bracket: BracketVec,
     match_spec: MatchSpec,
 ) -> Result<MatchSpec, ParseMatchSpecError> {
-    let mut match_spec = match_spec.clone();
+    let mut match_spec = match_spec;
 
     for elem in bracket {
         let (key, value) = elem;
         match key {
-            "version" => match_spec.version = Some(VersionSpec::from_str(&value)?),
+            "version" => match_spec.version = Some(VersionSpec::from_str(value)?),
             "build" => match_spec.build = Some(value.to_string()),
             "build_number" => match_spec.build_number = Some(value.parse()?),
             "fn" => match_spec.file_name = Some(value.to_string()),
@@ -299,7 +299,7 @@ fn parse(input: &str) -> Result<MatchSpec, ParseMatchSpecError> {
     match_spec.namespace = namespace.map(ToOwned::to_owned).or(match_spec.namespace);
 
     if let Some(channel_str) = channel_str {
-        if let Some((channel, subdir)) = channel_str.rsplit_once("/") {
+        if let Some((channel, subdir)) = channel_str.rsplit_once('/') {
             match_spec.channel = Some(channel.to_string());
             match_spec.subdir = Some(subdir.to_string());
         } else {
@@ -347,7 +347,7 @@ mod tests {
     use super::{
         split_version_and_build, strip_brackets, BracketVec, MatchSpec, ParseMatchSpecError,
     };
-    use crate::{channel, Channel, ChannelConfig, VersionSpec};
+    use crate::{VersionSpec};
     use smallvec::smallvec;
 
     #[test]

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -348,7 +348,7 @@ mod tests {
     use super::{
         split_version_and_build, strip_brackets, BracketVec, MatchSpec, ParseMatchSpecError,
     };
-    use crate::{VersionSpec};
+    use crate::VersionSpec;
     use smallvec::smallvec;
 
     #[test]

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -50,10 +50,11 @@ pub enum ParseMatchSpecError {
     InvalidBuildNumber(#[from] ParseIntError),
 }
 
-impl MatchSpec {
-    /// Parses a matchspec from a string.
-    pub fn from_str(input: &str) -> Result<MatchSpec, ParseMatchSpecError> {
-        parse(input)
+impl FromStr for MatchSpec {
+    type Err = ParseMatchSpecError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        parse(s)
     }
 }
 

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -57,8 +57,8 @@ mod parse;
 ///
 /// # Examples:
 ///
-/// 1.2g.beta15.rc  =>  [[0], [1], [2, 'g'], [0, 'beta', 15], [0, 'rc']]
-/// 1!2.15.1_ALPHA  =>  [[1], [2], [15], [1, '_alpha']]
+/// `1.2g.beta15.rc`  =>  `[[0], [1], [2, 'g'], [0, 'beta', 15], [0, 'rc']]`
+/// `1!2.15.1_ALPHA`  =>  `[[1], [2], [15], [1, '_alpha']]`
 ///
 /// The resulting lists are compared lexicographically, where the following
 /// rules are applied to each pair of corresponding subcomponents:

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -19,8 +19,102 @@ mod parse;
 /// optional epoch number - an integer followed by '!' - can precede the actual version string (this
 /// is useful to indicate a change in the versioning scheme itself). Version comparison is
 /// case-insensitive.
-/// A local version is an optional string that can be used to indicate a local version of a package.
-/// A local version is indicated by a '+' followed by the local version string.
+///
+/// Rattler supports six types of version strings:
+///
+/// * Release versions contain only integers, e.g. '1.0', '2.3.5'.
+/// * Pre-release versions use additional letters such as 'a' or 'rc', for example '1.0a1',
+///   '1.2.beta3', '2.3.5rc3'.
+/// * Development versions are indicated by the string 'dev', for example '1.0dev42', '2.3.5.dev12'.
+/// * Post-release versions are indicated by the string 'post', for example '1.0post1', '2.3.5.post2'.
+/// * Tagged versions have a suffix that specifies a particular property of interest, e.g. '1.1.parallel'.
+///   Tags can be added  to any of the preceding four types. As far as sorting is concerned,
+///   tags are treated like strings in pre-release versions.
+/// * An optional local version string separated by '+' can be appended to the main (upstream) version string.
+///   It is only considered in comparisons when the main versions are equal, but otherwise handled in
+///   exactly the same manner.
+///
+/// To obtain a predictable version ordering, it is crucial to keep the
+/// version number scheme of a given package consistent over time.
+///
+/// Specifically,
+///
+/// * version strings should always have the same number of components (except for an optional tag suffix
+///   or local version string),
+/// * letters/strings indicating non-release versions should always occur at the same position.
+///
+/// Before comparison, version strings are parsed as follows:
+///
+/// * They are first split into epoch, version number, and local version number at '!' and '+' respectively.
+///   If there is no '!', the epoch is set to 0. If there is no '+', the local version is empty.
+/// * The version part is then split into components at '.' and '_'.
+/// * Each component is split again into runs of numerals and non-numerals
+/// * Subcomponents containing only numerals are converted to integers.
+/// * Strings are converted to lower case, with special treatment for 'dev' and 'post'.
+/// * When a component starts with a letter, the fillvalue 0 is inserted to keep numbers and strings in phase,
+///   resulting in '1.1.a1' == 1.1.0a1'.
+/// * The same is repeated for the local version part.
+///
+/// # Examples:
+///
+/// 1.2g.beta15.rc  =>  [[0], [1], [2, 'g'], [0, 'beta', 15], [0, 'rc']]
+/// 1!2.15.1_ALPHA  =>  [[1], [2], [15], [1, '_alpha']]
+///
+/// The resulting lists are compared lexicographically, where the following
+/// rules are applied to each pair of corresponding subcomponents:
+///
+/// * integers are compared numerically
+/// * strings are compared lexicographically, case-insensitive
+/// * strings are smaller than integers, except
+/// * 'dev' versions are smaller than all corresponding versions of other types
+/// * 'post' versions are greater than all corresponding versions of other types
+/// * if a subcomponent has no correspondent, the missing correspondent is
+///   treated as integer 0 to ensure '1.1' == '1.1.0'.
+///
+/// The resulting order is:
+///
+/// ```txt
+///
+///        0.4
+///      < 0.4.0
+///      < 0.4.1.rc
+///     == 0.4.1.RC   # case-insensitive comparison
+///      < 0.4.1
+///      < 0.5a1
+///      < 0.5b3
+///      < 0.5C1      # case-insensitive comparison
+///      < 0.5
+///      < 0.9.6
+///      < 0.960923
+///      < 1.0
+///      < 1.1dev1    # special case 'dev'
+///      < 1.1_       # appended underscore is special case for openssl-like versions
+///      < 1.1a1
+///      < 1.1.0dev1  # special case 'dev'
+///     == 1.1.dev1   # 0 is inserted before string
+///      < 1.1.a1
+///      < 1.1.0rc1
+///      < 1.1.0
+///     == 1.1
+///      < 1.1.0post1 # special case 'post'
+///     == 1.1.post1  # 0 is inserted before string
+///      < 1.1post1   # special case 'post'
+///      < 1996.07.12
+///      < 1!0.4.1    # epoch increased
+///      < 1!3.1.1.6
+///      < 2!0.4.1    # epoch increased again
+/// ```
+///
+/// Some packages (most notably openssl) have incompatible version conventions.
+/// In particular, openssl interprets letters as version counters rather than
+/// pre-release identifiers. For openssl, the relation
+///
+/// 1.0.1 < 1.0.1a  =>  False  # should be true for openssl
+///
+/// holds, whereas conda packages use the opposite ordering. You can work-around
+/// this problem by appending an underscore to plain version numbers:
+///
+/// 1.0.1_ < 1.0.1a =>  True   # ensure correct ordering for openssl
 #[derive(Clone, Debug)]
 pub struct Version {
     /// The epoch of this version. This is an optional number that can be used to indicate a change

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -164,7 +164,7 @@ mod test_libsolv {
 
         let available_packages = vec![repo_data, repo_data_noarch];
 
-        let specs = vec![MatchSpec::from_str("python=3.9", &ChannelConfig::default()).unwrap()];
+        let specs = vec![MatchSpec::from_str("python=3.9").unwrap()];
 
         let problem = SolverProblem {
             available_packages,
@@ -399,10 +399,9 @@ mod test_libsolv {
     ) -> Result<Vec<RepoDataRecord>, SolveError> {
         let repo_data = read_repodata(&repo_path);
         let available_packages = vec![repo_data];
-        let channel_config = ChannelConfig::default();
         let specs = match_specs
             .into_iter()
-            .map(|m| MatchSpec::from_str(m, &channel_config).unwrap())
+            .map(|m| MatchSpec::from_str(m).unwrap())
             .collect();
 
         let problem = SolverProblem {

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -400,7 +400,7 @@ mod test_libsolv {
         let repo_data = read_repodata(&repo_path);
         let available_packages = vec![repo_data];
         let specs = match_specs
-            .into_iter()
+            .iter()
             .map(|m| MatchSpec::from_str(m).unwrap())
             .collect();
 
@@ -421,7 +421,7 @@ mod test_libsolv {
             )
         }
 
-        if pkgs.len() == 0 {
+        if pkgs.is_empty() {
             println!("No packages in the environment!");
         }
 

--- a/crates/rattler_solve/src/libsolv/wrapper/pool.rs
+++ b/crates/rattler_solve/src/libsolv/wrapper/pool.rs
@@ -244,7 +244,7 @@ mod test {
     use std::ffi::CString;
 
     use super::super::pool::Pool;
-    use rattler_conda_types::{MatchSpec};
+    use rattler_conda_types::MatchSpec;
 
     #[test]
     fn test_pool_string_interning() {

--- a/crates/rattler_solve/src/libsolv/wrapper/pool.rs
+++ b/crates/rattler_solve/src/libsolv/wrapper/pool.rs
@@ -285,8 +285,7 @@ mod test {
     #[test]
     fn test_matchspec_interning() {
         // Create a matchspec
-        let channel_config = ChannelConfig::default();
-        let spec = MatchSpec::from_str("foo=1.0=py27_0", &channel_config).unwrap();
+        let spec = MatchSpec::from_str("foo=1.0=py27_0").unwrap();
         // Intern it into the pool
         let pool = Pool::default();
         pool.intern_matchspec(&spec);

--- a/crates/rattler_solve/src/libsolv/wrapper/pool.rs
+++ b/crates/rattler_solve/src/libsolv/wrapper/pool.rs
@@ -241,7 +241,7 @@ impl From<MatchSpecId> for Id {
 
 #[cfg(test)]
 mod test {
-    use std::ffi::CString;
+    use std::{ffi::CString, str::FromStr};
 
     use super::super::pool::Pool;
     use rattler_conda_types::MatchSpec;

--- a/crates/rattler_solve/src/libsolv/wrapper/pool.rs
+++ b/crates/rattler_solve/src/libsolv/wrapper/pool.rs
@@ -244,7 +244,7 @@ mod test {
     use std::ffi::CString;
 
     use super::super::pool::Pool;
-    use rattler_conda_types::{ChannelConfig, MatchSpec};
+    use rattler_conda_types::{MatchSpec};
 
     #[test]
     fn test_pool_string_interning() {


### PR DESCRIPTION
I think we should attribute the original conda documentation/files that these were taken from. 

@baszalmstra do you want to check the matchspec parsing? some of the examples didn't work because of a `BracketsError`.