### PR TITLE
Fix: Generate valid tar archives

### DIFF
--- a/crates/rattler_package_streaming/src/write.rs
+++ b/crates/rattler_package_streaming/src/write.rs
@@ -6,7 +6,6 @@ use std::path::{Path, PathBuf};
 use itertools::sorted;
 
 use rattler_conda_types::package::PackageMetadata;
-use tar::EntryType;
 
 /// a function that sorts paths into two iterators, one that starts with `info/` and one that does not
 /// both iterators are sorted alphabetically for reproducibility


### PR DESCRIPTION
## Before this change

Archives produced from rattler-build, which under the hood use functionalities in this crate, couldn't be un-archived.

I manually proved this by persisting outputs of the `write_tar_bz2` function in one of the [tests](https://github.com/mamba-org/rattler/blob/cede9c1479fe9994c7fa03d5cca85075779a7ddf/crates/rattler_package_streaming/tests/write.rs#L163), and then manually running 
```
tar -xzvf pytweening-1.0.4-pyhd8ed1ab_0.tar-new.tar.bz2
```
which would before this change yield the following error:
```
tar: Error opening archive: Unrecognized archive format
```

This error would also appear if I were to try and install that package using mamba:
```
InvalidArchiveError('Error with archive /path/to/pytweening-1.0.4-pyhd8ed1ab_0.tar-new.tar.bz2.  You probably need to delete and re-download or re-create this file.  Message was:\n\nfailed with error: invalid header')
```

## After this change

I can successfully un-archive the file
```
$ tar -xzvf pytweening-1.0.4-pyhd8ed1ab_0.tar-new.tar.bz2
x info/about.json
x info/files
x info/git
x info/hash_input.json
x info/index.json
x info/licenses/LICENSE.txt
x info/link.json
x info/paths.json
x info/recipe/conda_build_config.yaml
x info/recipe/meta.yaml
x info/recipe/meta.yaml.template
x info/recipe/recipe-scripts-license.txt
x info/test/run_test.bat
x info/test/run_test.py
x info/test/run_test.sh
x info/test/test_time_dependencies.json
x site-packages/pytweening/__init__.py
x site-packages/pytweening-1.0.4.dist-info/AUTHORS.txt
x site-packages/pytweening-1.0.4.dist-info/INSTALLER
x site-packages/pytweening-1.0.4.dist-info/LICENSE.txt
x site-packages/pytweening-1.0.4.dist-info/METADATA
x site-packages/pytweening-1.0.4.dist-info/RECORD
x site-packages/pytweening-1.0.4.dist-info/REQUESTED
x site-packages/pytweening-1.0.4.dist-info/WHEEL
x site-packages/pytweening-1.0.4.dist-info/direct_url.json
x site-packages/pytweening-1.0.4.dist-info/top_level.txt
```

and also install it directly using mamba.