### PR TITLE
refactor: version implementation

### DIFF
--- a/crates/rattler/src/install/python.rs
+++ b/crates/rattler/src/install/python.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Clone)]
 pub struct PythonInfo {
     /// The major and minor version
-    pub short_version: (u32, u32),
+    pub short_version: (u64, u64),
 
     /// The relative path to the python executable
     pub path: PathBuf,

--- a/crates/rattler/src/install/python.rs
+++ b/crates/rattler/src/install/python.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 #[derive(Debug, Clone)]
 pub struct PythonInfo {
     /// The major and minor version
-    pub short_version: (usize, usize),
+    pub short_version: (u32, u32),
 
     /// The relative path to the python executable
     pub path: PathBuf,

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -763,4 +763,9 @@ mod test {
         let v2 = Version::from_str("1.2.3").unwrap();
         assert_ne!(get_hash(&v1), get_hash(&v2));
     }
+
+    #[test]
+    fn size_of_version() {
+        assert_eq!(std::mem::size_of::<Version>(), 136);
+    }
 }

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -343,17 +343,14 @@ impl Version {
         }
 
         let epoch = self.epoch();
-        let epoch_display = if epoch != 0 {
-            format!("{}!", epoch)
-        } else {
-            String::new()
-        };
+        let epoch_display = (epoch != 0)
+            .then(|| format!("{}!", epoch))
+            .unwrap_or_default();
         let segments_display = format_segments(self.segments());
-        let local_display = if self.has_local() {
-            format!("+{}", format_segments(self.local_segments()))
-        } else {
-            String::new()
-        };
+        let local_display = self
+            .has_local()
+            .then(|| format!("+{}", format_segments(self.local_segments())))
+            .unwrap_or_default();
 
         format!("{}{}{}", epoch_display, segments_display, local_display)
     }

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -331,7 +331,7 @@ impl Version {
             {
                 &components[1..]
             } else {
-                &components[..]
+                components
             };
             components.iter().join("")
         }
