### PR TITLE
refactor: detect current shell

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -14,7 +14,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: "-D warnings"
   CARGO_TERM_COLOR: always
-  DEFAULT_FEATURES: tokio,serde,reqwest,sparse
+  DEFAULT_FEATURES: tokio,serde,reqwest,sparse,sysinfo
 
 jobs:
   check:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored shell detection code using `$SHELL` or parent process name ([#219](https://github.com/mamba-org/rattler/pull/219))
+
 ## [0.3.0] - 2023-06-15
 
 ### Highlights

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -15,9 +15,10 @@ enum_dispatch = "0.3.11"
 indexmap = "1.9.3"
 itertools = "0.10.5"
 rattler_conda_types = { version = "0.3.0", path = "../rattler_conda_types" }
-serde_json = { version = "1.0.96", features = ["preserve_order"]}
+serde_json = { version = "1.0.96", features = ["preserve_order"] }
 thiserror = "1.0.40"
 tracing = "0.1.37"
+sysinfo = { version = "0.29.2", optional = true }
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/crates/rattler_shell/src/shell/mod.rs
+++ b/crates/rattler_shell/src/shell/mod.rs
@@ -7,6 +7,7 @@ use std::{
     fmt::Write,
     path::{Path, PathBuf},
 };
+use sysinfo::{get_current_pid, ProcessExt, SystemExt};
 
 /// A trait for generating shell scripts.
 /// The trait is implemented for each shell individually.
@@ -283,7 +284,7 @@ impl Shell for Fish {
 /// A generic [`Shell`] implementation for concrete shell types.
 #[enum_dispatch]
 #[allow(missing_docs)]
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ShellEnum {
     Bash,
     Zsh,
@@ -293,15 +294,92 @@ pub enum ShellEnum {
     Fish,
 }
 
-impl ShellEnum {
-    /// Returns the shell for the current system.
-    pub fn detect_from_environment() -> Option<Self> {
-        // TODO: Make this a bit better
+// The default shell is determined by the current OS.
+impl Default for ShellEnum {
+    fn default() -> Self {
         if cfg!(windows) {
+            CmdExe.into()
+        } else {
+            Bash.into()
+        }
+    }
+}
+
+impl ShellEnum {
+    /// Parse a shell from a path to the executable for the shell.
+    pub fn from_shell_path<P: AsRef<Path>>(path: P) -> Option<Self> {
+        parse_shell_from_path(path.as_ref())
+    }
+
+    /// Determine the user's current shell from the environment
+    ///
+    /// This will read the SHELL environment variable and try to determine which shell is in use
+    /// from that.
+    ///
+    /// If SHELL is set, but contains a value that doesn't correspond to one of the supported shell
+    /// types, then return `None`.
+    pub fn from_env() -> Option<Self> {
+        if let Some(env_shell) = std::env::var_os("SHELL") {
+            Self::from_shell_path(env_shell)
+        } else if cfg!(windows) {
+            Some(PowerShell.into())
+        } else {
+            None
+        }
+    }
+
+    /// Guesses the current shell by checking the name of the parent process.
+    #[cfg(feature="sysinfo")]
+    pub fn from_parent_process() -> Option<Self> {
+        let mut system_info = sysinfo::System::new();
+
+        // Get current process information
+        let current_pid = get_current_pid().ok()?;
+        system_info.refresh_process(current_pid);
+        let parent_process_id = system_info
+            .process(current_pid)
+            .and_then(|process| process.parent())?;
+
+        // Get the name of the parent process
+        system_info.refresh_process(parent_process_id);
+        let parent_process = system_info.process(parent_process_id)?;
+        let parent_process_name = parent_process.name().to_lowercase();
+
+        tracing::debug!(
+            "guessing ShellEnum. Parent process name: {}",
+            &parent_process_name
+        );
+
+        if parent_process_name.contains("bash") {
+            Some(Bash.into())
+        } else if parent_process_name.contains("zsh") {
+            Some(Zsh.into())
+        } else if parent_process_name.contains("xonsh") {
+            Some(Xonsh.into())
+        } else if parent_process_name.contains("fish") {
+            Some(Fish.into())
+        } else if parent_process_name.contains("powershell") || parent_process_name.contains("pwsh")
+        {
+            Some(PowerShell.into())
+        } else if parent_process_name.contains("cmd.exe") {
             Some(CmdExe.into())
         } else {
-            Some(Bash.into())
+            None
         }
+    }
+}
+
+/// Determine the shell from a path to a shell.
+fn parse_shell_from_path(path: &Path) -> Option<ShellEnum> {
+    let name = path.file_stem()?.to_str()?;
+    match name {
+        "bash" => Some(Bash.into()),
+        "zsh" => Some(Zsh.into()),
+        "xonsh" => Some(Xonsh.into()),
+        "fish" => Some(Fish.into()),
+        "cmd" => Some(CmdExe.into()),
+        "powershell" | "powershell_ise" => Some(PowerShell.into()),
+        _ => None,
     }
 }
 
@@ -367,5 +445,11 @@ mod tests {
             .run_script(&PathBuf::from_str("foo.sh").expect("blah"));
 
         insta::assert_snapshot!(script.contents);
+    }
+
+    #[test]
+    fn test_from_parent_process_doenst_crash() {
+        let shell = ShellEnum::from_parent_process();
+        println!("{:?}", shell);
     }
 }

--- a/crates/rattler_shell/src/shell/mod.rs
+++ b/crates/rattler_shell/src/shell/mod.rs
@@ -7,7 +7,6 @@ use std::{
     fmt::Write,
     path::{Path, PathBuf},
 };
-use sysinfo::{get_current_pid, ProcessExt, SystemExt};
 
 /// A trait for generating shell scripts.
 /// The trait is implemented for each shell individually.
@@ -329,8 +328,10 @@ impl ShellEnum {
     }
 
     /// Guesses the current shell by checking the name of the parent process.
-    #[cfg(feature="sysinfo")]
+    #[cfg(feature = "sysinfo")]
     pub fn from_parent_process() -> Option<Self> {
+        use sysinfo::{get_current_pid, ProcessExt, SystemExt};
+
         let mut system_info = sysinfo::System::new();
 
         // Get current process information
@@ -447,9 +448,16 @@ mod tests {
         insta::assert_snapshot!(script.contents);
     }
 
+    #[cfg(feature = "sysinfo")]
     #[test]
     fn test_from_parent_process_doenst_crash() {
         let shell = ShellEnum::from_parent_process();
-        println!("{:?}", shell);
+        println!("Detected shell: {:?}", shell);
+    }
+
+    #[test]
+    fn test_from_env() {
+        let shell = ShellEnum::from_env();
+        println!("Detected shell: {:?}", shell);
     }
 }


### PR DESCRIPTION
Refactored the shell detection code. The following changes were made.

- Added a function to detect the current shell based on the `SHELL` environment variable.
- Added a function to detect the current shell based on the parent process name (behind a feature flag).
- Removed the `ShellEnum::detect_from_environment()` method and moved implementation into `ShellEnum::default()`.

To determine an appropriate current shell use:

```rust
let shell = ShellEnum::from_env() // First try to detect from $SHELL
    .or_else(ShellEnum::from_parent_process())  // Otherwise check the parent process
    .unwrap_or_default();  // Otherwise fall back to the os's default
```

Fix #216 