### PR TITLE
misc: add not found error to the fetch repo data errors 

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -16,7 +16,7 @@ use rattler_repodata_gateway::fetch::{
 };
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use rattler_solve::{libsolv_c, libsolv_rs, SolverImpl, SolverTask};
-use reqwest::{Client, StatusCode};
+use reqwest::Client;
 use std::{
     borrow::Cow,
     env,
@@ -591,9 +591,7 @@ async fn fetch_repo_data_records_with_progress(
     // Error out if an error occurred, but also update the progress bar
     let result = match result {
         Err(e) => {
-            let not_found = matches!(&e,
-                FetchRepoDataError::HttpError(e) if e.status() == Some(StatusCode::NOT_FOUND)
-            );
+            let not_found = matches!(&e, FetchRepoDataError::NotFound(_));
             if not_found && platform != Platform::NoArch {
                 progress_bar.set_style(finished_progress_style());
                 progress_bar.finish_with_message("Not Found");

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -207,7 +207,7 @@ async fn repodata_from_file(
             ))
         } else {
             Err(FetchRepoDataError::FailedToDownloadRepoData(e))
-        }
+        };
     }
 
     // create a dummy cache state

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -215,7 +215,7 @@ async fn repodata_from_file(
         url: subdir_url.clone(),
         cache_size: tokio::fs::metadata(&out_path)
             .await
-            .map_err(RepoDataNotFoundError::FileSystemError)?
+            .map_err(FetchRepoDataError::FailedToDownloadRepoData)?
             .len(),
         cache_headers: CacheHeaders {
             etag: None,
@@ -640,7 +640,7 @@ async fn stream_and_decode_to_file(
     // Decode, hash and write the data to the file.
     let bytes = tokio::io::copy(&mut decoded_repo_data_json_bytes, &mut hashing_file_writer)
         .await
-        .map_err(RepoDataNotFoundError::FileSystemError)?;
+        .map_err(FetchRepoDataError::FailedToDownloadRepoData)?;
 
     // Finalize the hash
     let (_, hash) = hashing_file_writer.finalize();

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -208,12 +208,12 @@ async fn repodata_from_file(
     // copy file from subdir_url to out_path
     let copy_result = tokio::fs::copy(&subdir_url.to_file_path().unwrap(), &out_path).await;
     if let Err(e) = copy_result {
-        if e.kind() == ErrorKind::NotFound {
-            return Err(FetchRepoDataError::NotFound(
+        return if e.kind() == ErrorKind::NotFound {
+            Err(FetchRepoDataError::NotFound(
                 RepoDataNotFoundError::FileSystemError(e),
-            ));
+            ))
         } else {
-            return Err(FetchRepoDataError::FailedToDownloadRepoData(e));
+            Err(FetchRepoDataError::FailedToDownloadRepoData(e))
         }
     }
 


### PR DESCRIPTION
Make it easier to for the user to check if repodata was not found or if there was another error.