### PR TITLE
feat: alternative libc detection

### DIFF
--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -22,3 +22,6 @@ serde = { version = "1.0.130", features = ["derive"] }
 
 [target.'cfg(target_os="macos")'.dependencies]
 plist = "1"
+
+[target.'cfg(unix)'.dependencies]
+regex = "1.8.2"

--- a/crates/rattler_virtual_packages/src/libc.rs
+++ b/crates/rattler_virtual_packages/src/libc.rs
@@ -2,7 +2,6 @@
 
 use once_cell::sync::OnceCell;
 use rattler_conda_types::{ParseVersionError, Version};
-use std::process::Command;
 
 /// Returns the LibC version and family of the current platform.
 ///
@@ -36,7 +35,7 @@ fn try_detect_libc_version() -> Result<Option<(String, Version)>, DetectLibCErro
     // Run `ldd --version` to detect the libc version and family on the system. `ldd` is shipped
     // with libc so if an error occured during its execution we can assume no libc is available on
     // the system.
-    let output = match Command::new("ldd").arg("--version").output() {
+    let output = match std::process::Command::new("ldd").arg("--version").output() {
         Err(e) => {
             tracing::info!(
                 "failed to execute `ldd --version`: {e}. Assuming libc is not available."


### PR DESCRIPTION
Implements an alternative method to detect the *system* libc version. 

We ran into an issue that when a binary is build against musl the code was unable to detect the proper libc version of the system. The code used the libc family against which it was built instead. 

Although this implementation is less then ideal because it assumes a few things I think its good enough for now.