### PR TITLE
feat: support Debian CUDA detection

### DIFF
--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -113,8 +113,8 @@ fn nvml_library_paths() -> &'static [&'static str] {
         "/usr/lib/x86_64-linux-gnu/libnvidia-ml.so",
         "/usr/lib/wsl/lib/libnvidia-ml.so.1", // WSL
         "/usr/lib/wsl/lib/libnvidia-ml.so",
-        "/usr/lib/x86_64-linux-gnu/nvidia/current/libcuda.so.1", // Debian
-        "/usr/lib/x86_64-linux-gnu/nvidia/current/libcuda.so",
+        "/usr/lib/x86_64-linux-gnu/libcuda.so.1", // Debian
+        "/usr/lib/x86_64-linux-gnu/libcuda.so",
     ];
     #[cfg(windows)]
     static FILENAMES: &[&str] = &["nvml.dll"];

--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -113,6 +113,8 @@ fn nvml_library_paths() -> &'static [&'static str] {
         "/usr/lib/x86_64-linux-gnu/libnvidia-ml.so",
         "/usr/lib/wsl/lib/libnvidia-ml.so.1", // WSL
         "/usr/lib/wsl/lib/libnvidia-ml.so",
+        "/usr/lib/x86_64-linux-gnu/nvidia/current/libcuda.so.1", // Debian
+        "/usr/lib/x86_64-linux-gnu/nvidia/current/libcuda.so",
     ];
     #[cfg(windows)]
     static FILENAMES: &[&str] = &["nvml.dll"];


### PR DESCRIPTION
Uses paths from [Debian](https://packages.debian.org/bullseye/amd64/libcuda1/filelist). Created to fix https://github.com/prefix-dev/pixi/issues/294. As noted in the issue, simply building from source without this patch results in CUDA correctly being detected, but using the GitHub releases Linux binary doesn't work.