### PR TITLE
Also build aarch64

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -73,7 +73,7 @@ jobs:
       matrix:
         job:
           - { name: "Linux-x86_64",      target: x86_64-unknown-linux-musl,        os: ubuntu-latest, use-cross: true }
-          # - { name: "Linux-aarch64",     target: aarch64-unknown-linux-musl,       os: ubuntu-latest, use-cross: true, skip-tests: true }
+          - { name: "Linux-aarch64",     target: aarch64-unknown-linux-musl,       os: ubuntu-latest, use-cross: true, skip-tests: true }
           # - { name: "Linux-arm",         target: arm-unknown-linux-musleabi,       os: ubuntu-latest, use-cross: true                   }
 
           # - { name: "Linux-mips",        target: mips-unknown-linux-musl,          os: ubuntu-latest, use-cross: true, skip-tests: true }


### PR DESCRIPTION
Since I want to have a pixi build for aarch64, I would like to activate the build for aarch64 :)

Unfortunately, `ring` is still a dependency for rattler which makes us still unable to build this for ppc64le
```
❯ cargo tree -i ring
ring v0.16.20
├── rustls v0.21.2
│   ├── hyper-rustls v0.24.0
│   │   └── reqwest v0.11.18
│   │       ├── rattler v0.5.0 (/Users/pavel/projects/rattler/crates/rattler)
│   │       │   └── rattler-bin v0.5.0 (/Users/pavel/projects/rattler/crates/rattler-bin)
│   │       ├── rattler-bin v0.5.0 (/Users/pavel/projects/rattler/crates/rattler-bin)
│   │       ├── rattler_networking v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_networking)
│   │       │   ├── rattler v0.5.0 (/Users/pavel/projects/rattler/crates/rattler) (*)
│   │       │   ├── rattler-bin v0.5.0 (/Users/pavel/projects/rattler/crates/rattler-bin)
│   │       │   ├── rattler_package_streaming v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_package_streaming)
│   │       │   │   └── rattler v0.5.0 (/Users/pavel/projects/rattler/crates/rattler) (*)
│   │       │   │   [dev-dependencies]
│   │       │   │   └── rattler_conda_types v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_conda_types)
│   │       │   │       ├── rattler v0.5.0 (/Users/pavel/projects/rattler/crates/rattler) (*)
│   │       │   │       ├── rattler-bin v0.5.0 (/Users/pavel/projects/rattler/crates/rattler-bin)
│   │       │   │       ├── rattler_libsolv_rs v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_libsolv_rs)
│   │       │   │       │   └── rattler_solve v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_solve)
│   │       │   │       │       └── rattler-bin v0.5.0 (/Users/pavel/projects/rattler/crates/rattler-bin)
│   │       │   │       ├── rattler_package_streaming v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_package_streaming) (*)
│   │       │   │       ├── rattler_repodata_gateway v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_repodata_gateway)
│   │       │   │       │   └── rattler-bin v0.5.0 (/Users/pavel/projects/rattler/crates/rattler-bin)
│   │       │   │       │   [dev-dependencies]
│   │       │   │       │   └── rattler_solve v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_solve) (*)
│   │       │   │       ├── rattler_shell v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_shell)
│   │       │   │       ├── rattler_solve v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_solve) (*)
│   │       │   │       └── rattler_virtual_packages v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_virtual_packages)
│   │       │   │           └── rattler-bin v0.5.0 (/Users/pavel/projects/rattler/crates/rattler-bin)
│   │       │   └── rattler_repodata_gateway v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_repodata_gateway) (*)
│   │       ├── rattler_package_streaming v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_package_streaming) (*)
│   │       └── rattler_repodata_gateway v0.5.0 (/Users/pavel/projects/rattler/crates/rattler_repodata_gateway) (*)
│   ├── reqwest v0.11.18 (*)
│   └── tokio-rustls v0.24.1
│       ├── hyper-rustls v0.24.0 (*)
│       └── reqwest v0.11.18 (*)
├── rustls-webpki v0.100.1
│   └── rustls v0.21.2 (*)
├── sct v0.7.0
│   └── rustls v0.21.2 (*)
└── webpki v0.22.0
    └── webpki-roots v0.22.6
        └── reqwest v0.11.18 (*)
```