@@ -346,13 +346,13 @@ impl Version {
         let epoch_display = if epoch != 0 {
             format!("{}!", epoch)
         } else {
-            format!("")
+            String::new()
         };
         let segments_display = format_segments(self.segments());
         let local_display = if self.has_local() {
             format!("+{}", format_segments(self.local_segments()))
         } else {
-            format!("")
+            String::new()
         };
 
         format!("{}{}{}", epoch_display, segments_display, local_display)

--- a/crates/rattler_conda_types/src/version/parse.rs
+++ b/crates/rattler_conda_types/src/version/parse.rs
@@ -120,7 +120,7 @@ impl FromStr for Version {
 
         // Find epoch
         let (epoch, rest) = if let Some((epoch, rest)) = lowered.split_once('!') {
-            let epoch: u32 = epoch.parse().map_err(|e| {
+            let epoch: u64 = epoch.parse().map_err(|e| {
                 ParseVersionError::new(s, ParseVersionErrorKind::EpochMustBeInteger(e))
             })?;
             (Some(epoch), rest)
@@ -186,7 +186,7 @@ impl FromStr for Version {
 
         fn split_component<'a>(
             segments_iter: impl Iterator<Item = &'a str>,
-            segments: &mut SmallVec<[u16; 1]>,
+            segments: &mut SmallVec<[u16; 4]>,
             components: &mut SmallVec<[Component; 3]>,
         ) -> Result<(), ParseVersionErrorKind> {
             for component in segments_iter {
@@ -199,7 +199,7 @@ impl FromStr for Version {
                 let mut atoms = numeral_or_alpha_split
                     .map(|mtch| match mtch.as_str() {
                         num if num.chars().all(|c| c.is_ascii_digit()) => num
-                            .parse::<u32>()
+                            .parse()
                             .map_err(ParseVersionErrorKind::InvalidNumeral)
                             .map(Component::Numeral),
                         "post" => Ok(Component::Post),
@@ -257,7 +257,7 @@ impl FromStr for Version {
         };
 
         Ok(Self {
-            norm: lowered,
+            norm: lowered.into_boxed_str(),
             flags,
             segments,
             components,

--- a/crates/rattler_conda_types/src/version/parse.rs
+++ b/crates/rattler_conda_types/src/version/parse.rs
@@ -1,4 +1,4 @@
-use super::{NumeralOrOther, Version, VersionComponent};
+use super::{Component, Version};
 use smallvec::SmallVec;
 use std::{
     convert::Into,
@@ -37,6 +37,8 @@ impl Display for ParseVersionError {
             }
             ParseVersionErrorKind::EmptyVersionComponent => write!(f, "empty version component"),
             ParseVersionErrorKind::InvalidNumeral(e) => write!(f, "invalid numeral: {}", e),
+            ParseVersionErrorKind::TooManySegments => write!(f, "too many segments"),
+            ParseVersionErrorKind::TooManyComponentsInASegment => write!(f, "too many version components, a single version segment can at most contain {} components", (1<<16)-1),
         }
     }
 }
@@ -70,6 +72,10 @@ pub enum ParseVersionErrorKind {
     DuplicateLocalVersionSeparator,
     /// The string contained an empty version component
     EmptyVersionComponent,
+    /// Too many segments.
+    TooManySegments,
+    /// Too many segments.
+    TooManyComponentsInASegment,
 }
 
 /// Returns true if the specified char is a valid char for a version string.
@@ -114,12 +120,12 @@ impl FromStr for Version {
 
         // Find epoch
         let (epoch, rest) = if let Some((epoch, rest)) = lowered.split_once('!') {
-            let _: usize = epoch.parse().map_err(|e| {
+            let epoch: u32 = epoch.parse().map_err(|e| {
                 ParseVersionError::new(s, ParseVersionErrorKind::EpochMustBeInteger(e))
             })?;
-            ([epoch], rest)
+            (Some(epoch), rest)
         } else {
-            (["0"], lowered.as_str())
+            (None, lowered.as_str())
         };
 
         // Ensure the rest of the string no longer contains an epoch
@@ -167,60 +173,94 @@ impl FromStr for Version {
                 .map(ToOwned::to_owned)
                 .collect()
         };
-        let version_split = epoch
-            .iter()
-            .copied()
-            .chain(version.iter().map(|s| s.as_str()));
+        let version_split = version.iter().map(|s| s.as_str());
+
+        let mut components = SmallVec::default();
+        let mut segments = SmallVec::default();
+        let mut flags = 0u8;
+
+        if let Some(epoch) = epoch {
+            components.push(epoch.into());
+            flags |= 0x1; // Mark that the version contains an epoch
+        }
 
         fn split_component<'a>(
-            split_iter: impl Iterator<Item = &'a str>,
-        ) -> Result<VersionComponent, ParseVersionErrorKind> {
-            let mut result = VersionComponent::default();
-            for component in split_iter {
+            segments_iter: impl Iterator<Item = &'a str>,
+            segments: &mut SmallVec<[u16; 1]>,
+            components: &mut SmallVec<[Component; 3]>,
+        ) -> Result<(), ParseVersionErrorKind> {
+            for component in segments_iter {
                 let version_split_re = lazy_regex::regex!(r#"([0-9]+|[^0-9]+)"#);
                 let mut numeral_or_alpha_split = version_split_re.find_iter(component).peekable();
                 if numeral_or_alpha_split.peek().is_none() {
                     return Err(ParseVersionErrorKind::EmptyVersionComponent);
                 }
-                let range_start = result.components.len();
-                for numeral_or_alpha in numeral_or_alpha_split {
-                    let numeral_or_alpha = numeral_or_alpha.as_str();
-                    let parsed: NumeralOrOther = match numeral_or_alpha {
+
+                let mut atoms = numeral_or_alpha_split
+                    .map(|mtch| match mtch.as_str() {
                         num if num.chars().all(|c| c.is_ascii_digit()) => num
-                            .parse::<usize>()
-                            .map_err(ParseVersionErrorKind::InvalidNumeral)?
-                            .into(),
-                        "post" => NumeralOrOther::Infinity,
-                        "dev" => NumeralOrOther::Other(String::from("DEV")),
-                        ident => NumeralOrOther::Other(ident.to_owned()),
-                    };
-                    result.components.push(parsed);
-                }
-                if range_start < result.components.len()
-                    && !matches!(&result.components[range_start], NumeralOrOther::Numeral(_))
-                {
-                    result
-                        .components
-                        .insert(range_start, NumeralOrOther::Numeral(0))
+                            .parse::<u32>()
+                            .map_err(ParseVersionErrorKind::InvalidNumeral)
+                            .map(Component::Numeral),
+                        "post" => Ok(Component::Post),
+                        "dev" => Ok(Component::Dev),
+                        ident => Ok(Component::Iden(ident.to_owned().into_boxed_str())),
+                    })
+                    .peekable();
+
+                // A segment must always starts with a numeral
+                let mut component_count = 0u16;
+                if !matches!(atoms.peek(), Some(&Ok(Component::Numeral(_)))) {
+                    components.push(Component::Numeral(0));
+                    component_count = component_count
+                        .checked_add(1)
+                        .ok_or(ParseVersionErrorKind::TooManyComponentsInASegment)?;
                 }
 
-                let range_end = result.components.len();
-                result.ranges.push(range_start..range_end);
+                // Add the components
+                for component in atoms {
+                    components.push(component?);
+                    component_count = component_count
+                        .checked_add(1)
+                        .ok_or(ParseVersionErrorKind::TooManyComponentsInASegment)?;
+                }
+
+                // Add the segment information
+                segments.push(component_count);
             }
-            Ok(result)
+
+            Ok(())
         }
 
-        let version = split_component(version_split).map_err(|e| ParseVersionError::new(s, e))?;
-        let local = if local.is_empty() {
-            Default::default()
-        } else {
-            split_component(local_split).map_err(|e| ParseVersionError::new(s, e))?
+        split_component(version_split, &mut segments, &mut components)
+            .map_err(|e| ParseVersionError::new(s, e))?;
+
+        if !local.is_empty() {
+            if segments.len() >= (1 << 7) {
+                // There are too many segments to be able to encode the local segment parts into the
+                // special `flag` we store. The flags is 8 bits and the first bit is used to
+                // indicate if there is an epoch or not. The remaining 7 bits are used to indicate
+                // which segment is the first that belongs to the local version part. We can encode
+                // at most 127 positions so if there are more segments in the common version part,
+                // we cannot represent this version.
+                return Err(ParseVersionError::new(
+                    s,
+                    ParseVersionErrorKind::TooManySegments,
+                ));
+            }
+
+            // Encode that the local version segment starts at the given index.
+            flags |= (u8::try_from(segments.len()).unwrap()) << 1u8;
+
+            split_component(local_split, &mut segments, &mut components)
+                .map_err(|e| ParseVersionError::new(s, e))?
         };
 
         Ok(Self {
             norm: lowered,
-            version,
-            local,
+            flags,
+            segments,
+            components,
         })
     }
 }

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -214,8 +214,12 @@ impl VersionSpec {
             VersionSpec::Operator(VersionOperator::NotStartsWith, limit) => {
                 !version.starts_with(limit)
             }
-            VersionSpec::Operator(VersionOperator::Compatible, limit) => version >= limit,
-            VersionSpec::Operator(VersionOperator::NotCompatible, limit) => version < limit,
+            VersionSpec::Operator(VersionOperator::Compatible, limit) => {
+                version.compatible_with(limit)
+            }
+            VersionSpec::Operator(VersionOperator::NotCompatible, limit) => {
+                !version.compatible_with(limit)
+            }
             VersionSpec::Group(LogicalOperator::And, group) => {
                 group.iter().all(|spec| spec.matches(version))
             }
@@ -328,5 +332,14 @@ mod tests {
     #[test]
     fn issue_204() {
         assert!(VersionSpec::from_str(">=3.8<3.9").is_err());
+    }
+
+    #[test]
+    fn issue_225() {
+        let spec = VersionSpec::from_str("~=2.4").unwrap();
+        assert!(!spec.matches(&Version::from_str("3.1").unwrap()));
+        assert!(spec.matches(&Version::from_str("2.4").unwrap()));
+        assert!(spec.matches(&Version::from_str("2.5").unwrap()));
+        assert!(!spec.matches(&Version::from_str("2.1").unwrap()));
     }
 }


### PR DESCRIPTION
This PR does a complete refactor of the version implementation. The primary goal was to reduce the memory footprint because versions are used in RepoData quite a lot. The secondary goal was to simplify the implementation, I think I achieved this by returning an iterator of the version segments vs accessing multiple arrays to get to the data. The implementation of the `flag` makes it a bit more complex though. If based on a review this is the case I have some ideas.

Just like the previous implementation, this implementation tries to keep most memory on the stack unless the version requires more memory. Most versions are in the form of `1.2.3` so we can take advantage of that. The new implementation takes ~~136~~ 128 bytes of stack memory per Version. The old one was 440. Changes in heap allocations remain the same. More research is needed to figure out how to further reduce this.

I will follow up this PR with another one that refactors the parsing to make it more robust.

Ideally, I also wanted to add some benchmarking but didn't get the time to. Perhaps that's for later!

Oh yeah, this implementation also fixes #255. With the new implementation, it was much simpler to implement dropping a segment for comparison without allocation.

Fix #225 