### PR TITLE
fix: edge cases for matchspec parsing

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -72,7 +72,7 @@ use matcher::StringMatcher;
 ///
 /// let spec = MatchSpec::from_str("foo=1.0=py27_0").unwrap();
 /// assert_eq!(spec.name, Some("foo".to_string()));
-/// assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
+/// assert_eq!(spec.version, Some(VersionSpec::from_str("==1.0").unwrap()));
 /// assert_eq!(spec.build, Some(StringMatcher::from_str("py27_0").unwrap()));
 ///
 /// let spec = MatchSpec::from_str("conda-forge::foo[version=\"1.0.*\"]").unwrap();

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -380,7 +380,7 @@ fn parse(input: &str) -> Result<MatchSpec, ParseMatchSpecError> {
             // If the version starts with `==` and the build string is none we strip the `==` part.
             Cow::Borrowed(version_str)
         } else if let Some(version_str_part) = version_str.strip_prefix('=') {
-            let not_a_group = !version_str_part.contains(&['=', ',', '|']);
+            let not_a_group = !version_str_part.contains(['=', ',', '|']);
             if not_a_group {
                 // If the version starts with `=`, is not part of a group (e.g. 1|2) we append a *
                 // if it doesnt have one already.

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__parsed matchspecs.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__parsed matchspecs.snap
@@ -1,0 +1,25 @@
+---
+source: crates/rattler_conda_types/src/match_spec/parse.rs
+expression: evaluated
+---
+blas *.* mkl:
+  name: blas
+  version: "*"
+  build: mkl
+foo=1.0=py27_0:
+  name: foo
+  version: "==1.0"
+  build: py27_0
+foo==1.0=py27_0:
+  name: foo
+  version: "==1.0"
+  build: py27_0
+python 3.8.* *_cpython:
+  name: python
+  version: 3.8.*
+  build: "*_cpython"
+pytorch=*=cuda*:
+  name: pytorch
+  version: "*"
+  build: cuda*
+

--- a/crates/rattler_conda_types/src/version_spec/version_tree.rs
+++ b/crates/rattler_conda_types/src/version_spec/version_tree.rs
@@ -88,8 +88,8 @@ fn recognize_constraint<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     input: &'a str,
 ) -> Result<(&'a str, &'a str), nom::Err<E>> {
     alt((
-        // Any
-        tag("*"),
+        // Any (* or *.*)
+        terminated(tag("*"), cut(opt(tag(".*")))),
         // Regex
         recognize(delimited(tag("^"), not(tag("$")), tag("$"))),
         // Version with optional operator followed by optional glob.


### PR DESCRIPTION
Fixes parsing of `blas *.* mkl` and `pytorch=*=cuda*` which would both cause panics.