### PR TITLE
feat: extract python json formatter

### DIFF
--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -20,6 +20,7 @@ nom = "7.1.0"
 regex = "1.7.0"
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.91"
+serde-json-python-formatter = "0.1.0"
 serde_yaml = "0.9.17"
 serde_with = "2.0.0"
 serde_repr = "0.1"

--- a/crates/rattler_conda_types/src/conda_lock/content_hash.rs
+++ b/crates/rattler_conda_types/src/conda_lock/content_hash.rs
@@ -2,7 +2,7 @@ use crate::conda_lock::Channel;
 use crate::{MatchSpec, Platform};
 use rattler_digest::serde::SerializableHash;
 use serde::Serialize;
-use serde_json::ser::Formatter;
+use serde_json_python_formatter::PythonFormatter;
 use std::string::FromUtf8Error;
 
 #[derive(Debug, thiserror::Error)]
@@ -96,48 +96,9 @@ pub fn calculate_content_data(
     };
 
     let mut buf = Vec::new();
-    let mut ser = serde_json::Serializer::with_formatter(&mut buf, PythonFormatter {});
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, PythonFormatter::default());
     content_hash_data.serialize(&mut ser)?;
     Ok(String::from_utf8(buf)?)
-}
-
-/// This implements a formatter that uses the same formatting as
-/// as the standard lib python `json.dumps()`
-#[derive(Clone, Debug)]
-struct PythonFormatter {}
-
-impl Formatter for PythonFormatter {
-    #[inline]
-    fn begin_array_value<W>(&mut self, writer: &mut W, first: bool) -> std::io::Result<()>
-    where
-        W: ?Sized + std::io::Write,
-    {
-        if first {
-            Ok(())
-        } else {
-            writer.write_all(b", ")
-        }
-    }
-
-    #[inline]
-    fn begin_object_key<W>(&mut self, writer: &mut W, first: bool) -> std::io::Result<()>
-    where
-        W: ?Sized + std::io::Write,
-    {
-        if first {
-            Ok(())
-        } else {
-            writer.write_all(b", ")
-        }
-    }
-
-    #[inline]
-    fn begin_object_value<W>(&mut self, writer: &mut W) -> std::io::Result<()>
-    where
-        W: ?Sized + std::io::Write,
-    {
-        writer.write_all(b": ")
-    }
 }
 
 /// Calculate the content hash for a platform and set of match-specs


### PR DESCRIPTION
I extracted the Python json formatter code to a separate crate: https://github.com/prefix-dev/serde-json-python-formatter 

This PR integrates that crate.

Fixes: https://github.com/mamba-org/rattler/issues/168