### PR TITLE
fix: sort entries by package name in sparse index

### DIFF
--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -52,6 +52,7 @@ insta = { version = "1.16.0", features = ["yaml"] }
 axum = "0.6.2"
 assert_matches = "1.5.0"
 tokio = { version = "1.12.0", features = ["macros", "rt-multi-thread"] }
+rstest = "0.16.0"
 
 [features]
 sparse = ["rattler_conda_types", "memmap2", "ouroboros", "serde_with", "superslice", "itertools"]


### PR DESCRIPTION
Fixes an issue where records from other packages were returned when searching the sparse index.

See the explanation in the code. 