### PR TITLE
feat: more derives for conda lock

### DIFF
--- a/crates/rattler_conda_types/src/conda_lock/builder.rs
+++ b/crates/rattler_conda_types/src/conda_lock/builder.rs
@@ -6,7 +6,7 @@ use crate::conda_lock::{
     TimeMeta, VersionConstraint,
 };
 use crate::{MatchSpec, Platform};
-use std::collections::{HashMap, HashSet};
+use fxhash::{FxHashMap, FxHashSet};
 use url::Url;
 
 /// Struct used to build a conda-lock file
@@ -15,7 +15,7 @@ pub struct LockFileBuilder {
     /// Channels used to resolve dependencies
     pub channels: Vec<Channel>,
     /// The platforms this lock file supports
-    pub platforms: HashSet<Platform>,
+    pub platforms: FxHashSet<Platform>,
     /// Paths to source files, relative to the parent directory of the lockfile
     pub sources: Option<Vec<String>>,
     /// Metadata dealing with the time lockfile was created
@@ -24,7 +24,7 @@ pub struct LockFileBuilder {
     pub git_metadata: Option<GitMeta>,
 
     /// Keep track of locked packages per platform
-    pub locked_packages: HashMap<Platform, LockedPackages>,
+    pub locked_packages: FxHashMap<Platform, LockedPackages>,
 
     /// MatchSpecs input
     /// This is only used to calculate the content_hash
@@ -74,7 +74,7 @@ impl LockFileBuilder {
                     content_hash::calculate_content_hash(plat, &self.input_specs, &self.channels)?,
                 ))
             })
-            .collect::<Result<HashMap<_, _>, CalculateContentHashError>>()?;
+            .collect::<Result<FxHashMap<_, _>, CalculateContentHashError>>()?;
 
         let lock = CondaLock {
             metadata: LockMeta {
@@ -158,7 +158,7 @@ pub struct LockedPackage {
     /// Collection of package hash fields
     pub package_hashes: PackageHashes,
     /// List of dependencies for this package
-    pub dependency_list: HashMap<String, VersionConstraint>,
+    pub dependency_list: FxHashMap<String, VersionConstraint>,
     /// Check if package is optional
     pub optional: Option<bool>,
 }

--- a/crates/rattler_conda_types/src/platform.rs
+++ b/crates/rattler_conda_types/src/platform.rs
@@ -1,4 +1,5 @@
 use serde::{Deserializer, Serializer};
+use std::cmp::Ordering;
 use std::{fmt, fmt::Formatter, str::FromStr};
 use strum::{EnumIter, IntoEnumIterator};
 use thiserror::Error;
@@ -28,6 +29,18 @@ pub enum Platform {
     WinArm64,
 
     Emscripten32,
+}
+
+impl PartialOrd for Platform {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.as_str().partial_cmp(other.as_str())
+    }
+}
+
+impl Ord for Platform {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
 }
 
 /// Known architectures supported by Conda.

--- a/crates/rattler_conda_types/src/utils/serde.rs
+++ b/crates/rattler_conda_types/src/utils/serde.rs
@@ -1,7 +1,11 @@
 use chrono::{DateTime, Utc};
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_with::de::DeserializeAsWrap;
+use serde_with::ser::SerializeAsWrap;
 use serde_with::{DeserializeAs, SerializeAs};
+use std::collections::HashSet;
+use std::hash::{BuildHasher, Hash};
 use std::marker::PhantomData;
 use url::Url;
 
@@ -110,5 +114,61 @@ impl SerializeAs<chrono::DateTime<chrono::Utc>> for Timestamp {
 
         // Serialize the timestamp
         timestamp.serialize(serializer)
+    }
+}
+
+/// Used with serde_with to serialize a collection as a sorted collection.
+#[derive(Default)]
+pub(crate) struct Ordered<T>(PhantomData<T>);
+
+impl<'de, T: Eq + Hash, S: BuildHasher + Default, TAs> DeserializeAs<'de, HashSet<T, S>>
+    for Ordered<TAs>
+where
+    TAs: DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<HashSet<T, S>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let content =
+            DeserializeAsWrap::<Vec<T>, Vec<TAs>>::deserialize(deserializer)?.into_inner();
+        Ok(HashSet::from_iter(content.into_iter()))
+    }
+}
+
+impl<T: Ord, HS, TAs: SerializeAs<T>> SerializeAs<HashSet<T, HS>> for Ordered<TAs> {
+    fn serialize_as<S>(source: &HashSet<T, HS>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut elements = Vec::from_iter(source.iter());
+        elements.sort();
+        SerializeAsWrap::<Vec<&T>, Vec<&TAs>>::new(&elements).serialize(serializer)
+    }
+}
+
+impl<'de, T: Ord, TAs> DeserializeAs<'de, Vec<T>> for Ordered<TAs>
+where
+    TAs: DeserializeAs<'de, T>,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<Vec<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let mut content =
+            DeserializeAsWrap::<Vec<T>, Vec<TAs>>::deserialize(deserializer)?.into_inner();
+        content.sort();
+        Ok(content)
+    }
+}
+
+impl<T: Ord, TAs: SerializeAs<T>> SerializeAs<Vec<T>> for Ordered<TAs> {
+    fn serialize_as<S>(source: &Vec<T>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut elements = Vec::from_iter(source.iter());
+        elements.sort();
+        SerializeAsWrap::<Vec<&T>, Vec<&TAs>>::new(&elements).serialize(serializer)
     }
 }


### PR DESCRIPTION
This adds some small changes to the conda-lock code to:

* Use FXhash for maps
* Add `Eq`, `PartialEq`, `Clone`, `Debug`, `Hash` to datastructures that support it.
* Add the `Ordered<_>` `serde_as` helper to make sure fields are serialized deterministically. 