### PR TITLE
refactor: version tree parsing with nom

### DIFF
--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -324,4 +324,9 @@ mod tests {
         let vs3 = VersionSpec::from_str(">=1!1.2,<1!2").unwrap();
         assert!(vs3.matches(&v3));
     }
+
+    #[test]
+    fn issue_204() {
+        assert!(VersionSpec::from_str(">=3.8<3.9").is_err());
+    }
 }

--- a/crates/rattler_conda_types/src/version_spec/version_tree.rs
+++ b/crates/rattler_conda_types/src/version_spec/version_tree.rs
@@ -357,6 +357,12 @@ mod tests {
             parse_version_epoch::<Err>("1!1.0b2.post345.dev456"),
             Ok(("1.0b2.post345.dev456", 1))
         );
+
+        // Epochs must be integers
+        assert!(
+            parse_version_epoch::<Err>("12.23!1").is_err(),
+            "epochs should only be integers"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Refactors parsing of version trees by replacing the regex parser with nom. Hopefully, we can reuse these parsers in other parts of the library as well.

Fix #204 