### PR TITLE
fix: workaround for `PIP_REQUIRE_VIRTUALENV` env variable

### DIFF
--- a/py-rattler/pixi.toml
+++ b/py-rattler/pixi.toml
@@ -7,7 +7,7 @@ channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 
 [tasks]
-build = "maturin develop"
+build = "PIP_REQUIRE_VIRTUALENV=false maturin develop" 
 test = { cmd = "pytest --doctest-modules", depends_on = ["build"] }
 fmt-python = "black ."
 fmt-rust = "cargo fmt --all"

--- a/py-rattler/pixi.toml
+++ b/py-rattler/pixi.toml
@@ -7,7 +7,7 @@ channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 
 [tasks]
-build = "PIP_REQUIRE_VIRTUALENV=false maturin develop" 
+build = "PIP_REQUIRE_VIRTUALENV=false maturin develop"
 test = { cmd = "pytest --doctest-modules", depends_on = ["build"] }
 fmt-python = "black ."
 fmt-rust = "cargo fmt --all"


### PR DESCRIPTION
If `PIP_REQUIRE_VIRTUALENV` is set to `true` in the user's environment, `maturin develop` fails because the `pip` subcommand doesn't recognize the env as a venv.

This works around that.