### PR TITLE
Add support for sha256 and md5 field in matchspec

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -207,13 +207,21 @@ impl MatchSpec {
         }
 
         if let Some(md5_spec) = self.md5.as_ref() {
-            if !record.md5.as_ref().map_or(false, |md5_record| md5_spec == md5_record) {
+            if !record
+                .md5
+                .as_ref()
+                .map_or(false, |md5_record| md5_spec == md5_record)
+            {
                 return false;
             }
         }
 
         if let Some(sha256_spec) = self.sha256.as_ref() {
-            if !record.sha256.as_ref().map_or(false, |sha256_record| sha256_spec == sha256_record) {
+            if !record
+                .sha256
+                .as_ref()
+                .map_or(false, |sha256_record| sha256_spec == sha256_record)
+            {
                 return false;
             }
         }
@@ -266,13 +274,21 @@ impl NamelessMatchSpec {
         }
 
         if let Some(md5_spec) = self.md5.as_ref() {
-            if !record.md5.as_ref().map_or(false, |md5_record| md5_spec == md5_record) {
+            if !record
+                .md5
+                .as_ref()
+                .map_or(false, |md5_record| md5_spec == md5_record)
+            {
                 return false;
             }
         }
 
         if let Some(sha256_spec) = self.sha256.as_ref() {
-            if !record.sha256.as_ref().map_or(false, |sha256_record| sha256_spec == sha256_record) {
+            if !record
+                .sha256
+                .as_ref()
+                .map_or(false, |sha256_record| sha256_spec == sha256_record)
+            {
                 return false;
             }
         }
@@ -349,47 +365,40 @@ impl MatchSpec {
 mod tests {
     use std::str::FromStr;
 
-    use crate::{
-        package::{IndexJson, PackageFile},
-        MatchSpec, PackageRecord,
-    };
+    use rattler_digest::{parse_digest_from_hex, Md5, Sha256};
+
+    use crate::{MatchSpec, PackageRecord, Version};
 
     #[test]
     fn test_digest_match() {
-        let package_dir = tempfile::tempdir().unwrap();
-        let extract_result = rattler_package_streaming::fs::extract(
-            &crate::get_test_data_dir().join("mamba-1.0.0-py38hecfeebb_2.tar.bz2"),
-            package_dir.path(),
-        )
-        .unwrap();
-
-        let index = IndexJson::from_package_directory(package_dir.path()).unwrap();
-        let package_record = PackageRecord::from_index_json(
-            index,
-            None,
-            Some(extract_result.sha256),
-            Some(extract_result.md5),
-        )
-        .unwrap();
+        let record = PackageRecord {
+            name: "mamba".to_string(),
+            version: Version::from_str("1.0").unwrap(),
+            sha256: parse_digest_from_hex::<Sha256>(
+                "f44c4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97",
+            ),
+            md5: parse_digest_from_hex::<Md5>("dede6252c964db3f3e41c7d30d07f6bf"),
+            ..PackageRecord::default()
+        };
 
         let spec = MatchSpec::from_str("mamba[version==1.0, sha256=aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97]").unwrap();
-        assert!(!spec.matches(&package_record));
+        assert!(!spec.matches(&record));
 
         let spec = MatchSpec::from_str("mamba[version==1.0, sha256=f44c4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97]").unwrap();
-        assert!(spec.matches(&package_record));
+        assert!(spec.matches(&record));
 
         let spec = MatchSpec::from_str("mamba[version==1.0, md5=aaaa6252c964db3f3e41c7d30d07f6bf]")
             .unwrap();
-        assert!(!spec.matches(&package_record));
+        assert!(!spec.matches(&record));
 
         let spec = MatchSpec::from_str("mamba[version==1.0, md5=dede6252c964db3f3e41c7d30d07f6bf]")
             .unwrap();
-        assert!(spec.matches(&package_record));
+        assert!(spec.matches(&record));
 
         let spec = MatchSpec::from_str("mamba[version==1.0, md5=dede6252c964db3f3e41c7d30d07f6bf, sha256=f44c4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97]").unwrap();
-        assert!(spec.matches(&package_record));
+        assert!(spec.matches(&record));
 
         let spec = MatchSpec::from_str("mamba[version==1.0, md5=dede6252c964db3f3e41c7d30d07f6bf, sha256=aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97]").unwrap();
-        assert!(!spec.matches(&package_record));
+        assert!(!spec.matches(&record));
     }
 }

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -167,12 +167,18 @@ impl Display for MatchSpec {
             write!(f, " {}", build)?;
         }
 
+        let mut keys = Vec::new();
+
         if let Some(md5) = &self.md5 {
-            write!(f, " md5={md5:x}")?;
+            keys.push(format!("md5={md5:x}"));
         }
 
         if let Some(sha256) = &self.sha256 {
-            write!(f, " sha256={sha256:x}")?;
+            keys.push(format!("sha256={sha256:x}"));
+        }
+
+        if !keys.is_empty() {
+            write!(f, "[{}]", keys.join(", "))?;
         }
 
         Ok(())
@@ -201,18 +207,14 @@ impl MatchSpec {
         }
 
         if let Some(md5_spec) = self.md5.as_ref() {
-            if let Some(md5_record) = record.md5.as_ref() {
-                if md5_spec != md5_record {
-                    return false;
-                }
+            if !record.md5.as_ref().map_or(false, |md5_record| md5_spec == md5_record) {
+                return false;
             }
         }
 
         if let Some(sha256_spec) = self.sha256.as_ref() {
-            if let Some(sha256_record) = record.sha256.as_ref() {
-                if sha256_spec != sha256_record {
-                    return false;
-                }
+            if !record.sha256.as_ref().map_or(false, |sha256_record| sha256_spec == sha256_record) {
+                return false;
             }
         }
 
@@ -264,18 +266,14 @@ impl NamelessMatchSpec {
         }
 
         if let Some(md5_spec) = self.md5.as_ref() {
-            if let Some(md5_record) = record.md5.as_ref() {
-                if md5_spec != md5_record {
-                    return false;
-                }
+            if !record.md5.as_ref().map_or(false, |md5_record| md5_spec == md5_record) {
+                return false;
             }
         }
 
         if let Some(sha256_spec) = self.sha256.as_ref() {
-            if let Some(sha256_record) = record.sha256.as_ref() {
-                if sha256_spec != sha256_record {
-                    return false;
-                }
+            if !record.sha256.as_ref().map_or(false, |sha256_record| sha256_spec == sha256_record) {
+                return false;
             }
         }
 
@@ -295,15 +293,19 @@ impl Display for NamelessMatchSpec {
             write!(f, " {}", build)?;
         }
 
+        let mut keys = Vec::new();
+
         if let Some(md5) = &self.md5 {
-            write!(f, " md5={md5:x}")?;
+            keys.push(format!("md5={md5:x}"));
         }
 
         if let Some(sha256) = &self.sha256 {
-            write!(f, " sha256={sha256:x}")?;
+            keys.push(format!("sha256={sha256:x}"));
         }
 
-        // TODO: Add any additional properties as bracket arguments (e.g. `[channel=..]`)
+        if !keys.is_empty() {
+            write!(f, "[{}]", keys.join(", "))?;
+        }
 
         Ok(())
     }

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -367,7 +367,25 @@ mod tests {
 
     use rattler_digest::{parse_digest_from_hex, Md5, Sha256};
 
-    use crate::{MatchSpec, PackageRecord, Version};
+    use crate::{MatchSpec, NamelessMatchSpec, PackageRecord, Version};
+
+    #[test]
+    fn test_matchspec_format_eq() {
+        let spec = MatchSpec::from_str("mamba[version==1.0, sha256=aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97, md5=dede6252c964db3f3e41c7d30d07f6bf]").unwrap();
+        let spec_as_string = spec.to_string();
+        let rebuild_spec = MatchSpec::from_str(&spec_as_string).unwrap();
+
+        assert_eq!(spec, rebuild_spec)
+    }
+
+    #[test]
+    fn test_nameless_matchspec_format_eq() {
+        let spec = NamelessMatchSpec::from_str("*[version==1.0, sha256=aaac4bc9c6916ecc0e33137431645b029ade22190c7144eead61446dcbcc6f97, md5=dede6252c964db3f3e41c7d30d07f6bf]").unwrap();
+        let spec_as_string = spec.to_string();
+        let rebuild_spec = NamelessMatchSpec::from_str(&spec_as_string).unwrap();
+
+        assert_eq!(spec, rebuild_spec)
+    }
 
     #[test]
     fn test_digest_match() {

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -1,6 +1,7 @@
 use crate::{PackageRecord, VersionSpec};
+use rattler_digest::{serde::SerializableHash, Md5Hash, Sha256Hash};
 use serde::Serialize;
-use serde_with::skip_serializing_none;
+use serde_with::{serde_as, skip_serializing_none};
 use std::fmt::{Debug, Display, Formatter};
 
 pub mod matcher;
@@ -109,6 +110,7 @@ use matcher::StringMatcher;
 ///
 /// Alternatively, an exact spec is given by `*[sha256=01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b]`.
 #[skip_serializing_none]
+#[serde_as]
 #[derive(Debug, Default, Clone, Serialize, Eq, PartialEq)]
 pub struct MatchSpec {
     /// The name of the package
@@ -127,6 +129,12 @@ pub struct MatchSpec {
     pub subdir: Option<String>,
     /// The namespace of the package (currently not used)
     pub namespace: Option<String>,
+    /// The md5 hash of the package
+    #[serde_as(as = "Option<SerializableHash::<rattler_digest::Md5>>")]
+    pub md5: Option<Md5Hash>,
+    /// The sha256 hash of the package
+    #[serde_as(as = "Option<SerializableHash::<rattler_digest::Sha256>>")]
+    pub sha256: Option<Sha256Hash>,
 }
 
 impl Display for MatchSpec {
@@ -146,19 +154,26 @@ impl Display for MatchSpec {
             write!(f, "::")?;
         }
 
-        match &self.name {
-            Some(name) => write!(f, "{name}")?,
-            None => write!(f, "*")?,
+        if let Some(name) = &self.name {
+            write!(f, "{}", name)?;
+        } else {
+            write!(f, "*")?;
         }
 
-        match &self.version {
-            Some(version) => write!(f, " {version}")?,
-            None => (),
+        if let Some(version) = &self.version {
+            write!(f, " {}", version)?;
         }
 
-        match &self.build {
-            Some(build) => write!(f, " {build}")?,
-            None => (),
+        if let Some(build) = &self.build {
+            write!(f, " {}", build)?;
+        }
+
+        if let Some(md5) = &self.md5 {
+            write!(f, " md5={md5:x}")?;
+        }
+
+        if let Some(sha256) = &self.sha256 {
+            write!(f, " sha256={sha256:x}")?;
         }
 
         Ok(())
@@ -186,12 +201,29 @@ impl MatchSpec {
             }
         }
 
+        if let Some(md5_spec) = self.md5.as_ref() {
+            if let Some(md5_record) = record.md5.as_ref() {
+                if md5_spec != md5_record {
+                    return false;
+                }
+            }
+        }
+
+        if let Some(sha256_spec) = self.sha256.as_ref() {
+            if let Some(sha256_record) = record.sha256.as_ref() {
+                if sha256_spec != sha256_record {
+                    return false;
+                }
+            }
+        }
+
         true
     }
 }
 
 /// Similar to a [`MatchSpec`] but does not include the package name. This is useful in places
 /// where the package name is already known (e.g. `foo = "3.4.1 *cuda"`)
+#[serde_as]
 #[skip_serializing_none]
 #[derive(Debug, Default, Clone, Serialize, Eq, PartialEq)]
 pub struct NamelessMatchSpec {
@@ -209,6 +241,12 @@ pub struct NamelessMatchSpec {
     pub subdir: Option<String>,
     /// The namespace of the package (currently not used)
     pub namespace: Option<String>,
+    /// The md5 hash of the package
+    #[serde_as(as = "Option<SerializableHash::<rattler_digest::Md5>>")]
+    pub md5: Option<Md5Hash>,
+    /// The sha256 hash of the package
+    #[serde_as(as = "Option<SerializableHash::<rattler_digest::Sha256>>")]
+    pub sha256: Option<Sha256Hash>,
 }
 
 impl NamelessMatchSpec {
@@ -226,20 +264,44 @@ impl NamelessMatchSpec {
             }
         }
 
+        if let Some(md5_spec) = self.md5.as_ref() {
+            if let Some(md5_record) = record.md5.as_ref() {
+                if md5_spec != md5_record {
+                    return false;
+                }
+            }
+        }
+
+        if let Some(sha256_spec) = self.sha256.as_ref() {
+            if let Some(sha256_record) = record.sha256.as_ref() {
+                if sha256_spec != sha256_record {
+                    return false;
+                }
+            }
+        }
+
         true
     }
 }
 
 impl Display for NamelessMatchSpec {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match &self.version {
-            Some(version) => write!(f, "{version}")?,
-            None => write!(f, "*")?,
+        if let Some(version) = self.version.as_ref() {
+            write!(f, "{version}")?;
+        } else {
+            write!(f, "*")?;
         }
 
-        match &self.build {
-            Some(build) => write!(f, " {build}")?,
-            None => (),
+        if let Some(build) = &self.build {
+            write!(f, " {}", build)?;
+        }
+
+        if let Some(md5) = &self.md5 {
+            write!(f, " md5={md5:x}")?;
+        }
+
+        if let Some(sha256) = &self.sha256 {
+            write!(f, " sha256={sha256:x}")?;
         }
 
         // TODO: Add any additional properties as bracket arguments (e.g. `[channel=..]`)
@@ -258,6 +320,8 @@ impl From<MatchSpec> for NamelessMatchSpec {
             channel: spec.channel,
             subdir: spec.subdir,
             namespace: spec.namespace,
+            md5: spec.md5,
+            sha256: spec.sha256,
         }
     }
 }
@@ -274,6 +338,8 @@ impl MatchSpec {
             channel: spec.channel,
             subdir: spec.subdir,
             namespace: spec.namespace,
+            md5: spec.md5,
+            sha256: spec.sha256,
         }
     }
 }

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -207,21 +207,13 @@ impl MatchSpec {
         }
 
         if let Some(md5_spec) = self.md5.as_ref() {
-            if !record
-                .md5
-                .as_ref()
-                .map_or(false, |md5_record| md5_spec == md5_record)
-            {
+            if Some(md5_spec) != record.md5.as_ref() {
                 return false;
             }
         }
 
         if let Some(sha256_spec) = self.sha256.as_ref() {
-            if !record
-                .sha256
-                .as_ref()
-                .map_or(false, |sha256_record| sha256_spec == sha256_record)
-            {
+            if Some(sha256_spec) != record.sha256.as_ref() {
                 return false;
             }
         }
@@ -274,21 +266,13 @@ impl NamelessMatchSpec {
         }
 
         if let Some(md5_spec) = self.md5.as_ref() {
-            if !record
-                .md5
-                .as_ref()
-                .map_or(false, |md5_record| md5_spec == md5_record)
-            {
+            if Some(md5_spec) != record.md5.as_ref() {
                 return false;
             }
         }
 
         if let Some(sha256_spec) = self.sha256.as_ref() {
-            if !record
-                .sha256
-                .as_ref()
-                .map_or(false, |sha256_record| sha256_spec == sha256_record)
-            {
+            if Some(sha256_spec) != record.sha256.as_ref() {
                 return false;
             }
         }

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -148,16 +148,15 @@ impl Display for MatchSpec {
             write!(f, "/{}", subdir)?;
         }
 
+        match &self.name {
+            Some(name) => write!(f, "{name}")?,
+            None => write!(f, "*")?,
+        }
+
         if let Some(namespace) = &self.namespace {
             write!(f, ":{}:", namespace)?;
         } else if self.channel.is_some() || self.subdir.is_some() {
             write!(f, "::")?;
-        }
-
-        if let Some(name) = &self.name {
-            write!(f, "{}", name)?;
-        } else {
-            write!(f, "*")?;
         }
 
         if let Some(version) = &self.version {

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -283,10 +283,9 @@ impl NamelessMatchSpec {
 
 impl Display for NamelessMatchSpec {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        if let Some(version) = self.version.as_ref() {
-            write!(f, "{version}")?;
-        } else {
-            write!(f, "*")?;
+        match &self.version {
+            Some(version) => write!(f, "{version}")?,
+            None => write!(f, "*")?,
         }
 
         if let Some(build) = &self.build {

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -441,7 +441,7 @@ fn parse(input: &str) -> Result<MatchSpec, ParseMatchSpecError> {
 
 #[cfg(test)]
 mod tests {
-    use rattler_digest::{parse_digest_from_hex, Sha256, Md5};
+    use rattler_digest::{parse_digest_from_hex, Md5, Sha256};
     use serde::Serialize;
     use std::collections::BTreeMap;
     use std::str::FromStr;
@@ -577,15 +577,11 @@ mod tests {
             )
         );
 
-        let spec = MatchSpec::from_str("conda-forge::foo[md5=8b1a9953c4611296a827abf8c47804d7]").unwrap();
+        let spec =
+            MatchSpec::from_str("conda-forge::foo[md5=8b1a9953c4611296a827abf8c47804d7]").unwrap();
         assert_eq!(
             spec.md5,
-            Some(
-                parse_digest_from_hex::<Md5>(
-                    "8b1a9953c4611296a827abf8c47804d7"
-                )
-                .unwrap()
-            )
+            Some(parse_digest_from_hex::<Md5>("8b1a9953c4611296a827abf8c47804d7").unwrap())
         );
     }
 

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -62,7 +62,7 @@ pub struct ChannelInfo {
 #[serde_as]
 #[skip_serializing_none]
 #[sorted]
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd, Clone, Hash)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd, Clone, Hash, Default)]
 pub struct PackageRecord {
     /// Optionally the architecture the package supports
     pub arch: Option<String>,

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -128,7 +128,7 @@ const LOCAL_VERSION_OFFSET: u8 = 1;
 /// this problem by appending an underscore to plain version numbers:
 ///
 /// 1.0.1_ < 1.0.1a =>  True   # ensure correct ordering for openssl
-#[derive(Clone, Eq, Deserialize)]
+#[derive(Clone, Eq, Deserialize, Default)]
 pub struct Version {
     /// A normed copy of the original version string trimmed and converted to lower case.
     /// Also dashes are replaced with underscores if the version string does not contain


### PR DESCRIPTION
Closes #207

Currently, `MatchSpec` and `NamelessMatchSpec` share a considerable amount of logic and fields, with the former essentially being the latter plus a name field.

A future PR should look into merging these two classes to reduce redundancy, streamline the codebase and improve maintainability.