### PR TITLE
improve version parse error msg

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -252,7 +252,9 @@ fn split_version_and_build(input: &str) -> Result<(&str, Option<&str>), ParseMat
                 },
             ))
         }
-        Err(nom::error::Error { .. }) => Err(ParseMatchSpecError::InvalidVersionAndBuild(input.to_string())),
+        Err(nom::error::Error { .. }) => Err(ParseMatchSpecError::InvalidVersionAndBuild(
+            input.to_string(),
+        )),
     }
 }
 

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -42,8 +42,8 @@ pub enum ParseMatchSpecError {
     #[error("multiple bracket sections not allowed")]
     MultipleBracketSectionsNotAllowed,
 
-    #[error("invalid version and build")]
-    InvalidVersionAndBuild,
+    #[error("Unable to parse version spec: {0}")]
+    InvalidVersionAndBuild(String),
 
     #[error("invalid version spec: {0}")]
     InvalidVersionSpec(#[from] ParseVersionSpecError),
@@ -252,7 +252,7 @@ fn split_version_and_build(input: &str) -> Result<(&str, Option<&str>), ParseMat
                 },
             ))
         }
-        Err(nom::error::Error { .. }) => Err(ParseMatchSpecError::InvalidVersionAndBuild),
+        Err(nom::error::Error { .. }) => Err(ParseMatchSpecError::InvalidVersionAndBuild(input.to_string())),
     }
 }
 


### PR DESCRIPTION
I made the mistake of adding `=>1.2.3` which is very much illegal but it was not really clear from the error message