### PR TITLE
ignore trailing .0 in version comparison

### DIFF
--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -171,7 +171,26 @@ impl Version {
 
 impl PartialEq<Self> for Version {
     fn eq(&self, other: &Self) -> bool {
-        self.version == other.version && self.local == other.local
+        for ranges in self
+            .version
+            .components
+            .iter()
+            .zip_longest(other.version.components.iter())
+        {
+            match ranges {
+                EitherOrBoth::Both(left, right) => {
+                    if left != right {
+                        return false;
+                    }
+                }
+                EitherOrBoth::Left(el) | EitherOrBoth::Right(el) => {
+                    if el != &NumeralOrOther::Numeral(0) {
+                        return false;
+                    }
+                }
+            }
+        }
+        self.local.components == other.local.components
     }
 }
 

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -260,7 +260,7 @@ impl Display for NumeralOrOther {
     }
 }
 
-#[derive(Default, Clone, Eq, Hash, Serialize, Deserialize)]
+#[derive(Default, Clone, Eq, Serialize, Deserialize)]
 struct VersionComponent {
     components: SmallVec<[NumeralOrOther; 4]>,
     ranges: SmallVec<[Range<usize>; 4]>,
@@ -308,6 +308,19 @@ impl VersionComponent {
             }
         }
         true
+    }
+}
+
+impl Hash for VersionComponent {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let default = NumeralOrOther::default();
+        for range in self.ranges.iter().cloned() {
+            for component in self.components[range].iter() {
+                if component != &default {
+                    component.hash(state);
+                }
+            }
+        }
     }
 }
 

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -230,6 +230,8 @@ impl VersionSpec {
 mod tests {
     use crate::version_spec::{LogicalOperator, VersionOperator};
     use crate::{Version, VersionSpec};
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
     use std::str::FromStr;
 
     #[test]
@@ -309,8 +311,6 @@ mod tests {
         assert!(!vs1.matches(&v1));
 
         let vs2 = VersionSpec::from_str("1.2").unwrap();
-        println!("{:?}", vs2);
-        println!("{:?}", v1);
         assert!(vs2.matches(&v1));
 
         let v2 = Version::from_str("1.2.3").unwrap();

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -249,6 +249,7 @@ mod tests {
             ))
         );
     }
+
     #[test]
     fn test_group() {
         assert_eq!(
@@ -299,5 +300,19 @@ mod tests {
                 ]
             ))
         );
+    }
+
+    #[test]
+    fn test_matches() {
+        let v1 = Version::from_str("1.2.0").unwrap();
+        let vs1 = VersionSpec::from_str(">=1.2.3,<2.0.0").unwrap();
+        assert!(!vs1.matches(&v1));
+
+        let vs2 = VersionSpec::from_str("1.2").unwrap();
+        assert!(vs2.matches(&v1));
+
+        let v2 = Version::from_str("1.2.3").unwrap();
+        assert!(vs1.matches(&v2));
+        assert!(!vs2.matches(&v2));
     }
 }

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -230,8 +230,6 @@ impl VersionSpec {
 mod tests {
     use crate::version_spec::{LogicalOperator, VersionOperator};
     use crate::{Version, VersionSpec};
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
     use std::str::FromStr;
 
     #[test]

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -309,10 +309,21 @@ mod tests {
         assert!(!vs1.matches(&v1));
 
         let vs2 = VersionSpec::from_str("1.2").unwrap();
+        println!("{:?}", vs2);
+        println!("{:?}", v1);
         assert!(vs2.matches(&v1));
 
         let v2 = Version::from_str("1.2.3").unwrap();
         assert!(vs1.matches(&v2));
         assert!(!vs2.matches(&v2));
+
+        let v3 = Version::from_str("1!1.2.3").unwrap();
+        println!("{:?}", v3);
+
+        assert!(!vs1.matches(&v3));
+        assert!(!vs2.matches(&v3));
+
+        let vs3 = VersionSpec::from_str(">=1!1.2,<1!2").unwrap();
+        assert!(vs3.matches(&v3));
     }
 }


### PR DESCRIPTION
Not sure if this is the cleanest way of implementing this behavior, but in order to fix #194 we need to ignore trailing `0` when comparing versions for equality.