### PR TITLE
fix: issue #235

### DIFF
--- a/crates/rattler_conda_types/src/version_spec/constraint.rs
+++ b/crates/rattler_conda_types/src/version_spec/constraint.rs
@@ -76,7 +76,10 @@ impl FromStr for Constraint {
             if version_str.starts_with(char::is_whitespace) {
                 return Err(ParseConstraintError::OperatorFollowedByWhitespace);
             }
-            let (version_str, op) = if let Some(version_str) = version_str.strip_suffix(".*") {
+            let (version_str, op) = if let Some(version_str) = version_str
+                .strip_suffix(".*")
+                .or(version_str.strip_suffix('*'))
+            {
                 match op {
                     VersionOperator::StartsWith | VersionOperator::GreaterEquals => {
                         (version_str, op)

--- a/crates/rattler_conda_types/src/version_spec/constraint.rs
+++ b/crates/rattler_conda_types/src/version_spec/constraint.rs
@@ -84,6 +84,7 @@ impl FromStr for Constraint {
                     VersionOperator::StartsWith | VersionOperator::GreaterEquals => {
                         (version_str, op)
                     }
+                    VersionOperator::Greater => (version_str, VersionOperator::GreaterEquals),
                     VersionOperator::NotEquals => (version_str, VersionOperator::NotStartsWith),
                     op => {
                         // return Err(ParseConstraintError::GlobVersionIncompatibleWithOperator(

--- a/crates/rattler_conda_types/src/version_spec/constraint.rs
+++ b/crates/rattler_conda_types/src/version_spec/constraint.rs
@@ -260,7 +260,7 @@ mod test {
         assert_eq!(
             Constraint::from_str(">1.2.*"),
             Ok(Constraint::Comparison(
-                VersionOperator::Greater,
+                VersionOperator::GreaterEquals,
                 Version::from_str("1.2").unwrap()
             ))
         );

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -347,7 +347,7 @@ mod tests {
     fn issue_235() {
         assert_eq!(
             VersionSpec::from_str(">2.10*").unwrap(),
-            VersionSpec::from_str(">2.10").unwrap()
+            VersionSpec::from_str(">=2.10").unwrap()
         );
     }
 }

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -234,6 +234,7 @@ impl VersionSpec {
 mod tests {
     use crate::version_spec::{LogicalOperator, VersionOperator};
     use crate::{Version, VersionSpec};
+    use assert_matches::assert_matches;
     use std::str::FromStr;
 
     #[test]
@@ -341,5 +342,10 @@ mod tests {
         assert!(spec.matches(&Version::from_str("2.4").unwrap()));
         assert!(spec.matches(&Version::from_str("2.5").unwrap()));
         assert!(!spec.matches(&Version::from_str("2.1").unwrap()));
+    }
+
+    #[test]
+    fn issue_235() {
+        assert_matches!(VersionSpec::from_str(">2.10*"), Ok(_));
     }
 }

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -234,7 +234,6 @@ impl VersionSpec {
 mod tests {
     use crate::version_spec::{LogicalOperator, VersionOperator};
     use crate::{Version, VersionSpec};
-    use assert_matches::assert_matches;
     use std::str::FromStr;
 
     #[test]
@@ -346,6 +345,9 @@ mod tests {
 
     #[test]
     fn issue_235() {
-        assert_matches!(VersionSpec::from_str(">2.10*"), Ok(_));
+        assert_eq!(
+            VersionSpec::from_str(">2.10*").unwrap(),
+            VersionSpec::from_str(">2.10").unwrap()
+        );
     }
 }


### PR DESCRIPTION
Fix #235 

The matchspec `>2.10*` doesnt make any sense and its actually a bug introduced during build if someone uses `=>2.10` instead of `>=2.10`.

Rattler previously already sorta ignored this case but the check didn include a version just ending in `*`. It does now.