### PR TITLE
feat: extra methods to query spare repodata

### DIFF
--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -36,6 +36,7 @@ memmap2 = { version = "0.5.8", optional = true }
 ouroboros = { version = "0.15.6", optional = true }
 serde_with = { version = "2.0.0", optional = true }
 superslice = { version = "1.0.0", optional = true }
+itertools = { version = "0.10.5", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -53,4 +54,4 @@ assert_matches = "1.5.0"
 tokio = { version = "1.12.0", features = ["macros", "rt-multi-thread"] }
 
 [features]
-sparse = ["rattler_conda_types", "memmap2", "ouroboros", "serde_with", "superslice"]
+sparse = ["rattler_conda_types", "memmap2", "ouroboros", "serde_with", "superslice", "itertools"]


### PR DESCRIPTION
* Sometimes `repodata.json` files dont include the `subdir` field for their entries. This PR adds this information back when using the sparse index.
* Adds a method to query the package names that exist in a spare repodata.json file.
* Adds a method to download only the entries for a specific package without also loading its dependencies.
* Renamed some functions to include the recursive nature.