### PR TITLE
feat: use nvidia-smi on musl targets

### DIFF
--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -19,9 +19,7 @@ rattler_conda_types = { version = "0.8.0", path = "../rattler_conda_types" }
 thiserror = "1.0.43"
 tracing = "0.1.37"
 serde = { version = "1.0.171", features = ["derive"] }
+regex = "1.9.1"
 
 [target.'cfg(target_os="macos")'.dependencies]
 plist = "1"
-
-[target.'cfg(unix)'.dependencies]
-regex = "1.9.1"


### PR DESCRIPTION
Adds a new CUDA driver version detector using the nvidia-smi executable. The implementation defaults to this on musl-based targets because dynamically linked libraries are not supported there. 

Fixes https://github.com/prefix-dev/pixi/issues/294