### PR TITLE
feat: add methods to manipulate a version

### DIFF
--- a/crates/rattler_conda_types/src/version/parse.rs
+++ b/crates/rattler_conda_types/src/version/parse.rs
@@ -258,7 +258,7 @@ impl FromStr for Version {
         };
 
         Ok(Self {
-            norm: lowered.into_boxed_str(),
+            norm: Some(lowered.into_boxed_str()),
             flags,
             segment_lengths: segments,
             components,


### PR DESCRIPTION
Adds the following method to `Version`:

- `Version::with_segments` extract specific segments of a version to turn `1.2a.3b.4` into for instance `2a.3b`.
- `Version::pop_segments` helper method to pop a number of segments from the back. E.g. turn `1.2.3` into `1.2`.
- `Version::strip_local` removes the local part of a version if it has it. Otherwise returns the version itself.

Fix #228