### PR TITLE
Adding documentation example, fixing typo

### DIFF
--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -238,7 +238,7 @@ async fn repodata_from_file(
 ///
 /// The successful result of this function also returns a lockfile which ensures that both the state
 /// and the repodata that is pointed to remain in sync. However, not releasing the lockfile (by
-/// dropping it) could block other threads and processes, it is therefor advices to release it as
+/// dropping it) could block other threads and processes, it is therefore advisable to release it as
 /// quickly as possible.
 ///
 /// This method implements several different methods to download the repodata.json file from the

--- a/crates/rattler_repodata_gateway/src/lib.rs
+++ b/crates/rattler_repodata_gateway/src/lib.rs
@@ -6,6 +6,60 @@
 //!
 //! In the future this crate will also provide more high-level functionality to query information
 //! about specific packages from different sources.
+//! 
+//! # Install
+//! 
+//! Add the following to your *Cargo.toml*:
+//! 
+//! ```toml
+//! [dependencies]
+//! rattler_repodata_gateway = "0.2.0"
+//! ```
+//! 
+//! or run
+//! 
+//! ```bash
+//! cargo add rattler_repodata_gateway
+//! ```
+//! 
+//! # Examples
+//! 
+//! Below is a basic example that shows how to retrieve and cache the repodata for a conda channel
+//! using the [`fetch::fetch_repo_data`] function:
+//! 
+//! ```rust
+//! use std::{path::Path, default::Default};
+//! use reqwest::Client;
+//! use url::Url;
+//! use rattler_repodata_gateway::fetch;
+//! 
+//! #[tokio::main]
+//! async fn main() {
+//!     let repodata_url = Url::parse("https://conda.anaconda.org/conda-forge/osx-64/").unwrap();
+//! 
+//!     let client = Client::new();
+//!     let cache = Path::new("./cache");
+//! 
+//!     let result = fetch::fetch_repo_data(
+//!         repodata_url,
+//!         client,
+//!         cache,
+//!         fetch::FetchRepoDataOptions { ..Default::default() }
+//!     ).await;
+//! 
+//!     let result = match result {
+//!         Err(err) => {
+//!             panic!("{:?}", err);
+//!         },
+//!         Ok(result) => result
+//!     };
+//! 
+//!     println!("{:?}", result.cache_state);
+//!     println!("{:?}", result.cache_result);
+//!     println!("{:?}", result.lock_file);
+//!     println!("{:?}", result.repo_data_json_path);
+//! }
+//! ```
 
 pub mod fetch;
 #[cfg(feature = "sparse")]


### PR DESCRIPTION
While going through the code in preparation for completing this issue https://github.com/mamba-org/rattler/issues/81, I thought it would be nice to add a working example to the crate documentation. I also fixed a typo I found.