### PR TITLE
expose `sort_topologically` function

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -3,6 +3,7 @@
 
 pub mod patches;
 mod topological_sort;
+pub use topological_sort::sort_topologically;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::{Display, Formatter};


### PR DESCRIPTION
I wanted to use this function in `rattler-server` but could not (or did I do something wrong?) :)