### PR TITLE
fix: >=1!164.3095,<1!165

### DIFF
--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -2,7 +2,7 @@
 //! [`crate::MatchSpec`], e.g.: `>=3.4,<4.0`.
 
 mod constraint;
-mod version_tree;
+pub(crate) mod version_tree;
 
 use crate::version_spec::constraint::{Constraint, ParseConstraintError};
 use crate::version_spec::version_tree::ParseVersionTreeError;

--- a/crates/rattler_conda_types/src/version_spec/version_tree.rs
+++ b/crates/rattler_conda_types/src/version_spec/version_tree.rs
@@ -84,7 +84,7 @@ fn recognize_version<'a, E: ParseError<&'a str>>(
 }
 
 /// A parser that recognized a constraint but does not actually parse it.
-fn recognize_constraint<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
+pub(crate) fn recognize_constraint<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
     input: &'a str,
 ) -> Result<(&'a str, &'a str), nom::Err<E>> {
     alt((
@@ -95,7 +95,11 @@ fn recognize_constraint<'a, E: ParseError<&'a str> + ContextError<&'a str>>(
         // Version with optional operator followed by optional glob.
         recognize(terminated(
             preceded(
-                opt(parse_operator),
+                opt(delimited(
+                    opt(multispace0),
+                    parse_operator,
+                    opt(multispace0),
+                )),
                 cut(context("version", recognize_version)),
             ),
             opt(alt((tag(".*"), tag("*")))),


### PR DESCRIPTION
Parsing of `>=1!164.3095,<1!165` failed due to the epoch selector. This has now been fixed by reusing the logic of recognizing constraints.