### PR TITLE
always write file type

### DIFF
--- a/crates/rattler_conda_types/src/package/paths.rs
+++ b/crates/rattler_conda_types/src/package/paths.rs
@@ -166,7 +166,7 @@ pub struct PathsEntry {
     pub path_type: PathType,
 
     /// The type of the file, either binary or text.
-    // #[serde(default, skip_serializing_if = "FileMode::is_binary")]
+    #[serde(default)]
     pub file_mode: FileMode,
 
     /// Optionally the placeholder prefix used in the file. If this value is `None` the prefix is not

--- a/crates/rattler_conda_types/src/package/paths.rs
+++ b/crates/rattler_conda_types/src/package/paths.rs
@@ -166,7 +166,7 @@ pub struct PathsEntry {
     pub path_type: PathType,
 
     /// The type of the file, either binary or text.
-    #[serde(default, skip_serializing_if = "FileMode::is_binary")]
+    // #[serde(default, skip_serializing_if = "FileMode::is_binary")]
     pub file_mode: FileMode,
 
     /// Optionally the placeholder prefix used in the file. If this value is `None` the prefix is not


### PR DESCRIPTION
For some reason, micromamba didn't end up in the binary replacement loop when not explicitly mentioning `binary`. I think we should check wether that is wrong behavior in micromamba, or wether we should (always) write the filetype when binary vs. text or idk.

I also noticed a mix of text & binary and no classification when I checked some other paths.json files and couldn't figure out what the default is from just looking at them now.