### PR TITLE
zsh also uses `sh` as shell extension

### DIFF
--- a/crates/rattler_shell/src/shell/mod.rs
+++ b/crates/rattler_shell/src/shell/mod.rs
@@ -150,7 +150,7 @@ impl Shell for Zsh {
     }
 
     fn extension(&self) -> &str {
-        "zsh"
+        "sh"
     }
 
     fn create_run_script_command(&self, path: &Path) -> Command {

--- a/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__activation_script_zsh.snap
+++ b/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__activation_script_zsh.snap
@@ -4,4 +4,5 @@ expression: script
 ---
 export PATH="__PREFIX__/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
 export CONDA_PREFIX="__PREFIX__"
+. "__PREFIX__/etc/conda/activate.d/script1.sh"
 


### PR DESCRIPTION
This should fix activation for `zsh` shells (didn't find and execute any activation scripts).