### PR TITLE
fix: couple file_mode and prefix_placeholder

### DIFF
--- a/crates/rattler_conda_types/src/package/mod.rs
+++ b/crates/rattler_conda_types/src/package/mod.rs
@@ -29,7 +29,7 @@ pub use {
     no_link::NoLink,
     no_softlink::NoSoftlink,
     package_metadata::PackageMetadata,
-    paths::{FileMode, PathType, PathsEntry, PathsJson},
+    paths::{FileMode, PathType, PathsEntry, PathsJson, PrefixPlaceholder},
     run_exports::RunExportsJson,
 };
 

--- a/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__paths__test__reconstruct_paths_json.snap
+++ b/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__paths__test__reconstruct_paths_json.snap
@@ -1,33 +1,26 @@
 ---
 source: crates/rattler_conda_types/src/package/paths.rs
-expression: "PathsJson::from_deprecated_package_directory(&package_dir).unwrap()"
+assertion_line: 249
+expression: "PathsJson::from_deprecated_package_directory(package_dir.path()).unwrap()"
 ---
 paths_version: 1
 paths:
   - _path: Library/bin/zlib.dll
     path_type: hardlink
-    file_mode: text
   - _path: Library/include/zconf.h
     path_type: hardlink
-    file_mode: text
   - _path: Library/include/zlib.h
     path_type: hardlink
-    file_mode: text
   - _path: Library/lib/z.lib
     path_type: hardlink
-    file_mode: text
   - _path: Library/lib/zdll.lib
     path_type: hardlink
-    file_mode: text
   - _path: Library/lib/zlib.lib
     path_type: hardlink
-    file_mode: text
   - _path: Library/lib/zlibstatic.lib
     path_type: hardlink
-    file_mode: text
   - _path: Library/share/man/man3/zlib.3
     path_type: hardlink
-    file_mode: text
   - _path: Library/share/pkgconfig/zlib.pc
     path_type: hardlink
     file_mode: text

--- a/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__paths__test__reconstruct_paths_json_with_symlinks.snap
+++ b/crates/rattler_conda_types/src/package/snapshots/rattler_conda_types__package__paths__test__reconstruct_paths_json_with_symlinks.snap
@@ -6,22 +6,16 @@ paths_version: 1
 paths:
   - _path: include/zconf.h
     path_type: hardlink
-    file_mode: text
   - _path: include/zlib.h
     path_type: hardlink
-    file_mode: text
   - _path: lib/libz.a
     path_type: hardlink
-    file_mode: text
   - _path: lib/libz.so
     path_type: softlink
-    file_mode: text
   - _path: lib/libz.so.1
     path_type: softlink
-    file_mode: text
   - _path: lib/libz.so.1.2.8
     path_type: hardlink
-    file_mode: text
   - _path: lib/pkgconfig/zlib.pc
     path_type: hardlink
     file_mode: text


### PR DESCRIPTION
@wolfv figured out that the `file_mode` is only set if the `prefix_placeholder` is set. This makes sense since the file_mode refers to how the placeholder should be interpreted in the file.

To make this more explicit I pulled out both fields and added a new type `PrefixPlaceholder` that combines the two. This means they are either both set or not at all. Using `serde(flatten)` the structure of the file remains the same.

Supersedes #132 