### PR TITLE
add retry behavior for package cache downloads

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -401,6 +401,7 @@ async fn execute_operation(
                     &install_record.package_record,
                     install_record.url.clone(),
                     download_client.clone(),
+                    None,
                 )
                 .map_ok(|cache_dir| Some((install_record.clone(), cache_dir)))
                 .map_err(anyhow::Error::from)

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -11,7 +11,9 @@ use rattler_conda_types::{
     Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, PackageRecord, Platform,
     PrefixRecord, RepoDataRecord, Version,
 };
-use rattler_networking::{default_retry_policy, AuthenticatedClient, AuthenticationStorage};
+use rattler_networking::{
+    retry_policies::default_retry_policy, AuthenticatedClient, AuthenticationStorage,
+};
 use rattler_repodata_gateway::fetch::{
     CacheResult, DownloadProgress, FetchRepoDataError, FetchRepoDataOptions,
 };

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -11,7 +11,7 @@ use rattler_conda_types::{
     Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, PackageRecord, Platform,
     PrefixRecord, RepoDataRecord, Version,
 };
-use rattler_networking::{AuthenticatedClient, AuthenticationStorage};
+use rattler_networking::{default_retry_policy, AuthenticatedClient, AuthenticationStorage};
 use rattler_repodata_gateway::fetch::{
     CacheResult, DownloadProgress, FetchRepoDataError, FetchRepoDataOptions,
 };
