### PR TITLE
run_command ends with a newline

### DIFF
--- a/crates/rattler_shell/src/shell/mod.rs
+++ b/crates/rattler_shell/src/shell/mod.rs
@@ -47,7 +47,7 @@ pub trait Shell {
         f: &mut impl Write,
         command: impl IntoIterator<Item = &'a str> + 'a,
     ) -> std::fmt::Result {
-        write!(f, "{}", command.into_iter().join(" "))
+        writeln!(f, "{}", command.into_iter().join(" "))
     }
 
     /// Set the PATH variable to the given paths.
@@ -311,7 +311,7 @@ impl Shell for CmdExe {
         f: &mut impl Write,
         command: impl IntoIterator<Item = &'a str> + 'a,
     ) -> std::fmt::Result {
-        write!(f, "@{}", command.into_iter().join(" "))
+        writeln!(f, "@{}", command.into_iter().join(" "))
     }
 
     fn extension(&self) -> &str {


### PR DESCRIPTION
Adds a newline to the `run_command` functions.