### PR TITLE
make ParseError public and reuse ArchiveType

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -4,7 +4,7 @@ use serde_with::skip_serializing_none;
 use std::fmt::{Debug, Display, Formatter};
 
 pub mod matcher;
-mod parse;
+pub mod parse;
 
 use matcher::StringMatcher;
 

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -1,5 +1,6 @@
 use super::matcher::{StringMatcher, StringMatcherParseError};
 use super::MatchSpec;
+use crate::package::ArchiveType;
 use crate::version_spec::{is_start_of_version_constraint, ParseVersionSpecError};
 use crate::{ParseChannelError, VersionSpec};
 use nom::branch::alt;
@@ -83,7 +84,7 @@ fn strip_if(input: &str) -> (&str, Option<&str>) {
 
 /// Returns true if the specified string represents a package path.
 fn is_package_file(input: &str) -> bool {
-    input.ends_with(".conda") || input.ends_with(".tar.bz2")
+    ArchiveType::try_from(input).is_some()
 }
 
 /// An optimized data structure to store key value pairs in between a bracket string


### PR DESCRIPTION
I couldn't use `ParseMatchSpecError` in another `#[derive(thiserror)]` because the module wasn't pub. We could also specifically re-export the error only at another level?

lmk what you think