@@ -397,11 +397,11 @@ async fn execute_operation(
         async {
             // Make sure the package is available in the package cache.
             let result = package_cache
-                .get_or_fetch_from_url(
+                .get_or_fetch_from_url_with_retry(
                     &install_record.package_record,
                     install_record.url.clone(),
                     download_client.clone(),
-                    None,
+                    default_retry_policy(),
                 )
                 .map_ok(|cache_dir| Some((install_record.clone(), cache_dir)))
                 .map_err(anyhow::Error::from)

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -56,3 +56,8 @@ rand = "0.8.5"
 rstest = "0.18.1"
 tracing-test = { version = "0.2.4" }
 insta = { version = "1.30.0", features = ["yaml"] }
+
+tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread"] }
+axum = "0.6.18"
+tower-http = { version = "0.4.1", features = ["fs"] }
+tower = { version = "0.4.13", default-features = false, features = ["util"] }

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -37,7 +37,6 @@ rattler_networking = { version = "0.7.0", path = "../rattler_networking", defaul
 rattler_package_streaming = { version = "0.7.0", path = "../rattler_package_streaming", features = ["reqwest", "tokio"], default-features = false }
 regex = "1.9.1"
 reqwest = { version = "0.11.18", default-features = false, features = ["stream", "json", "gzip"] }
-retry-policies = { version = "0.2.0", default-features = false }
 serde = { version = "1.0.171", features = ["derive"] }
 serde_json = { version = "1.0.102", features = ["raw_value"] }
 serde_with = "3.0.0"

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -37,6 +37,7 @@ rattler_networking = { version = "0.7.0", path = "../rattler_networking", defaul
 rattler_package_streaming = { version = "0.7.0", path = "../rattler_package_streaming", features = ["reqwest", "tokio"], default-features = false }
 regex = "1.9.1"
 reqwest = { version = "0.11.18", default-features = false, features = ["stream", "json", "gzip"] }
+retry-policies = { version = "0.2.0", default-features = false }
 serde = { version = "1.0.171", features = ["derive"] }
 serde_json = { version = "1.0.102", features = ["raw_value"] }
 serde_with = "3.0.0"

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -678,12 +678,7 @@ mod test {
                     // Populate the cache
                     let package_info = ArchiveIdentifier::try_from_url(package_url).unwrap();
                     let package_dir = package_cache
-                        .get_or_fetch_from_url(
-                            package_info,
-                            package_url.clone(),
-                            client.clone(),
-                            None,
-                        )
+                        .get_or_fetch_from_url(package_info, package_url.clone(), client.clone())
                         .await
                         .unwrap();
 

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -678,7 +678,12 @@ mod test {
                     // Populate the cache
                     let package_info = ArchiveIdentifier::try_from_url(package_url).unwrap();
                     let package_dir = package_cache
-                        .get_or_fetch_from_url(package_info, package_url.clone(), client.clone())
+                        .get_or_fetch_from_url(
+                            package_info,
+                            package_url.clone(),
+                            client.clone(),
+                            None,
+                        )
                         .await
                         .unwrap();
 

--- a/crates/rattler/src/package_cache.rs
+++ b/crates/rattler/src/package_cache.rs
@@ -5,10 +5,12 @@ use chrono::Utc;
 use fxhash::FxHashMap;
 use itertools::Itertools;
 use rattler_conda_types::{package::ArchiveIdentifier, PackageRecord};
-use rattler_networking::AuthenticatedClient;
+use rattler_networking::{
+    retry_policies::{DoNotRetryPolicy, RetryDecision, RetryPolicy},
+    AuthenticatedClient,
+};
 use rattler_package_streaming::ExtractError;
 use reqwest::StatusCode;
-use retry_policies::{RetryDecision, RetryPolicy};
 use std::error::Error;
 use std::{
     fmt::{Display, Formatter},
@@ -19,14 +21,6 @@ use std::{
 use tokio::sync::broadcast;
 use tracing::Instrument;
 use url::Url;
-
-/// A simple [`RetryPolicy`] that just never retries.
-struct DoNotRetryPolicy;
-impl RetryPolicy for DoNotRetryPolicy {
-    fn should_retry(&self, _: u32) -> RetryDecision {
-        RetryDecision::DoNotRetry
-    }
-}
 
 /// A [`PackageCache`] manages a cache of extracted Conda packages on disk.
 ///

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -21,6 +21,7 @@ keyring = "2.0.4"
 lazy_static = "1.4.0"
 libc = "0.2.147"
 reqwest = { version = "0.11.18", features = ["blocking"], default-features = false}
+retry-policies = { version = "0.2.0", default-features = false }
 serde = "1.0.171"
 serde_json = "1.0.102"
 thiserror = "1.0.43"

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -6,17 +6,9 @@ use std::path::PathBuf;
 
 pub use authentication_storage::{authentication::Authentication, storage::AuthenticationStorage};
 use reqwest::{Client, IntoUrl, Method, Url};
-use retry_policies::policies::ExponentialBackoff;
 
 pub mod authentication_storage;
-
-/// Returns the default retry policy that can be used .
-///
-/// This is useful if you just do not care about a retry policy and you just want something
-/// sensible. Note that the behavior of what is "sensible" might change over time.
-pub fn default_retry_policy() -> ExponentialBackoff {
-    ExponentialBackoff::builder().build_with_max_retries(3)
-}
+pub mod retry_policies;
 
 /// A client that can be used to make authenticated requests, based on the [`reqwest::Client`]
 #[derive(Clone)]

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -6,8 +6,17 @@ use std::path::PathBuf;
 
 pub use authentication_storage::{authentication::Authentication, storage::AuthenticationStorage};
 use reqwest::{Client, IntoUrl, Method, Url};
+use retry_policies::policies::ExponentialBackoff;
 
 pub mod authentication_storage;
+
+/// Returns the default retry policy that can be used .
+///
+/// This is useful if you just do not care about a retry policy and you just want something
+/// sensible. Note that the behavior of what is "sensible" might change over time.
+pub fn default_retry_policy() -> ExponentialBackoff {
+    ExponentialBackoff::builder().build_with_max_retries(3)
+}
 
 /// A client that can be used to make authenticated requests, based on the [`reqwest::Client`]
 #[derive(Clone)]

--- a/crates/rattler_networking/src/retry_policies.rs
+++ b/crates/rattler_networking/src/retry_policies.rs
@@ -1,0 +1,23 @@
+//! Reexports the trait [`RetryPolicy`] from the `retry_policies` crate as well as all
+//! implementations.
+//!
+//! This module also provides the [`DoNotRetryPolicy`] which is useful if you do not want to retry
+//! anything.
+
+pub use retry_policies::{policies::*, Jitter, RetryDecision, RetryPolicy};
+
+/// A simple [`RetryPolicy`] that just never retries.
+pub struct DoNotRetryPolicy;
+impl RetryPolicy for DoNotRetryPolicy {
+    fn should_retry(&self, _: u32) -> RetryDecision {
+        RetryDecision::DoNotRetry
+    }
+}
+
+/// Returns the default retry policy that can be used .
+///
+/// This is useful if you just do not care about a retry policy and you just want something
+/// sensible. Note that the behavior of what is "sensible" might change over time.
+pub fn default_retry_policy() -> ExponentialBackoff {
+    ExponentialBackoff::builder().build_with_max_retries(3)
+}


### PR DESCRIPTION
Adds retry behavior for extracting packages. I'm not entirely sure how I can test this properly though...

This was reported in pixi: https://github.com/prefix-dev/pixi/issues/273 . I will try to test-drive it with pixi. 