### PR TITLE
feat: add some missing fields

### DIFF
--- a/crates/rattler_conda_types/src/channel_data.rs
+++ b/crates/rattler_conda_types/src/channel_data.rs
@@ -115,9 +115,9 @@ pub struct ChannelDataPackage {
     pub text_prefix: bool,
 
     /// Last update time
-    pub timestamp: usize,
+    pub timestamp: Option<usize>,
 
     /// Latest version
-    #[serde_as(as = "DisplayFromStr")]
-    pub version: Version,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub version: Option<Version>,
 }

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -70,6 +70,12 @@ pub struct PackageRecord {
     /// Optionally a SHA256 hash of the package archive
     pub sha256: Option<String>,
 
+    /// A deprecated md5 hash
+    pub legacy_bz2_md5: Option<String>,
+
+    /// A deprecated package archive size.
+    pub legacy_bz2_size: Option<usize>,
+
     /// Optionally the size of the package archive in bytes
     pub size: Option<usize>,
 
@@ -116,12 +122,11 @@ pub struct PackageRecord {
     /// The UNIX Epoch timestamp when this package was created. Note that sometimes this is specified in
     /// seconds and sometimes in milliseconds.
     pub timestamp: Option<usize>,
+
     // Looking at the `PackageRecord` class in the Conda source code a record can also include all
     // these fields. However, I have no idea if or how they are used so I left them out.
     //pub preferred_env: Option<String>,
     //pub date: Option<String>,
-    //pub legacy_bz2_md5: Option<String>,
-    //pub legacy_bz2_size: Option<usize>,
     //pub package_type: ?
 }
 

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -122,7 +122,6 @@ pub struct PackageRecord {
     /// The UNIX Epoch timestamp when this package was created. Note that sometimes this is specified in
     /// seconds and sometimes in milliseconds.
     pub timestamp: Option<u64>,
-    
     // Looking at the `PackageRecord` class in the Conda source code a record can also include all
     // these fields. However, I have no idea if or how they are used so I left them out.
     //pub preferred_env: Option<String>,

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -141,6 +141,8 @@ mod test_libsolv {
                 license: None,
                 license_family: None,
                 timestamp: None,
+                legacy_bz2_size: None,
+                legacy_bz2_md5: None,
             },
         }
     }


### PR DESCRIPTION
Adds some fields that were missing from package records. 

Also made the version and timestamp of channeldata packages optional since apparently, they don't all contain those fields..