### PR TITLE
add more tests and evict removed packages from repodata

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__patches__test__removing_1.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__patches__test__removing_1.snap
@@ -1,0 +1,33 @@
+---
+source: crates/rattler_conda_types/src/repo_data/patches.rs
+expression: repodata
+---
+info:
+  subdir: linux-64
+packages: {}
+packages.conda:
+  cross-python_emscripten-32-3.12.1-h60d57d3_8.conda:
+    build: h60d57d3_8
+    build_number: 8
+    depends:
+      - coreutils
+      - crossenv >=1.2
+      - emscripten_emscripten-32
+      - pip
+      - python 3.12.*
+      - rsync
+      - sed
+      - setuptools
+    md5: 07b8bdf69566cd63e6e49759033830ad
+    name: cross-python_emscripten-32
+    sha256: 12064d294599734090b9a33a2194a94f5d3743325d5bae61fab3fa5151acf0f9
+    size: 7069
+    subdir: linux-64
+    timestamp: 1679045249592
+    version: 3.10.1
+removed:
+  - cross-python_emscripten-32-3.10.1-h60d57d3_8.conda
+  - cross-python_emscripten-32-3.10.1-h60d57d3_8.tar.bz2
+  - emscripten_emscripten-32-3.1.27-h60d57d3_5.tar.bz2
+repodata_version: 1
+

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__patches__test__removing_2.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__patches__test__removing_2.snap
@@ -8,15 +8,15 @@ packages:
   cross-python_emscripten-32-3.10.1-h60d57d3_8.tar.bz2:
     build: h60d57d3_8
     build_number: 8
-    constrains:
-      - curl >5.0
     depends:
       - coreutils
       - crossenv >=1.2
       - emscripten_emscripten-32
       - pip
-      - wolfssl 12.0
-    license: WOLF LICENSE
+      - python 3.10.*
+      - rsync
+      - sed
+      - setuptools
     md5: 07b8bdf69566cd63e6e49759033830ad
     name: cross-python_emscripten-32
     sha256: 50064d294599734090b9a33a2194a94f5d3743325d5bae61fab3fa5151acf0f9
@@ -37,25 +37,6 @@ packages:
     timestamp: 1678986155405
     version: 3.1.27
 packages.conda:
-  cross-python_emscripten-32-3.10.1-h60d57d3_8.conda:
-    build: h60d57d3_8
-    build_number: 8
-    constrains:
-      - curl >5.0
-    depends:
-      - coreutils
-      - crossenv >=1.2
-      - emscripten_emscripten-32
-      - pip
-      - wolfssl 12.0
-    license: WOLF LICENSE
-    md5: 07b8bdf69566cd63e6e49759033830ad
-    name: cross-python_emscripten-32
-    sha256: 12064d294599734090b9a33a2194a94f5d3743325d5bae61fab3fa5151acf0f9
-    size: 7069
-    subdir: linux-64
-    timestamp: 1679045249592
-    version: 3.10.1
   cross-python_emscripten-32-3.12.1-h60d57d3_8.conda:
     build: h60d57d3_8
     build_number: 8
@@ -68,7 +49,6 @@ packages.conda:
       - rsync
       - sed
       - setuptools
-    license: WOLF LICENSE II
     md5: 07b8bdf69566cd63e6e49759033830ad
     name: cross-python_emscripten-32
     sha256: 12064d294599734090b9a33a2194a94f5d3743325d5bae61fab3fa5151acf0f9
@@ -76,5 +56,7 @@ packages.conda:
     subdir: linux-64
     timestamp: 1679045249592
     version: 3.10.1
+removed:
+  - cross-python_emscripten-32-3.10.1-h60d57d3_8.conda
 repodata_version: 1
 

--- a/test-data/channels/patch/linux-64/patch_instructions.json
+++ b/test-data/channels/patch/linux-64/patch_instructions.json
@@ -13,5 +13,10 @@
                 "curl >5.0"
             ]
         }
+    },
+    "packages.conda": {
+        "cross-python_emscripten-32-3.12.1-h60d57d3_8.conda": {
+            "license": "WOLF LICENSE II"
+        }
     }
 }

--- a/test-data/channels/patch/linux-64/repodata_from_packages.json
+++ b/test-data/channels/patch/linux-64/repodata_from_packages.json
@@ -39,7 +39,50 @@
         "version": "3.1.27"
       }
     },
-    "packages.conda": {},
+    "packages.conda": {
+        "cross-python_emscripten-32-3.10.1-h60d57d3_8.conda": {
+            "build": "h60d57d3_8",
+            "build_number": 8,
+            "depends": [
+              "coreutils",
+              "crossenv >=1.2",
+              "emscripten_emscripten-32",
+              "pip",
+              "python 3.10.*",
+              "rsync",
+              "sed",
+              "setuptools"
+            ],
+            "md5": "07b8bdf69566cd63e6e49759033830ad",
+            "name": "cross-python_emscripten-32",
+            "sha256": "12064d294599734090b9a33a2194a94f5d3743325d5bae61fab3fa5151acf0f9",
+            "size": 7069,
+            "subdir": "linux-64",
+            "timestamp": 1679045249592,
+            "version": "3.10.1"
+        },
+          "cross-python_emscripten-32-3.12.1-h60d57d3_8.conda": {
+            "build": "h60d57d3_8",
+            "build_number": 8,
+            "depends": [
+              "coreutils",
+              "crossenv >=1.2",
+              "emscripten_emscripten-32",
+              "pip",
+              "python 3.12.*",
+              "rsync",
+              "sed",
+              "setuptools"
+            ],
+            "md5": "07b8bdf69566cd63e6e49759033830ad",
+            "name": "cross-python_emscripten-32",
+            "sha256": "12064d294599734090b9a33a2194a94f5d3743325d5bae61fab3fa5151acf0f9",
+            "size": 7069,
+            "subdir": "linux-64",
+            "timestamp": 1679045249592,
+            "version": "3.10.1"
+        }
+    },
     "removed": [],
     "repodata_version": 1
   }


### PR DESCRIPTION
This is closer to the original conda index way of doing things (still not handling `revoke` though.

https://github.com/conda/conda-index/blob/90879f56e23b1d7b1c14fa632f5d20163130dfc8/conda_index/index/__init__.py#L218