### PR TITLE
Fix/powershell on unix

### DIFF
--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -3,7 +3,6 @@
 //! This crate provides helper functions to activate and deactivate virtual environments.
 
 use std::ffi::OsStr;
-use std::fmt::Write;
 use std::{
     fs,
     path::{Path, PathBuf},

--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -326,12 +326,6 @@ impl<T: Shell + Clone> Activator<T> {
     ) -> Result<ActivationResult, ActivationError> {
         let mut script = String::new();
 
-        // Add shebang on unix systems to activation script.
-        if self.platform.is_unix() {
-            writeln!(script, "#!/bin/sh")
-                .map_err(ActivationError::FailedToWriteActivationScript)?;
-        }
-
         let mut path = variables.path.clone().unwrap_or_default();
         if let Some(conda_prefix) = variables.conda_prefix {
             let deactivate = Activator::from_path(

--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -362,6 +362,7 @@ impl<T: Shell + Clone> Activator<T> {
                 &mut script,
                 path.as_slice(),
                 variables.path_modification_behaviour,
+                &self.platform,
             )
             .map_err(ActivationError::FailedToWriteActivationScript)?;
 

--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -3,11 +3,11 @@
 //! This crate provides helper functions to activate and deactivate virtual environments.
 
 use std::ffi::OsStr;
+use std::fmt::Write;
 use std::{
     fs,
     path::{Path, PathBuf},
 };
-use std::fmt::Write;
 
 use crate::shell::Shell;
 use indexmap::IndexMap;
@@ -328,7 +328,8 @@ impl<T: Shell + Clone> Activator<T> {
 
         // Add shebang on unix systems to activation script.
         if self.platform.is_unix() {
-            writeln!(script, "#!/bin/sh").map_err(ActivationError::FailedToWriteActivationScript)?;
+            writeln!(script, "#!/bin/sh")
+                .map_err(ActivationError::FailedToWriteActivationScript)?;
         }
 
         let mut path = variables.path.clone().unwrap_or_default();

--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -7,6 +7,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
+use std::fmt::Write;
 
 use crate::shell::Shell;
 use indexmap::IndexMap;
@@ -324,6 +325,11 @@ impl<T: Shell + Clone> Activator<T> {
         variables: ActivationVariables,
     ) -> Result<ActivationResult, ActivationError> {
         let mut script = String::new();
+
+        // Add shebang on unix systems to activation script.
+        if self.platform.is_unix() {
+            writeln!(script, "#!/bin/sh").map_err(ActivationError::FailedToWriteActivationScript)?;
+        }
 
         let mut path = variables.path.clone().unwrap_or_default();
         if let Some(conda_prefix) = variables.conda_prefix {

--- a/crates/rattler_shell/src/shell/mod.rs
+++ b/crates/rattler_shell/src/shell/mod.rs
@@ -8,6 +8,7 @@ use std::{
     fmt::Write,
     path::{Path, PathBuf},
 };
+use rattler_conda_types::Platform;
 
 /// A trait for generating shell scripts.
 /// The trait is implemented for each shell individually.
@@ -52,6 +53,7 @@ pub trait Shell {
         f: &mut impl Write,
         paths: &[PathBuf],
         modification_behaviour: PathModificationBehaviour,
+        platform: &Platform,
     ) -> std::fmt::Result {
         let mut paths_vec = paths
             .iter()
@@ -64,7 +66,7 @@ pub trait Shell {
             PathModificationBehaviour::Prepend => paths_vec.push(self.format_env_var("PATH")),
         }
         // Create the shell specific list of paths.
-        let paths_string = paths_vec.join(self.path_seperator());
+        let paths_string = paths_vec.join(self.path_seperator(platform));
 
         self.set_env_var(f, "PATH", paths_string.as_str())
     }
@@ -79,8 +81,8 @@ pub trait Shell {
     fn create_run_script_command(&self, path: &Path) -> Command;
 
     /// Path seperator
-    fn path_seperator(&self) -> &str {
-        ":"
+    fn path_seperator(&self, platform: &Platform) -> &str {
+        if platform.is_unix() { ":" } else { ";" }
     }
 
     /// Format the environment variable for the shell.
@@ -138,6 +140,7 @@ impl Shell for Bash {
         f: &mut impl Write,
         paths: &[PathBuf],
         modification_behaviour: PathModificationBehaviour,
+        platform: &Platform,
     ) -> std::fmt::Result {
         // Put paths in a vector of the correct format.
         let mut paths_vec = paths
@@ -159,7 +162,7 @@ impl Shell for Bash {
             PathModificationBehaviour::Append => paths_vec.insert(0, self.format_env_var("PATH")),
         }
         // Create the shell specific list of paths.
-        let paths_string = paths_vec.join(self.path_seperator());
+        let paths_string = paths_vec.join(self.path_seperator(platform));
 
         self.set_env_var(f, "PATH", paths_string.as_str())
     }
@@ -289,10 +292,6 @@ impl Shell for CmdExe {
         cmd
     }
 
-    fn path_seperator(&self) -> &str {
-        ";"
-    }
-
     fn format_env_var(&self, var_name: &str) -> String {
         format!("%{var_name}%")
     }
@@ -329,10 +328,6 @@ impl Shell for PowerShell {
         let mut cmd = Command::new(self.executable());
         cmd.arg(path);
         cmd
-    }
-
-    fn path_seperator(&self) -> &str {
-        ";"
     }
 
     fn format_env_var(&self, var_name: &str) -> String {
@@ -487,14 +482,17 @@ pub struct ShellScript<T: Shell> {
     shell: T,
     /// The contents of the script.
     pub contents: String,
+    /// The platform for which the script will be generated
+    platform: Platform,
 }
 
 impl<T: Shell> ShellScript<T> {
     /// Create a new [`ShellScript`] for the given shell.
-    pub fn new(shell: T) -> Self {
+    pub fn new(shell: T, platform: Platform) -> Self {
         Self {
             shell,
             contents: String::new(),
+            platform
         }
     }
 
@@ -517,7 +515,7 @@ impl<T: Shell> ShellScript<T> {
     /// Set the PATH environment variable to the given paths.
     pub fn set_path(&mut self, paths: &[PathBuf]) -> &mut Self {
         self.shell
-            .set_path(&mut self.contents, paths, PathModificationBehaviour::Append)
+            .set_path(&mut self.contents, paths, PathModificationBehaviour::Prepend, &self.platform)
             .unwrap();
         self
     }
@@ -537,7 +535,7 @@ mod tests {
 
     #[test]
     fn test_bash() {
-        let mut script = ShellScript::new(Bash);
+        let mut script = ShellScript::new(Bash, Platform::Linux64);
 
         script
             .set_env_var("FOO", "bar")
@@ -558,5 +556,16 @@ mod tests {
     fn test_from_env() {
         let shell = ShellEnum::from_env();
         println!("Detected shell: {:?}", shell);
+    }
+
+    #[test]
+    fn test_path_seperator() {
+        let mut script = ShellScript::new(Bash, Platform::Linux64);
+        script.set_path(&[PathBuf::from("/foo"), PathBuf::from("/bar")]);
+        assert!(script.contents.contains("/foo:/bar"));
+
+        let mut script = ShellScript::new(Bash, Platform::Win64);
+        script.set_path(&[PathBuf::from("/foo"), PathBuf::from("/bar")]);
+        assert!(script.contents.contains("/foo;/bar"));
     }
 }

--- a/crates/rattler_shell/src/shell/mod.rs
+++ b/crates/rattler_shell/src/shell/mod.rs
@@ -3,12 +3,12 @@
 use crate::activation::PathModificationBehaviour;
 use enum_dispatch::enum_dispatch;
 use itertools::Itertools;
+use rattler_conda_types::Platform;
 use std::process::Command;
 use std::{
     fmt::Write,
     path::{Path, PathBuf},
 };
-use rattler_conda_types::Platform;
 
 /// A trait for generating shell scripts.
 /// The trait is implemented for each shell individually.
@@ -82,7 +82,11 @@ pub trait Shell {
 
     /// Path seperator
     fn path_seperator(&self, platform: &Platform) -> &str {
-        if platform.is_unix() { ":" } else { ";" }
+        if platform.is_unix() {
+            ":"
+        } else {
+            ";"
+        }
     }
 
     /// Format the environment variable for the shell.
@@ -492,7 +496,7 @@ impl<T: Shell> ShellScript<T> {
         Self {
             shell,
             contents: String::new(),
-            platform
+            platform,
         }
     }
 
@@ -515,7 +519,12 @@ impl<T: Shell> ShellScript<T> {
     /// Set the PATH environment variable to the given paths.
     pub fn set_path(&mut self, paths: &[PathBuf]) -> &mut Self {
         self.shell
-            .set_path(&mut self.contents, paths, PathModificationBehaviour::Prepend, &self.platform)
+            .set_path(
+                &mut self.contents,
+                paths,
+                PathModificationBehaviour::Prepend,
+                &self.platform,
+            )
             .unwrap();
         self
     }

--- a/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_cmd_append.snap
+++ b/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_cmd_append.snap
@@ -2,6 +2,6 @@
 source: crates/rattler_shell/src/activation.rs
 expression: script
 ---
-@SET "PATH=%PATH%;__PREFIX__/bin;/usr/bin;/bin;/usr/sbin;/sbin;/usr/local/bin"
+@SET "PATH=%PATH%:__PREFIX__/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
 @SET "CONDA_PREFIX=__PREFIX__"
 

--- a/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_cmd_prepend.snap
+++ b/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_cmd_prepend.snap
@@ -2,6 +2,6 @@
 source: crates/rattler_shell/src/activation.rs
 expression: script
 ---
-@SET "PATH=__PREFIX__/bin;/usr/bin;/bin;/usr/sbin;/sbin;/usr/local/bin;%PATH%"
+@SET "PATH=__PREFIX__/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:%PATH%"
 @SET "CONDA_PREFIX=__PREFIX__"
 

--- a/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_cmd_replace.snap
+++ b/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_cmd_replace.snap
@@ -2,6 +2,6 @@
 source: crates/rattler_shell/src/activation.rs
 expression: script
 ---
-@SET "PATH=__PREFIX__/bin;/usr/bin;/bin;/usr/sbin;/sbin;/usr/local/bin"
+@SET "PATH=__PREFIX__/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
 @SET "CONDA_PREFIX=__PREFIX__"
 

--- a/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_powershell_append.snap
+++ b/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_powershell_append.snap
@@ -2,6 +2,6 @@
 source: crates/rattler_shell/src/activation.rs
 expression: script
 ---
-$Env:PATH = "$Env:PATH;__PREFIX__/bin;/usr/bin;/bin;/usr/sbin;/sbin;/usr/local/bin"
+$Env:PATH = "$Env:PATH:__PREFIX__/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
 $Env:CONDA_PREFIX = "__PREFIX__"
 

--- a/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_powershell_prepend.snap
+++ b/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_powershell_prepend.snap
@@ -2,6 +2,6 @@
 source: crates/rattler_shell/src/activation.rs
 expression: script
 ---
-$Env:PATH = "__PREFIX__/bin;/usr/bin;/bin;/usr/sbin;/sbin;/usr/local/bin;$Env:PATH"
+$Env:PATH = "__PREFIX__/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$Env:PATH"
 $Env:CONDA_PREFIX = "__PREFIX__"
 

--- a/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_powershell_replace.snap
+++ b/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__test_activation_script_powershell_replace.snap
@@ -2,6 +2,6 @@
 source: crates/rattler_shell/src/activation.rs
 expression: script
 ---
-$Env:PATH = "__PREFIX__/bin;/usr/bin;/bin;/usr/sbin;/sbin;/usr/local/bin"
+$Env:PATH = "__PREFIX__/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
 $Env:CONDA_PREFIX = "__PREFIX__"
 


### PR DESCRIPTION
Now a `#!/bin/sh` is added to the activation scripts and the path_seperator of the paths in the path variable are platform based. 
This change is needed for `pwsh` users on unix.