### PR TITLE
perf: cache candidates seperate from their sorting

### DIFF
--- a/crates/libsolv_rs/Cargo.toml
+++ b/crates/libsolv_rs/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
+ahash = "0.8.3"
 itertools = "0.11.0"
 petgraph = "0.6.3"
 rattler_conda_types = { version = "0.5.0", path = "../rattler_conda_types" }

--- a/crates/libsolv_rs/Cargo.toml
+++ b/crates/libsolv_rs/Cargo.toml
@@ -11,7 +11,6 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-ahash = "0.8.3"
 itertools = "0.11.0"
 petgraph = "0.6.3"
 rattler_conda_types = { version = "0.5.0", path = "../rattler_conda_types" }

--- a/crates/libsolv_rs/src/conda_util.rs
+++ b/crates/libsolv_rs/src/conda_util.rs
@@ -3,7 +3,6 @@ use crate::id::{NameId, SolvableId};
 use crate::mapping::Mapping;
 use crate::solvable::Solvable;
 use crate::MatchSpecId;
-use ahash::AHashMap;
 use rattler_conda_types::{MatchSpec, Version};
 use std::cell::OnceCell;
 use std::cmp::Ordering;
@@ -15,7 +14,7 @@ pub(crate) fn compare_candidates(
     a: SolvableId,
     b: SolvableId,
     solvables: &Arena<SolvableId, Solvable>,
-    interned_strings: &AHashMap<String, NameId>,
+    interned_strings: &HashMap<String, NameId>,
     packages_by_name: &Mapping<NameId, Vec<SolvableId>>,
     match_specs: &Arena<MatchSpecId, MatchSpec>,
     match_spec_to_candidates: &Mapping<MatchSpecId, OnceCell<Vec<SolvableId>>>,
@@ -141,7 +140,7 @@ pub(crate) fn compare_candidates(
 pub(crate) fn find_highest_version(
     match_spec_id: MatchSpecId,
     solvables: &Arena<SolvableId, Solvable>,
-    interned_strings: &AHashMap<String, NameId>,
+    interned_strings: &HashMap<String, NameId>,
     packages_by_name: &Mapping<NameId, Vec<SolvableId>>,
     match_specs: &Arena<MatchSpecId, MatchSpec>,
     match_spec_to_candidates: &Mapping<MatchSpecId, OnceCell<Vec<SolvableId>>>,
@@ -185,7 +184,7 @@ pub(crate) fn find_highest_version(
 pub(crate) fn find_candidates<'b>(
     match_spec_id: MatchSpecId,
     match_specs: &Arena<MatchSpecId, MatchSpec>,
-    names_to_ids: &AHashMap<String, NameId>,
+    names_to_ids: &HashMap<String, NameId>,
     packages_by_name: &Mapping<NameId, Vec<SolvableId>>,
     solvables: &Arena<SolvableId, Solvable>,
     match_spec_to_candidates: &'b Mapping<MatchSpecId, OnceCell<Vec<SolvableId>>>,

--- a/crates/libsolv_rs/src/conda_util.rs
+++ b/crates/libsolv_rs/src/conda_util.rs
@@ -7,6 +7,7 @@ use rattler_conda_types::{MatchSpec, Version};
 use std::cell::OnceCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use ahash::AHashMap;
 
 /// Returns the order of two candidates based on the order used by conda.
 #[allow(clippy::too_many_arguments)]
@@ -14,7 +15,7 @@ pub(crate) fn compare_candidates(
     a: SolvableId,
     b: SolvableId,
     solvables: &Arena<SolvableId, Solvable>,
-    interned_strings: &HashMap<String, NameId>,
+    interned_strings: &AHashMap<String, NameId>,
     packages_by_name: &Mapping<NameId, Vec<SolvableId>>,
     match_specs: &Arena<MatchSpecId, MatchSpec>,
     match_spec_to_candidates: &Mapping<MatchSpecId, OnceCell<Vec<SolvableId>>>,
@@ -140,7 +141,7 @@ pub(crate) fn compare_candidates(
 pub(crate) fn find_highest_version(
     match_spec_id: MatchSpecId,
     solvables: &Arena<SolvableId, Solvable>,
-    interned_strings: &HashMap<String, NameId>,
+    interned_strings: &AHashMap<String, NameId>,
     packages_by_name: &Mapping<NameId, Vec<SolvableId>>,
     match_specs: &Arena<MatchSpecId, MatchSpec>,
     match_spec_to_candidates: &Mapping<MatchSpecId, OnceCell<Vec<SolvableId>>>,
@@ -184,7 +185,7 @@ pub(crate) fn find_highest_version(
 pub(crate) fn find_candidates<'b>(
     match_spec_id: MatchSpecId,
     match_specs: &Arena<MatchSpecId, MatchSpec>,
-    names_to_ids: &HashMap<String, NameId>,
+    names_to_ids: &AHashMap<String, NameId>,
     packages_by_name: &Mapping<NameId, Vec<SolvableId>>,
     solvables: &Arena<SolvableId, Solvable>,
     match_spec_to_candidates: &'b Mapping<MatchSpecId, OnceCell<Vec<SolvableId>>>,

--- a/crates/libsolv_rs/src/conda_util.rs
+++ b/crates/libsolv_rs/src/conda_util.rs
@@ -4,7 +4,7 @@ use crate::mapping::Mapping;
 use crate::solvable::Solvable;
 use crate::MatchSpecId;
 use rattler_conda_types::{MatchSpec, Version};
-use std::cell::{OnceCell};
+use std::cell::OnceCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 

--- a/crates/libsolv_rs/src/conda_util.rs
+++ b/crates/libsolv_rs/src/conda_util.rs
@@ -9,6 +9,7 @@ use std::cmp::Ordering;
 use std::collections::HashMap;
 
 /// Returns the order of two candidates based on the order used by conda.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn compare_candidates(
     a: SolvableId,
     b: SolvableId,
@@ -17,6 +18,7 @@ pub(crate) fn compare_candidates(
     packages_by_name: &Mapping<NameId, Vec<SolvableId>>,
     match_specs: &Arena<MatchSpecId, MatchSpec>,
     match_spec_to_candidates: &Mapping<MatchSpecId, OnceCell<Vec<SolvableId>>>,
+    match_spec_highest_version: &Mapping<MatchSpecId, OnceCell<Option<(Version, bool)>>>,
 ) -> Ordering {
     let a_solvable = solvables[a].package();
     let b_solvable = solvables[b].package();
@@ -81,6 +83,7 @@ pub(crate) fn compare_candidates(
                 packages_by_name,
                 match_specs,
                 match_spec_to_candidates,
+                match_spec_highest_version,
             );
             let highest_b = find_highest_version(
                 *b_spec_id,
@@ -89,6 +92,7 @@ pub(crate) fn compare_candidates(
                 packages_by_name,
                 match_specs,
                 match_spec_to_candidates,
+                match_spec_highest_version,
             );
 
             // Skip version if no package is selected by either spec
@@ -140,43 +144,49 @@ pub(crate) fn find_highest_version(
     packages_by_name: &Mapping<NameId, Vec<SolvableId>>,
     match_specs: &Arena<MatchSpecId, MatchSpec>,
     match_spec_to_candidates: &Mapping<MatchSpecId, OnceCell<Vec<SolvableId>>>,
+    match_spec_highest_version: &Mapping<MatchSpecId, OnceCell<Option<(Version, bool)>>>,
 ) -> Option<(Version, bool)> {
-    let candidates = find_candidates(
-        match_spec_id,
-        match_specs,
-        interned_strings,
-        packages_by_name,
-        solvables,
-        match_spec_to_candidates,
-    );
+    match_spec_highest_version[match_spec_id]
+        .get_or_init(|| {
+            let candidates = find_candidates(
+                match_spec_id,
+                match_specs,
+                interned_strings,
+                packages_by_name,
+                solvables,
+                match_spec_to_candidates,
+            );
 
-    candidates
-        .iter()
-        .map(|id| &solvables[*id].package().record)
-        .fold(None, |init, record| {
-            Some(init.map_or_else(
-                || {
-                    (
-                        record.version.version().clone(),
-                        !record.track_features.is_empty(),
-                    )
-                },
-                |(version, has_tracked_features)| {
-                    (
-                        version.max(record.version.version().clone()),
-                        has_tracked_features && record.track_features.is_empty(),
-                    )
-                },
-            ))
+            candidates
+                .iter()
+                .map(|id| &solvables[*id].package().record)
+                .fold(None, |init, record| {
+                    Some(init.map_or_else(
+                        || {
+                            (
+                                record.version.version().clone(),
+                                !record.track_features.is_empty(),
+                            )
+                        },
+                        |(version, has_tracked_features)| {
+                            (
+                                version.max(record.version.version().clone()),
+                                has_tracked_features && record.track_features.is_empty(),
+                            )
+                        },
+                    ))
+                })
         })
+        .as_ref()
+        .map(|(version, has_tracked_features)| (version.clone(), *has_tracked_features))
 }
 
-pub(crate) fn find_candidates<'a, 'b>(
+pub(crate) fn find_candidates<'b>(
     match_spec_id: MatchSpecId,
     match_specs: &Arena<MatchSpecId, MatchSpec>,
     names_to_ids: &HashMap<String, NameId>,
     packages_by_name: &Mapping<NameId, Vec<SolvableId>>,
-    solvables: &Arena<SolvableId, Solvable<'a>>,
+    solvables: &Arena<SolvableId, Solvable>,
     match_spec_to_candidates: &'b Mapping<MatchSpecId, OnceCell<Vec<SolvableId>>>,
 ) -> &'b Vec<SolvableId> {
     match_spec_to_candidates[match_spec_id].get_or_init(|| {

--- a/crates/libsolv_rs/src/conda_util.rs
+++ b/crates/libsolv_rs/src/conda_util.rs
@@ -3,11 +3,11 @@ use crate::id::{NameId, SolvableId};
 use crate::mapping::Mapping;
 use crate::solvable::Solvable;
 use crate::MatchSpecId;
+use ahash::AHashMap;
 use rattler_conda_types::{MatchSpec, Version};
 use std::cell::OnceCell;
 use std::cmp::Ordering;
 use std::collections::HashMap;
-use ahash::AHashMap;
 
 /// Returns the order of two candidates based on the order used by conda.
 #[allow(clippy::too_many_arguments)]

--- a/crates/libsolv_rs/src/id.rs
+++ b/crates/libsolv_rs/src/id.rs
@@ -74,6 +74,12 @@ impl ArenaId for SolvableId {
     }
 }
 
+impl From<SolvableId> for u32 {
+    fn from(value: SolvableId) -> Self {
+        value.0
+    }
+}
+
 #[repr(transparent)]
 #[derive(Copy, Clone, PartialOrd, Ord, Eq, PartialEq, Debug, Hash)]
 pub(crate) struct ClauseId(u32);

--- a/crates/libsolv_rs/src/pool.rs
+++ b/crates/libsolv_rs/src/pool.rs
@@ -1,10 +1,10 @@
-use std::cell::{OnceCell};
 use crate::arena::Arena;
 use crate::conda_util;
 use crate::id::{MatchSpecId, NameId, RepoId, SolvableId};
 use crate::mapping::Mapping;
 use crate::solvable::{PackageSolvable, Solvable};
 use rattler_conda_types::{MatchSpec, PackageRecord};
+use std::cell::OnceCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::str::FromStr;

--- a/crates/libsolv_rs/src/pool.rs
+++ b/crates/libsolv_rs/src/pool.rs
@@ -3,13 +3,13 @@ use crate::conda_util;
 use crate::id::{MatchSpecId, NameId, RepoId, SolvableId};
 use crate::mapping::Mapping;
 use crate::solvable::{PackageSolvable, Solvable};
+use ahash::AHashMap;
 use rattler_conda_types::{MatchSpec, PackageRecord, Version};
 use std::cell::OnceCell;
 use std::cmp::Ordering;
 use std::collections::hash_map::Entry;
-use std::collections::{HashMap};
+use std::collections::HashMap;
 use std::str::FromStr;
-use ahash::AHashMap;
 
 /// A pool that stores data related to the available packages
 ///

--- a/crates/libsolv_rs/src/pool.rs
+++ b/crates/libsolv_rs/src/pool.rs
@@ -3,7 +3,6 @@ use crate::conda_util;
 use crate::id::{MatchSpecId, NameId, RepoId, SolvableId};
 use crate::mapping::Mapping;
 use crate::solvable::{PackageSolvable, Solvable};
-use ahash::AHashMap;
 use rattler_conda_types::{MatchSpec, PackageRecord, Version};
 use std::cell::OnceCell;
 use std::cmp::Ordering;
@@ -26,7 +25,7 @@ pub struct Pool<'a> {
     package_names: Arena<NameId, String>,
 
     /// Map from package names to the id of their interned counterpart
-    pub(crate) names_to_ids: AHashMap<String, NameId>,
+    pub(crate) names_to_ids: HashMap<String, NameId>,
 
     /// Map from interned package names to the solvables that have that name
     pub(crate) packages_by_name: Mapping<NameId, Vec<SolvableId>>,
@@ -35,7 +34,7 @@ pub struct Pool<'a> {
     pub(crate) match_specs: Arena<MatchSpecId, MatchSpec>,
 
     /// Map from match spec strings to the id of their interned counterpart
-    match_specs_to_ids: AHashMap<String, MatchSpecId>,
+    match_specs_to_ids: HashMap<String, MatchSpecId>,
 
     /// Cached candidates for each match spec
     pub(crate) match_spec_to_sorted_candidates: Mapping<MatchSpecId, Vec<SolvableId>>,
@@ -133,7 +132,7 @@ impl<'a> Pool<'a> {
         match_spec_to_sorted_candidates: &mut Mapping<MatchSpecId, Vec<SolvableId>>,
         match_spec_to_candidates: &Mapping<MatchSpecId, OnceCell<Vec<SolvableId>>>,
         match_spec_highest_version: &Mapping<MatchSpecId, OnceCell<Option<(Version, bool)>>>,
-        solvable_order: &mut AHashMap<u64, Ordering>,
+        solvable_order: &mut HashMap<u64, Ordering>,
     ) {
         let match_spec = &self.match_specs[match_spec_id];
         let match_spec_name = match_spec

--- a/crates/libsolv_rs/src/pool.rs
+++ b/crates/libsolv_rs/src/pool.rs
@@ -3,7 +3,7 @@ use crate::conda_util;
 use crate::id::{MatchSpecId, NameId, RepoId, SolvableId};
 use crate::mapping::Mapping;
 use crate::solvable::{PackageSolvable, Solvable};
-use rattler_conda_types::{MatchSpec, PackageRecord};
+use rattler_conda_types::{MatchSpec, PackageRecord, Version};
 use std::cell::OnceCell;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -130,6 +130,7 @@ impl<'a> Pool<'a> {
         favored_map: &HashMap<NameId, SolvableId>,
         match_spec_to_sorted_candidates: &mut Mapping<MatchSpecId, Vec<SolvableId>>,
         match_spec_to_candidates: &Mapping<MatchSpecId, OnceCell<Vec<SolvableId>>>,
+        match_spec_highest_version: &Mapping<MatchSpecId, OnceCell<Option<(Version, bool)>>>,
     ) {
         let match_spec = &self.match_specs[match_spec_id];
         let match_spec_name = match_spec
@@ -160,6 +161,7 @@ impl<'a> Pool<'a> {
                 &self.packages_by_name,
                 &self.match_specs,
                 match_spec_to_candidates,
+                match_spec_highest_version,
             )
         });
 

--- a/crates/libsolv_rs/src/problem.rs
+++ b/crates/libsolv_rs/src/problem.rs
@@ -52,7 +52,7 @@ impl Problem {
                 Clause::Requires(package_id, match_spec_id) => {
                     let package_node = Self::add_node(&mut graph, &mut nodes, package_id);
 
-                    let candidates = &solver.pool().match_spec_to_candidates[match_spec_id];
+                    let candidates = &solver.pool().match_spec_to_sorted_candidates[match_spec_id];
                     if candidates.is_empty() {
                         tracing::info!(
                             "{package_id:?} requires {match_spec_id:?}, which has no candidates"

--- a/crates/libsolv_rs/src/solver/clause.rs
+++ b/crates/libsolv_rs/src/solver/clause.rs
@@ -230,6 +230,7 @@ impl ClauseState {
         }
     }
 
+    #[inline]
     pub fn next_watched_clause(&self, solvable_id: SolvableId) -> ClauseId {
         if solvable_id == self.watched_literals[0] {
             self.next_watches[0]

--- a/crates/libsolv_rs/src/solver/clause.rs
+++ b/crates/libsolv_rs/src/solver/clause.rs
@@ -130,7 +130,7 @@ impl Clause {
                     negate: true,
                 });
 
-                for &solvable_id in &pool.match_spec_to_candidates[match_spec_id] {
+                for &solvable_id in &pool.match_spec_to_sorted_candidates[match_spec_id] {
                     visit(Literal {
                         solvable_id,
                         negate: false,
@@ -345,7 +345,7 @@ impl ClauseState {
                 }
 
                 // The available candidates
-                for &candidate in &pool.match_spec_to_candidates[match_spec_id] {
+                for &candidate in &pool.match_spec_to_sorted_candidates[match_spec_id] {
                     let lit = Literal {
                         solvable_id: candidate,
                         negate: false,

--- a/crates/libsolv_rs/src/solver/mod.rs
+++ b/crates/libsolv_rs/src/solver/mod.rs
@@ -169,6 +169,8 @@ impl<'a> Solver<'a> {
             Mapping::new(vec![Vec::new(); self.pool.match_specs.len()]);
         let match_spec_to_candidates =
             Mapping::new(vec![OnceCell::new(); self.pool.match_specs.len()]);
+        let match_spec_to_highest_version =
+            Mapping::new(vec![OnceCell::new(); self.pool.match_specs.len()]);
         let mut seen_requires = HashSet::new();
         let mut seen_forbidden = HashSet::new();
         let empty_vec = Vec::new();
@@ -187,6 +189,7 @@ impl<'a> Solver<'a> {
                         favored_map,
                         &mut match_spec_to_sorted_candidates,
                         &match_spec_to_candidates,
+                        &match_spec_to_highest_version,
                     );
                 }
 

--- a/crates/libsolv_rs/src/solver/mod.rs
+++ b/crates/libsolv_rs/src/solver/mod.rs
@@ -9,10 +9,10 @@ use crate::solve_jobs::SolveJobs;
 use crate::transaction::Transaction;
 use std::cell::OnceCell;
 
+use ahash::{AHashMap, AHashSet};
 use itertools::Itertools;
 use rattler_conda_types::MatchSpec;
 use std::collections::{HashMap, HashSet};
-use ahash::{AHashMap, AHashSet};
 
 use clause::{Clause, ClauseState, Literal};
 use decision::Decision;

--- a/crates/libsolv_rs/src/solver/mod.rs
+++ b/crates/libsolv_rs/src/solver/mod.rs
@@ -9,7 +9,6 @@ use crate::solve_jobs::SolveJobs;
 use crate::transaction::Transaction;
 use std::cell::OnceCell;
 
-use ahash::{AHashMap, AHashSet};
 use itertools::Itertools;
 use rattler_conda_types::MatchSpec;
 use std::collections::{HashMap, HashSet};
@@ -172,9 +171,9 @@ impl<'a> Solver<'a> {
             Mapping::new(vec![OnceCell::new(); self.pool.match_specs.len()]);
         let match_spec_to_highest_version =
             Mapping::new(vec![OnceCell::new(); self.pool.match_specs.len()]);
-        let mut sorting_cache = AHashMap::new();
-        let mut seen_requires = AHashSet::new();
-        let mut seen_forbidden = AHashSet::new();
+        let mut sorting_cache = HashMap::new();
+        let mut seen_requires = HashSet::new();
+        let mut seen_forbidden = HashSet::new();
         let empty_vec = Vec::new();
 
         while let Some(solvable_id) = stack.pop() {

--- a/crates/libsolv_rs/src/solver/mod.rs
+++ b/crates/libsolv_rs/src/solver/mod.rs
@@ -12,6 +12,7 @@ use std::cell::OnceCell;
 use itertools::Itertools;
 use rattler_conda_types::MatchSpec;
 use std::collections::{HashMap, HashSet};
+use ahash::{AHashMap, AHashSet};
 
 use clause::{Clause, ClauseState, Literal};
 use decision::Decision;
@@ -171,9 +172,9 @@ impl<'a> Solver<'a> {
             Mapping::new(vec![OnceCell::new(); self.pool.match_specs.len()]);
         let match_spec_to_highest_version =
             Mapping::new(vec![OnceCell::new(); self.pool.match_specs.len()]);
-        let mut sorting_cache = HashMap::new();
-        let mut seen_requires = HashSet::new();
-        let mut seen_forbidden = HashSet::new();
+        let mut sorting_cache = AHashMap::new();
+        let mut seen_requires = AHashSet::new();
+        let mut seen_forbidden = AHashSet::new();
         let empty_vec = Vec::new();
 
         while let Some(solvable_id) = stack.pop() {

--- a/crates/libsolv_rs/src/solver/mod.rs
+++ b/crates/libsolv_rs/src/solver/mod.rs
@@ -171,6 +171,7 @@ impl<'a> Solver<'a> {
             Mapping::new(vec![OnceCell::new(); self.pool.match_specs.len()]);
         let match_spec_to_highest_version =
             Mapping::new(vec![OnceCell::new(); self.pool.match_specs.len()]);
+        let mut sorting_cache = HashMap::new();
         let mut seen_requires = HashSet::new();
         let mut seen_forbidden = HashSet::new();
         let empty_vec = Vec::new();
@@ -190,6 +191,7 @@ impl<'a> Solver<'a> {
                         &mut match_spec_to_sorted_candidates,
                         &match_spec_to_candidates,
                         &match_spec_to_highest_version,
+                        &mut sorting_cache,
                     );
                 }
 

--- a/crates/libsolv_rs/src/solver/mod.rs
+++ b/crates/libsolv_rs/src/solver/mod.rs
@@ -7,6 +7,7 @@ use crate::problem::Problem;
 use crate::solvable::SolvableInner;
 use crate::solve_jobs::SolveJobs;
 use crate::transaction::Transaction;
+use std::cell::{OnceCell};
 
 use itertools::Itertools;
 use rattler_conda_types::MatchSpec;
@@ -72,7 +73,7 @@ impl<'a> Solver<'a> {
         self.clauses = vec![ClauseState::new(
             Clause::InstallRoot,
             &self.learnt_clauses,
-            &self.pool.match_spec_to_candidates,
+            &self.pool.match_spec_to_sorted_candidates,
         )];
 
         // Favored map
@@ -99,7 +100,7 @@ impl<'a> Solver<'a> {
                     self.clauses.push(ClauseState::new(
                         Clause::ForbidMultipleInstances(candidate, other_candidate),
                         &self.learnt_clauses,
-                        &self.pool.match_spec_to_candidates,
+                        &self.pool.match_spec_to_sorted_candidates,
                     ));
                 }
             }
@@ -114,7 +115,7 @@ impl<'a> Solver<'a> {
                     self.clauses.push(ClauseState::new(
                         Clause::Lock(locked_solvable_id, other_candidate),
                         &self.learnt_clauses,
-                        &self.pool.match_spec_to_candidates,
+                        &self.pool.match_spec_to_sorted_candidates,
                     ));
                 }
             }
@@ -162,10 +163,14 @@ impl<'a> Solver<'a> {
 
         stack.push(SolvableId::root());
 
-        let mut match_spec_to_candidates =
+        let mut match_spec_to_sorted_candidates =
             Mapping::new(vec![Vec::new(); self.pool.match_specs.len()]);
         let mut match_spec_to_forbidden =
             Mapping::new(vec![Vec::new(); self.pool.match_specs.len()]);
+        let match_spec_to_candidates = Mapping::new(vec![
+            OnceCell::new();
+            self.pool.match_specs.len()
+        ]);
         let mut seen_requires = HashSet::new();
         let mut seen_forbidden = HashSet::new();
         let empty_vec = Vec::new();
@@ -179,11 +184,18 @@ impl<'a> Solver<'a> {
             // Enqueue the candidates of the dependencies
             for &dep in deps {
                 if seen_requires.insert(dep) {
-                    self.pool
-                        .populate_candidates(dep, favored_map, &mut match_spec_to_candidates);
+                    self.pool.populate_candidates(
+                        dep,
+                        favored_map,
+                        &mut match_spec_to_sorted_candidates,
+                        &match_spec_to_candidates,
+                    );
                 }
 
-                for &candidate in match_spec_to_candidates.get(dep).unwrap_or(&empty_vec) {
+                for &candidate in match_spec_to_sorted_candidates
+                    .get(dep)
+                    .unwrap_or(&empty_vec)
+                {
                     // Note: we skip candidates we have already seen
                     if visited.insert(candidate) {
                         stack.push(candidate);
@@ -196,7 +208,7 @@ impl<'a> Solver<'a> {
                 self.clauses.push(ClauseState::new(
                     Clause::Requires(solvable_id, dep),
                     &self.learnt_clauses,
-                    &match_spec_to_candidates,
+                    &match_spec_to_sorted_candidates,
                 ));
             }
 
@@ -211,13 +223,13 @@ impl<'a> Solver<'a> {
                     self.clauses.push(ClauseState::new(
                         Clause::Constrains(solvable_id, dep),
                         &self.learnt_clauses,
-                        &match_spec_to_candidates,
+                        &match_spec_to_sorted_candidates,
                     ));
                 }
             }
         }
 
-        self.pool.match_spec_to_candidates = match_spec_to_candidates;
+        self.pool.match_spec_to_sorted_candidates = match_spec_to_sorted_candidates;
         self.pool.match_spec_to_forbidden = match_spec_to_forbidden;
     }
 
@@ -339,7 +351,7 @@ impl<'a> Solver<'a> {
                 }
 
                 // Consider only clauses in which no candidates have been installed
-                let candidates = &self.pool.match_spec_to_candidates[deps];
+                let candidates = &self.pool.match_spec_to_sorted_candidates[deps];
                 if candidates
                     .iter()
                     .any(|&c| self.decision_tracker.assigned_value(c) == Some(true))
@@ -844,7 +856,7 @@ impl<'a> Solver<'a> {
         let mut clause = ClauseState::new(
             Clause::Learnt(learnt_id),
             &self.learnt_clauses,
-            &self.pool.match_spec_to_candidates,
+            &self.pool.match_spec_to_sorted_candidates,
         );
 
         if clause.has_watches() {

--- a/crates/libsolv_rs/src/solver/mod.rs
+++ b/crates/libsolv_rs/src/solver/mod.rs
@@ -7,7 +7,7 @@ use crate::problem::Problem;
 use crate::solvable::SolvableInner;
 use crate::solve_jobs::SolveJobs;
 use crate::transaction::Transaction;
-use std::cell::{OnceCell};
+use std::cell::OnceCell;
 
 use itertools::Itertools;
 use rattler_conda_types::MatchSpec;
@@ -167,10 +167,8 @@ impl<'a> Solver<'a> {
             Mapping::new(vec![Vec::new(); self.pool.match_specs.len()]);
         let mut match_spec_to_forbidden =
             Mapping::new(vec![Vec::new(); self.pool.match_specs.len()]);
-        let match_spec_to_candidates = Mapping::new(vec![
-            OnceCell::new();
-            self.pool.match_specs.len()
-        ]);
+        let match_spec_to_candidates =
+            Mapping::new(vec![OnceCell::new(); self.pool.match_specs.len()]);
         let mut seen_requires = HashSet::new();
         let mut seen_forbidden = HashSet::new();
         let empty_vec = Vec::new();


### PR DESCRIPTION
Improve performance of the solver by caching the candidates separately from the sorted candidates. The candidates were also computed to compare different solvables.

With these improvements libsolv-rs beats the C impl in every case. (on my machine..)

|                                    | libsolv | libsolv-rs |
|------------------------------------|---------|------------|
| python=3.9                         | 13.267ms | **8.60ms**    |
| xtensor, xsimd                     | 9.7439ms | **4.15ms**    |
| tensorflow                           | 1.3159s | **0.753s**    |
| quetz                                   | 3.09s | **2.38s**    |
| tensorboard=2.1.1, grpc-cpp=1.39.1 | 1.5399s | **0.241s**    |