### PR TITLE
fix: sparse requires raw_value

### DIFF
--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -59,4 +59,4 @@ rstest = "0.17.0"
 default = ['native-tls']
 native-tls = ['reqwest/native-tls']
 rustls-tls = ['reqwest/rustls-tls']
-sparse = ["rattler_conda_types", "memmap2", "ouroboros", "serde_with", "superslice", "itertools"]
+sparse = ["rattler_conda_types", "memmap2", "ouroboros", "serde_with", "superslice", "itertools", "serde_json/raw_value"]


### PR DESCRIPTION
When using the `sparse` feature you also need the `serde_json/raw_value` feature.