### PR TITLE
Allow setting timestamp when writing archives

### DIFF
--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -24,6 +24,7 @@ rattler_conda_types = { version = "0.2.0", path = "../rattler_conda_types" }
 itertools = "0.10.5"
 serde_json = "1.0.94"
 url = "2.3.1"
+chrono = "0.4.24"
 
 [features]
 tokio = ["dep:tokio", "bzip2/tokio", "tokio/fs", "tokio-util/io", "tokio-util/io-util", "reqwest?/stream", "futures-util"]

--- a/crates/rattler_package_streaming/tests/write.rs
+++ b/crates/rattler_package_streaming/tests/write.rs
@@ -179,7 +179,14 @@ fn test_rewrite_tar_bz2() {
 
         let writer = File::create(&new_archive).unwrap();
         let paths = find_all_package_files(&target_dir);
-        write_tar_bz2_package(writer, &target_dir, &paths, CompressionLevel::Default).unwrap();
+        write_tar_bz2_package(
+            writer,
+            &target_dir,
+            &paths,
+            CompressionLevel::Default,
+            &None,
+        )
+        .unwrap();
 
         // compare the two archives
         let mut f1 = File::open(&file_path).unwrap();
@@ -217,6 +224,7 @@ fn test_rewrite_conda() {
             &paths,
             CompressionLevel::Default,
             &name,
+            None,
         )
         .unwrap();
 

--- a/crates/rattler_package_streaming/tests/write.rs
+++ b/crates/rattler_package_streaming/tests/write.rs
@@ -179,14 +179,8 @@ fn test_rewrite_tar_bz2() {
 
         let writer = File::create(&new_archive).unwrap();
         let paths = find_all_package_files(&target_dir);
-        write_tar_bz2_package(
-            writer,
-            &target_dir,
-            &paths,
-            CompressionLevel::Default,
-            &None,
-        )
-        .unwrap();
+        write_tar_bz2_package(writer, &target_dir, &paths, CompressionLevel::Default, None)
+            .unwrap();
 
         // compare the two archives
         let mut f1 = File::open(&file_path).unwrap();


### PR DESCRIPTION
I cobbled something together to help build "reproducible" archives. 

This deterministically sets the timestamp of all files in an archive. That worked for a quick test of building a reproducible package :)

However, we could come up with more interesting schemes of modifying the timestamps (e.g. only forcing the timestamp on files that have been written in the past 24 hours or so, and leave those files that were just copied from the source archive as they are).

Some references: https://reproducible-builds.org/docs/timestamps/

