### PR TITLE
perf: dont parse matchspec in inner loop

### DIFF
--- a/crates/libsolv_rs/src/pool.rs
+++ b/crates/libsolv_rs/src/pool.rs
@@ -147,7 +147,8 @@ impl<'a> Pool<'a> {
 
         pkgs.sort_by(|&p1, &p2| {
             conda_util::compare_candidates(
-                p1,p2,
+                p1,
+                p2,
                 &self.solvables,
                 &self.names_to_ids,
                 &self.packages_by_name,

--- a/crates/libsolv_rs/src/pool.rs
+++ b/crates/libsolv_rs/src/pool.rs
@@ -147,11 +147,11 @@ impl<'a> Pool<'a> {
 
         pkgs.sort_by(|&p1, &p2| {
             conda_util::compare_candidates(
+                p1,p2,
                 &self.solvables,
                 &self.names_to_ids,
                 &self.packages_by_name,
-                self.solvables[p1].package().record,
-                self.solvables[p2].package().record,
+                &self.match_specs,
             )
         });
 


### PR DESCRIPTION
Reuse the previously parsed MatchSpec to eliminate re-parsing in an inner loop.


|                                    | libsolv | libsolv-rs | diff         |
|------------------------------------|---------|------------|--------------|
| python=3.9                         | 13.19ms | **8.22ms**    | -4.97ms (35%) |
| tensorboard=2.1.1, grpc-cpp=1.39.1 | 1.56s   | **1.24s**      | -0.31s (20%)  |