### PR TITLE
fix: ensure consistent sorting of locked packages

### DIFF
--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -39,7 +39,7 @@ regex = "1.9.1"
 reqwest = { version = "0.11.18", default-features = false, features = ["stream", "json", "gzip"] }
 serde = { version = "1.0.171", features = ["derive"] }
 serde_json = { version = "1.0.102", features = ["raw_value"] }
-serde_with = "3.0.0"
+serde_with = "3.3.0"
 smallvec = { version = "1.11.0", features = ["serde", "const_new", "const_generics", "union"] }
 tempfile = "3.6.0"
 thiserror = "1.0.43"

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -14,6 +14,7 @@ readme.workspace = true
 chrono = "0.4.26"
 fxhash = "0.2.1"
 hex = "0.4.3"
+indexmap = { version = "2.0.0", features = ["serde"] }
 itertools = "0.11.0"
 lazy-regex = "3.0.0"
 nom = "7.1.3"
@@ -22,7 +23,7 @@ serde = { version = "1.0.171", features = ["derive"] }
 serde_json = "1.0.102"
 serde-json-python-formatter = "0.1.0"
 serde_yaml = "0.9.22"
-serde_with = "3.0.0"
+serde_with = { version = "3.3.0", features = ["indexmap_2"] }
 serde_repr = "0.1"
 smallvec = { version = "1.11.0", features = ["serde", "const_new", "const_generics", "union"] }
 strum = { version = "0.25.0", features = ["derive"] }

--- a/crates/rattler_conda_types/src/conda_lock/builder.rs
+++ b/crates/rattler_conda_types/src/conda_lock/builder.rs
@@ -95,7 +95,6 @@ impl LockFileBuilder {
                 .into_values()
                 .flat_map(|package| package.build())
                 .collect(),
-            version: super::default_version(),
         };
         Ok(lock)
     }

--- a/crates/rattler_conda_types/src/conda_lock/snapshots/rattler_conda_types__conda_lock__test__read_conda_lock.snap
+++ b/crates/rattler_conda_types/src/conda_lock/snapshots/rattler_conda_types__conda_lock__test__read_conda_lock.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/conda_lock/mod.rs
+assertion_line: 529
 expression: conda_lock
 ---
 metadata:
@@ -36,6 +37,1276 @@ package:
       sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
     optional: false
     category: main
+  - name: _libgcc_mutex
+    version: "0.1"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/_libgcc_mutex-0.1-conda_forge.tar.bz2"
+    hash:
+      md5: e96f48755dc7c9f86c4aecf4cac40477
+      sha256: 5dd34b412e6274c0614d01a2f616844376ae873dfb8782c2c67d055779de6df6
+    optional: false
+    category: main
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      _libgcc_mutex: "==0.1 conda_forge"
+      libgomp: ">=7.5.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2"
+    hash:
+      md5: 73aaf86a425cc6e73fcf236a5a46396d
+      sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+    optional: false
+    category: main
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgomp: ">=7.5.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2"
+    hash:
+      md5: 6168d71addc746e8f2b8d57dfd2edcea
+      sha256: 3702bef2f0a4d38bd8288bbe54aace623602a1343c2cfbefd3fa188e015bebf0
+    optional: false
+    category: main
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      _libgcc_mutex: "==0.1 conda_forge"
+      libgomp: ">=7.5.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/_openmp_mutex-4.5-2_gnu.tar.bz2"
+    hash:
+      md5: 3e41cbaba7e4988d15a24c4e85e6171b
+      sha256: 4c89c2067cf5e7b0fbbdc3200c3f7affa5896e14812acf10f51575be87ae0c05
+    optional: false
+    category: main
+  - name: alabaster
+    version: 0.7.13
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 06006184e203b61d3525f90de394471e
+      sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
+    optional: false
+    category: main
+  - name: alabaster
+    version: 0.7.13
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 06006184e203b61d3525f90de394471e
+      sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
+    optional: false
+    category: main
+  - name: alabaster
+    version: 0.7.13
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 06006184e203b61d3525f90de394471e
+      sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
+    optional: false
+    category: main
+  - name: alabaster
+    version: 0.7.13
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 06006184e203b61d3525f90de394471e
+      sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
+    optional: false
+    category: main
+  - name: alabaster
+    version: 0.7.13
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 06006184e203b61d3525f90de394471e
+      sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
+    optional: false
+    category: main
+  - name: alsa-lib
+    version: 1.2.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.8-h166bdaf_0.tar.bz2"
+    hash:
+      md5: be733e69048951df1e4b4b7bb8c7666f
+      sha256: 2c0a618d0fa695e4e01a30e7ff31094be540c52e9085cbd724edb132c65cf9cd
+    optional: false
+    category: main
+  - name: appdirs
+    version: 1.4.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 5f095bc6454094e96f146491fd03633b
+      sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+    optional: false
+    category: main
+  - name: appdirs
+    version: 1.4.4
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 5f095bc6454094e96f146491fd03633b
+      sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+    optional: false
+    category: main
+  - name: appdirs
+    version: 1.4.4
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 5f095bc6454094e96f146491fd03633b
+      sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+    optional: false
+    category: main
+  - name: appdirs
+    version: 1.4.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 5f095bc6454094e96f146491fd03633b
+      sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+    optional: false
+    category: main
+  - name: appdirs
+    version: 1.4.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 5f095bc6454094e96f146491fd03633b
+      sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
+    optional: false
+    category: main
+  - name: appnope
+    version: 0.1.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 54ac328d703bff191256ffa1183126d1
+      sha256: b209a68ac55eb9ecad7042f0d4eedef5da924699f6cdf54ac1826869cfdae742
+    optional: false
+    category: main
+  - name: appnope
+    version: 0.1.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 54ac328d703bff191256ffa1183126d1
+      sha256: b209a68ac55eb9ecad7042f0d4eedef5da924699f6cdf54ac1826869cfdae742
+    optional: false
+    category: main
+  - name: asttokens
+    version: 2.2.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.5"
+      six: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: bf7f54dd0f25c3f06ecb82a07341841a
+      sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
+    optional: false
+    category: main
+  - name: asttokens
+    version: 2.2.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.5"
+      six: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: bf7f54dd0f25c3f06ecb82a07341841a
+      sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
+    optional: false
+    category: main
+  - name: asttokens
+    version: 2.2.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.5"
+      six: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: bf7f54dd0f25c3f06ecb82a07341841a
+      sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
+    optional: false
+    category: main
+  - name: asttokens
+    version: 2.2.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.5"
+      six: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: bf7f54dd0f25c3f06ecb82a07341841a
+      sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
+    optional: false
+    category: main
+  - name: asttokens
+    version: 2.2.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.5"
+      six: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: bf7f54dd0f25c3f06ecb82a07341841a
+      sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
+    optional: false
+    category: main
+  - name: attr
+    version: 2.5.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2"
+    hash:
+      md5: d9c69a24ad678ffce24c6543a0176b00
+      sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
+    optional: false
+    category: main
+  - name: attrs
+    version: 22.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/attrs-22.2.0-pyh71513ae_0.conda"
+    hash:
+      md5: 8b76db7818a4e401ed4486c4c1635cd9
+      sha256: 3a58d4a4933fa8735471c782d35326ab78e0bcfce84756408515f82a94e4dec4
+    optional: false
+    category: main
+  - name: attrs
+    version: 22.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/attrs-22.2.0-pyh71513ae_0.conda"
+    hash:
+      md5: 8b76db7818a4e401ed4486c4c1635cd9
+      sha256: 3a58d4a4933fa8735471c782d35326ab78e0bcfce84756408515f82a94e4dec4
+    optional: false
+    category: main
+  - name: attrs
+    version: 22.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/attrs-22.2.0-pyh71513ae_0.conda"
+    hash:
+      md5: 8b76db7818a4e401ed4486c4c1635cd9
+      sha256: 3a58d4a4933fa8735471c782d35326ab78e0bcfce84756408515f82a94e4dec4
+    optional: false
+    category: main
+  - name: attrs
+    version: 22.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/attrs-22.2.0-pyh71513ae_0.conda"
+    hash:
+      md5: 8b76db7818a4e401ed4486c4c1635cd9
+      sha256: 3a58d4a4933fa8735471c782d35326ab78e0bcfce84756408515f82a94e4dec4
+    optional: false
+    category: main
+  - name: attrs
+    version: 22.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/attrs-22.2.0-pyh71513ae_0.conda"
+    hash:
+      md5: 8b76db7818a4e401ed4486c4c1635cd9
+      sha256: 3a58d4a4933fa8735471c782d35326ab78e0bcfce84756408515f82a94e4dec4
+    optional: false
+    category: main
+  - name: babel
+    version: 2.11.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+      pytz: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/babel-2.11.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 2ea70fde8d581ba9425a761609eed6ba
+      sha256: 21a8403d886136c0a80f965ae5387fa1693b19ddd69023bcd0e844f2510d7e2f
+    optional: false
+    category: main
+  - name: babel
+    version: 2.11.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+      pytz: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/babel-2.11.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 2ea70fde8d581ba9425a761609eed6ba
+      sha256: 21a8403d886136c0a80f965ae5387fa1693b19ddd69023bcd0e844f2510d7e2f
+    optional: false
+    category: main
+  - name: babel
+    version: 2.11.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+      pytz: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/babel-2.11.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 2ea70fde8d581ba9425a761609eed6ba
+      sha256: 21a8403d886136c0a80f965ae5387fa1693b19ddd69023bcd0e844f2510d7e2f
+    optional: false
+    category: main
+  - name: babel
+    version: 2.11.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+      pytz: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/babel-2.11.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 2ea70fde8d581ba9425a761609eed6ba
+      sha256: 21a8403d886136c0a80f965ae5387fa1693b19ddd69023bcd0e844f2510d7e2f
+    optional: false
+    category: main
+  - name: babel
+    version: 2.11.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+      pytz: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/babel-2.11.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 2ea70fde8d581ba9425a761609eed6ba
+      sha256: 21a8403d886136c0a80f965ae5387fa1693b19ddd69023bcd0e844f2510d7e2f
+    optional: false
+    category: main
+  - name: backcall
+    version: 0.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 6006a6d08a3fa99268a2681c7fb55213
+      sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
+    optional: false
+    category: main
+  - name: backcall
+    version: 0.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 6006a6d08a3fa99268a2681c7fb55213
+      sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
+    optional: false
+    category: main
+  - name: backcall
+    version: 0.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 6006a6d08a3fa99268a2681c7fb55213
+      sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
+    optional: false
+    category: main
+  - name: backcall
+    version: 0.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 6006a6d08a3fa99268a2681c7fb55213
+      sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
+    optional: false
+    category: main
+  - name: backcall
+    version: 0.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 6006a6d08a3fa99268a2681c7fb55213
+      sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
+    optional: false
+    category: main
+  - name: backports
+    version: "1.0"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda"
+    hash:
+      md5: 54ca2e08b3220c148a1d8329c2678e02
+      sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+    optional: false
+    category: main
+  - name: backports
+    version: "1.0"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda"
+    hash:
+      md5: 54ca2e08b3220c148a1d8329c2678e02
+      sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+    optional: false
+    category: main
+  - name: backports
+    version: "1.0"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda"
+    hash:
+      md5: 54ca2e08b3220c148a1d8329c2678e02
+      sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+    optional: false
+    category: main
+  - name: backports
+    version: "1.0"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda"
+    hash:
+      md5: 54ca2e08b3220c148a1d8329c2678e02
+      sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+    optional: false
+    category: main
+  - name: backports
+    version: "1.0"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda"
+    hash:
+      md5: 54ca2e08b3220c148a1d8329c2678e02
+      sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
+    optional: false
+    category: main
+  - name: backports.functools_lru_cache
+    version: 1.6.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      backports: "*"
+      python: ">=3.6"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c5b3edc62d6309088f4970b3eaaa65a6
+      sha256: fdea00d4b79990f3fe938e2716bc32bd895eb5c44b6c75b8261db095a1b33c16
+    optional: false
+    category: main
+  - name: backports.functools_lru_cache
+    version: 1.6.4
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      backports: "*"
+      python: ">=3.6"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c5b3edc62d6309088f4970b3eaaa65a6
+      sha256: fdea00d4b79990f3fe938e2716bc32bd895eb5c44b6c75b8261db095a1b33c16
+    optional: false
+    category: main
+  - name: backports.functools_lru_cache
+    version: 1.6.4
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      backports: "*"
+      python: ">=3.6"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c5b3edc62d6309088f4970b3eaaa65a6
+      sha256: fdea00d4b79990f3fe938e2716bc32bd895eb5c44b6c75b8261db095a1b33c16
+    optional: false
+    category: main
+  - name: backports.functools_lru_cache
+    version: 1.6.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      backports: "*"
+      python: ">=3.6"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c5b3edc62d6309088f4970b3eaaa65a6
+      sha256: fdea00d4b79990f3fe938e2716bc32bd895eb5c44b6c75b8261db095a1b33c16
+    optional: false
+    category: main
+  - name: backports.functools_lru_cache
+    version: 1.6.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      backports: "*"
+      python: ">=3.6"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c5b3edc62d6309088f4970b3eaaa65a6
+      sha256: fdea00d4b79990f3fe938e2716bc32bd895eb5c44b6c75b8261db095a1b33c16
+    optional: false
+    category: main
+  - name: backports.zoneinfo
+    version: 0.2.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/backports.zoneinfo-0.2.1-py39hf3d152e_7.tar.bz2"
+    hash:
+      md5: b1a72c73acf3527aa5c1e2eed594fa25
+      sha256: 1e9ca141550b6b515dec4ff32a7ca32948f6ac01e0fec207d8a14a7170b2973c
+    optional: false
+    category: main
+  - name: backports.zoneinfo
+    version: 0.2.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/backports.zoneinfo-0.2.1-py39h4420490_7.tar.bz2"
+    hash:
+      md5: 81f95bd3b0e4370ac3aef6e19eef8763
+      sha256: 340b8c181416f6811c80601d8cdd8a8ba9d0540e31e3bde1f901e8e71d7c56d8
+    optional: false
+    category: main
+  - name: backports.zoneinfo
+    version: 0.2.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/backports.zoneinfo-0.2.1-py39h0b1cf3c_7.tar.bz2"
+    hash:
+      md5: c1167f40e89755cc23c64c6f7fd3dbe3
+      sha256: f136781ac1b95d3565c2f2e5b32742d716e1b8bdd5d20d34b300a68a07f6fe2c
+    optional: false
+    category: main
+  - name: backports.zoneinfo
+    version: 0.2.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/backports.zoneinfo-0.2.1-py39h6e9494a_7.tar.bz2"
+    hash:
+      md5: 5727630b9e2234fbe5ba637c763a80c7
+      sha256: 4dda0fc050802b0ad30eda1a4b13ad82172627f1601fae9e36344e41de8be5e2
+    optional: false
+    category: main
+  - name: backports.zoneinfo
+    version: 0.2.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/backports.zoneinfo-0.2.1-py39h2804cbe_7.tar.bz2"
+    hash:
+      md5: 53ed254446fa05b6c7efda9cabe03630
+      sha256: e149a5598cd38ee3db357a09d16384ea119d56be7d41decd10e078c8d326b28e
+    optional: false
+    category: main
+  - name: beautifulsoup4
+    version: 4.11.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+      soupsieve: ">=1.2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.11.2-pyha770c72_0.conda"
+    hash:
+      md5: 88b59f6989f0ed5ab3433af0b82555e1
+      sha256: deb43944425b3ec7fdfd5e6620cf97a4ed888a279237f90cd67a338d123efd15
+    optional: false
+    category: main
+  - name: beautifulsoup4
+    version: 4.11.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+      soupsieve: ">=1.2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.11.2-pyha770c72_0.conda"
+    hash:
+      md5: 88b59f6989f0ed5ab3433af0b82555e1
+      sha256: deb43944425b3ec7fdfd5e6620cf97a4ed888a279237f90cd67a338d123efd15
+    optional: false
+    category: main
+  - name: beautifulsoup4
+    version: 4.11.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+      soupsieve: ">=1.2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.11.2-pyha770c72_0.conda"
+    hash:
+      md5: 88b59f6989f0ed5ab3433af0b82555e1
+      sha256: deb43944425b3ec7fdfd5e6620cf97a4ed888a279237f90cd67a338d123efd15
+    optional: false
+    category: main
+  - name: beautifulsoup4
+    version: 4.11.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+      soupsieve: ">=1.2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.11.2-pyha770c72_0.conda"
+    hash:
+      md5: 88b59f6989f0ed5ab3433af0b82555e1
+      sha256: deb43944425b3ec7fdfd5e6620cf97a4ed888a279237f90cd67a338d123efd15
+    optional: false
+    category: main
+  - name: beautifulsoup4
+    version: 4.11.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+      soupsieve: ">=1.2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.11.2-pyha770c72_0.conda"
+    hash:
+      md5: 88b59f6989f0ed5ab3433af0b82555e1
+      sha256: deb43944425b3ec7fdfd5e6620cf97a4ed888a279237f90cd67a338d123efd15
+    optional: false
+    category: main
+  - name: binutils
+    version: "2.39"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      binutils_impl_linux-64: ">=2.39,<2.40.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/binutils-2.39-hdd6e379_1.conda"
+    hash:
+      md5: 1276c18b0a562739185dbf5bd14b57b2
+      sha256: 8edbd5a01feaf22053d7c02e7d5066a3b35b265deee0a5ad3f69054289bbbd7e
+    optional: false
+    category: main
+  - name: binutils
+    version: "2.39"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      binutils_impl_linux-aarch64: ">=2.39,<2.40.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.39-h64c2a2e_1.conda"
+    hash:
+      md5: 9c096a144d04d6701d5ecc530e711934
+      sha256: 0f37fe063a6111c38272abef6c42b881c7fe71958313638701206c0e8669b2ae
+    optional: false
+    category: main
+  - name: binutils
+    version: "2.39"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      binutils_impl_linux-ppc64le: ">=2.39,<2.40.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/binutils-2.39-h7f02139_1.conda"
+    hash:
+      md5: 93ad8fe1ef01293548b6fc28169d40fe
+      sha256: 986d2a9388cb6176b91aacc7cda9f6d317a34e0f61d6d323fc121c3718bc9392
+    optional: false
+    category: main
+  - name: binutils_impl_linux-64
+    version: "2.39"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      ld_impl_linux-64: "==2.39 hcc3a1bd_1"
+      sysroot_linux-64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.39-he00db2b_1.conda"
+    hash:
+      md5: 3d726e8b51a1f5bfd66892a2b7d9db2d
+      sha256: 69a7c32141475dab43de2f19b7a67c14596cbb357cdb5891ff866918f8f65a2e
+    optional: false
+    category: main
+  - name: binutils_impl_linux-aarch64
+    version: "2.39"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      ld_impl_linux-aarch64: "==2.39 h16cd69b_1"
+      sysroot_linux-aarch64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.39-h48546ad_1.conda"
+    hash:
+      md5: 74724e155402aa2391b99fe919b6af17
+      sha256: dbdcca1fc9601ebc035d61283ceb317fe9b006dc7a9aa65d696769e9c74c5580
+    optional: false
+    category: main
+  - name: binutils_impl_linux-ppc64le
+    version: "2.39"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      ld_impl_linux-ppc64le: "==2.39 hea198f4_1"
+      sysroot_linux-ppc64le: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/binutils_impl_linux-ppc64le-2.39-heb37b50_1.conda"
+    hash:
+      md5: d4fd843dce0edcc58c63e995b7837293
+      sha256: 91e5401f436aa2686f0dfa36066674f4e26e43efade059acaff3d5c4f25d90d1
+    optional: false
+    category: main
+  - name: binutils_linux-64
+    version: "2.39"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      binutils_impl_linux-64: 2.39.*
+      sysroot_linux-64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.39-h5fc0e48_11.tar.bz2"
+    hash:
+      md5: b7d26ab37be17ea4c366a97138684bcb
+      sha256: acf554585c011689ce6c58472200545c9512dce1b9dfc5e853f25771c0c3e12e
+    optional: false
+    category: main
+  - name: binutils_linux-aarch64
+    version: "2.39"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      binutils_impl_linux-aarch64: 2.39.*
+      sysroot_linux-aarch64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.39-h489c705_11.tar.bz2"
+    hash:
+      md5: 4b7f9e2048a3b75aca16b9612d7f49c7
+      sha256: 21da410295e7e42e7459fa633a72c213b19c88d12a95c6b08599935e975694c4
+    optional: false
+    category: main
+  - name: binutils_linux-ppc64le
+    version: "2.39"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      binutils_impl_linux-ppc64le: 2.39.*
+      sysroot_linux-ppc64le: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/binutils_linux-ppc64le-2.39-h5e55cfe_11.tar.bz2"
+    hash:
+      md5: cb19199c186994b286cbb1afb447a9d0
+      sha256: b6b696f484684ad58e9509cc9414fc65349ea9e6fdb6d84822e39b738fa34ed3
+    optional: false
+    category: main
+  - name: breathe
+    version: 4.34.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      docutils: ">=0.12"
+      jinja2: ">=2.7.3"
+      markupsafe: ">=0.23"
+      pygments: ">=1.6"
+      python: ">=3.6"
+      sphinx: ">=4.0,<6.0.0a"
+    url: "https://conda.anaconda.org/conda-forge/noarch/breathe-4.34.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: a2a04f8e8c2d91adb08ff929b4d73654
+      sha256: 40f86cd741a443363e8928d5d36ba3a49071aaffc26c5a7b24a8167c5bcbba81
+    optional: false
+    category: main
+  - name: breathe
+    version: 4.34.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      docutils: ">=0.12"
+      jinja2: ">=2.7.3"
+      markupsafe: ">=0.23"
+      pygments: ">=1.6"
+      python: ">=3.6"
+      sphinx: ">=4.0,<6.0.0a"
+    url: "https://conda.anaconda.org/conda-forge/noarch/breathe-4.34.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: a2a04f8e8c2d91adb08ff929b4d73654
+      sha256: 40f86cd741a443363e8928d5d36ba3a49071aaffc26c5a7b24a8167c5bcbba81
+    optional: false
+    category: main
+  - name: breathe
+    version: 4.34.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      docutils: ">=0.12"
+      jinja2: ">=2.7.3"
+      markupsafe: ">=0.23"
+      pygments: ">=1.6"
+      python: ">=3.6"
+      sphinx: ">=4.0,<6.0.0a"
+    url: "https://conda.anaconda.org/conda-forge/noarch/breathe-4.34.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: a2a04f8e8c2d91adb08ff929b4d73654
+      sha256: 40f86cd741a443363e8928d5d36ba3a49071aaffc26c5a7b24a8167c5bcbba81
+    optional: false
+    category: main
+  - name: breathe
+    version: 4.34.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      docutils: ">=0.12"
+      jinja2: ">=2.7.3"
+      markupsafe: ">=0.23"
+      pygments: ">=1.6"
+      python: ">=3.6"
+      sphinx: ">=4.0,<6.0.0a"
+    url: "https://conda.anaconda.org/conda-forge/noarch/breathe-4.34.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: a2a04f8e8c2d91adb08ff929b4d73654
+      sha256: 40f86cd741a443363e8928d5d36ba3a49071aaffc26c5a7b24a8167c5bcbba81
+    optional: false
+    category: main
+  - name: breathe
+    version: 4.34.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      docutils: ">=0.12"
+      jinja2: ">=2.7.3"
+      markupsafe: ">=0.23"
+      pygments: ">=1.6"
+      python: ">=3.6"
+      sphinx: ">=4.0,<6.0.0a"
+    url: "https://conda.anaconda.org/conda-forge/noarch/breathe-4.34.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: a2a04f8e8c2d91adb08ff929b4d73654
+      sha256: 40f86cd741a443363e8928d5d36ba3a49071aaffc26c5a7b24a8167c5bcbba81
+    optional: false
+    category: main
+  - name: brotli
+    version: 1.0.9
+    manager: conda
+    platform: linux-64
+    dependencies:
+      brotli-bin: "==1.0.9 h166bdaf_8"
+      libbrotlidec: "==1.0.9 h166bdaf_8"
+      libbrotlienc: "==1.0.9 h166bdaf_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_8.tar.bz2"
+    hash:
+      md5: 2ff08978892a3e8b954397c461f18418
+      sha256: 74c0fa22ea7c62d2c8f7a7aea03a3bd4919f7f3940ef5b027ce0dfb5feb38c06
+    optional: false
+    category: main
+  - name: brotli
+    version: 1.0.9
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      brotli-bin: "==1.0.9 h4e544f5_8"
+      libbrotlidec: "==1.0.9 h4e544f5_8"
+      libbrotlienc: "==1.0.9 h4e544f5_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-1.0.9-h4e544f5_8.tar.bz2"
+    hash:
+      md5: 259d82bd990ba225508389509634b157
+      sha256: e775343c34d04c6e27b4967b6edeac4793c9f0bd6c843990497c72798f49808f
+    optional: false
+    category: main
+  - name: brotli
+    version: 1.0.9
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      brotli-bin: "==1.0.9 hb283c62_8"
+      libbrotlidec: "==1.0.9 hb283c62_8"
+      libbrotlienc: "==1.0.9 hb283c62_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/brotli-1.0.9-hb283c62_8.tar.bz2"
+    hash:
+      md5: f623f277928564629dc18ff3426ac984
+      sha256: 8c871a332088e2d1055042a21007426d863cc54e5b7416c9a55d20a6f0a1a236
+    optional: false
+    category: main
+  - name: brotli
+    version: 1.0.9
+    manager: conda
+    platform: osx-64
+    dependencies:
+      brotli-bin: "==1.0.9 hb7f2c08_8"
+      libbrotlidec: "==1.0.9 hb7f2c08_8"
+      libbrotlienc: "==1.0.9 hb7f2c08_8"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/brotli-1.0.9-hb7f2c08_8.tar.bz2"
+    hash:
+      md5: 55f612fe4a9b5f6ac76348b6de94aaeb
+      sha256: 1272426370f1e8db1a8b245a7b522afe27413b09eab169990512a7676b802e3b
+    optional: false
+    category: main
+  - name: brotli
+    version: 1.0.9
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      brotli-bin: "==1.0.9 h1a8c8d9_8"
+      libbrotlidec: "==1.0.9 h1a8c8d9_8"
+      libbrotlienc: "==1.0.9 h1a8c8d9_8"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.0.9-h1a8c8d9_8.tar.bz2"
+    hash:
+      md5: e2a5e381ddd6529eb62e7710270b2ec5
+      sha256: f97debd05c2caeeefba22e0b71173f1fff99c1e5e66e6e9caa91c1c66eb59741
+    optional: false
+    category: main
+  - name: brotli-bin
+    version: 1.0.9
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libbrotlidec: "==1.0.9 h166bdaf_8"
+      libbrotlienc: "==1.0.9 h166bdaf_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_8.tar.bz2"
+    hash:
+      md5: e5613f2bc717e9945840ff474419b8e4
+      sha256: ab1994e03bdd88e4b27f9f802ac18e45ed29b92cce25e1fd86da43b89734950f
+    optional: false
+    category: main
+  - name: brotli-bin
+    version: 1.0.9
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libbrotlidec: "==1.0.9 h4e544f5_8"
+      libbrotlienc: "==1.0.9 h4e544f5_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.0.9-h4e544f5_8.tar.bz2"
+    hash:
+      md5: 0980429a0148a53edd0f1f207ec28a39
+      sha256: 30214484976cc0a6f37c6e2473578d4602d66d01acf3ccfd2f97238cbb91621b
+    optional: false
+    category: main
+  - name: brotli-bin
+    version: 1.0.9
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libbrotlidec: "==1.0.9 hb283c62_8"
+      libbrotlienc: "==1.0.9 hb283c62_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/brotli-bin-1.0.9-hb283c62_8.tar.bz2"
+    hash:
+      md5: 3909235bac04f832ff9b02c764dbee23
+      sha256: 98fc147dcdfb2196b4e267a1fd0250934a9ad16fb4ce9dfb2466b4c51cd6123a
+    optional: false
+    category: main
+  - name: brotli-bin
+    version: 1.0.9
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libbrotlidec: "==1.0.9 hb7f2c08_8"
+      libbrotlienc: "==1.0.9 hb7f2c08_8"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.0.9-hb7f2c08_8.tar.bz2"
+    hash:
+      md5: aac5ad0d8f747ef7f871508146df75d9
+      sha256: 36f79eb26da032c5d1ddc11e0bcac5526f249bf60d332e4743c8d48bb7334db0
+    optional: false
+    category: main
+  - name: brotli-bin
+    version: 1.0.9
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libbrotlidec: "==1.0.9 h1a8c8d9_8"
+      libbrotlienc: "==1.0.9 h1a8c8d9_8"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.0.9-h1a8c8d9_8.tar.bz2"
+    hash:
+      md5: f212620a4f3606ff8f800b8b1077415a
+      sha256: d171637710bffc322b35198c03bcfd3d04f454433e845138e5120729f8941996
+    optional: false
+    category: main
+  - name: brotlipy
+    version: 0.7.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      cffi: ">=1.0.0"
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/brotlipy-0.7.0-py39hb9d737c_1005.tar.bz2"
+    hash:
+      md5: a639fdd9428d8b25f8326a3838d54045
+      sha256: 293229afcd31e81626e5cfe0478be402b35d29b73aa421a49470645debda5019
+    optional: false
+    category: main
+  - name: brotlipy
+    version: 0.7.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      cffi: ">=1.0.0"
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/brotlipy-0.7.0-py39h0fd3b05_1005.tar.bz2"
+    hash:
+      md5: 5d37ef329c084829d3ff5b172a08b8f9
+      sha256: b62b8ba3688978d1344a4ea639b4ab28988fac5318a9842af4e7b9f5feb8374d
+    optional: false
+    category: main
+  - name: brotlipy
+    version: 0.7.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      cffi: ">=1.0.0"
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/brotlipy-0.7.0-py39h98ec90c_1005.tar.bz2"
+    hash:
+      md5: d8c035f4b1b28f25bfbcc199aae52d3d
+      sha256: e534cdeef029b8fb255dd60336e2f6e6a81d011ce231517d5fe6dcd0440c4d08
+    optional: false
+    category: main
+  - name: brotlipy
+    version: 0.7.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      cffi: ">=1.0.0"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/brotlipy-0.7.0-py39ha30fb19_1005.tar.bz2"
+    hash:
+      md5: 201d86c1f0b0132954fc72251b09df8a
+      sha256: 0204c1d5ab773e956233c0a6941f87faf7e9dc3fe30dec0d34f04091309859d8
+    optional: false
+    category: main
+  - name: brotlipy
+    version: 0.7.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      cffi: ">=1.0.0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/brotlipy-0.7.0-py39h02fc5c5_1005.tar.bz2"
+    hash:
+      md5: cf0b1f6f29ee28e7b20d49cb66bae19e
+      sha256: d56a680b34d84144d396619eee5331493a9a611ee4ee21bd88a73bcac642abf4
+    optional: false
+    category: main
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2"
+    hash:
+      md5: a1fd65c7ccbf10880423d82bca54eb54
+      sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
+    optional: false
+    category: main
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-hf897c2e_4.tar.bz2"
+    hash:
+      md5: 2d787570a729e273a4e75775ddf3348a
+      sha256: 3aeb6ab92aa0351722497b2d2a735dc20921cf6c60d9196c04b7a2b9ece198d2
+    optional: false
+    category: main
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/bzip2-1.0.8-h4e0d66e_4.tar.bz2"
+    hash:
+      md5: 3cbc4e0eede8b25bc53b6a462815aceb
+      sha256: e0edf3c1804547239de9f678f9b650684d0f215e4c277e1d92c281f4d61559b8
+    optional: false
+    category: main
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2"
+    hash:
+      md5: 37edc4e6304ca87316e160f5ca0bd1b5
+      sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
+    optional: false
+    category: main
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2"
+    hash:
+      md5: fc76ace7b94fb1f694988ab1b14dd248
+      sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
+    optional: false
+    category: main
+  - name: c-compiler
+    version: 1.5.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      binutils: "*"
+      gcc: "*"
+      gcc_linux-64: 11.*
+    url: "https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.5.2-h0b41bf4_0.conda"
+    hash:
+      md5: 69afb4e35be6366c2c1f9ed7f49bc3e6
+      sha256: fe4c0080648c3448939919ddc49339cd8e250124b69a518e66ef6989794fa58a
+    optional: false
+    category: main
+  - name: c-compiler
+    version: 1.5.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      binutils: "*"
+      gcc: "*"
+      gcc_linux-aarch64: 11.*
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.5.2-hb4cce97_0.conda"
+    hash:
+      md5: ea29c067379169a815018c1c94a05b9e
+      sha256: 3c63e0126e5a21e62bff541253a6c235b7130e984f39b2fa6acc3773d744ff23
+    optional: false
+    category: main
+  - name: c-compiler
+    version: 1.5.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      binutils: "*"
+      gcc: "*"
+      gcc_linux-ppc64le: 11.*
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/c-compiler-1.5.2-h4194056_0.conda"
+    hash:
+      md5: 906fd28502767b375b9456b4fd59bc4d
+      sha256: 929e32538223e861d1a4efabf95317278fa24602683852f86189bb03ff76aa62
+    optional: false
+    category: main
+  - name: c-compiler
+    version: 1.5.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      cctools: ">=949.0.1"
+      clang_osx-64: 14.*
+      ld64: ">=530"
+      llvm-openmp: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.5.2-hbf74d83_0.conda"
+    hash:
+      md5: c1413ef5a20d658923e12dd3b566d8f3
+      sha256: 0f97b6cc2215f0789ffa2781eb8a6304efaf5c4592c4c619d6e0a63c23f2b877
+    optional: false
+    category: main
+  - name: c-compiler
+    version: 1.5.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      cctools: ">=949.0.1"
+      clang_osx-arm64: 14.*
+      ld64: ">=530"
+      llvm-openmp: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.5.2-h5008568_0.conda"
+    hash:
+      md5: 56a88306583601d05b6eeded173d73d9
+      sha256: 54fabbef178e857a639a9c7a302cdab072ca5c2b94052ac939a7ebcf9dad32e4
+    optional: false
+    category: main
   - name: ca-certificates
     version: 2022.12.7
     manager: conda
@@ -45,6 +1316,1567 @@ package:
     hash:
       md5: ff9f73d45c4a07d6f424495288a26080
       sha256: 8f6c81b0637771ae0ea73dc03a6d30bec3326ba3927f2a7b91931aa2d59b1789
+    optional: false
+    category: main
+  - name: ca-certificates
+    version: 2022.12.7
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2022.12.7-h4fd8a4c_0.conda"
+    hash:
+      md5: 2450fbcaf65634e0d071e47e2b8487b4
+      sha256: bb4e6340d55775738a5867a16071658c294d46cceff7f652f65d8dc6a495a578
+    optional: false
+    category: main
+  - name: ca-certificates
+    version: 2022.12.7
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ca-certificates-2022.12.7-h1084571_0.conda"
+    hash:
+      md5: e3becd49c6d0e94d1b67c9f9a4d50587
+      sha256: 82b77cb085c961b085fbbb5ea3920c1933bda08c2e1dd53685f6f21b16a336ac
+    optional: false
+    category: main
+  - name: ca-certificates
+    version: 2022.12.7
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2022.12.7-h033912b_0.conda"
+    hash:
+      md5: af2bdcd68f16ce030ca957cdeb83d88a
+      sha256: 898276d86de89fb034ecfae05103045d0a0d6a356ced1b6d1832cdbd07a8fc18
+    optional: false
+    category: main
+  - name: ca-certificates
+    version: 2022.12.7
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2022.12.7-h4653dfc_0.conda"
+    hash:
+      md5: 7dc111916edc905957b7417a247583b6
+      sha256: a9634dc719fc9cd4c91cf8ad3167532e59051cace3e90ef2ba305a41c316784a
+    optional: false
+    category: main
+  - name: cairo
+    version: 1.16.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      fontconfig: ">=2.13.96,<3.0a0"
+      fonts-conda-ecosystem: "*"
+      freetype: ">=2.12.1,<3.0a0"
+      icu: ">=70.1,<71.0a0"
+      libgcc-ng: ">=12"
+      libglib: ">=2.72.1,<3.0a0"
+      libpng: ">=1.6.38,<1.7.0a0"
+      libxcb: ">=1.13,<1.14.0a0"
+      libzlib: ">=1.2.12,<1.3.0a0"
+      pixman: ">=0.40.0,<1.0a0"
+      xorg-libice: "*"
+      xorg-libsm: "*"
+      xorg-libx11: "*"
+      xorg-libxext: "*"
+      xorg-libxrender: "*"
+      zlib: ">=1.2.12,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/cairo-1.16.0-ha61ee94_1014.tar.bz2"
+    hash:
+      md5: d1a88f3ed5b52e1024b80d4bcd26a7a0
+      sha256: f062cf56e6e50d3ad4b425ebb3765ca9138c6ebc52e6a42d1377de8bc8d954f6
+    optional: false
+    category: main
+  - name: cctools
+    version: 973.0.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      cctools_osx-64: "==973.0.1 hcc6d90d_11"
+      ld64: "==609 hc6ad406_11"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-h76f1dac_11.conda"
+    hash:
+      md5: 77d8192c013d7a4a355aee5b0ae1ae20
+      sha256: afe5a8d93ae1ecc09d98a15f6edea6b14e0f99fb3f64d4d04501461afb56ccd9
+    optional: false
+    category: main
+  - name: cctools
+    version: 973.0.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      cctools_osx-arm64: "==973.0.1 hef52d2f_11"
+      ld64: "==609 h619f069_11"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-hcbb26d4_11.conda"
+    hash:
+      md5: fed06888f63eed25f43fdd6a475f9533
+      sha256: 2e24a64f78b0362431d1b2f92e1986b4696b08f33cd27b2b17f8e72aa56882dc
+    optional: false
+    category: main
+  - name: cctools_osx-64
+    version: 973.0.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      ld64_osx-64: ">=609,<610.0a0"
+      libcxx: "*"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      sigtool: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-hcc6d90d_11.conda"
+    hash:
+      md5: f1af817221bc31e7c770e1ea15374355
+      sha256: 35c805738300e15a77977849b540b2ba54d8cbc915cb531cf88240a8968fc00d
+    optional: false
+    category: main
+  - name: cctools_osx-arm64
+    version: 973.0.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      ld64_osx-arm64: ">=609,<610.0a0"
+      libcxx: "*"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      sigtool: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-hef52d2f_11.conda"
+    hash:
+      md5: b4f37afd4ae6d094626d1cd10c4af0a8
+      sha256: 434e1ae972a0cd2980c414cb3d9bf2b31518c29dfd5e0124ad30aa6d9219a8f7
+    optional: false
+    category: main
+  - name: certifi
+    version: 2022.12.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/certifi-2022.12.7-pyhd8ed1ab_0.conda"
+    hash:
+      md5: fb9addc3db06e56abe03e0e9f21a63e6
+      sha256: 5e22af4776700200fab2c1df41a2188ab9cfe90a50c4f388592bb978562c88ec
+    optional: false
+    category: main
+  - name: certifi
+    version: 2022.12.7
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/certifi-2022.12.7-pyhd8ed1ab_0.conda"
+    hash:
+      md5: fb9addc3db06e56abe03e0e9f21a63e6
+      sha256: 5e22af4776700200fab2c1df41a2188ab9cfe90a50c4f388592bb978562c88ec
+    optional: false
+    category: main
+  - name: certifi
+    version: 2022.12.7
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/certifi-2022.12.7-pyhd8ed1ab_0.conda"
+    hash:
+      md5: fb9addc3db06e56abe03e0e9f21a63e6
+      sha256: 5e22af4776700200fab2c1df41a2188ab9cfe90a50c4f388592bb978562c88ec
+    optional: false
+    category: main
+  - name: certifi
+    version: 2022.12.7
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/certifi-2022.12.7-pyhd8ed1ab_0.conda"
+    hash:
+      md5: fb9addc3db06e56abe03e0e9f21a63e6
+      sha256: 5e22af4776700200fab2c1df41a2188ab9cfe90a50c4f388592bb978562c88ec
+    optional: false
+    category: main
+  - name: certifi
+    version: 2022.12.7
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/certifi-2022.12.7-pyhd8ed1ab_0.conda"
+    hash:
+      md5: fb9addc3db06e56abe03e0e9f21a63e6
+      sha256: 5e22af4776700200fab2c1df41a2188ab9cfe90a50c4f388592bb978562c88ec
+    optional: false
+    category: main
+  - name: cffi
+    version: 1.15.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libffi: ">=3.4,<4.0a0"
+      libgcc-ng: ">=12"
+      pycparser: "*"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/cffi-1.15.1-py39he91dace_3.conda"
+    hash:
+      md5: 20080319ef73fbad74dcd6d62f2a3ffe
+      sha256: 485a8f65c58c26c7d48bfea20ed1d6f1493f3329dd2c9c0a888a1c2b7c2365c5
+    optional: false
+    category: main
+  - name: cffi
+    version: 1.15.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libffi: ">=3.4,<4.0a0"
+      libgcc-ng: ">=12"
+      pycparser: "*"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-1.15.1-py39hb26bf21_3.conda"
+    hash:
+      md5: dee0362c4fde8edce396183fd6390d6e
+      sha256: 0a3690929b3a22c4e2db8001293509e38b5d90eb2ff57d5d71456e81c9c0f8eb
+    optional: false
+    category: main
+  - name: cffi
+    version: 1.15.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libffi: ">=3.4,<4.0a0"
+      libgcc-ng: ">=12"
+      pycparser: "*"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/cffi-1.15.1-py39h1929af6_3.conda"
+    hash:
+      md5: ff9e253220ea6ff14aea651d2328396f
+      sha256: b19050c387389ad2d0f817f3865a6a1f9706da40b53c6657d1fb8cb417457ff7
+    optional: false
+    category: main
+  - name: cffi
+    version: 1.15.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libffi: ">=3.4,<4.0a0"
+      pycparser: "*"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/cffi-1.15.1-py39h131948b_3.conda"
+    hash:
+      md5: 35c1b89ab4359002865052df70939c48
+      sha256: e099e8ce3f35906071035fef85cbca94bbbb90d18f231ba8cd1a88577c7d84b3
+    optional: false
+    category: main
+  - name: cffi
+    version: 1.15.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libffi: ">=3.4,<4.0a0"
+      pycparser: "*"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.15.1-py39h7e6b969_3.conda"
+    hash:
+      md5: 259002f955175cc89beb8477de5de291
+      sha256: 0fdb684286cb933d398d32f306a2dbbd605acafc4a0f85ebb3c54ff30d604b41
+    optional: false
+    category: main
+  - name: charset-normalizer
+    version: 2.1.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c1d5b294fbf9a795dec349a6f4d8be8e
+      sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
+    optional: false
+    category: main
+  - name: charset-normalizer
+    version: 2.1.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c1d5b294fbf9a795dec349a6f4d8be8e
+      sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
+    optional: false
+    category: main
+  - name: charset-normalizer
+    version: 2.1.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c1d5b294fbf9a795dec349a6f4d8be8e
+      sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
+    optional: false
+    category: main
+  - name: charset-normalizer
+    version: 2.1.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c1d5b294fbf9a795dec349a6f4d8be8e
+      sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
+    optional: false
+    category: main
+  - name: charset-normalizer
+    version: 2.1.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c1d5b294fbf9a795dec349a6f4d8be8e
+      sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
+    optional: false
+    category: main
+  - name: clang
+    version: 14.0.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      clang-14: "==14.0.6 default_h55ffa42_0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/clang-14.0.6-h694c41f_0.tar.bz2"
+    hash:
+      md5: 77667c3c75b88f12782f628d171ffeda
+      sha256: dc38927cc81c81c64ab632f3aaa4bb17ed776794b2bfd3fa3375b38ad768ace7
+    optional: false
+    category: main
+  - name: clang
+    version: 14.0.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      clang-14: "==14.0.6 default_h81a5282_0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/clang-14.0.6-hce30654_0.tar.bz2"
+    hash:
+      md5: 4b60f8635f0d1c6e143551fa82e91945
+      sha256: a001a0aee5076c7c64f0f695f171dcc59f23ce21dd61be94352f16598833a1d5
+    optional: false
+    category: main
+  - name: clang-14
+    version: 14.0.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libclang-cpp14: "==14.0.6 default_h55ffa42_0"
+      libcxx: ">=13.0.1"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/clang-14-14.0.6-default_h55ffa42_0.tar.bz2"
+    hash:
+      md5: f4b08faae104f8a5483c06f7c6464b35
+      sha256: 8c421568bce373e71ade9768f0f7e3563eaec84cb2cd51a7f2e03c6c3bb7be94
+    optional: false
+    category: main
+  - name: clang-14
+    version: 14.0.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libclang-cpp14: "==14.0.6 default_h81a5282_0"
+      libcxx: ">=13.0.1"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/clang-14-14.0.6-default_h81a5282_0.tar.bz2"
+    hash:
+      md5: ad7388bad4d7416ce2bbacddb2faa577
+      sha256: 20a8d11fca5be934d9d8990b688396c0a4be8bd8cc29be2e79be5e3e4baefbeb
+    optional: false
+    category: main
+  - name: clang_osx-64
+    version: 14.0.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      cctools_osx-64: "*"
+      clang: 14.0.6.*
+      compiler-rt: 14.0.6.*
+      ld64_osx-64: "*"
+      llvm-tools: 14.0.6.*
+    url: "https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-14.0.6-h3113cd8_4.conda"
+    hash:
+      md5: e1828ef1597292a9ea25627fdfacb9f3
+      sha256: 4cdce8a6e1b1ea671e6f10839548983f93f9c4ab86cb89acf439d414283162b5
+    optional: false
+    category: main
+  - name: clang_osx-arm64
+    version: 14.0.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      cctools_osx-arm64: "*"
+      clang: 14.0.6.*
+      compiler-rt: 14.0.6.*
+      ld64_osx-arm64: "*"
+      llvm-tools: 14.0.6.*
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-14.0.6-h15773ab_4.conda"
+    hash:
+      md5: d0db37e26bfd89ca03a40a5b8ce15635
+      sha256: 4d23a3b87660ee13516d9d04da665587d488b791eb8300da1a0e6c93f6d8aaf8
+    optional: false
+    category: main
+  - name: clangxx
+    version: 14.0.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      clang: "==14.0.6 h694c41f_0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/clangxx-14.0.6-default_h55ffa42_0.tar.bz2"
+    hash:
+      md5: 6a46064b0506895d090302433e70397b
+      sha256: 11b6d9f11aae45ac36a4d87d0f5367d00eda6f53c43bac38594024e25a366b04
+    optional: false
+    category: main
+  - name: clangxx
+    version: 14.0.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      clang: "==14.0.6 hce30654_0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-14.0.6-default_hb7ecf47_0.tar.bz2"
+    hash:
+      md5: abb3bf7081791c101fcb2851c64900ca
+      sha256: 8b54e9ad48eac3d38c82ece984915f096be11d9279a0c59ccc0b9740e26ea58a
+    optional: false
+    category: main
+  - name: clangxx_osx-64
+    version: 14.0.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      clang_osx-64: "==14.0.6 h3113cd8_4"
+      clangxx: 14.0.6.*
+      libcxx: ">=14.0.6"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-14.0.6-h6f97653_4.conda"
+    hash:
+      md5: f9f2cc37068e5f2f4332793640329fe3
+      sha256: 9da6a17e9ae0b51ecc2ab2f25f850a38902f696de1d05cf2ad9374146cfc1d3a
+    optional: false
+    category: main
+  - name: clangxx_osx-arm64
+    version: 14.0.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      clang_osx-arm64: "==14.0.6 h15773ab_4"
+      clangxx: 14.0.6.*
+      libcxx: ">=14.0.6"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-14.0.6-he29aa18_4.conda"
+    hash:
+      md5: 85157d29e430829c4cc5b1f152306f9b
+      sha256: 87d60f5785f2ab4fe119eb43d7c9ae6a7f6a064ebf95409b0165e0fc6c3a2258
+    optional: false
+    category: main
+  - name: click
+    version: 8.1.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __unix: "*"
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2"
+    hash:
+      md5: 20e4087407c7cb04a40817114b333dbf
+      sha256: 23676470b591b100393bb0f6c46fe10624dcbefc696a6a9f42932ed8816ef0ea
+    optional: false
+    category: main
+  - name: click
+    version: 8.1.3
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      __unix: "*"
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2"
+    hash:
+      md5: 20e4087407c7cb04a40817114b333dbf
+      sha256: 23676470b591b100393bb0f6c46fe10624dcbefc696a6a9f42932ed8816ef0ea
+    optional: false
+    category: main
+  - name: click
+    version: 8.1.3
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      __unix: "*"
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2"
+    hash:
+      md5: 20e4087407c7cb04a40817114b333dbf
+      sha256: 23676470b591b100393bb0f6c46fe10624dcbefc696a6a9f42932ed8816ef0ea
+    optional: false
+    category: main
+  - name: click
+    version: 8.1.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __unix: "*"
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2"
+    hash:
+      md5: 20e4087407c7cb04a40817114b333dbf
+      sha256: 23676470b591b100393bb0f6c46fe10624dcbefc696a6a9f42932ed8816ef0ea
+    optional: false
+    category: main
+  - name: click
+    version: 8.1.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __unix: "*"
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2"
+    hash:
+      md5: 20e4087407c7cb04a40817114b333dbf
+      sha256: 23676470b591b100393bb0f6c46fe10624dcbefc696a6a9f42932ed8816ef0ea
+    optional: false
+    category: main
+  - name: colorama
+    version: 0.4.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 3faab06a954c2a04039983f2c4a50d99
+      sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+    optional: false
+    category: main
+  - name: colorama
+    version: 0.4.6
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 3faab06a954c2a04039983f2c4a50d99
+      sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+    optional: false
+    category: main
+  - name: colorama
+    version: 0.4.6
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 3faab06a954c2a04039983f2c4a50d99
+      sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+    optional: false
+    category: main
+  - name: colorama
+    version: 0.4.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 3faab06a954c2a04039983f2c4a50d99
+      sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+    optional: false
+    category: main
+  - name: colorama
+    version: 0.4.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 3faab06a954c2a04039983f2c4a50d99
+      sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+    optional: false
+    category: main
+  - name: compiler-rt
+    version: 14.0.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      clang: 14.0.6.*
+      clangxx: 14.0.6.*
+      compiler-rt_osx-64: 14.0.6.*
+    url: "https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-14.0.6-h613da45_0.tar.bz2"
+    hash:
+      md5: b44e0625319f9933e584dc3b96f5baf7
+      sha256: 2dea3b5efea587329320c70a335fa5666c3a814e70e76464734b90a40b70e8a8
+    optional: false
+    category: main
+  - name: compiler-rt
+    version: 14.0.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      clang: 14.0.6.*
+      clangxx: 14.0.6.*
+      compiler-rt_osx-arm64: 14.0.6.*
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-14.0.6-h30b49de_0.tar.bz2"
+    hash:
+      md5: b88a5457fa7def557e5902046ab56b6e
+      sha256: 266578ae49450e6b4a778b454f8e7fd988676dd9146bb186093066ab1589ba06
+    optional: false
+    category: main
+  - name: compiler-rt_osx-64
+    version: 14.0.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      clang: 14.0.6.*
+      clangxx: 14.0.6.*
+    url: "https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-14.0.6-hab78ec2_0.tar.bz2"
+    hash:
+      md5: 4fdde3f4ed31722a1c811723f5db82f0
+      sha256: a8351d6a47a8a2cd8267862d36ad5a06f16955c68111140b8b147ee126433712
+    optional: false
+    category: main
+  - name: compiler-rt_osx-arm64
+    version: 14.0.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      clang: 14.0.6.*
+      clangxx: 14.0.6.*
+    url: "https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-14.0.6-h48302dc_0.tar.bz2"
+    hash:
+      md5: ebcb473032038866101b70f9f270a9a2
+      sha256: f9f63e8779ff31368cc92ee668308c8e7e974f68457f62148c5663aa0136a42d
+    optional: false
+    category: main
+  - name: compilers
+    version: 1.5.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      c-compiler: "==1.5.2 h0b41bf4_0"
+      cxx-compiler: "==1.5.2 hf52228f_0"
+      fortran-compiler: "==1.5.2 hdb1a99f_0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/compilers-1.5.2-ha770c72_0.conda"
+    hash:
+      md5: f95226244ee1c487cf53272f971323f4
+      sha256: 8ca9a7581c9522fa299782e28ac1e196f67df72b2f01c1e6ed09a2d3a77ec310
+    optional: false
+    category: main
+  - name: compilers
+    version: 1.5.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      c-compiler: "==1.5.2 hb4cce97_0"
+      cxx-compiler: "==1.5.2 h4c384f3_0"
+      fortran-compiler: "==1.5.2 h878be85_0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/compilers-1.5.2-h8af1aa0_0.conda"
+    hash:
+      md5: 3505d3b81bd518ea3fd084f33f6d486f
+      sha256: 84c71456b39a9693d471c9b279073afa67c47611f5fdaa99b72f069f46454e96
+    optional: false
+    category: main
+  - name: compilers
+    version: 1.5.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      c-compiler: "==1.5.2 h4194056_0"
+      cxx-compiler: "==1.5.2 he01d56d_0"
+      fortran-compiler: "==1.5.2 hc9fb769_0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/compilers-1.5.2-ha3edaa6_0.conda"
+    hash:
+      md5: 46edabff80f1b3208e74cc858f733f5a
+      sha256: da5910e38483edcaf941c6d6c124274a900a899d55c91f82ca3324a68f99608b
+    optional: false
+    category: main
+  - name: compilers
+    version: 1.5.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      c-compiler: "==1.5.2 hbf74d83_0"
+      cxx-compiler: "==1.5.2 hb8565cd_0"
+      fortran-compiler: "==1.5.2 haad3a49_0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/compilers-1.5.2-h694c41f_0.conda"
+    hash:
+      md5: 1fdd3bc173dad6e7a0439962c7764ab8
+      sha256: fe35c96a228d9e245e9cc05fdff5078e8f31a9ae44bd320f5cb48e6ab0fca139
+    optional: false
+    category: main
+  - name: compilers
+    version: 1.5.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      c-compiler: "==1.5.2 h5008568_0"
+      cxx-compiler: "==1.5.2 hffc8910_0"
+      fortran-compiler: "==1.5.2 h2ccabda_0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/compilers-1.5.2-hce30654_0.conda"
+    hash:
+      md5: 4bf0aaf590a633d103a70841bb9f2f2e
+      sha256: 9a21d680350cf836160476852d18f2fdfb3c95ea9556d061dc08422907c02c1e
+    optional: false
+    category: main
+  - name: contourpy
+    version: 1.0.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      numpy: ">=1.16"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.0.7-py39h4b4f3f3_0.conda"
+    hash:
+      md5: c5387f3fb1f5b8b71e1c865fc55f4951
+      sha256: 74a767b73686caf0bb1d1186cd62a54f01e03ad5432eaaf0a7babad7634c4067
+    optional: false
+    category: main
+  - name: contourpy
+    version: 1.0.7
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      numpy: ">=1.16"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.0.7-py39hd9a2fea_0.conda"
+    hash:
+      md5: efa783bf5c2b30aba3cf22599fe0274e
+      sha256: 0da3e468f4ee6cc3d708e32ab4d1e4d6e8ed899168693e3e33570d1e8ce927d9
+    optional: false
+    category: main
+  - name: contourpy
+    version: 1.0.7
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      numpy: ">=1.16"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/contourpy-1.0.7-py39h9e1b185_0.conda"
+    hash:
+      md5: 13b641a7acb57ac3c52747d2cec170e2
+      sha256: 017e14b677471c076e978e9e8e625f2ff03e3d0cb88d1807b2b40501adf041e2
+    optional: false
+    category: main
+  - name: contourpy
+    version: 1.0.7
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=14.0.6"
+      numpy: ">=1.16"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.0.7-py39h92daf61_0.conda"
+    hash:
+      md5: 3b50cfd6ea07613741693ba535fcefda
+      sha256: e62b248506d690eaea2de499555288665ca0508d54efe63690638f1b39e6e775
+    optional: false
+    category: main
+  - name: contourpy
+    version: 1.0.7
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=14.0.6"
+      numpy: ">=1.16"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.0.7-py39haaf3ac1_0.conda"
+    hash:
+      md5: 221d648082c1ebdd89e6968441b5a9c5
+      sha256: 141e4de214f13537aee7acfa3ed49e43346af017d66030794cd0a4f62ceda9e6
+    optional: false
+    category: main
+  - name: coverage
+    version: 7.1.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      tomli: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/coverage-7.1.0-py39h72bdee0_0.conda"
+    hash:
+      md5: 915b100b564875cceb85cbeab61fd678
+      sha256: 074f44d601cae7c972183e915e7ea53ea433c59a43cb0c8964bb4d897e514512
+    optional: false
+    category: main
+  - name: coverage
+    version: 7.1.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      tomli: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.1.0-py39h599bc27_0.conda"
+    hash:
+      md5: 642b33264c733811d45640fc5d035a5c
+      sha256: 7d02e1632234311db52c247b7d59ea8173cc06ac43943147a5291be62885a6c3
+    optional: false
+    category: main
+  - name: coverage
+    version: 7.1.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      tomli: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/coverage-7.1.0-py39h3c7ea95_0.conda"
+    hash:
+      md5: dd671f8adf5a91298fea2aa3f067c910
+      sha256: 5cd7aeb415ba5581cf10782b0d41b0b5e30ce236f074267944c21db57fa23569
+    optional: false
+    category: main
+  - name: coverage
+    version: 7.1.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      tomli: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/coverage-7.1.0-py39ha30fb19_0.conda"
+    hash:
+      md5: be24d2d5a14dd95d77376ca68df86e94
+      sha256: 7c3ee64099be5aa022f0126b5c5ace87cfb616a19fdcc7d88731ed432595fbc3
+    optional: false
+    category: main
+  - name: coverage
+    version: 7.1.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+      tomli: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.1.0-py39h02fc5c5_0.conda"
+    hash:
+      md5: abe9ca542c29c3b9963f5baaf64bf827
+      sha256: 57bcb6504fee2cc252ed2cec5e5aa07d10b8419f0b611078c56bc156dd7d66a1
+    optional: false
+    category: main
+  - name: cryptography
+    version: 39.0.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      cffi: ">=1.12"
+      libgcc-ng: ">=12"
+      openssl: ">=3.0.8,<4.0a0"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/cryptography-39.0.1-py39h079d5ae_0.conda"
+    hash:
+      md5: 3245013812dfbff6a22e57533ac6f69d
+      sha256: 4349d5416c718c331454b957e0a077500fb4fb9e8f3b7eadb8777a3842021818
+    optional: false
+    category: main
+  - name: cryptography
+    version: 39.0.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      cffi: ">=1.12"
+      libgcc-ng: ">=12"
+      openssl: ">=3.0.8,<4.0a0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-39.0.1-py39h8a84b6a_0.conda"
+    hash:
+      md5: 836c852bcc8f60392bfe4f9305f541b7
+      sha256: a0918f5094edff472291dc2889431a17aaff4b0ee38ae321ff2ea5b420a4b42a
+    optional: false
+    category: main
+  - name: cryptography
+    version: 39.0.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      cffi: ">=1.12"
+      libgcc-ng: ">=12"
+      openssl: ">=3.0.8,<4.0a0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/cryptography-39.0.1-py39h31bd36e_0.conda"
+    hash:
+      md5: 83f2e100cadaabaeae02f29dc3263f98
+      sha256: 4dd0c3fa9da6b1e542c812ac421b28bbff222906d79587855a8d8f51d64d81e5
+    optional: false
+    category: main
+  - name: cryptography
+    version: 39.0.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      cffi: ">=1.12"
+      openssl: ">=3.0.8,<4.0a0"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/cryptography-39.0.1-py39hbeae22c_0.conda"
+    hash:
+      md5: fac2793ec157233017912d190fa15f00
+      sha256: 3b98fbb4a457fb3136e832079b5cf112063bd3c91b655f640db0b455328b3767
+    optional: false
+    category: main
+  - name: cryptography
+    version: 39.0.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      cffi: ">=1.12"
+      openssl: ">=3.0.8,<4.0a0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-39.0.1-py39he2a39a8_0.conda"
+    hash:
+      md5: 8a645fce995651a072a449b23a713954
+      sha256: d7a28a987198925ccc2a6f7d9b2e5e6da0fa97b5f18f844ff4aae1a2c57ec3f7
+    optional: false
+    category: main
+  - name: cxx-compiler
+    version: 1.5.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      c-compiler: "==1.5.2 h0b41bf4_0"
+      gxx: "*"
+      gxx_linux-64: 11.*
+    url: "https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.5.2-hf52228f_0.conda"
+    hash:
+      md5: 6b3b19e359824b97df7145c8c878c8be
+      sha256: c6916082ea28b905dd59d4b6b5b07be413a3a5a814193df43c28101e4d29a7fc
+    optional: false
+    category: main
+  - name: cxx-compiler
+    version: 1.5.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      c-compiler: "==1.5.2 hb4cce97_0"
+      gxx: "*"
+      gxx_linux-aarch64: 11.*
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.5.2-h4c384f3_0.conda"
+    hash:
+      md5: 8ce6c4bc31f879baedd1f726f430fa6a
+      sha256: a2560d134c72f29f193ec195f25e774a6855c8bc1588427abfdfbb52c6769620
+    optional: false
+    category: main
+  - name: cxx-compiler
+    version: 1.5.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      c-compiler: "==1.5.2 h4194056_0"
+      gxx: "*"
+      gxx_linux-ppc64le: 11.*
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/cxx-compiler-1.5.2-he01d56d_0.conda"
+    hash:
+      md5: b3e397799dcf3015c437a3d0ed17abfa
+      sha256: ce7f60cf80c215d740be900c17599fd635e504ce412f0cecb5918018a9724cc8
+    optional: false
+    category: main
+  - name: cxx-compiler
+    version: 1.5.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      c-compiler: "==1.5.2 hbf74d83_0"
+      clangxx_osx-64: 14.*
+    url: "https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.5.2-hb8565cd_0.conda"
+    hash:
+      md5: 349ae14723b98f76ea0fcb8e532b2ead
+      sha256: 91193c9029594d102217457ce8b4fe1cfd4a1e13e652451e94f851e91b45a147
+    optional: false
+    category: main
+  - name: cxx-compiler
+    version: 1.5.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      c-compiler: "==1.5.2 h5008568_0"
+      clangxx_osx-arm64: 14.*
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.5.2-hffc8910_0.conda"
+    hash:
+      md5: 3dd2dd956573a59e32711e2e08bb5d8b
+      sha256: 84f23671f8b18aeabcfd4b5315383442c3bdff3c9194b85c30ec5690d14e721a
+    optional: false
+    category: main
+  - name: cycler
+    version: 0.11.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: a50559fad0affdbb33729a68669ca1cb
+      sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
+    optional: false
+    category: main
+  - name: cycler
+    version: 0.11.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: a50559fad0affdbb33729a68669ca1cb
+      sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
+    optional: false
+    category: main
+  - name: cycler
+    version: 0.11.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: a50559fad0affdbb33729a68669ca1cb
+      sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
+    optional: false
+    category: main
+  - name: cycler
+    version: 0.11.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: a50559fad0affdbb33729a68669ca1cb
+      sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
+    optional: false
+    category: main
+  - name: cycler
+    version: 0.11.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: a50559fad0affdbb33729a68669ca1cb
+      sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
+    optional: false
+    category: main
+  - name: cython
+    version: 0.29.33
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/cython-0.29.33-py39h227be39_0.conda"
+    hash:
+      md5: 34bab6ef3e8cdf86fe78c46a984d3217
+      sha256: 908715a56fe7633df894464c59c3799d88300772fc62011fa96593ce4ad92ef4
+    optional: false
+    category: main
+  - name: cython
+    version: 0.29.33
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/cython-0.29.33-py39hdcdd789_0.conda"
+    hash:
+      md5: 7a94705550f5c09d4a3b069f0488caed
+      sha256: 9e7162fd241d306a0274c970dc266c9684747b1b31bfee795572ceb232b004bf
+    optional: false
+    category: main
+  - name: cython
+    version: 0.29.33
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/cython-0.29.33-py39h89b8a7f_0.conda"
+    hash:
+      md5: ee427d1817a2e2f0683c77bdc0bc6ee9
+      sha256: 17ce872a2c27af5fcc84485e65072ce9549b516a14142acedd867edbfc1fc884
+    optional: false
+    category: main
+  - name: cython
+    version: 0.29.33
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=14.0.6"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/cython-0.29.33-py39h7a8716b_0.conda"
+    hash:
+      md5: 04be8513f2ce60858396afbd0353688a
+      sha256: 3ee611cc2d9793089ef54e20d7521655b2ef8017b4c56003f872ffdb16eafee2
+    optional: false
+    category: main
+  - name: cython
+    version: 0.29.33
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=14.0.6"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cython-0.29.33-py39h23fbdae_0.conda"
+    hash:
+      md5: 39e8c4d178e2c54e910f8b59624fb796
+      sha256: 036c45bf33e0c167b4d518c649722290c1779a067b1f1c197e27b7f735d8af9b
+    optional: false
+    category: main
+  - name: dbus
+    version: 1.13.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      expat: ">=2.4.2,<3.0a0"
+      libgcc-ng: ">=9.4.0"
+      libglib: ">=2.70.2,<3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2"
+    hash:
+      md5: ecfff944ba3960ecb334b9a2663d708d
+      sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
+    optional: false
+    category: main
+  - name: decorator
+    version: 5.1.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 43afe5ab04e35e17ba28649471dd7364
+      sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+    optional: false
+    category: main
+  - name: decorator
+    version: 5.1.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 43afe5ab04e35e17ba28649471dd7364
+      sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+    optional: false
+    category: main
+  - name: decorator
+    version: 5.1.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 43afe5ab04e35e17ba28649471dd7364
+      sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+    optional: false
+    category: main
+  - name: decorator
+    version: 5.1.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 43afe5ab04e35e17ba28649471dd7364
+      sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+    optional: false
+    category: main
+  - name: decorator
+    version: 5.1.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 43afe5ab04e35e17ba28649471dd7364
+      sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+    optional: false
+    category: main
+  - name: docutils
+    version: "0.19"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/docutils-0.19-py39hf3d152e_1.tar.bz2"
+    hash:
+      md5: adb733ec2ee669f6d010758d054da60f
+      sha256: 826ae2374fc37a9bb29dd3c7783ba11ffa1e215660a60144e7f759c49686b1af
+    optional: false
+    category: main
+  - name: docutils
+    version: "0.19"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/docutils-0.19-py39ha65689a_1.tar.bz2"
+    hash:
+      md5: fd0d3cb6620a155e9a1bbb5f0d5f2456
+      sha256: 01587e209ffd4f7b9f7ef9988068a9ef6a008f405c397c60a48a95584c30a4a8
+    optional: false
+    category: main
+  - name: docutils
+    version: "0.19"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/docutils-0.19-py39hc1b9086_1.tar.bz2"
+    hash:
+      md5: b0c85fe5865a2d03afbd2b01ae03e69e
+      sha256: 490f080af53643f1e61fa042b69594079786a16c8889a151922642a3dec48377
+    optional: false
+    category: main
+  - name: docutils
+    version: "0.19"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/docutils-0.19-py39h6e9494a_1.tar.bz2"
+    hash:
+      md5: d9db9ab3a721b9f36017d6b93060b462
+      sha256: 232f045f5935309bd3c7901027a728c1dcfdab385e8ad104f54b6a70c315a219
+    optional: false
+    category: main
+  - name: docutils
+    version: "0.19"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.19-py39h2804cbe_1.tar.bz2"
+    hash:
+      md5: 509daec50d39e5f31eb2992d2248752e
+      sha256: 910ef18f7b43aeef7a6cc51274c68895c64c28b7fa05979dae8917106d9f5cd7
+    optional: false
+    category: main
+  - name: doxygen
+    version: 1.9.5
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libiconv: ">=1.16,<2.0.0a0"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.9.5-h583eb01_0.tar.bz2"
+    hash:
+      md5: a94d4fb8005f9d8d286e06bbb1bec448
+      sha256: f8379387abdb1c51ec72165fbd7e2c54b83c40224ea9eed825a18895ab60273f
+    optional: false
+    category: main
+  - name: doxygen
+    version: 1.9.5
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libiconv: ">=1.16,<2.0.0a0"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/doxygen-1.9.5-h04155f4_0.tar.bz2"
+    hash:
+      md5: 8b648aebf430cde9aa32cc55a51dc3b2
+      sha256: 4ccd5a8f2434ba04fcda419e690dec233f381432e23adceb0f2fe11029b67770
+    optional: false
+    category: main
+  - name: doxygen
+    version: 1.9.5
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libiconv: ">=1.16,<2.0.0a0"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/doxygen-1.9.5-hc3812df_0.tar.bz2"
+    hash:
+      md5: 1bab180eb34c97ed9814436fecab3a0f
+      sha256: 4a22d0c893e52ef49dbfbc7f408ff4422aca8d41e40194cab623c580cbb50172
+    optional: false
+    category: main
+  - name: doxygen
+    version: 1.9.5
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=14.0.4"
+      libiconv: ">=1.16,<2.0.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/doxygen-1.9.5-h6ca31d6_0.tar.bz2"
+    hash:
+      md5: 100e85351a872cfc6e5036329a10f589
+      sha256: 6900910a349b4a54fd42aa67c940c53efe137e0fe4160ec05aafb15dc9c6903e
+    optional: false
+    category: main
+  - name: doxygen
+    version: 1.9.5
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=14.0.4"
+      libiconv: ">=1.16,<2.0.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.9.5-hd78112f_0.tar.bz2"
+    hash:
+      md5: 0b5059999731cad5ca96b597f0b6c77b
+      sha256: 48a4bafdacca69e6ee38ea635d81e300bad86eda34869600fbdeff50ed74976f
+    optional: false
+    category: main
+  - name: exceptiongroup
+    version: 1.1.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: a385c3e8968b4cf8fbc426ace915fd1a
+      sha256: cf668360331552b2903e440cda1b4e47062c3f3775342e4a278ef4d141c28d1d
+    optional: false
+    category: main
+  - name: exceptiongroup
+    version: 1.1.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: a385c3e8968b4cf8fbc426ace915fd1a
+      sha256: cf668360331552b2903e440cda1b4e47062c3f3775342e4a278ef4d141c28d1d
+    optional: false
+    category: main
+  - name: exceptiongroup
+    version: 1.1.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: a385c3e8968b4cf8fbc426ace915fd1a
+      sha256: cf668360331552b2903e440cda1b4e47062c3f3775342e4a278ef4d141c28d1d
+    optional: false
+    category: main
+  - name: exceptiongroup
+    version: 1.1.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: a385c3e8968b4cf8fbc426ace915fd1a
+      sha256: cf668360331552b2903e440cda1b4e47062c3f3775342e4a278ef4d141c28d1d
+    optional: false
+    category: main
+  - name: exceptiongroup
+    version: 1.1.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: a385c3e8968b4cf8fbc426ace915fd1a
+      sha256: cf668360331552b2903e440cda1b4e47062c3f3775342e4a278ef4d141c28d1d
+    optional: false
+    category: main
+  - name: execnet
+    version: 1.9.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: "==2.7|>=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/execnet-1.9.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 0e521f7a5e60d508b121d38b04874fb2
+      sha256: 1900bbc1764d01405e55be2e369d1b830fb435eb0f27c57033372c60f34c675c
+    optional: false
+    category: main
+  - name: execnet
+    version: 1.9.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: "==2.7|>=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/execnet-1.9.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 0e521f7a5e60d508b121d38b04874fb2
+      sha256: 1900bbc1764d01405e55be2e369d1b830fb435eb0f27c57033372c60f34c675c
+    optional: false
+    category: main
+  - name: execnet
+    version: 1.9.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: "==2.7|>=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/execnet-1.9.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 0e521f7a5e60d508b121d38b04874fb2
+      sha256: 1900bbc1764d01405e55be2e369d1b830fb435eb0f27c57033372c60f34c675c
+    optional: false
+    category: main
+  - name: execnet
+    version: 1.9.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: "==2.7|>=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/execnet-1.9.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 0e521f7a5e60d508b121d38b04874fb2
+      sha256: 1900bbc1764d01405e55be2e369d1b830fb435eb0f27c57033372c60f34c675c
+    optional: false
+    category: main
+  - name: execnet
+    version: 1.9.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: "==2.7|>=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/execnet-1.9.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 0e521f7a5e60d508b121d38b04874fb2
+      sha256: 1900bbc1764d01405e55be2e369d1b830fb435eb0f27c57033372c60f34c675c
+    optional: false
+    category: main
+  - name: executing
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 4c1bc140e2be5c8ba6e3acab99e25c50
+      sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
+    optional: false
+    category: main
+  - name: executing
+    version: 1.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 4c1bc140e2be5c8ba6e3acab99e25c50
+      sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
+    optional: false
+    category: main
+  - name: executing
+    version: 1.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 4c1bc140e2be5c8ba6e3acab99e25c50
+      sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
+    optional: false
+    category: main
+  - name: executing
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 4c1bc140e2be5c8ba6e3acab99e25c50
+      sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
+    optional: false
+    category: main
+  - name: executing
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 4c1bc140e2be5c8ba6e3acab99e25c50
+      sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
+    optional: false
+    category: main
+  - name: expat
+    version: 2.5.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-h27087fc_0.tar.bz2"
+    hash:
+      md5: c4fbad8d4bddeb3c085f18cbf97fbfad
+      sha256: b44db0b92ae926b3fbbcd57c179fceb64fa11a9f9d09082e03be58b74dcad832
+    optional: false
+    category: main
+  - name: fftw
+    version: 3.3.10
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libgfortran-ng: "*"
+      libgfortran5: ">=10.4.0"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/fftw-3.3.10-nompi_hf0379b8_106.conda"
+    hash:
+      md5: d7407e695358f068a2a7f8295cde0567
+      sha256: 8b735848df623fab555a6d7fc400636116d6ed5686ae0e50adb7df4c1c3a9cef
     optional: false
     category: main
   - name: font-ttf-dejavu-sans-mono
@@ -91,103 +2923,32 @@ package:
       sha256: 470d5db54102bd51dbb0c5990324a2f4a0bc976faa493b22193338adb9882e2e
     optional: false
     category: main
-  - name: kernel-headers_linux-64
-    version: 2.6.32
+  - name: fontconfig
+    version: 2.14.2
     manager: conda
     platform: linux-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_15.tar.bz2"
+    dependencies:
+      expat: ">=2.5.0,<3.0a0"
+      freetype: ">=2.12.1,<3.0a0"
+      libgcc-ng: ">=12"
+      libuuid: ">=2.32.1,<3.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda"
     hash:
-      md5: 5dd5127afd710f91f6a75821bac0a4f0
-      sha256: c9f33acc0f1095bd4e7a2b577dfa41fc3fef3713b3975e8467a0fbed188fe6f4
+      md5: 0f69b688f52ff6da70bccb7ff7001d1d
+      sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
     optional: false
     category: main
-  - name: ld_impl_linux-64
-    version: "2.39"
+  - name: fonts-conda-ecosystem
+    version: "1"
     manager: conda
     platform: linux-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.39-hcc3a1bd_1.conda"
+    dependencies:
+      fonts-conda-forge: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2"
     hash:
-      md5: 737be0d34c22d24432049ab7a3214de4
-      sha256: 3e7f203e33ea497b6e468279cc5fdef7d556473c25e7466b35fd672940392469
-    optional: false
-    category: main
-  - name: libgcc-devel_linux-64
-    version: 11.3.0
-    manager: conda
-    platform: linux-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-11.3.0-h210ce93_19.tar.bz2"
-    hash:
-      md5: 9b7bdb0b42ce4e4670d32bfe0532b56a
-      sha256: 70b2c370cc616304f732eeb4014825390dbee044ecbc3875e968b0ea01bd7503
-    optional: false
-    category: main
-  - name: libgfortran5
-    version: 12.2.0
-    manager: conda
-    platform: linux-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-12.2.0-h337968e_19.tar.bz2"
-    hash:
-      md5: 164b4b1acaedc47ee7e658ae6b308ca3
-      sha256: 03ea784edd12037dc3a7a0078ff3f9c3383feabb34d5ba910bb2fd7a21a2d961
-    optional: false
-    category: main
-  - name: libstdcxx-devel_linux-64
-    version: 11.3.0
-    manager: conda
-    platform: linux-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-11.3.0-h210ce93_19.tar.bz2"
-    hash:
-      md5: 8aee006c0662f551f3acef9a7077a5b9
-      sha256: abfcbf3a0f770be88eefebf84ae3a901da9e933799c9eecf3e9b06f34b00a0a5
-    optional: false
-    category: main
-  - name: libstdcxx-ng
-    version: 12.2.0
-    manager: conda
-    platform: linux-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-12.2.0-h46fd767_19.tar.bz2"
-    hash:
-      md5: 1030b1f38c129f2634eae026f704fe60
-      sha256: 0289e6a7b9a5249161a3967909e12dcfb4ab4475cdede984635d3fb65c606f08
-    optional: false
-    category: main
-  - name: nomkl
-    version: "1.0"
-    manager: conda
-    platform: linux-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2"
-    hash:
-      md5: 9a66894dfd07c4510beb6b3f9672ccc0
-      sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
-    optional: false
-    category: main
-  - name: python_abi
-    version: "3.9"
-    manager: conda
-    platform: linux-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.9-3_cp39.conda"
-    hash:
-      md5: 0dd193187d54e585cac7eab942a8847e
-      sha256: 89e8c4436dd04d8b4a0c13c508e930be56973a480a9714171969de953bdafd3a
-    optional: false
-    category: main
-  - name: tzdata
-    version: 2022g
-    manager: conda
-    platform: linux-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
-    hash:
-      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
-      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
+      md5: fee5683a3f04bd15cbd8318b096a27ab
+      sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
     optional: false
     category: main
   - name: fonts-conda-forge
@@ -205,180 +2966,364 @@ package:
       sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
     optional: false
     category: main
-  - name: libgfortran-ng
-    version: 12.2.0
+  - name: fonttools
+    version: 4.38.0
     manager: conda
     platform: linux-64
     dependencies:
-      libgfortran5: "==12.2.0 h337968e_19"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-12.2.0-h69a702a_19.tar.bz2"
+      brotli: "*"
+      libgcc-ng: ">=12"
+      munkres: "*"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      unicodedata2: ">=14.0.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.38.0-py39hb9d737c_1.tar.bz2"
     hash:
-      md5: cd7a806282c16e1f2d39a7e80d3a3e0d
-      sha256: c7d061f323e80fbc09564179073d8af303bf69b953b0caddcf79b47e352c746f
+      md5: 3f2d104f2fefdd5e8a205dd3aacbf1d7
+      sha256: 55dff2dd401ef1d6fc4a27cf8e74af899c609519d35eafff3b097d7fc1836d83
     optional: false
     category: main
-  - name: libgomp
-    version: 12.2.0
+  - name: fonttools
+    version: 4.38.0
     manager: conda
-    platform: linux-64
+    platform: linux-aarch64
     dependencies:
-      _libgcc_mutex: "==0.1 conda_forge"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libgomp-12.2.0-h65d4601_19.tar.bz2"
+      brotli: "*"
+      libgcc-ng: ">=12"
+      munkres: "*"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+      unicodedata2: ">=14.0.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.38.0-py39h0fd3b05_1.tar.bz2"
     hash:
-      md5: cedcee7c064c01c403f962c9e8d3c373
-      sha256: 81a76d20cfdee9fe0728b93ef057ba93494fd1450d42bc3717af4e468235661e
+      md5: c4eda904dc52f53c948d64d20662525f
+      sha256: f8160177436c15a924a539f3074d36ad10960b0243340a1b9d79633432fff65e
     optional: false
     category: main
-  - name: sysroot_linux-64
-    version: "2.12"
+  - name: fonttools
+    version: 4.38.0
     manager: conda
-    platform: linux-64
+    platform: linux-ppc64le
     dependencies:
-      kernel-headers_linux-64: "==2.6.32 he073ed8_15"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_15.tar.bz2"
+      brotli: "*"
+      libgcc-ng: ">=12"
+      munkres: "*"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+      unicodedata2: ">=14.0.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/fonttools-4.38.0-py39h98ec90c_1.tar.bz2"
     hash:
-      md5: 66c192522eacf5bb763568b4e415d133
-      sha256: 8498c73b60a7ea6faedf36204ec5a339c78d430fa838860f2b9d5d3a1c354eff
+      md5: 505389efe350445e400f250c35b3a300
+      sha256: ef5ce78150a726933e52a5e7f0886edf64eb2f0b9e2eb533d9f58ff5ae851671
     optional: false
     category: main
-  - name: _openmp_mutex
-    version: "4.5"
+  - name: fonttools
+    version: 4.38.0
     manager: conda
-    platform: linux-64
+    platform: osx-64
     dependencies:
-      _libgcc_mutex: "==0.1 conda_forge"
-      libgomp: ">=7.5.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2"
+      brotli: "*"
+      munkres: "*"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      unicodedata2: ">=14.0.0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.38.0-py39ha30fb19_1.tar.bz2"
     hash:
-      md5: 73aaf86a425cc6e73fcf236a5a46396d
-      sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
+      md5: d4ef9879362c40c8c346a0b6cd79f2e0
+      sha256: 6875cb8e44e09332b59f276c3b32be05906206f8a19e773d8c765feeae6dac4b
     optional: false
     category: main
-  - name: binutils_impl_linux-64
-    version: "2.39"
+  - name: fonttools
+    version: 4.38.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      brotli: "*"
+      munkres: "*"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+      unicodedata2: ">=14.0.0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.38.0-py39h02fc5c5_1.tar.bz2"
+    hash:
+      md5: bad1666f9a5aa9743e2be7b6818d752a
+      sha256: 7abe958b39d09b15ec6ec4847525d77a347e43fa05d480c95ce2453f4a394006
+    optional: false
+    category: main
+  - name: fortran-compiler
+    version: 1.5.2
     manager: conda
     platform: linux-64
     dependencies:
-      ld_impl_linux-64: "==2.39 hcc3a1bd_1"
+      binutils: "*"
+      c-compiler: "==1.5.2 h0b41bf4_0"
+      gfortran: "*"
+      gfortran_linux-64: 11.*
+    url: "https://conda.anaconda.org/conda-forge/linux-64/fortran-compiler-1.5.2-hdb1a99f_0.conda"
+    hash:
+      md5: 265323e1bd53709aeb739c9b1794b398
+      sha256: 985733294fe9b3dc6f126ee95b4b934e097060ca0c12fe469812596a4763228e
+    optional: false
+    category: main
+  - name: fortran-compiler
+    version: 1.5.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      binutils: "*"
+      c-compiler: "==1.5.2 hb4cce97_0"
+      gfortran: "*"
+      gfortran_linux-aarch64: 11.*
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/fortran-compiler-1.5.2-h878be85_0.conda"
+    hash:
+      md5: 0fc27753a4f9b39286bd58ce8870605e
+      sha256: e9d8407d1a4030b3faef9a7278cea55de3343f2507680ef673d32dff14d9060b
+    optional: false
+    category: main
+  - name: fortran-compiler
+    version: 1.5.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      binutils: "*"
+      c-compiler: "==1.5.2 h4194056_0"
+      gfortran: "*"
+      gfortran_linux-ppc64le: 11.*
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/fortran-compiler-1.5.2-hc9fb769_0.conda"
+    hash:
+      md5: 0fd7f97c0c750664bd80c0ce33b64184
+      sha256: dddb38309e547593b9086eeeda9989b4032e89bbf27a87a3df65b0871df3725a
+    optional: false
+    category: main
+  - name: fortran-compiler
+    version: 1.5.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      cctools: ">=949.0.1"
+      gfortran: "*"
+      gfortran_osx-64: 11.*
+      ld64: ">=530"
+      llvm-openmp: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/fortran-compiler-1.5.2-haad3a49_0.conda"
+    hash:
+      md5: 649a324b13eb77c6d5e98d36ea0c59f4
+      sha256: db482cbd1f8046a6d51c0af47d98f97e0c157bf9029bbc95b71c72972f3fa01f
+    optional: false
+    category: main
+  - name: fortran-compiler
+    version: 1.5.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      cctools: ">=949.0.1"
+      gfortran: "*"
+      gfortran_osx-arm64: 11.*
+      ld64: ">=530"
+      llvm-openmp: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/fortran-compiler-1.5.2-h2ccabda_0.conda"
+    hash:
+      md5: 21d7e4d79b87bf28d865241f7dff5629
+      sha256: d5b7b998c28252a1a7ee07d4558c89ba0fa43fa12b27f336ab02115e18add806
+    optional: false
+    category: main
+  - name: freetype
+    version: 2.12.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libpng: ">=1.6.39,<1.7.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-hca18f0e_1.conda"
+    hash:
+      md5: e1232042de76d24539a436d37597eb06
+      sha256: 1eb913727b54e9aa63c6d9a1177db4e2894cee97c5f26910a2b61899d5ac904f
+    optional: false
+    category: main
+  - name: freetype
+    version: 2.12.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libpng: ">=1.6.39,<1.7.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hbbbf32d_1.conda"
+    hash:
+      md5: e0891290982420d67651589c8584eec3
+      sha256: f574138dd4fcec3acbd87df049bb9161af95ad194120cf322d884fdf0df477b5
+    optional: false
+    category: main
+  - name: freetype
+    version: 2.12.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libpng: ">=1.6.39,<1.7.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/freetype-2.12.1-h90753b0_1.conda"
+    hash:
+      md5: 55076efce6db8419ba5b1b854f455c4a
+      sha256: a46c8d870bc41b15e0d8362911fe8fef4d7e6626bf23b1fc53e477788a149582
+    optional: false
+    category: main
+  - name: freetype
+    version: 2.12.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libpng: ">=1.6.39,<1.7.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h3f81eb7_1.conda"
+    hash:
+      md5: 852224ea3e8991a8342228eab274840e
+      sha256: 0aea2b93d0da8bf022501857de93f2fc0e362fabcd83c4579be8d8f5bc3e17cb
+    optional: false
+    category: main
+  - name: freetype
+    version: 2.12.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libpng: ">=1.6.39,<1.7.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hd633e50_1.conda"
+    hash:
+      md5: 33ea6326e26d1da25eb8dfa768195b82
+      sha256: 9f20ac782386cca6295cf02a07bbc6aedc4739330dc9caba242630602a9ab7f4
+    optional: false
+    category: main
+  - name: gcc
+    version: 11.3.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      gcc_impl_linux-64: 11.3.0.*
+    url: "https://conda.anaconda.org/conda-forge/linux-64/gcc-11.3.0-h02d0930_11.tar.bz2"
+    hash:
+      md5: 6037ebe5f1e3054519ce78b11eec9cd4
+      sha256: 1946d6c3ea7e98231de51d506c978c00ae97c7b27379ab34a368218d014758c8
+    optional: false
+    category: main
+  - name: gcc
+    version: 11.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      gcc_impl_linux-aarch64: 11.3.0.*
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-11.3.0-he2d1185_11.tar.bz2"
+    hash:
+      md5: 72f1c88a327e40a7bdf030be352e9f49
+      sha256: 70ee0c88cec738b6b5932b0e5c72b8d929aa3e167e9cb34823aed40d02a7e233
+    optional: false
+    category: main
+  - name: gcc
+    version: 11.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      gcc_impl_linux-ppc64le: 11.3.0.*
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gcc-11.3.0-ha746174_11.tar.bz2"
+    hash:
+      md5: 6391f876f8572d2de23f5db0a8e863fa
+      sha256: a5373b326c9cef306250f9e159d1f55d37698bdf74a7b55e5b82dea463484e3f
+    optional: false
+    category: main
+  - name: gcc_impl_linux-64
+    version: 11.3.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      binutils_impl_linux-64: ">=2.39"
+      libgcc-devel_linux-64: "==11.3.0 h210ce93_19"
+      libgcc-ng: ">=11.3.0"
+      libgomp: ">=11.3.0"
+      libsanitizer: "==11.3.0 h239ccf8_19"
+      libstdcxx-ng: ">=11.3.0"
       sysroot_linux-64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.39-he00db2b_1.conda"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-11.3.0-hab1b70f_19.tar.bz2"
     hash:
-      md5: 3d726e8b51a1f5bfd66892a2b7d9db2d
-      sha256: 69a7c32141475dab43de2f19b7a67c14596cbb357cdb5891ff866918f8f65a2e
+      md5: 89ac16d36e66ccb9ca5d34c9217e5799
+      sha256: 51c6e39148c9da4a9889d34f0daebdf961ca93f032b1e86f621a67ecff2bd915
     optional: false
     category: main
-  - name: fonts-conda-ecosystem
-    version: "1"
+  - name: gcc_impl_linux-aarch64
+    version: 11.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      binutils_impl_linux-aarch64: ">=2.39"
+      libgcc-devel_linux-aarch64: "==11.3.0 h02014c4_19"
+      libgcc-ng: ">=11.3.0"
+      libgomp: ">=11.3.0"
+      libsanitizer: "==11.3.0 hdddb281_19"
+      libstdcxx-ng: ">=11.3.0"
+      sysroot_linux-aarch64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-11.3.0-h771ed3b_19.tar.bz2"
+    hash:
+      md5: 3b89b2222e3ade690a36e419e85d4988
+      sha256: 9f83e3b05644fd28a681ec9a98a75662299a0643cb5c3697025a6450d19000ae
+    optional: false
+    category: main
+  - name: gcc_impl_linux-ppc64le
+    version: 11.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      binutils_impl_linux-ppc64le: ">=2.39"
+      libgcc-devel_linux-ppc64le: "==11.3.0 hcb32637_19"
+      libgcc-ng: ">=11.3.0"
+      libgomp: ">=11.3.0"
+      libsanitizer: "==11.3.0 hc94946d_19"
+      libstdcxx-ng: ">=11.3.0"
+      sysroot_linux-ppc64le: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gcc_impl_linux-ppc64le-11.3.0-h8f9c6bb_19.tar.bz2"
+    hash:
+      md5: 0aeb44f45dbeb26ff69acf55562669de
+      sha256: b37216b165b1e914111f562fdc30c7c4f132a4ee2e093869f76ee4952aee46b5
+    optional: false
+    category: main
+  - name: gcc_linux-64
+    version: 11.3.0
     manager: conda
     platform: linux-64
     dependencies:
-      fonts-conda-forge: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2"
-    hash:
-      md5: fee5683a3f04bd15cbd8318b096a27ab
-      sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-    optional: false
-    category: main
-  - name: binutils
-    version: "2.39"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      binutils_impl_linux-64: ">=2.39,<2.40.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/binutils-2.39-hdd6e379_1.conda"
-    hash:
-      md5: 1276c18b0a562739185dbf5bd14b57b2
-      sha256: 8edbd5a01feaf22053d7c02e7d5066a3b35b265deee0a5ad3f69054289bbbd7e
-    optional: false
-    category: main
-  - name: binutils_linux-64
-    version: "2.39"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      binutils_impl_linux-64: 2.39.*
+      binutils_linux-64: "==2.39 h5fc0e48_11"
+      gcc_impl_linux-64: 11.3.0.*
       sysroot_linux-64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.39-h5fc0e48_11.tar.bz2"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-11.3.0-he6f903b_11.tar.bz2"
     hash:
-      md5: b7d26ab37be17ea4c366a97138684bcb
-      sha256: acf554585c011689ce6c58472200545c9512dce1b9dfc5e853f25771c0c3e12e
+      md5: 25f76cb82e483ce96d118b9edffd12c9
+      sha256: c0041b6f805b6b3c01bfb51232b606c9a50a8e0154d17bbf61af36d62c600f00
     optional: false
     category: main
-  - name: libgcc-ng
-    version: 12.2.0
+  - name: gcc_linux-aarch64
+    version: 11.3.0
     manager: conda
-    platform: linux-64
+    platform: linux-aarch64
     dependencies:
-      _libgcc_mutex: "==0.1 conda_forge"
-      _openmp_mutex: ">=4.5"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-12.2.0-h65d4601_19.tar.bz2"
+      binutils_linux-aarch64: "==2.39 h489c705_11"
+      gcc_impl_linux-aarch64: 11.3.0.*
+      sysroot_linux-aarch64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-11.3.0-h2cafa97_11.tar.bz2"
     hash:
-      md5: e4c94f80aef025c17ab0828cd85ef535
-      sha256: f3899c26824cee023f1e360bd0859b0e149e2b3e8b1668bc6dd04bfc70dcd659
+      md5: 4cdc6d5a965f658b823d4d5829422e8a
+      sha256: 35232fa113d8cb3b15217e3b6ff00d0fbc3dff33c742a2851919b73a2cf010e1
     optional: false
     category: main
-  - name: alsa-lib
-    version: 1.2.8
+  - name: gcc_linux-ppc64le
+    version: 11.3.0
     manager: conda
-    platform: linux-64
+    platform: linux-ppc64le
     dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.8-h166bdaf_0.tar.bz2"
+      binutils_linux-ppc64le: "==2.39 h5e55cfe_11"
+      gcc_impl_linux-ppc64le: 11.3.0.*
+      sysroot_linux-ppc64le: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gcc_linux-ppc64le-11.3.0-h89f38ce_11.tar.bz2"
     hash:
-      md5: be733e69048951df1e4b4b7bb8c7666f
-      sha256: 2c0a618d0fa695e4e01a30e7ff31094be540c52e9085cbd724edb132c65cf9cd
-    optional: false
-    category: main
-  - name: attr
-    version: 2.5.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2"
-    hash:
-      md5: d9c69a24ad678ffce24c6543a0176b00
-      sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
-    optional: false
-    category: main
-  - name: bzip2
-    version: 1.0.8
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2"
-    hash:
-      md5: a1fd65c7ccbf10880423d82bca54eb54
-      sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
-    optional: false
-    category: main
-  - name: expat
-    version: 2.5.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-h27087fc_0.tar.bz2"
-    hash:
-      md5: c4fbad8d4bddeb3c085f18cbf97fbfad
-      sha256: b44db0b92ae926b3fbbcd57c179fceb64fa11a9f9d09082e03be58b74dcad832
-    optional: false
-    category: main
-  - name: fftw
-    version: 3.3.10
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libgfortran-ng: "*"
-      libgfortran5: ">=10.4.0"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/fftw-3.3.10-nompi_hf0379b8_106.conda"
-    hash:
-      md5: d7407e695358f068a2a7f8295cde0567
-      sha256: 8b735848df623fab555a6d7fc400636116d6ed5686ae0e50adb7df4c1c3a9cef
+      md5: 814568bab97f272b70b8970bda7d1734
+      sha256: 8e7691ff0b96738b6dc627564c000419e33239407879327e1af6309ec6638dbc
     optional: false
     category: main
   - name: gettext
@@ -391,6 +3336,453 @@ package:
     hash:
       md5: 14947d8770185e5153fdd04d4673ed37
       sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
+    optional: false
+    category: main
+  - name: gettext
+    version: 0.21.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libiconv: ">=1.17,<2.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2"
+    hash:
+      md5: 63d2ff6fddfa74e5458488fd311bf635
+      sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
+    optional: false
+    category: main
+  - name: gfortran
+    version: 11.3.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      gcc: 11.3.0.*
+      gcc_impl_linux-64: 11.3.0.*
+      gfortran_impl_linux-64: 11.3.0.*
+    url: "https://conda.anaconda.org/conda-forge/linux-64/gfortran-11.3.0-ha859ce3_11.tar.bz2"
+    hash:
+      md5: 9a6a0c6fc4d192fddc7347a0ca31a329
+      sha256: 9ec8753064dc7379958788952346fc1f0caa18affe093cac62c8a8e267f5f38e
+    optional: false
+    category: main
+  - name: gfortran
+    version: 11.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      gcc: 11.3.0.*
+      gcc_impl_linux-aarch64: 11.3.0.*
+      gfortran_impl_linux-aarch64: 11.3.0.*
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran-11.3.0-h6b6addb_11.tar.bz2"
+    hash:
+      md5: e918df1fe2a391d9b715a79a5232ea2f
+      sha256: b6556bd72c554d55ca0cd8f1ab2281838e2a8b817d4276c61f7f1be5546b4edf
+    optional: false
+    category: main
+  - name: gfortran
+    version: 11.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      gcc: 11.3.0.*
+      gcc_impl_linux-ppc64le: 11.3.0.*
+      gfortran_impl_linux-ppc64le: 11.3.0.*
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gfortran-11.3.0-h47285a8_11.tar.bz2"
+    hash:
+      md5: 6050ddfbd06be074a4a4b31973528c7f
+      sha256: 07de312619594359318edda76557fdede88c9cdb9df3869465decd4c8dc281b1
+    optional: false
+    category: main
+  - name: gfortran
+    version: 11.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      cctools: "*"
+      gfortran_osx-64: "*"
+      ld64: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/gfortran-11.3.0-h2c809b3_0.tar.bz2"
+    hash:
+      md5: db5338d1fb1ad08498bdc1b42277a0d5
+      sha256: 4f5c1dc5323e888d4fa372eba6f4540b60f557963209502cfad569fdc3d47495
+    optional: false
+    category: main
+  - name: gfortran
+    version: 11.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      cctools: "*"
+      gfortran_osx-arm64: "*"
+      ld64: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/gfortran-11.3.0-h1ca8e4b_0.tar.bz2"
+    hash:
+      md5: 75b415dac7f64e2af572a24469b581d4
+      sha256: 8422479e2ef6937956635ad70303b9dc1aa82d7fde70a49fac4759e73a022464
+    optional: false
+    category: main
+  - name: gfortran_impl_linux-64
+    version: 11.3.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      gcc_impl_linux-64: ">=11.3.0"
+      libgcc-ng: ">=4.9"
+      libgfortran5: ">=11.3.0"
+      libstdcxx-ng: ">=4.9"
+      sysroot_linux-64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-11.3.0-he34c6f7_19.tar.bz2"
+    hash:
+      md5: 3de873ee757f1a2e583416a3583f84c4
+      sha256: 3263c7b7d4c9d0c0a25e92ca201b7c014c00257cecf08ac28953dfda43c93803
+    optional: false
+    category: main
+  - name: gfortran_impl_linux-aarch64
+    version: 11.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      gcc_impl_linux-aarch64: ">=11.3.0"
+      libgcc-ng: ">=4.9"
+      libgfortran5: ">=11.3.0"
+      libstdcxx-ng: ">=4.9"
+      sysroot_linux-aarch64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-11.3.0-h0a651b8_19.tar.bz2"
+    hash:
+      md5: fc45cd438909a1e5e5d39565bd3b3ecd
+      sha256: 9baf7d7c29ee9dc62638c74414253ad1b5fd2140e108a5d8fb582520ca3d981f
+    optional: false
+    category: main
+  - name: gfortran_impl_linux-ppc64le
+    version: 11.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      gcc_impl_linux-ppc64le: ">=11.3.0"
+      libgcc-ng: ">=4.9"
+      libgfortran5: ">=11.3.0"
+      libstdcxx-ng: ">=4.9"
+      sysroot_linux-ppc64le: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gfortran_impl_linux-ppc64le-11.3.0-h230bcad_19.tar.bz2"
+    hash:
+      md5: e1dfcd199291fbe2535186c8ac26c38e
+      sha256: ea6822fe121d2236d6c1b604cf9566498dc2e5fdf2240cd3de4cb1cd98d0569e
+    optional: false
+    category: main
+  - name: gfortran_impl_osx-64
+    version: 11.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      gmp: ">=6.2.1,<7.0a0"
+      isl: ">=0.25,<0.26.0a0"
+      libcxx: ">=14.0.6"
+      libgfortran-devel_osx-64: 11.3.0.*
+      libgfortran5: ">=11.3.0"
+      libiconv: ">=1.17,<2.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      mpc: ">=1.2.1,<2.0a0"
+      mpfr: ">=4.1.0,<5.0a0"
+      zlib: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/gfortran_impl_osx-64-11.3.0-h1f927f5_27.conda"
+    hash:
+      md5: 0bb7f54e22a2136588b33e7b0bf24148
+      sha256: e8be46ff4aa486a808e3494cf6b44758cce199d2888d91553261f65bd02cf7f0
+    optional: false
+    category: main
+  - name: gfortran_impl_osx-arm64
+    version: 11.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      gmp: ">=6.2.1,<7.0a0"
+      isl: ">=0.25,<0.26.0a0"
+      libcxx: ">=14.0.6"
+      libgfortran-devel_osx-arm64: 11.3.0.*
+      libgfortran5: ">=11.3.0"
+      libiconv: ">=1.17,<2.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      mpc: ">=1.2.1,<2.0a0"
+      mpfr: ">=4.1.0,<5.0a0"
+      zlib: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/gfortran_impl_osx-arm64-11.3.0-h2a9d086_27.conda"
+    hash:
+      md5: 038e7f8ccaa6348bc5da9bd019e1bb61
+      sha256: bfe545a666ae47782e0a29eed499d006903f8b374e7c733ba6e559e99d7dc553
+    optional: false
+    category: main
+  - name: gfortran_linux-64
+    version: 11.3.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      binutils_linux-64: "==2.39 h5fc0e48_11"
+      gcc_linux-64: "==11.3.0 he6f903b_11"
+      gfortran_impl_linux-64: 11.3.0.*
+      sysroot_linux-64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-11.3.0-h3c55166_11.tar.bz2"
+    hash:
+      md5: f70b169eb69320d71f193758b7df67e8
+      sha256: 7c3bc99fc0d32647681f9b8ce44f137f16ae5ec37f040b66506c6634c299f071
+    optional: false
+    category: main
+  - name: gfortran_linux-aarch64
+    version: 11.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      binutils_linux-aarch64: "==2.39 h489c705_11"
+      gcc_linux-aarch64: "==11.3.0 h2cafa97_11"
+      gfortran_impl_linux-aarch64: 11.3.0.*
+      sysroot_linux-aarch64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_linux-aarch64-11.3.0-hff98631_11.tar.bz2"
+    hash:
+      md5: a7be589b27f26b2c447a4c703c588244
+      sha256: 5ca1326e20b37b2e91dd2d7553a0be569623f96d60fdd740354b2a93be2c948e
+    optional: false
+    category: main
+  - name: gfortran_linux-ppc64le
+    version: 11.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      binutils_linux-ppc64le: "==2.39 h5e55cfe_11"
+      gcc_linux-ppc64le: "==11.3.0 h89f38ce_11"
+      gfortran_impl_linux-ppc64le: 11.3.0.*
+      sysroot_linux-ppc64le: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gfortran_linux-ppc64le-11.3.0-h7e72f06_11.tar.bz2"
+    hash:
+      md5: 5c1a3d92a26afe01e17ebcf99a1b3c11
+      sha256: 8ad5addbb3d147189aaa895c954e459dc278dc8da145e482c631038bbff2acee
+    optional: false
+    category: main
+  - name: gfortran_osx-64
+    version: 11.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      cctools_osx-64: "*"
+      clang: "*"
+      clang_osx-64: "*"
+      gfortran_impl_osx-64: "==11.3.0"
+      ld64_osx-64: "*"
+      libgfortran: 5.*
+      libgfortran-devel_osx-64: "==11.3.0"
+      libgfortran5: ">=11.3.0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/gfortran_osx-64-11.3.0-h18f7dce_0.tar.bz2"
+    hash:
+      md5: 72320d23ed499315d1d1ac332b94bc66
+      sha256: 7abe5dd161c8e4cdb67ceefecf27906d208e46bdb86b71e444b71409fc0857a1
+    optional: false
+    category: main
+  - name: gfortran_osx-arm64
+    version: 11.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      cctools_osx-arm64: "*"
+      clang: "*"
+      clang_osx-arm64: "*"
+      gfortran_impl_osx-arm64: "==11.3.0"
+      ld64_osx-arm64: "*"
+      libgfortran: 5.*
+      libgfortran-devel_osx-arm64: "==11.3.0"
+      libgfortran5: ">=11.3.0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/gfortran_osx-arm64-11.3.0-h57527a5_0.tar.bz2"
+    hash:
+      md5: ebf560369c33d9a4f568a2c5b5922b52
+      sha256: f8372955a71bef3ae6f06df20d164a9aeb233a4553c7eb92cb8c0d8bae445d6f
+    optional: false
+    category: main
+  - name: gitdb
+    version: 4.0.10
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.4"
+      smmap: ">=3.0.1,<4"
+    url: "https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.10-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 3706d2f3d7cb5dae600c833345a76132
+      sha256: 0003ab2b971913380633c711bf49a54dcf06e179986c725b0925854b58878377
+    optional: false
+    category: main
+  - name: gitdb
+    version: 4.0.10
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.4"
+      smmap: ">=3.0.1,<4"
+    url: "https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.10-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 3706d2f3d7cb5dae600c833345a76132
+      sha256: 0003ab2b971913380633c711bf49a54dcf06e179986c725b0925854b58878377
+    optional: false
+    category: main
+  - name: gitdb
+    version: 4.0.10
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.4"
+      smmap: ">=3.0.1,<4"
+    url: "https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.10-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 3706d2f3d7cb5dae600c833345a76132
+      sha256: 0003ab2b971913380633c711bf49a54dcf06e179986c725b0925854b58878377
+    optional: false
+    category: main
+  - name: gitdb
+    version: 4.0.10
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.4"
+      smmap: ">=3.0.1,<4"
+    url: "https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.10-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 3706d2f3d7cb5dae600c833345a76132
+      sha256: 0003ab2b971913380633c711bf49a54dcf06e179986c725b0925854b58878377
+    optional: false
+    category: main
+  - name: gitdb
+    version: 4.0.10
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.4"
+      smmap: ">=3.0.1,<4"
+    url: "https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.10-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 3706d2f3d7cb5dae600c833345a76132
+      sha256: 0003ab2b971913380633c711bf49a54dcf06e179986c725b0925854b58878377
+    optional: false
+    category: main
+  - name: gitpython
+    version: 3.1.30
+    manager: conda
+    platform: linux-64
+    dependencies:
+      gitdb: ">=4.0.1,<5"
+      python: ">=3.7"
+      typing_extensions: ">=3.7.4.3"
+    url: "https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.30-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 0c217ab2f5ef6925e4e52c70b57cfc4a
+      sha256: 2ccd8aa401701947398a087b1aa11042b1b088e7331fed574b7ec9909bee09d6
+    optional: false
+    category: main
+  - name: gitpython
+    version: 3.1.30
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      gitdb: ">=4.0.1,<5"
+      python: ">=3.7"
+      typing_extensions: ">=3.7.4.3"
+    url: "https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.30-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 0c217ab2f5ef6925e4e52c70b57cfc4a
+      sha256: 2ccd8aa401701947398a087b1aa11042b1b088e7331fed574b7ec9909bee09d6
+    optional: false
+    category: main
+  - name: gitpython
+    version: 3.1.30
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      gitdb: ">=4.0.1,<5"
+      python: ">=3.7"
+      typing_extensions: ">=3.7.4.3"
+    url: "https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.30-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 0c217ab2f5ef6925e4e52c70b57cfc4a
+      sha256: 2ccd8aa401701947398a087b1aa11042b1b088e7331fed574b7ec9909bee09d6
+    optional: false
+    category: main
+  - name: gitpython
+    version: 3.1.30
+    manager: conda
+    platform: osx-64
+    dependencies:
+      gitdb: ">=4.0.1,<5"
+      python: ">=3.7"
+      typing_extensions: ">=3.7.4.3"
+    url: "https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.30-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 0c217ab2f5ef6925e4e52c70b57cfc4a
+      sha256: 2ccd8aa401701947398a087b1aa11042b1b088e7331fed574b7ec9909bee09d6
+    optional: false
+    category: main
+  - name: gitpython
+    version: 3.1.30
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      gitdb: ">=4.0.1,<5"
+      python: ">=3.7"
+      typing_extensions: ">=3.7.4.3"
+    url: "https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.30-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 0c217ab2f5ef6925e4e52c70b57cfc4a
+      sha256: 2ccd8aa401701947398a087b1aa11042b1b088e7331fed574b7ec9909bee09d6
+    optional: false
+    category: main
+  - name: glib
+    version: 2.74.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      gettext: ">=0.21.1,<1.0a0"
+      glib-tools: "==2.74.1 h6239696_1"
+      libgcc-ng: ">=12"
+      libglib: "==2.74.1 h606061b_1"
+      libstdcxx-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/glib-2.74.1-h6239696_1.tar.bz2"
+    hash:
+      md5: f3220a9e9d3abcbfca43419a219df7e4
+      sha256: bc3f1d84e976a62ae8388e3b44f260d867beb7a307c18147048a8301a3c12e47
+    optional: false
+    category: main
+  - name: glib-tools
+    version: 2.74.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libglib: "==2.74.1 h606061b_1"
+      libstdcxx-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.74.1-h6239696_1.tar.bz2"
+    hash:
+      md5: 5f442e6bc9d89ba236eb25a25c5c2815
+      sha256: 029533e2e1cb03a80ae07a0a1a6bdd76b524e8f551d82e832a4d846a77b615c9
+    optional: false
+    category: main
+  - name: gmp
+    version: 6.2.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=10.0.1"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/gmp-6.2.1-h2e338ed_0.tar.bz2"
+    hash:
+      md5: dedc96914428dae572a39e69ee2a392f
+      sha256: d6386708f6b7bcf790c57e985a5ca5636ec6ccaed0493b8ddea231aaeb8bfb00
+    optional: false
+    category: main
+  - name: gmp
+    version: 6.2.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=11.0.0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.2.1-h9f76cd9_0.tar.bz2"
+    hash:
+      md5: f8140773b6ca51bf32feec9b4290a8c5
+      sha256: 2fd12c3e78b6c632f7f34883b942b973bdd24302c74f2b9b78e776b654baf591
     optional: false
     category: main
   - name: graphite2
@@ -406,6 +3798,46 @@ package:
       sha256: 65da967f3101b737b08222de6a6a14e20e480e7d523a5d1e19ace7b960b5d6b1
     optional: false
     category: main
+  - name: gst-plugins-base
+    version: 1.22.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      alsa-lib: ">=1.2.8,<1.2.9.0a0"
+      gettext: ">=0.21.1,<1.0a0"
+      gstreamer: "==1.22.0 h25f0c4b_0"
+      libgcc-ng: ">=12"
+      libglib: ">=2.74.1,<3.0a0"
+      libopus: ">=1.3.1,<2.0a0"
+      libpng: ">=1.6.39,<1.7.0a0"
+      libstdcxx-ng: ">=12"
+      libvorbis: ">=1.3.7,<1.4.0a0"
+      libxcb: ">=1.13,<1.14.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.0-h4243ec0_0.conda"
+    hash:
+      md5: 81c20b15d2281a1ea48eac5b4eee8cfa
+      sha256: dfa2794ea19248f13a1eb067727c70d11e8bba228b82a4bee18ad6a26fdc99fe
+    optional: false
+    category: main
+  - name: gstreamer
+    version: 1.22.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      gettext: ">=0.21.1,<1.0a0"
+      glib: ">=2.74.1,<3.0a0"
+      libgcc-ng: ">=12"
+      libglib: ">=2.74.1,<3.0a0"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.0-h25f0c4b_0.conda"
+    hash:
+      md5: d764367398de61c0d5531dd912e6cc96
+      sha256: ebf7839171f7ae6228c9650b13f551da9812486bbb6cd5e78985574b82dc6bbc
+    optional: false
+    category: main
   - name: gstreamer-orc
     version: 0.4.33
     manager: conda
@@ -416,6 +3848,240 @@ package:
     hash:
       md5: 879c93426c9d0b84a9de4513fbce5f4f
       sha256: c4fdbaaeb66eed280ef6875c6a4b6916ed168166277e9317fbe25b15d3758897
+    optional: false
+    category: main
+  - name: gxx
+    version: 11.3.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      gcc: 11.3.0.*
+      gxx_impl_linux-64: 11.3.0.*
+    url: "https://conda.anaconda.org/conda-forge/linux-64/gxx-11.3.0-h02d0930_11.tar.bz2"
+    hash:
+      md5: e47dd4b4e577f03bb6aab18f48be5419
+      sha256: 3614201ab2f09f27429b7faea7dcd9e24e089a325bca878f76cdd0dca4676520
+    optional: false
+    category: main
+  - name: gxx
+    version: 11.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      gcc: 11.3.0.*
+      gxx_impl_linux-aarch64: 11.3.0.*
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-11.3.0-he2d1185_11.tar.bz2"
+    hash:
+      md5: 0730f39c40a80d5003c5f8bddd514777
+      sha256: bf2a6e358a7256f4d9d65b72c914112b6f1bd4de47d8d2dee5fd62e57d7823ca
+    optional: false
+    category: main
+  - name: gxx
+    version: 11.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      gcc: 11.3.0.*
+      gxx_impl_linux-ppc64le: 11.3.0.*
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gxx-11.3.0-ha746174_11.tar.bz2"
+    hash:
+      md5: 203a2faa2e8aa3f329d0bf0c6ff351dd
+      sha256: 58b7742cdb4c6c4fa79f9c5e3a70fc4d01dc02cbb57d986a51ab90bd1e9b6a8a
+    optional: false
+    category: main
+  - name: gxx_impl_linux-64
+    version: 11.3.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      gcc_impl_linux-64: "==11.3.0 hab1b70f_19"
+      libstdcxx-devel_linux-64: "==11.3.0 h210ce93_19"
+      sysroot_linux-64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-11.3.0-hab1b70f_19.tar.bz2"
+    hash:
+      md5: b73564a352e64bb5f2c9bfd3cd6dd127
+      sha256: b86a4d15050c8ad5b8a4273c55f468847d891ceb08f3702408c3a0e921a5b5ea
+    optional: false
+    category: main
+  - name: gxx_impl_linux-aarch64
+    version: 11.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      gcc_impl_linux-aarch64: "==11.3.0 h771ed3b_19"
+      libstdcxx-devel_linux-aarch64: "==11.3.0 h02014c4_19"
+      sysroot_linux-aarch64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-11.3.0-h771ed3b_19.tar.bz2"
+    hash:
+      md5: 567374f76eeac7b755e5d5873459fe98
+      sha256: c58c38263c10700cd3af75ce9a847a14dea67fe18cf9948059bb8a6e95dd641a
+    optional: false
+    category: main
+  - name: gxx_impl_linux-ppc64le
+    version: 11.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      gcc_impl_linux-ppc64le: "==11.3.0 h8f9c6bb_19"
+      libstdcxx-devel_linux-ppc64le: "==11.3.0 hcb32637_19"
+      sysroot_linux-ppc64le: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gxx_impl_linux-ppc64le-11.3.0-h8f9c6bb_19.tar.bz2"
+    hash:
+      md5: 6cae39b12f2baaf665838496d09f746e
+      sha256: d7ff5ce2eec8cf9b95d23c0fc8cf7a1eef64a7f7f2155369d8fd97ec42f20d4b
+    optional: false
+    category: main
+  - name: gxx_linux-64
+    version: 11.3.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      binutils_linux-64: "==2.39 h5fc0e48_11"
+      gcc_linux-64: "==11.3.0 he6f903b_11"
+      gxx_impl_linux-64: 11.3.0.*
+      sysroot_linux-64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-11.3.0-hc203a17_11.tar.bz2"
+    hash:
+      md5: 15fbc9079f191d468403639a6515652c
+      sha256: 7be17e1fdb200e8b9afe8f4e88b3b821740be6024e433565abda94e5d021c9cb
+    optional: false
+    category: main
+  - name: gxx_linux-aarch64
+    version: 11.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      binutils_linux-aarch64: "==2.39 h489c705_11"
+      gcc_linux-aarch64: "==11.3.0 h2cafa97_11"
+      gxx_impl_linux-aarch64: 11.3.0.*
+      sysroot_linux-aarch64: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-11.3.0-h7ccc656_11.tar.bz2"
+    hash:
+      md5: 7b4ebbdadc6c61ce3e98fb2d5605f5dc
+      sha256: 229f44d96f37b471e5b7b26f7c617a09636dc6f258c13cbdf322ca27f0e6b2f0
+    optional: false
+    category: main
+  - name: gxx_linux-ppc64le
+    version: 11.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      binutils_linux-ppc64le: "==2.39 h5e55cfe_11"
+      gcc_linux-ppc64le: "==11.3.0 h89f38ce_11"
+      gxx_impl_linux-ppc64le: 11.3.0.*
+      sysroot_linux-ppc64le: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gxx_linux-ppc64le-11.3.0-h3c74164_11.tar.bz2"
+    hash:
+      md5: a0f1353564cfcbf1310cfd9f744319c8
+      sha256: be7f130dba954b876a292ee0039efd0563a60621e6430f486d231775b35c05af
+    optional: false
+    category: main
+  - name: harfbuzz
+    version: 6.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      cairo: ">=1.16.0,<2.0a0"
+      freetype: ">=2.12.1,<3.0a0"
+      graphite2: "*"
+      icu: ">=70.1,<71.0a0"
+      libgcc-ng: ">=12"
+      libglib: ">=2.74.1,<3.0a0"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-6.0.0-h8e241bc_0.conda"
+    hash:
+      md5: 448fe40d2fed88ccf4d9ded37cbb2b38
+      sha256: f300fcb390253d6d63346ee71e56f82bc830783d1682ac933fe9ac86f39da942
+    optional: false
+    category: main
+  - name: hypothesis
+    version: 6.68.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      attrs: ">=19.2.0"
+      backports.zoneinfo: ">=0.2.1"
+      click: ">=7.0"
+      exceptiongroup: ">=1.0.0rc8"
+      python: ">=3.8"
+      setuptools: "*"
+      sortedcontainers: ">=2.1.0,<3.0.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.68.1-pyha770c72_0.conda"
+    hash:
+      md5: 3c044b3b920eb287f8c095c7f086ba64
+      sha256: e3a29c1303b563e450e0f706e4d78a281d1aa519d3e1094fc642305bceff72e1
+    optional: false
+    category: main
+  - name: hypothesis
+    version: 6.68.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      attrs: ">=19.2.0"
+      backports.zoneinfo: ">=0.2.1"
+      click: ">=7.0"
+      exceptiongroup: ">=1.0.0rc8"
+      python: ">=3.8"
+      setuptools: "*"
+      sortedcontainers: ">=2.1.0,<3.0.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.68.1-pyha770c72_0.conda"
+    hash:
+      md5: 3c044b3b920eb287f8c095c7f086ba64
+      sha256: e3a29c1303b563e450e0f706e4d78a281d1aa519d3e1094fc642305bceff72e1
+    optional: false
+    category: main
+  - name: hypothesis
+    version: 6.68.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      attrs: ">=19.2.0"
+      backports.zoneinfo: ">=0.2.1"
+      click: ">=7.0"
+      exceptiongroup: ">=1.0.0rc8"
+      python: ">=3.8"
+      setuptools: "*"
+      sortedcontainers: ">=2.1.0,<3.0.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.68.1-pyha770c72_0.conda"
+    hash:
+      md5: 3c044b3b920eb287f8c095c7f086ba64
+      sha256: e3a29c1303b563e450e0f706e4d78a281d1aa519d3e1094fc642305bceff72e1
+    optional: false
+    category: main
+  - name: hypothesis
+    version: 6.68.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      attrs: ">=19.2.0"
+      backports.zoneinfo: ">=0.2.1"
+      click: ">=7.0"
+      exceptiongroup: ">=1.0.0rc8"
+      python: ">=3.8"
+      setuptools: "*"
+      sortedcontainers: ">=2.1.0,<3.0.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.68.1-pyha770c72_0.conda"
+    hash:
+      md5: 3c044b3b920eb287f8c095c7f086ba64
+      sha256: e3a29c1303b563e450e0f706e4d78a281d1aa519d3e1094fc642305bceff72e1
+    optional: false
+    category: main
+  - name: hypothesis
+    version: 6.68.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      attrs: ">=19.2.0"
+      backports.zoneinfo: ">=0.2.1"
+      click: ">=7.0"
+      exceptiongroup: ">=1.0.0rc8"
+      python: ">=3.8"
+      setuptools: "*"
+      sortedcontainers: ">=2.1.0,<3.0.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.68.1-pyha770c72_0.conda"
+    hash:
+      md5: 3c044b3b920eb287f8c095c7f086ba64
+      sha256: e3a29c1303b563e450e0f706e4d78a281d1aa519d3e1094fc642305bceff72e1
     optional: false
     category: main
   - name: icu
@@ -431,6 +4097,538 @@ package:
       sha256: 1d7950f3be4637ab915d886304e57731d39a41ab705ffc95c4681655c459374a
     optional: false
     category: main
+  - name: idna
+    version: "3.4"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 34272b248891bddccc64479f9a7fffed
+      sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+    optional: false
+    category: main
+  - name: idna
+    version: "3.4"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 34272b248891bddccc64479f9a7fffed
+      sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+    optional: false
+    category: main
+  - name: idna
+    version: "3.4"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 34272b248891bddccc64479f9a7fffed
+      sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+    optional: false
+    category: main
+  - name: idna
+    version: "3.4"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 34272b248891bddccc64479f9a7fffed
+      sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+    optional: false
+    category: main
+  - name: idna
+    version: "3.4"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 34272b248891bddccc64479f9a7fffed
+      sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
+    optional: false
+    category: main
+  - name: imagesize
+    version: 1.4.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.4"
+    url: "https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 7de5386c8fea29e76b303f37dde4c352
+      sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
+    optional: false
+    category: main
+  - name: imagesize
+    version: 1.4.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.4"
+    url: "https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 7de5386c8fea29e76b303f37dde4c352
+      sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
+    optional: false
+    category: main
+  - name: imagesize
+    version: 1.4.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.4"
+    url: "https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 7de5386c8fea29e76b303f37dde4c352
+      sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
+    optional: false
+    category: main
+  - name: imagesize
+    version: 1.4.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.4"
+    url: "https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 7de5386c8fea29e76b303f37dde4c352
+      sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
+    optional: false
+    category: main
+  - name: imagesize
+    version: 1.4.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.4"
+    url: "https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 7de5386c8fea29e76b303f37dde4c352
+      sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
+    optional: false
+    category: main
+  - name: importlib-metadata
+    version: 6.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.8"
+      zipp: ">=0.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.0.0-pyha770c72_0.conda"
+    hash:
+      md5: 691644becbcdca9f73243450b1c63e62
+      sha256: 0062e6ae1719395c25f0b60a21215470b4ea67514fed8a9330869da8604acfca
+    optional: false
+    category: main
+  - name: importlib-metadata
+    version: 6.0.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.8"
+      zipp: ">=0.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.0.0-pyha770c72_0.conda"
+    hash:
+      md5: 691644becbcdca9f73243450b1c63e62
+      sha256: 0062e6ae1719395c25f0b60a21215470b4ea67514fed8a9330869da8604acfca
+    optional: false
+    category: main
+  - name: importlib-metadata
+    version: 6.0.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.8"
+      zipp: ">=0.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.0.0-pyha770c72_0.conda"
+    hash:
+      md5: 691644becbcdca9f73243450b1c63e62
+      sha256: 0062e6ae1719395c25f0b60a21215470b4ea67514fed8a9330869da8604acfca
+    optional: false
+    category: main
+  - name: importlib-metadata
+    version: 6.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.8"
+      zipp: ">=0.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.0.0-pyha770c72_0.conda"
+    hash:
+      md5: 691644becbcdca9f73243450b1c63e62
+      sha256: 0062e6ae1719395c25f0b60a21215470b4ea67514fed8a9330869da8604acfca
+    optional: false
+    category: main
+  - name: importlib-metadata
+    version: 6.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.8"
+      zipp: ">=0.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.0.0-pyha770c72_0.conda"
+    hash:
+      md5: 691644becbcdca9f73243450b1c63e62
+      sha256: 0062e6ae1719395c25f0b60a21215470b4ea67514fed8a9330869da8604acfca
+    optional: false
+    category: main
+  - name: iniconfig
+    version: 2.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f800d2da156d08e289b14e87e43c1ae5
+      sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+    optional: false
+    category: main
+  - name: iniconfig
+    version: 2.0.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f800d2da156d08e289b14e87e43c1ae5
+      sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+    optional: false
+    category: main
+  - name: iniconfig
+    version: 2.0.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f800d2da156d08e289b14e87e43c1ae5
+      sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+    optional: false
+    category: main
+  - name: iniconfig
+    version: 2.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f800d2da156d08e289b14e87e43c1ae5
+      sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+    optional: false
+    category: main
+  - name: iniconfig
+    version: 2.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f800d2da156d08e289b14e87e43c1ae5
+      sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
+    optional: false
+    category: main
+  - name: ipython
+    version: 8.10.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __linux: "*"
+      backcall: "*"
+      decorator: "*"
+      jedi: ">=0.16"
+      matplotlib-inline: "*"
+      pexpect: ">4.3"
+      pickleshare: "*"
+      prompt-toolkit: ">=3.0.30,<3.1.0"
+      pygments: ">=2.4.0"
+      python: ">=3.8"
+      stack_data: "*"
+      traitlets: ">=5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/ipython-8.10.0-pyh41d4057_0.conda"
+    hash:
+      md5: 4703355103974293bbd8a32449b3ff28
+      sha256: 350847af23f964a1002c712547e26a1e144e5bbc1662016263c5fb8fc963dcff
+    optional: false
+    category: main
+  - name: ipython
+    version: 8.10.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      __linux: "*"
+      backcall: "*"
+      decorator: "*"
+      jedi: ">=0.16"
+      matplotlib-inline: "*"
+      pexpect: ">4.3"
+      pickleshare: "*"
+      prompt-toolkit: ">=3.0.30,<3.1.0"
+      pygments: ">=2.4.0"
+      python: ">=3.8"
+      stack_data: "*"
+      traitlets: ">=5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/ipython-8.10.0-pyh41d4057_0.conda"
+    hash:
+      md5: 4703355103974293bbd8a32449b3ff28
+      sha256: 350847af23f964a1002c712547e26a1e144e5bbc1662016263c5fb8fc963dcff
+    optional: false
+    category: main
+  - name: ipython
+    version: 8.10.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      __linux: "*"
+      backcall: "*"
+      decorator: "*"
+      jedi: ">=0.16"
+      matplotlib-inline: "*"
+      pexpect: ">4.3"
+      pickleshare: "*"
+      prompt-toolkit: ">=3.0.30,<3.1.0"
+      pygments: ">=2.4.0"
+      python: ">=3.8"
+      stack_data: "*"
+      traitlets: ">=5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/ipython-8.10.0-pyh41d4057_0.conda"
+    hash:
+      md5: 4703355103974293bbd8a32449b3ff28
+      sha256: 350847af23f964a1002c712547e26a1e144e5bbc1662016263c5fb8fc963dcff
+    optional: false
+    category: main
+  - name: ipython
+    version: 8.10.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: "*"
+      appnope: "*"
+      backcall: "*"
+      decorator: "*"
+      jedi: ">=0.16"
+      matplotlib-inline: "*"
+      pexpect: ">4.3"
+      pickleshare: "*"
+      prompt-toolkit: ">=3.0.30,<3.1.0"
+      pygments: ">=2.4.0"
+      python: ">=3.8"
+      stack_data: "*"
+      traitlets: ">=5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/ipython-8.10.0-pyhd1c38e8_0.conda"
+    hash:
+      md5: e67b634578fefbb312cd6cfd34b63d86
+      sha256: 5951fbddbd8be803c38b75d7d34ff78d366e57e55a7afa2604be6fd0abacb882
+    optional: false
+    category: main
+  - name: ipython
+    version: 8.10.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: "*"
+      appnope: "*"
+      backcall: "*"
+      decorator: "*"
+      jedi: ">=0.16"
+      matplotlib-inline: "*"
+      pexpect: ">4.3"
+      pickleshare: "*"
+      prompt-toolkit: ">=3.0.30,<3.1.0"
+      pygments: ">=2.4.0"
+      python: ">=3.8"
+      stack_data: "*"
+      traitlets: ">=5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/ipython-8.10.0-pyhd1c38e8_0.conda"
+    hash:
+      md5: e67b634578fefbb312cd6cfd34b63d86
+      sha256: 5951fbddbd8be803c38b75d7d34ff78d366e57e55a7afa2604be6fd0abacb882
+    optional: false
+    category: main
+  - name: isl
+    version: "0.25"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=13.0.1"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/isl-0.25-hb486fe8_0.tar.bz2"
+    hash:
+      md5: 45a9a46c78c0ea5c275b535f7923bde3
+      sha256: f0a10b2be179809d4444bee0a60d5aa286b306520d55897b29d22b9848ab71fb
+    optional: false
+    category: main
+  - name: isl
+    version: "0.25"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=13.0.1"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/isl-0.25-h9a09cb3_0.tar.bz2"
+    hash:
+      md5: b0c90b63ffeb9e2d045be8f5bc64741c
+      sha256: 6c6b486de9db1c2c897b24f6b0eb9a1ecdaf355ede1ee2ccb0c1aaee4bd9ef59
+    optional: false
+    category: main
+  - name: jack
+    version: 1.9.22
+    manager: conda
+    platform: linux-64
+    dependencies:
+      alsa-lib: ">=1.2.8,<1.2.9.0a0"
+      libdb: ">=6.2.32,<6.3.0a0"
+      libgcc-ng: ">=12"
+      libopus: ">=1.3.1,<2.0a0"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/jack-1.9.22-h11f4161_0.conda"
+    hash:
+      md5: 504fa9e712b99494a9cf4630e3ca7d78
+      sha256: 9f173c6633f7ef049b05cd92a9fc028402972ddc44a56d5bb51d8879d73bbde7
+    optional: false
+    category: main
+  - name: jedi
+    version: 0.18.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      parso: ">=0.8.0,<0.9.0"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda"
+    hash:
+      md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
+      sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
+    optional: false
+    category: main
+  - name: jedi
+    version: 0.18.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      parso: ">=0.8.0,<0.9.0"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda"
+    hash:
+      md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
+      sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
+    optional: false
+    category: main
+  - name: jedi
+    version: 0.18.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      parso: ">=0.8.0,<0.9.0"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda"
+    hash:
+      md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
+      sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
+    optional: false
+    category: main
+  - name: jedi
+    version: 0.18.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      parso: ">=0.8.0,<0.9.0"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda"
+    hash:
+      md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
+      sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
+    optional: false
+    category: main
+  - name: jedi
+    version: 0.18.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      parso: ">=0.8.0,<0.9.0"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda"
+    hash:
+      md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
+      sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
+    optional: false
+    category: main
+  - name: jinja2
+    version: 3.1.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      markupsafe: ">=2.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: c8490ed5c70966d232fdd389d0dbed37
+      sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+    optional: false
+    category: main
+  - name: jinja2
+    version: 3.1.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      markupsafe: ">=2.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: c8490ed5c70966d232fdd389d0dbed37
+      sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+    optional: false
+    category: main
+  - name: jinja2
+    version: 3.1.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      markupsafe: ">=2.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: c8490ed5c70966d232fdd389d0dbed37
+      sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+    optional: false
+    category: main
+  - name: jinja2
+    version: 3.1.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      markupsafe: ">=2.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: c8490ed5c70966d232fdd389d0dbed37
+      sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+    optional: false
+    category: main
+  - name: jinja2
+    version: 3.1.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      markupsafe: ">=2.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: c8490ed5c70966d232fdd389d0dbed37
+      sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
+    optional: false
+    category: main
   - name: jpeg
     version: 9e
     manager: conda
@@ -441,6 +4639,85 @@ package:
     hash:
       md5: c7a069243e1fbe9a556ed2ec030e6407
       sha256: 8f73194d09c9ea4a7e2b3562766b8d72125cc147b62c7cf83393e3a3bbfd581b
+    optional: false
+    category: main
+  - name: jpeg
+    version: 9e
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/jpeg-9e-h2a766a3_3.conda"
+    hash:
+      md5: 9530170a461f31c2c04753fc664eb6b0
+      sha256: 9a99054cdd1b67bc3319b863d17045045455cfb3ff1a3cb166f2f2a206aedf4d
+    optional: false
+    category: main
+  - name: jpeg
+    version: 9e
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/jpeg-9e-h4194056_3.conda"
+    hash:
+      md5: 90cc27ac2032b05e4131bc62d33635dd
+      sha256: 41ab5b1f339fb2ab0a8938081bf972111a7d730e106eec3987c718e093ab07a9
+    optional: false
+    category: main
+  - name: jpeg
+    version: 9e
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/jpeg-9e-hb7f2c08_3.conda"
+    hash:
+      md5: 6b55131ae9445ef38746dc6b080acda9
+      sha256: 1ef5f9b4d9817820224c92b016da210b1356250d7272e16901c547e156b3e615
+    optional: false
+    category: main
+  - name: jpeg
+    version: 9e
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/jpeg-9e-h1a8c8d9_3.conda"
+    hash:
+      md5: ef1cce2ab799e0c2f32c3344125ff218
+      sha256: 7e21d03917fb535b39c3af0cc7b7115617556a4ca2fe13018c09407987883b34
+    optional: false
+    category: main
+  - name: kernel-headers_linux-64
+    version: 2.6.32
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_15.tar.bz2"
+    hash:
+      md5: 5dd5127afd710f91f6a75821bac0a4f0
+      sha256: c9f33acc0f1095bd4e7a2b577dfa41fc3fef3713b3975e8467a0fbed188fe6f4
+    optional: false
+    category: main
+  - name: kernel-headers_linux-aarch64
+    version: 4.18.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_13.tar.bz2"
+    hash:
+      md5: a9385e5b11a076c40d75915986f498d7
+      sha256: 14e227d98193550f9da275e58e27de104ab569849f1ce16b810fae4d7b351d49
+    optional: false
+    category: main
+  - name: kernel-headers_linux-ppc64le
+    version: 3.10.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-ppc64le-3.10.0-h23d7e6c_13.tar.bz2"
+    hash:
+      md5: 2c36c739b5b1827404dcc96860f9b7e1
+      sha256: 6752a00b9bf73087c90fbc3da9284745ec7fb5f960a132d3189c6a053d59cfb8
     optional: false
     category: main
   - name: keyutils
@@ -455,6 +4732,95 @@ package:
       sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
     optional: false
     category: main
+  - name: kiwisolver
+    version: 1.4.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.4-py39hf939315_1.tar.bz2"
+    hash:
+      md5: 41679a052a8ce841c74df1ebc802e411
+      sha256: eb28254cc7029e702d0059536d986b010221de62f9c8588a5a83e95a00b4e74d
+    optional: false
+    category: main
+  - name: kiwisolver
+    version: 1.4.4
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/kiwisolver-1.4.4-py39h110580c_1.tar.bz2"
+    hash:
+      md5: 9c045502f6ab8c89bfda6be3c389e503
+      sha256: 9bf3781b4f46988b7e97d9fbaeab666340d3818d162d362b11529809349c9741
+    optional: false
+    category: main
+  - name: kiwisolver
+    version: 1.4.4
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/kiwisolver-1.4.4-py39h2bf7372_1.tar.bz2"
+    hash:
+      md5: b2e6cbe5c430337f19676048e429d5c6
+      sha256: bd998a1dbaaaa9073ee6cfacbb8f28fcd1cec4817683272d9a09c8857276ef64
+    optional: false
+    category: main
+  - name: kiwisolver
+    version: 1.4.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=14.0.4"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.4-py39h92daf61_1.tar.bz2"
+    hash:
+      md5: 7720e059630e25ab17ab12677e59c615
+      sha256: c397173c92ca77678d645bf8ef8064e81b821169db056217963f020acc09d42c
+    optional: false
+    category: main
+  - name: kiwisolver
+    version: 1.4.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=14.0.4"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.4-py39haaf3ac1_1.tar.bz2"
+    hash:
+      md5: 5f43e4d5437b93606167c640ea2d06c1
+      sha256: afe4759ca7572eb98361cd4c68ae3819a16d368c963d1134b926d2963434b3e6
+    optional: false
+    category: main
+  - name: krb5
+    version: 1.20.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      keyutils: ">=1.6.1,<2.0a0"
+      libedit: ">=3.1.20191231,<4.0a0"
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      openssl: ">=3.0.7,<4.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/krb5-1.20.1-h81ceb04_0.conda"
+    hash:
+      md5: 89a41adce7106749573d883b2f657d78
+      sha256: 51a346807ce981e1450eb04c3566415b05eed705bc9e6c98c198ec62367b7c62
+    optional: false
+    category: main
   - name: lame
     version: "3.100"
     manager: conda
@@ -465,6 +4831,163 @@ package:
     hash:
       md5: a8832b479f93521a9e7b5b743803be51
       sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
+    optional: false
+    category: main
+  - name: lcms2
+    version: "2.14"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      jpeg: ">=9e,<10a"
+      libgcc-ng: ">=12"
+      libtiff: ">=4.5.0,<4.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.14-hfd0df8a_1.conda"
+    hash:
+      md5: c2566c2ea5f153ddd6bf4acaf7547d97
+      sha256: 632f191ac65bc673f8fcef9947e2c8431b0db6ca357ceebde3bdc4ed187af814
+    optional: false
+    category: main
+  - name: lcms2
+    version: "2.14"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      jpeg: ">=9e,<10a"
+      libgcc-ng: ">=12"
+      libtiff: ">=4.5.0,<4.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.14-h7576be9_1.conda"
+    hash:
+      md5: 33f4117db8c2b9ff0888cedd74b2f8e9
+      sha256: 1210de1fbb82cc73fb81f8db3e5ea26071855f3695198fe45fd4382c33aaf1c2
+    optional: false
+    category: main
+  - name: lcms2
+    version: "2.14"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      jpeg: ">=9e,<10a"
+      libgcc-ng: ">=12"
+      libtiff: ">=4.5.0,<4.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/lcms2-2.14-h4cdffb3_1.conda"
+    hash:
+      md5: 3dc2f029758b3692b6c0bca31e20f3f6
+      sha256: a5ba8adce3919b492527e638897bbf5843e75ea01358bac148f7d3c846c9f38b
+    optional: false
+    category: main
+  - name: lcms2
+    version: "2.14"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      jpeg: ">=9e,<10a"
+      libtiff: ">=4.5.0,<4.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.14-h29502cd_1.conda"
+    hash:
+      md5: 1e42174021ffc69545f0814b9478dee3
+      sha256: 64efad232b892c2511ba56bbd821e0b1e2e80a7a8ccf3524c20b5f964793ce43
+    optional: false
+    category: main
+  - name: lcms2
+    version: "2.14"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      jpeg: ">=9e,<10a"
+      libtiff: ">=4.5.0,<4.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.14-h481adae_1.conda"
+    hash:
+      md5: aad4fc7ce783e7d109576df5a9bb78c7
+      sha256: 65c0a292be935a5e499b1e782b7ddada93b16ec77fef7416e2846aa2b3e16f3b
+    optional: false
+    category: main
+  - name: ld64
+    version: "609"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      ld64_osx-64: "==609 hfd63004_11"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/ld64-609-hc6ad406_11.conda"
+    hash:
+      md5: 9e14075f26a915bc6180b40789138adf
+      sha256: fd1d2aa9a08c52599fb03dbd65fe32e788f34bcd6d509f22eac7897233282d60
+    optional: false
+    category: main
+  - name: ld64
+    version: "609"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      ld64_osx-arm64: "==609 h7167370_11"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h619f069_11.conda"
+    hash:
+      md5: 00e421a01015e5246eca89480c6f7264
+      sha256: 2dafdecd71c4eb71524d1d9bc4df94bfd456144ddd7d88fec9813eced8993ee2
+    optional: false
+    category: main
+  - name: ld64_osx-64
+    version: "609"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: "*"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+      sigtool: "*"
+      tapi: ">=1100.0.11,<1101.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-hfd63004_11.conda"
+    hash:
+      md5: 8881d41cb8fa1104d4545c6b7ddc9671
+      sha256: 0c658f698bc12e0c7dc2def81c0b2a45aab810f5a11136dc99a5e944b47a3b97
+    optional: false
+    category: main
+  - name: ld64_osx-arm64
+    version: "609"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: "*"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+      sigtool: "*"
+      tapi: ">=1100.0.11,<1101.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-h7167370_11.conda"
+    hash:
+      md5: 5158e240a2318c11dba7e8493bf1b42b
+      sha256: 0a0a9d26eb1e14d1ff4b9ee7a05eb3f338f258dd2c78a6a649d7fe9037ae5f8c
+    optional: false
+    category: main
+  - name: ld_impl_linux-64
+    version: "2.39"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.39-hcc3a1bd_1.conda"
+    hash:
+      md5: 737be0d34c22d24432049ab7a3214de4
+      sha256: 3e7f203e33ea497b6e468279cc5fdef7d556473c25e7466b35fd672940392469
+    optional: false
+    category: main
+  - name: ld_impl_linux-aarch64
+    version: "2.39"
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.39-h16cd69b_1.conda"
+    hash:
+      md5: 9daf385ebefaea92087d3a315e398964
+      sha256: aae71464a25bc5f32db5211621798a0725fc910a6a2a19a6161dbfcb0a7b1e35
+    optional: false
+    category: main
+  - name: ld_impl_linux-ppc64le
+    version: "2.39"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ld_impl_linux-ppc64le-2.39-hea198f4_1.conda"
+    hash:
+      md5: c7db6cc5b9479df1ed884b6147601613
+      sha256: 20d6db1053ae4af65677fc4b4cf9b2d5884ce26ea6b38f7088a5ebad1de62746
     optional: false
     category: main
   - name: lerc
@@ -480,6 +5003,116 @@ package:
       sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
     optional: false
     category: main
+  - name: lerc
+    version: 4.0.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2"
+    hash:
+      md5: 1a0ffc65e03ce81559dbcb0695ad1476
+      sha256: 2d09ef9b7796d83364957e420b41c32d94e628c3f0520b61c332518a7b5cd586
+    optional: false
+    category: main
+  - name: lerc
+    version: 4.0.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/lerc-4.0.0-hbbae597_0.tar.bz2"
+    hash:
+      md5: fc65ed3c14d2236d5917f11eaf2b949f
+      sha256: 694594f8344b02e0c18ae80d898b248a5afc228f8033fe0c57cb52d8c1839152
+    optional: false
+    category: main
+  - name: lerc
+    version: 4.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=13.0.1"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2"
+    hash:
+      md5: f9d6a4c82889d5ecedec1d90eb673c55
+      sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
+    optional: false
+    category: main
+  - name: lerc
+    version: 4.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=13.0.1"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2"
+    hash:
+      md5: de462d5aacda3b30721b512c5da4e742
+      sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
+    optional: false
+    category: main
+  - name: libblas
+    version: 3.9.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libopenblas: ">=0.3.21,<1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-16_linux64_openblas.tar.bz2"
+    hash:
+      md5: d9b7a8639171f6c6fa0a983edabcfe2b
+      sha256: 4e4c60d3fe0b95ffb25911dace509e3532979f5deef4364141c533c5ca82dd39
+    optional: false
+    category: main
+  - name: libblas
+    version: 3.9.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libopenblas: ">=0.3.21,<1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-16_linuxaarch64_openblas.tar.bz2"
+    hash:
+      md5: 188f02883567d5b7f96c7aa12e7007c9
+      sha256: 6fdf73da8b717f207979f77660646ca2d7e17671482435f281b676ac27eb288e
+    optional: false
+    category: main
+  - name: libblas
+    version: 3.9.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libopenblas: ">=0.3.21,<1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libblas-3.9.0-16_linuxppc64le_openblas.tar.bz2"
+    hash:
+      md5: 762b1dc9aab318ee9ba7386d2418e165
+      sha256: 4a4ce4387841e3cf267b61907df06403ded365322fff3926f842f080957f82ee
+    optional: false
+    category: main
+  - name: libblas
+    version: 3.9.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libopenblas: ">=0.3.21,<1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-16_osx64_openblas.tar.bz2"
+    hash:
+      md5: 644d63e9379867490b67bace400b2a0f
+      sha256: 7678dab49b552957ddfa1fc5ddf3a09963c788bca81adb0cd9626f6385e205c5
+    optional: false
+    category: main
+  - name: libblas
+    version: 3.9.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libopenblas: ">=0.3.21,<1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-16_osxarm64_openblas.tar.bz2"
+    hash:
+      md5: 53d6d5097f0d62e24db8c1979a21102e
+      sha256: 17dd67806f7e31981a1ac8abb63ed004eac416a1061c7737028f5af269430fa6
+    optional: false
+    category: main
   - name: libbrotlicommon
     version: 1.0.9
     manager: conda
@@ -490,6 +5123,345 @@ package:
     hash:
       md5: 9194c9bf9428035a05352d031462eae4
       sha256: ddc961a36d498aaafd5b71078836ad5dd247cc6ba7924157f3801a2f09b77b14
+    optional: false
+    category: main
+  - name: libbrotlicommon
+    version: 1.0.9
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.0.9-h4e544f5_8.tar.bz2"
+    hash:
+      md5: 3cedc3935cfaa2a5303daa25fb12cb1d
+      sha256: 8eedfeb9097042f1005d4764bda83de0eda907e55d77408654367760ad46053d
+    optional: false
+    category: main
+  - name: libbrotlicommon
+    version: 1.0.9
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libbrotlicommon-1.0.9-hb283c62_8.tar.bz2"
+    hash:
+      md5: 9981d8b1ed12d10234fa31973de47c10
+      sha256: 69a03504a38fb6b99322896de35df1b76ac34fd25d01d6fed4cb9de7cb18ceb0
+    optional: false
+    category: main
+  - name: libbrotlicommon
+    version: 1.0.9
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.0.9-hb7f2c08_8.tar.bz2"
+    hash:
+      md5: 37157d273eaf3bc7d6862104161d9ec9
+      sha256: c983101653f5bffea605c4423d84fd5ca28ee36b290cdb6207ec246e293f7d94
+    optional: false
+    category: main
+  - name: libbrotlicommon
+    version: 1.0.9
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.0.9-h1a8c8d9_8.tar.bz2"
+    hash:
+      md5: 84eb0c3c995a865079080d092e4a3c06
+      sha256: 1bd70570aee08fe0274dd46879d0b4c36c662c18d3afc03c41c375c84658af88
+    optional: false
+    category: main
+  - name: libbrotlidec
+    version: 1.0.9
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libbrotlicommon: "==1.0.9 h166bdaf_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_8.tar.bz2"
+    hash:
+      md5: 4ae4d7795d33e02bd20f6b23d91caf82
+      sha256: d88ba07c3be27c89cb4975cc7edf63ee7b1c62d01f70d5c3f7efeb987c82b052
+    optional: false
+    category: main
+  - name: libbrotlidec
+    version: 1.0.9
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libbrotlicommon: "==1.0.9 h4e544f5_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.0.9-h4e544f5_8.tar.bz2"
+    hash:
+      md5: 319956380b383ec9f6a46d585599c028
+      sha256: 5c735e238743bda58f44fcb5bef564dc5262c0ea0219ccdb8cbcb168c98a58e0
+    optional: false
+    category: main
+  - name: libbrotlidec
+    version: 1.0.9
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libbrotlicommon: "==1.0.9 hb283c62_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libbrotlidec-1.0.9-hb283c62_8.tar.bz2"
+    hash:
+      md5: 66fb01acc327a224248ab33d16e4b8c0
+      sha256: 180aa63160d710e08855b3ff9b30f4321c5674913dd3f0b5c8f54cebdd669cc2
+    optional: false
+    category: main
+  - name: libbrotlidec
+    version: 1.0.9
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libbrotlicommon: "==1.0.9 hb7f2c08_8"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.0.9-hb7f2c08_8.tar.bz2"
+    hash:
+      md5: 7f952a036d9014b4dab96c6ea0f8c2a7
+      sha256: 52d8e8929b2476cf13fd397d88cefd911f805de00e77090fdc50b8fb11c372ca
+    optional: false
+    category: main
+  - name: libbrotlidec
+    version: 1.0.9
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libbrotlicommon: "==1.0.9 h1a8c8d9_8"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.0.9-h1a8c8d9_8.tar.bz2"
+    hash:
+      md5: 640ea7b788cdd0420409bd8479f023f9
+      sha256: a0a52941eb59369a8b33b01b41bcf56efd313850c583f4814e2db59448439880
+    optional: false
+    category: main
+  - name: libbrotlienc
+    version: 1.0.9
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libbrotlicommon: "==1.0.9 h166bdaf_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_8.tar.bz2"
+    hash:
+      md5: 04bac51ba35ea023dc48af73c1c88c25
+      sha256: a0468858b2f647f51509a32040e93512818a8f9980f20b3554cccac747bcc4be
+    optional: false
+    category: main
+  - name: libbrotlienc
+    version: 1.0.9
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libbrotlicommon: "==1.0.9 h4e544f5_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.0.9-h4e544f5_8.tar.bz2"
+    hash:
+      md5: 56a0a025208af24e2b43b2bbeee79802
+      sha256: 2f6617b2ac53ab440d50a062d08e39cb207dc3ac36a5abe61efe0fa11d2205a1
+    optional: false
+    category: main
+  - name: libbrotlienc
+    version: 1.0.9
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libbrotlicommon: "==1.0.9 hb283c62_8"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libbrotlienc-1.0.9-hb283c62_8.tar.bz2"
+    hash:
+      md5: 4c4ecee0aec784fe72e73935f5344676
+      sha256: bd6247e1ef777d697f546680242c9937dd43339c55077fef0964e6b1a2f2c5b7
+    optional: false
+    category: main
+  - name: libbrotlienc
+    version: 1.0.9
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libbrotlicommon: "==1.0.9 hb7f2c08_8"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.0.9-hb7f2c08_8.tar.bz2"
+    hash:
+      md5: b36a3bfe866d9127f25f286506982166
+      sha256: be7e794c6208e7e12982872922df13fbf020ab594d516b7bc306a384ac7d3ac6
+    optional: false
+    category: main
+  - name: libbrotlienc
+    version: 1.0.9
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libbrotlicommon: "==1.0.9 h1a8c8d9_8"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.0.9-h1a8c8d9_8.tar.bz2"
+    hash:
+      md5: 572907b78be867937c258421bc0807a8
+      sha256: c5f65062cd41d5f5fd93eadd276885efbe7ce7c9346155852d4f5b619f8a166f
+    optional: false
+    category: main
+  - name: libcap
+    version: "2.66"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      attr: ">=2.5.1,<2.6.0a0"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libcap-2.66-ha37c62d_0.tar.bz2"
+    hash:
+      md5: 2d7665abd0997f1a6d4b7596bc27b657
+      sha256: db113b0bacb45533ec6f5c13a548054af8bd0ca2f7583e8bc5989f17e1e1638b
+    optional: false
+    category: main
+  - name: libcblas
+    version: 3.9.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libblas: "==3.9.0 16_linux64_openblas"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-16_linux64_openblas.tar.bz2"
+    hash:
+      md5: 20bae26d0a1db73f758fc3754cab4719
+      sha256: e4ceab90a49cb3ac1af20177016dc92066aa278eded19646bb928d261b98367f
+    optional: false
+    category: main
+  - name: libcblas
+    version: 3.9.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libblas: "==3.9.0 16_linuxaarch64_openblas"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-16_linuxaarch64_openblas.tar.bz2"
+    hash:
+      md5: 520a3ecbebc63239c27dd6f70c2ababe
+      sha256: c1d4fa9a99475647c7904009c026fe7f9c0b3159b2f7d2bcecac102751104302
+    optional: false
+    category: main
+  - name: libcblas
+    version: 3.9.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libblas: "==3.9.0 16_linuxppc64le_openblas"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libcblas-3.9.0-16_linuxppc64le_openblas.tar.bz2"
+    hash:
+      md5: 7c92b1e5f94e656d9d2f4c6164c3dd7d
+      sha256: f1141c257846202190deebd326b37e6147168e40e2511dffae5db48089c4f201
+    optional: false
+    category: main
+  - name: libcblas
+    version: 3.9.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libblas: "==3.9.0 16_osx64_openblas"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-16_osx64_openblas.tar.bz2"
+    hash:
+      md5: 28592eab0f05bcf9969789e87f754e11
+      sha256: 072a214ab1d596b99b985773bdb6f6e5f38774c7f73d70962700e0fc0d77d91f
+    optional: false
+    category: main
+  - name: libcblas
+    version: 3.9.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libblas: "==3.9.0 16_osxarm64_openblas"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-16_osxarm64_openblas.tar.bz2"
+    hash:
+      md5: c7cfc18378f00d3faf7f8a9a2553be3c
+      sha256: 99a04c6a273e76b01ace4f3a8f333b96a76b7351a155aaeba179e283da5c264e
+    optional: false
+    category: main
+  - name: libclang
+    version: 15.0.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libclang13: "==15.0.7 default_h3e3d535_1"
+      libgcc-ng: ">=12"
+      libllvm15: ">=15.0.7,<15.1.0a0"
+      libstdcxx-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_had23c3d_1.conda"
+    hash:
+      md5: 36c65ed73b7c92589bd9562ef8a6023d
+      sha256: eba3ed760c72c992a04d86455556ecb90c0e1e3688defcac44b28a848d71651c
+    optional: false
+    category: main
+  - name: libclang-cpp14
+    version: 14.0.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=13.0.1"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp14-14.0.6-default_h55ffa42_0.tar.bz2"
+    hash:
+      md5: 9b9bc2f878d47e6846e3d01ca0fcb921
+      sha256: 01f7c50ef3414ea00026e5845e6ac8f0395af8ea7d585e4977fd6d7aa3e215d0
+    optional: false
+    category: main
+  - name: libclang-cpp14
+    version: 14.0.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=13.0.1"
+      libllvm14: ">=14.0.6,<14.1.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp14-14.0.6-default_h81a5282_0.tar.bz2"
+    hash:
+      md5: 6cfc1343e167d250367983b1864adc04
+      sha256: 86a606d0d76cdae79d3d89c686313cda22ecbbde182b4e906759500078653d6b
+    optional: false
+    category: main
+  - name: libclang13
+    version: 15.0.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libllvm15: ">=15.0.7,<15.1.0a0"
+      libstdcxx-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h3e3d535_1.conda"
+    hash:
+      md5: a3a0f7a6f0885f5e1e0ec691566afb77
+      sha256: e48481c37d02aefeddcfac20d48cf13b838c5f7b9018300fa7eac404d30f3d7f
+    optional: false
+    category: main
+  - name: libcups
+    version: 2.3.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      krb5: ">=1.20.1,<1.21.0a0"
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h36d4200_3.conda"
+    hash:
+      md5: c9f4416a34bc91e0eb029f912c68f81f
+      sha256: 0ccd610207807f53328f137b2adc99c413f8e1dcd1302f0325412796a94eaaf7
+    optional: false
+    category: main
+  - name: libcxx
+    version: 14.0.6
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libcxx-14.0.6-hccf4f1f_0.tar.bz2"
+    hash:
+      md5: 208a6a874b073277374de48a782f6b10
+      sha256: ebb75dd9f854b1f184a98d0b9128a3faed6cd2f05f83677e1f399c253580afe7
+    optional: false
+    category: main
+  - name: libcxx
+    version: 14.0.6
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-14.0.6-h2692d47_0.tar.bz2"
+    hash:
+      md5: 716c4b72ff3808ade65748fd9b49cc44
+      sha256: 8e199c6956fad3abcbe9a1468c6219d9e95b64b898e9cf009b82d669c3bfdaf6
     optional: false
     category: main
   - name: libdb
@@ -517,6 +5489,78 @@ package:
       sha256: f9983a8ea03531f2c14bce76c870ca325c0fddf0c4e872bff1f78bc52624179c
     optional: false
     category: main
+  - name: libdeflate
+    version: "1.17"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.17-hb4cce97_0.conda"
+    hash:
+      md5: 0a26f36963967687f4cab7c4a017a189
+      sha256: 3602858d16549239f036ccb8763e6b0e4a027f2f28e0b2d9d8e65fbbb34a9ded
+    optional: false
+    category: main
+  - name: libdeflate
+    version: "1.17"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libdeflate-1.17-h4194056_0.conda"
+    hash:
+      md5: 02f45219ac7b6b3d2af66fbbb2a7c8e5
+      sha256: aa28ce878cbe18757b4acca5341b91bab3531a42ddd092227ebc34c255781135
+    optional: false
+    category: main
+  - name: libdeflate
+    version: "1.17"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.17-hac1461d_0.conda"
+    hash:
+      md5: e3894420cf8b6abbf6c4d3d9742fbb4a
+      sha256: b322e190fd6fe631e1f4836ef99cbfb8352c03c30b51cb5baa216f7c9124d82e
+    optional: false
+    category: main
+  - name: libdeflate
+    version: "1.17"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.17-h1a8c8d9_0.conda"
+    hash:
+      md5: cae34d3f6ab02e0abf92ec3caaf0bd39
+      sha256: 9a1979b3f6dc155b8c48987cfae6b13ba19b3e176e4470b87f60011e806218f5
+    optional: false
+    category: main
+  - name: libedit
+    version: 3.1.20191231
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=7.5.0"
+      ncurses: ">=6.2,<7.0.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2"
+    hash:
+      md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
+      sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
+    optional: false
+    category: main
+  - name: libevent
+    version: 2.1.10
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+      openssl: ">=3.0.0,<4.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.10-h28343ad_4.tar.bz2"
+    hash:
+      md5: 4a049fc560e00e43151dc51368915fdd
+      sha256: 31ac7124c92628cd1c6bea368e38d7f43f8ec68d88128ecdc177773e6d00c60a
+    optional: false
+    category: main
   - name: libffi
     version: 3.4.2
     manager: conda
@@ -527,6 +5571,374 @@ package:
     hash:
       md5: d645c6d2ac96843a2bfaccd2d62b3ac3
       sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+    optional: false
+    category: main
+  - name: libffi
+    version: 3.4.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2"
+    hash:
+      md5: dddd85f4d52121fab0a8b099c5e06501
+      sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
+    optional: false
+    category: main
+  - name: libffi
+    version: 3.4.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libffi-3.4.2-h4e0d66e_5.tar.bz2"
+    hash:
+      md5: 79c37a0a50ef77fea4ee5f6d257b8b3c
+      sha256: 178ca9f82e2144a8834dd01f9af3b4b9b5d482892675931edccff06aee524953
+    optional: false
+    category: main
+  - name: libffi
+    version: 3.4.2
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2"
+    hash:
+      md5: ccb34fb14960ad8b125962d3d79b31a9
+      sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+    optional: false
+    category: main
+  - name: libffi
+    version: 3.4.2
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2"
+    hash:
+      md5: 086914b672be056eb70fd4285b6783b6
+      sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+    optional: false
+    category: main
+  - name: libflac
+    version: 1.4.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      gettext: ">=0.21.1,<1.0a0"
+      libgcc-ng: ">=12"
+      libogg: ">=1.3.4,<1.4.0a0"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.2-h27087fc_0.tar.bz2"
+    hash:
+      md5: 7daf72d8e2a8e848e11d63ed6d1026e0
+      sha256: 095cfa4e2df8622b8f9eebec3c60710ea0f4732c64cd24769ccf9ed63fd45545
+    optional: false
+    category: main
+  - name: libgcc-devel_linux-64
+    version: 11.3.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-11.3.0-h210ce93_19.tar.bz2"
+    hash:
+      md5: 9b7bdb0b42ce4e4670d32bfe0532b56a
+      sha256: 70b2c370cc616304f732eeb4014825390dbee044ecbc3875e968b0ea01bd7503
+    optional: false
+    category: main
+  - name: libgcc-devel_linux-aarch64
+    version: 11.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-devel_linux-aarch64-11.3.0-h02014c4_19.tar.bz2"
+    hash:
+      md5: dde2aeef8efee13089f2fbb2bdb4879e
+      sha256: 40f1288935150ab0b524c030d852aa67826db379ff61350c817006b9ce1b2b97
+    optional: false
+    category: main
+  - name: libgcc-devel_linux-ppc64le
+    version: 11.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-devel_linux-ppc64le-11.3.0-hcb32637_19.tar.bz2"
+    hash:
+      md5: e652f909e48f3e16a1f4c2a26aaa900b
+      sha256: f4270a73600fe1debf364cfc4b74aac4ca90a052abe9e302301ab62189fc255a
+    optional: false
+    category: main
+  - name: libgcc-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      _libgcc_mutex: "==0.1 conda_forge"
+      _openmp_mutex: ">=4.5"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-12.2.0-h65d4601_19.tar.bz2"
+    hash:
+      md5: e4c94f80aef025c17ab0828cd85ef535
+      sha256: f3899c26824cee023f1e360bd0859b0e149e2b3e8b1668bc6dd04bfc70dcd659
+    optional: false
+    category: main
+  - name: libgcc-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      _openmp_mutex: ">=4.5"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-12.2.0-h607ecd0_19.tar.bz2"
+    hash:
+      md5: 8456a29b6d9fc3123ccb9a966b6b2c49
+      sha256: 0dd30553f6f38b011c9c81471a50f85e98a79e4dd672fdc1fc97904b54b5419b
+    optional: false
+    category: main
+  - name: libgcc-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      _libgcc_mutex: "==0.1 conda_forge"
+      _openmp_mutex: ">=4.5"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-ng-12.2.0-hbc1322c_19.tar.bz2"
+    hash:
+      md5: 9ad34f95d6fb05300bbd0f553f3bece4
+      sha256: 335a2b7415cb5fbbf05459f6cfcca4dd8bafd43bcbe5bf6aa56bf66b7ed6bf42
+    optional: false
+    category: main
+  - name: libgcrypt
+    version: 1.10.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=10.3.0"
+      libgpg-error: ">=1.44,<2.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.1-h166bdaf_0.tar.bz2"
+    hash:
+      md5: f967fc95089cd247ceed56eda31de3a9
+      sha256: 8fd7e6db1021cd9298d9896233454de204116840eb66a06fcb712e1015ff132a
+    optional: false
+    category: main
+  - name: libgfortran
+    version: 5.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libgfortran5: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-11_3_0_h97931a8_27.conda"
+    hash:
+      md5: 7d25335e67256924aa04de681e68e807
+      sha256: 834f1547a41fe53a23563b7702eb83b7156129a88460b5de701e8e019f7933a1
+    optional: false
+    category: main
+  - name: libgfortran
+    version: 5.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libgfortran5: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-11_3_0_hd922786_27.conda"
+    hash:
+      md5: 61d66d1a81d08e3f82049aa279f4cd7f
+      sha256: fce7eb15948e1fec90508a4a7ca1fa350225f03e46c5a6e6df5b4f7b523db695
+    optional: false
+    category: main
+  - name: libgfortran-devel_osx-64
+    version: 11.3.0
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/libgfortran-devel_osx-64-11.3.0-h824d247_27.conda"
+    hash:
+      md5: 3729d4388eb5a801b148dd4802899dba
+      sha256: d93b662d07aeb99417be9b62ca511520865e691d1fc224a63e383727791ac3b7
+    optional: false
+    category: main
+  - name: libgfortran-devel_osx-arm64
+    version: 11.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/libgfortran-devel_osx-arm64-11.3.0-hfe9555d_27.conda"
+    hash:
+      md5: 28cf7c6b44b099d8cb4f801dc547cc5c
+      sha256: e0e304772a9c572081ee04b316327cec0659c77890db26548ea600ab9b20e1c8
+    optional: false
+    category: main
+  - name: libgfortran-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgfortran5: "==12.2.0 h337968e_19"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-12.2.0-h69a702a_19.tar.bz2"
+    hash:
+      md5: cd7a806282c16e1f2d39a7e80d3a3e0d
+      sha256: c7d061f323e80fbc09564179073d8af303bf69b953b0caddcf79b47e352c746f
+    optional: false
+    category: main
+  - name: libgfortran-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgfortran5: "==12.2.0 hf695500_19"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-12.2.0-he9431aa_19.tar.bz2"
+    hash:
+      md5: b5b34211bbf681bd3e7a5a4d80cce77b
+      sha256: 3ac162edf354bfa46076f52f3bff3a8ac10e626ebb9ed5e01aad954ebd386829
+    optional: false
+    category: main
+  - name: libgfortran-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgfortran5: "==12.2.0 hda65b67_19"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgfortran-ng-12.2.0-hfdc3801_19.tar.bz2"
+    hash:
+      md5: 81d5153ea3ba783743ab08b859fc8e1f
+      sha256: 5221449383ddf2f73777337f788b7367ae2f035373ff1e9030ea98fe891c73ab
+    optional: false
+    category: main
+  - name: libgfortran5
+    version: 12.2.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-12.2.0-h337968e_19.tar.bz2"
+    hash:
+      md5: 164b4b1acaedc47ee7e658ae6b308ca3
+      sha256: 03ea784edd12037dc3a7a0078ff3f9c3383feabb34d5ba910bb2fd7a21a2d961
+    optional: false
+    category: main
+  - name: libgfortran5
+    version: 12.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-12.2.0-hf695500_19.tar.bz2"
+    hash:
+      md5: bc890809e1f807b51bf04dfbee70ddf5
+      sha256: e0496081c3a26c578abd0e292317c80159ebfbd5bb1ecca446894b9adf39abd7
+    optional: false
+    category: main
+  - name: libgfortran5
+    version: 12.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgfortran5-12.2.0-hda65b67_19.tar.bz2"
+    hash:
+      md5: 62f0191db9d8e634ed676c0645aee79b
+      sha256: 6131391202198279f8a3744fa08e6f3f6513d8211799608410bca8fe6b76bf37
+    optional: false
+    category: main
+  - name: libgfortran5
+    version: 11.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      llvm-openmp: ">=8.0.0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-11.3.0-h082f757_27.conda"
+    hash:
+      md5: f7602714b2be91be36f00fb75c45cb14
+      sha256: 78173905004e7d13501db619391b113f3b96f2c78ba3ed0273152d1340d6a818
+    optional: false
+    category: main
+  - name: libgfortran5
+    version: 11.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      llvm-openmp: ">=8.0.0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-11.3.0-hdaf2cc0_27.conda"
+    hash:
+      md5: 4514d8c30cda679e66ca297965e4b043
+      sha256: 88325ae7043712ba02a616281d37bfbab63c4c9b2a7f18ef8410b13d84947350
+    optional: false
+    category: main
+  - name: libglib
+    version: 2.74.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      gettext: ">=0.21.1,<1.0a0"
+      libffi: ">=3.4,<4.0a0"
+      libgcc-ng: ">=12"
+      libiconv: ">=1.17,<2.0a0"
+      libstdcxx-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      pcre2: ">=10.40,<10.41.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libglib-2.74.1-h606061b_1.tar.bz2"
+    hash:
+      md5: ed5349aa96776e00b34eccecf4a948fe
+      sha256: 3cbad3d63cff2dd9ac1dc9cce54fd3d657f3aff53df41bfe5bae9d760562a5af
+    optional: false
+    category: main
+  - name: libglib
+    version: 2.74.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      gettext: ">=0.21.1,<1.0a0"
+      libcxx: ">=14.0.4"
+      libffi: ">=3.4,<4.0a0"
+      libiconv: ">=1.17,<2.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      pcre2: ">=10.40,<10.41.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.74.1-h4646484_1.tar.bz2"
+    hash:
+      md5: 4321cf67e46674567f419e95bae18522
+      sha256: c312e93652734424b30ed017743ea9e37a5efcdf42e14d3f78ca96cf64fd266d
+    optional: false
+    category: main
+  - name: libgomp
+    version: 12.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      _libgcc_mutex: "==0.1 conda_forge"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libgomp-12.2.0-h65d4601_19.tar.bz2"
+    hash:
+      md5: cedcee7c064c01c403f962c9e8d3c373
+      sha256: 81a76d20cfdee9fe0728b93ef057ba93494fd1450d42bc3717af4e468235661e
+    optional: false
+    category: main
+  - name: libgomp
+    version: 12.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-12.2.0-h607ecd0_19.tar.bz2"
+    hash:
+      md5: 65b9cb876525dcb2e74a90cf02c6762a
+      sha256: d802eaceaf6f77fb8cb2e990aacf9b3eaa83361b16369a760fc1585841d7885c
+    optional: false
+    category: main
+  - name: libgomp
+    version: 12.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      _libgcc_mutex: "==0.1 conda_forge"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgomp-12.2.0-hbc1322c_19.tar.bz2"
+    hash:
+      md5: 25647ac31b4d467fce690c6a561a58aa
+      sha256: 56a43985f648c358c6b3eb949863e393dbdb48d8f017315e03ff703031b8a951
+    optional: false
+    category: main
+  - name: libgpg-error
+    version: "1.46"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      gettext: ">=0.21.1,<1.0a0"
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.46-h620e276_0.conda"
+    hash:
+      md5: 27e745f6f2e4b757e95dd7225fbe6bdb
+      sha256: a2e3df80a5713b4143f7d276a9354d78f2b2927b22831dc24c3246a82674aaba
     optional: false
     category: main
   - name: libiconv
@@ -541,6 +5953,154 @@ package:
       sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
     optional: false
     category: main
+  - name: libiconv
+    version: "1.17"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=10.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h9cdd2b7_0.tar.bz2"
+    hash:
+      md5: efc27cfbc82a027f65c02c661832ecfc
+      sha256: e3c95d751ea71a638f781e82b1498e914e1d11536ea52fc354fecb2e65d3a7d3
+    optional: false
+    category: main
+  - name: libiconv
+    version: "1.17"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=10.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libiconv-1.17-hb283c62_0.tar.bz2"
+    hash:
+      md5: 4c3d267837da62ef2b79d56729d3fe65
+      sha256: 39c0fb8eaec7b378d88b458376da90261afbdb076eb4c6dd11f51de69d36384f
+    optional: false
+    category: main
+  - name: libiconv
+    version: "1.17"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2"
+    hash:
+      md5: 691d103d11180486154af49c037b7ed9
+      sha256: 4a3294037d595754f7da7c11a41f3922f995aaa333f3cb66f02d8afa032a7bc2
+    optional: false
+    category: main
+  - name: libiconv
+    version: "1.17"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2"
+    hash:
+      md5: 686f9c755574aa221f29fbcf36a67265
+      sha256: 2eb33065783b802f71d52bef6f15ce0fafea0adc8506f10ebd0d490244087bec
+    optional: false
+    category: main
+  - name: liblapack
+    version: 3.9.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libblas: "==3.9.0 16_linux64_openblas"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-16_linux64_openblas.tar.bz2"
+    hash:
+      md5: 955d993f41f9354bf753d29864ea20ad
+      sha256: f5f30b8049dfa368599e5a08a4f35cb1966af0abc539d1fd1f50d93db76a74e6
+    optional: false
+    category: main
+  - name: liblapack
+    version: 3.9.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libblas: "==3.9.0 16_linuxaarch64_openblas"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-16_linuxaarch64_openblas.tar.bz2"
+    hash:
+      md5: 62990b2d1efc22d0beb394e893d39541
+      sha256: 80a809ce2c965b27d8b8b90753ab01d467b9bf2a66467ca98fc363e4a41da5ec
+    optional: false
+    category: main
+  - name: liblapack
+    version: 3.9.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libblas: "==3.9.0 16_linuxppc64le_openblas"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/liblapack-3.9.0-16_linuxppc64le_openblas.tar.bz2"
+    hash:
+      md5: 6078295a03db891bce81100c41283109
+      sha256: a14d82536cea5d9f1bb64089f371f37172c7070ffe89274c4b38618e75143ba4
+    optional: false
+    category: main
+  - name: liblapack
+    version: 3.9.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libblas: "==3.9.0 16_osx64_openblas"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-16_osx64_openblas.tar.bz2"
+    hash:
+      md5: 406ad426aade5578b90544cc2ed4a79b
+      sha256: 456a6e8bfc2e97846d9e157b5f51c23e0c4e9c922ccf7b2321be5362c835d35f
+    optional: false
+    category: main
+  - name: liblapack
+    version: 3.9.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libblas: "==3.9.0 16_osxarm64_openblas"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-16_osxarm64_openblas.tar.bz2"
+    hash:
+      md5: 52d270c579bfca986d6cdd81eb5ed6e7
+      sha256: 87204cb0ff22f260b3aa5fc7c938157b471eb2bd287acf1ba7e61a67f86ba959
+    optional: false
+    category: main
+  - name: libllvm14
+    version: 14.0.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=14"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-h5b596cc_1.tar.bz2"
+    hash:
+      md5: c61f692b0e98efc1ef772fdf7d14e81a
+      sha256: 8e72bb60d707dfecca0cfb7378cbabe43de4537513a938fb0ab75ce58c5c7d91
+    optional: false
+    category: main
+  - name: libllvm14
+    version: 14.0.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=14"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hf6e71e7_1.tar.bz2"
+    hash:
+      md5: 2ec0ff9a370305311ce222bcb085b72d
+      sha256: e3b9eee8abc1e3c315094aa6452e01424e3da8aef8dd42093836183d55f5df4b
+    optional: false
+    category: main
+  - name: libllvm15
+    version: 15.0.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      libxml2: ">=2.10.3,<2.11.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      zstd: ">=1.5.2,<1.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hadd5161_0.conda"
+    hash:
+      md5: 70cbb0c2033665f2a7339bf0ec51a67f
+      sha256: 3fb9a9cfd2f5c79e8116c67f95d5a9b790ec66807ae0d8cebefc26fda9f836a7
+    optional: false
+    category: main
   - name: libnsl
     version: 2.0.0
     manager: conda
@@ -551,6 +6111,30 @@ package:
     hash:
       md5: 39b1328babf85c7c3a61636d9cd50206
       sha256: 32f4fb94d99946b0dabfbbfd442b25852baf909637f2eed1ffe3baea15d02aad
+    optional: false
+    category: main
+  - name: libnsl
+    version: 2.0.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.0-hf897c2e_0.tar.bz2"
+    hash:
+      md5: 36fdbc05c9d9145ece86f5a63c3f352e
+      sha256: 182dbc318b7ab3ab10bc5a9d3ca161b143ae8db6df8aa11b65140009e322e642
+    optional: false
+    category: main
+  - name: libnsl
+    version: 2.0.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libnsl-2.0.0-h4e0d66e_0.tar.bz2"
+    hash:
+      md5: e6c718cb0e01f2af330da0a8dbd55b68
+      sha256: 2aa6cd044633586588c7105a3702788ee65b679801ab5d00b48d64265ae2f13c
     optional: false
     category: main
   - name: libogg
@@ -579,6 +6163,62 @@ package:
       sha256: 018372af663987265cb3ca8f37ac8c22b5f39219f65a0c162b056a30af11bba0
     optional: false
     category: main
+  - name: libopenblas
+    version: 0.3.21
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libgfortran-ng: "*"
+      libgfortran5: ">=10.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.21-pthreads_h6cb6f83_3.tar.bz2"
+    hash:
+      md5: bc66302748a788c3bce59999ed6d737d
+      sha256: 78a93de015d389597d9bdd470ffcfa3901d4b39b85d6516f242ff71d18dc6607
+    optional: false
+    category: main
+  - name: libopenblas
+    version: 0.3.21
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libgfortran-ng: "*"
+      libgfortran5: ">=10.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libopenblas-0.3.21-pthreads_h60f2977_3.tar.bz2"
+    hash:
+      md5: 8d9a4d593fea2ccf376b5e459651dd87
+      sha256: 5b624bbe5f0de77e1979a508c57f55b052155eabf806756b0153d2f97a1d581c
+    optional: false
+    category: main
+  - name: libopenblas
+    version: 0.3.21
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libgfortran: 5.*
+      libgfortran5: ">=11.3.0"
+      llvm-openmp: ">=14.0.4"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.21-openmp_h429af6e_3.tar.bz2"
+    hash:
+      md5: 968c46aa7f4032c3f3873f3452ed4c34
+      sha256: a5a0b6ccef165ffb38e6a53e7b8808e33c77e081174315d2333ae93b593ae957
+    optional: false
+    category: main
+  - name: libopenblas
+    version: 0.3.21
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libgfortran: 5.*
+      libgfortran5: ">=11.3.0"
+      llvm-openmp: ">=14.0.4"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.21-openmp_hc731615_3.tar.bz2"
+    hash:
+      md5: 2a980a5d8cc34ce70d339b983f9920de
+      sha256: 92e341be106c00adf1f1757ec9f9586a3848af94b434554c75dd7c5023f84ea2
+    optional: false
+    category: main
   - name: libopus
     version: 1.3.1
     manager: conda
@@ -591,6 +6231,84 @@ package:
       sha256: 0e1c2740ebd1c93226dc5387461bbcf8142c518f2092f3ea7551f77755decc8f
     optional: false
     category: main
+  - name: libpng
+    version: 1.6.39
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda"
+    hash:
+      md5: e1c890aebdebbfbf87e2c917187b4416
+      sha256: a32b36d34e4f2490b99bddbc77d01a674d304f667f0e62c89e02c961addef462
+    optional: false
+    category: main
+  - name: libpng
+    version: 1.6.39
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.39-hf9034f9_0.conda"
+    hash:
+      md5: 5ec9052384a6ac85e9111e9ac7c5ec4c
+      sha256: a43ab7cb0a66febe26e33b75e4aef6ce4ce532f69e6336e24ce00235ed000fd9
+    optional: false
+    category: main
+  - name: libpng
+    version: 1.6.39
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libpng-1.6.39-hcc10993_0.conda"
+    hash:
+      md5: bcd557c46d754ede06e9a1554eb0c68c
+      sha256: fd374fc3c1900eeec3bdbdf4426795d8068e910b953fb9b35dffef86e8cd27ac
+    optional: false
+    category: main
+  - name: libpng
+    version: 1.6.39
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda"
+    hash:
+      md5: 35e4928794c5391aec14ffdf1deaaee5
+      sha256: 5ad9f5e96e6770bfc8b0a826f48835e7f337c2d2e9512d76027a62f9c120b2a3
+    optional: false
+    category: main
+  - name: libpng
+    version: 1.6.39
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda"
+    hash:
+      md5: 0078e6327c13cfdeae6ff7601e360383
+      sha256: 21ab8409a8e66f9408b96428c0a36a9768faee9fe623c56614576f9e12962981
+    optional: false
+    category: main
+  - name: libpq
+    version: "15.2"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      krb5: ">=1.20.1,<1.21.0a0"
+      libgcc-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      openssl: ">=3.0.8,<4.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libpq-15.2-hb675445_0.conda"
+    hash:
+      md5: 4654b17eccaba55b8581d6b9c77f53cc
+      sha256: 5693c492ca0280e62edd114d91b7aa9c81fa60276b594f31d18a852636603f9e
+    optional: false
+    category: main
   - name: libsanitizer
     version: 11.3.0
     manager: conda
@@ -601,6 +6319,294 @@ package:
     hash:
       md5: d17fd55aed84ab6592c5419b6600501c
       sha256: 5e53a50c9b5fd04790f4cc63aa74cd6172151246248438b9bc154392ebe0bd17
+    optional: false
+    category: main
+  - name: libsanitizer
+    version: 11.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=11.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-11.3.0-hdddb281_19.tar.bz2"
+    hash:
+      md5: bd023c6dd60bd0102ce12e1e0257265b
+      sha256: e1e263d2fc39c329d97b50a20a355e641a37ab7fe724133ffdfedb32ab53cf4d
+    optional: false
+    category: main
+  - name: libsanitizer
+    version: 11.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=11.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libsanitizer-11.3.0-hc94946d_19.tar.bz2"
+    hash:
+      md5: e9d33799921c73fb1af2dfaba774b19e
+      sha256: b7da522d965117797d9e79e4c83494958cba00b6e5d2c0afba7bcf34385162de
+    optional: false
+    category: main
+  - name: libsndfile
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      lame: ">=3.100,<3.101.0a0"
+      libflac: ">=1.4.2,<1.5.0a0"
+      libgcc-ng: ">=12"
+      libogg: ">=1.3.4,<1.4.0a0"
+      libopus: ">=1.3.1,<2.0a0"
+      libstdcxx-ng: ">=12"
+      libvorbis: ">=1.3.7,<1.4.0a0"
+      mpg123: ">=1.31.1,<1.32.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.0-hb75c966_0.conda"
+    hash:
+      md5: c648d19cd9c8625898d5d370414de7c7
+      sha256: 52ab2460d626d1cc95092daa4f7191f84d4950aeb9925484135f96af6b6391d8
+    optional: false
+    category: main
+  - name: libsqlite
+    version: 3.40.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.40.0-h753d276_0.tar.bz2"
+    hash:
+      md5: 2e5f9a37d487e1019fd4d8113adb2f9f
+      sha256: 6008a0b914bd1a3510a3dba38eada93aa0349ebca3a21e5fa276833c8205bf49
+    optional: false
+    category: main
+  - name: libsqlite
+    version: 3.40.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.40.0-hf9034f9_0.tar.bz2"
+    hash:
+      md5: 9afb0d5dbaa403858a660cd0b4a31d29
+      sha256: 15e4a4bef065f73c2aae630c0408fd6108f5915d4640c7d97578f2e07b3f5d11
+    optional: false
+    category: main
+  - name: libsqlite
+    version: 3.39.4
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libzlib: ">=1.2.12,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libsqlite-3.39.4-hcc10993_0.tar.bz2"
+    hash:
+      md5: 49799ec532f260e4264705336d01310b
+      sha256: 93cdea9743cf1f86fdf9e9516061d5c68b9b5c43b99b7db1dd81d5b3452c4759
+    optional: false
+    category: main
+  - name: libsqlite
+    version: 3.40.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.40.0-ha978bb4_0.tar.bz2"
+    hash:
+      md5: ceb13b6726534b96e3b4e3dda91e9050
+      sha256: ae19f866188cc0c514fed754468460ae9e8dd763ebbd7b7afc4e818d71844297
+    optional: false
+    category: main
+  - name: libsqlite
+    version: 3.40.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.40.0-h76d750c_0.tar.bz2"
+    hash:
+      md5: d090fcec993f4ef0a90e6df7f231a273
+      sha256: 5e8992b2099bb4767996e1bed70945ba39f61399ab912ba2a2770d12c165acb5
+    optional: false
+    category: main
+  - name: libstdcxx-devel_linux-64
+    version: 11.3.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-11.3.0-h210ce93_19.tar.bz2"
+    hash:
+      md5: 8aee006c0662f551f3acef9a7077a5b9
+      sha256: abfcbf3a0f770be88eefebf84ae3a901da9e933799c9eecf3e9b06f34b00a0a5
+    optional: false
+    category: main
+  - name: libstdcxx-devel_linux-aarch64
+    version: 11.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-devel_linux-aarch64-11.3.0-h02014c4_19.tar.bz2"
+    hash:
+      md5: 1951ddce2b043a2597eb8317f6fee950
+      sha256: 83a35253ac31c38d502bcff450457a86a9cd175f164cabc82400ea07ad2679be
+    optional: false
+    category: main
+  - name: libstdcxx-devel_linux-ppc64le
+    version: 11.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-devel_linux-ppc64le-11.3.0-hcb32637_19.tar.bz2"
+    hash:
+      md5: 7c528de8f0dddad1ef05aa11151f66d6
+      sha256: f4f4869b24af9d3f37ac15ced5efd51323a0b92886ba0a50fb79d199ba402dd2
+    optional: false
+    category: main
+  - name: libstdcxx-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-12.2.0-h46fd767_19.tar.bz2"
+    hash:
+      md5: 1030b1f38c129f2634eae026f704fe60
+      sha256: 0289e6a7b9a5249161a3967909e12dcfb4ab4475cdede984635d3fb65c606f08
+    optional: false
+    category: main
+  - name: libstdcxx-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-12.2.0-hc13a102_19.tar.bz2"
+    hash:
+      md5: 981741cd4321edd5c504b48f74fe91f2
+      sha256: db906f0ad19acc6aefcd5409a7a72fea76302f72013dce7593467ae07dbf54f3
+    optional: false
+    category: main
+  - name: libstdcxx-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-ng-12.2.0-h99369c6_19.tar.bz2"
+    hash:
+      md5: 7fd9892955253a7e5f49ae0e94703dd7
+      sha256: 6e630d9cbb4c0680757e4cbe86a09302125283afd791e997d0ae2fc7ce863384
+    optional: false
+    category: main
+  - name: libsystemd0
+    version: "252"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libcap: ">=2.66,<2.67.0a0"
+      libgcc-ng: ">=12"
+      libgcrypt: ">=1.10.1,<2.0a0"
+      lz4-c: ">=1.9.3,<1.10.0a0"
+      xz: ">=5.2.6,<6.0a0"
+      zstd: ">=1.5.2,<1.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-252-h2a991cd_0.tar.bz2"
+    hash:
+      md5: 3c5ae9f61f663b3d5e1bf7f7da0c85f5
+      sha256: a181e25a04207179da598a5a89747a026642341e193dca125620f5f4e268804a
+    optional: false
+    category: main
+  - name: libtiff
+    version: 4.5.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      jpeg: ">=9e,<10a"
+      lerc: ">=4.0.0,<5.0a0"
+      libdeflate: ">=1.17,<1.18.0a0"
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      libwebp-base: ">=1.2.4,<2.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      xz: ">=5.2.6,<6.0a0"
+      zstd: ">=1.5.2,<1.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-h6adf6a1_2.conda"
+    hash:
+      md5: 2e648a34072eb39d7c4fc2a9981c5f0c
+      sha256: e3e18d91fb282b61288d4fd2574dfa31f7ae90ef2737f96722fb6ad3257862ee
+    optional: false
+    category: main
+  - name: libtiff
+    version: 4.5.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      jpeg: ">=9e,<10a"
+      lerc: ">=4.0.0,<5.0a0"
+      libdeflate: ">=1.17,<1.18.0a0"
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      libwebp-base: ">=1.2.4,<2.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      xz: ">=5.2.6,<6.0a0"
+      zstd: ">=1.5.2,<1.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.5.0-h4c1066a_2.conda"
+    hash:
+      md5: 45b240c8ce410ecc8f82cd085279dce9
+      sha256: a0e7bf098114756ef6e675414dde37b24c508816d3e525ba27d271cfbea0ab68
+    optional: false
+    category: main
+  - name: libtiff
+    version: 4.5.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      jpeg: ">=9e,<10a"
+      lerc: ">=4.0.0,<5.0a0"
+      libdeflate: ">=1.17,<1.18.0a0"
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      libwebp-base: ">=1.2.4,<2.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      xz: ">=5.2.6,<6.0a0"
+      zstd: ">=1.5.2,<1.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libtiff-4.5.0-h43527b7_2.conda"
+    hash:
+      md5: 0d6957963ed574ddd3f2fcf87a1e4169
+      sha256: 8d935040dcb5a3ecad23140947dd194069cb0cc5178b8104584e05c4155668fe
+    optional: false
+    category: main
+  - name: libtiff
+    version: 4.5.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      jpeg: ">=9e,<10a"
+      lerc: ">=4.0.0,<5.0a0"
+      libcxx: ">=14.0.6"
+      libdeflate: ">=1.17,<1.18.0a0"
+      libwebp-base: ">=1.2.4,<2.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      xz: ">=5.2.6,<6.0a0"
+      zstd: ">=1.5.2,<1.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.5.0-hee9004a_2.conda"
+    hash:
+      md5: 35f714269a801f7c3cb522aacd3c0e69
+      sha256: 03d00d6a3b1e569e9a8da66a9ad75a29c9c676dc7de6c16771abbb961abded2c
+    optional: false
+    category: main
+  - name: libtiff
+    version: 4.5.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      jpeg: ">=9e,<10a"
+      lerc: ">=4.0.0,<5.0a0"
+      libcxx: ">=14.0.6"
+      libdeflate: ">=1.17,<1.18.0a0"
+      libwebp-base: ">=1.2.4,<2.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      xz: ">=5.2.6,<6.0a0"
+      zstd: ">=1.5.2,<1.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.5.0-h5dffbdd_2.conda"
+    hash:
+      md5: 8e08eae60de32c940096ee9b4da35685
+      sha256: 0207f4234571d393d2f790aedaa1e127dfcd9d7fe3fe886ebdf31c9e7b9f7ce2
     optional: false
     category: main
   - name: libtool
@@ -640,417 +6646,28 @@ package:
       sha256: 54f118845498353c936826f8da79b5377d23032bcac8c4a02de2019e26c3f6b3
     optional: false
     category: main
-  - name: libwebp-base
-    version: 1.2.4
+  - name: libuuid
+    version: 2.32.1
     manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.2.4-h166bdaf_0.tar.bz2"
-    hash:
-      md5: ac2ccf7323d21f2994e4d1f5da664f37
-      sha256: 221f2e138dd264b7394b88f08884d93825d38800a51415059e813c02467abfd1
-    optional: false
-    category: main
-  - name: libzlib
-    version: 1.2.13
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h166bdaf_4.tar.bz2"
-    hash:
-      md5: f3f9de449d32ca9b9c66a22863c96f41
-      sha256: 22f3663bcf294d349327e60e464a51cd59664a71b8ed70c28a9f512d10bc77dd
-    optional: false
-    category: main
-  - name: lz4-c
-    version: 1.9.4
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda"
-    hash:
-      md5: 318b08df404f9c9be5712aaa5a6f0bb0
-      sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
-    optional: false
-    category: main
-  - name: mpg123
-    version: 1.31.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.31.2-hcb278e6_0.conda"
-    hash:
-      md5: 08efb1e1813f1a151b7a945b972a049b
-      sha256: cc8cb2097e96d2420dd698951ab524b6c8268fa691d370020a0eae3e65197c04
-    optional: false
-    category: main
-  - name: ncurses
-    version: "6.3"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.3-h27087fc_1.tar.bz2"
-    hash:
-      md5: 4acfc691e64342b9dae57cf2adc63238
-      sha256: b801e8cf4b2c9a30bce5616746c6c2a4e36427f045b46d9fc08a4ed40a9f7065
-    optional: false
-    category: main
-  - name: ninja
-    version: 1.11.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-      libstdcxx-ng: ">=10.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.0-h924138e_0.tar.bz2"
-    hash:
-      md5: 18c563c26253a21c1aa9d662e874b0cd
-      sha256: 1d3659abc4e3dfa9c8c03a664f6d0323503b75a4506fb9d28f28448be5540fc5
-    optional: false
-    category: main
-  - name: nspr
-    version: "4.35"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda"
-    hash:
-      md5: da0ec11a6454ae19bff5b02ed881a2b1
-      sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
-    optional: false
-    category: main
-  - name: openssl
-    version: 3.0.8
-    manager: conda
-    platform: linux-64
-    dependencies:
-      ca-certificates: "*"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/openssl-3.0.8-h0b41bf4_0.conda"
-    hash:
-      md5: e043403cd18faf815bf7705ab6c1e092
-      sha256: cd981c5c18463bc7a164fcf45c5cf697d58852b780b4dfa5e83c18c1fda6d7cd
-    optional: false
-    category: main
-  - name: pixman
-    version: 0.40.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=7.5.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/pixman-0.40.0-h36c2ea0_0.tar.bz2"
-    hash:
-      md5: 660e72c82f2e75a6b3fe6a6e75c79f19
-      sha256: 6a0630fff84b5a683af6185a6c67adc8bdfa2043047fcb251add0d352ef60e79
-    optional: false
-    category: main
-  - name: pkg-config
-    version: 0.29.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=7.5.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h36c2ea0_1008.tar.bz2"
-    hash:
-      md5: fbef41ff6a4c8140c30057466a1cdd47
-      sha256: 8b35a077ceccdf6888f1e82bd3ea281175014aefdc2d4cf63d7a4c7e169c125c
-    optional: false
-    category: main
-  - name: pthread-stubs
-    version: "0.4"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=7.5.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2"
-    hash:
-      md5: 22dad4df6e8630e8dff2428f6f6a7036
-      sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
-    optional: false
-    category: main
-  - name: xorg-kbproto
-    version: 1.0.7
-    manager: conda
-    platform: linux-64
+    platform: linux-aarch64
     dependencies:
       libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.32.1-hf897c2e_1000.tar.bz2"
     hash:
-      md5: 4b230e8381279d76131116660f5a241a
-      sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
+      md5: e038da5ef9095b0d79aac14a311394e7
+      sha256: 8f7eead3723c32631b252aea336bb39fbbde433b8d0c5a75745f03eaa980447d
     optional: false
     category: main
-  - name: xorg-libice
-    version: 1.0.10
+  - name: libuuid
+    version: 2.32.1
     manager: conda
-    platform: linux-64
+    platform: linux-ppc64le
     dependencies:
       libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.0.10-h7f98852_0.tar.bz2"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libuuid-2.32.1-h4e0d66e_1000.tar.bz2"
     hash:
-      md5: d6b0b50b49eccfe0be0373be628be0f3
-      sha256: f15ce1dff16823888bcc2be1738aadcb36699be1e2dd2afa347794c7ec6c1587
-    optional: false
-    category: main
-  - name: xorg-libxau
-    version: 1.0.9
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.9-h7f98852_0.tar.bz2"
-    hash:
-      md5: bf6f803a544f26ebbdc3bfff272eb179
-      sha256: 9e9b70c24527289ac7ae31925d1eb3b0c1e9a78cb7b8f58a3110cc8bbfe51c26
-    optional: false
-    category: main
-  - name: xorg-libxdmcp
-    version: 1.1.3
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2"
-    hash:
-      md5: be93aabceefa2fac576e971aef407908
-      sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
-    optional: false
-    category: main
-  - name: xorg-renderproto
-    version: 0.11.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2"
-    hash:
-      md5: 06feff3d2634e3097ce2fe681474b534
-      sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
-    optional: false
-    category: main
-  - name: xorg-xextproto
-    version: 7.3.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h7f98852_1002.tar.bz2"
-    hash:
-      md5: 1e15f6ad85a7d743a2ac68dae6c82b98
-      sha256: d45c4d1c8372c546711eb3863c76d899d03a67c3edb3b5c2c46c9492814cbe03
-    optional: false
-    category: main
-  - name: xorg-xproto
-    version: 7.0.31
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2"
-    hash:
-      md5: b4a4381d54784606820704f7b5f05a15
-      sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
-    optional: false
-    category: main
-  - name: xz
-    version: 5.2.6
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2"
-    hash:
-      md5: 2161070d867d1b1204ea749c8eec4ef0
-      sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
-    optional: false
-    category: main
-  - name: doxygen
-    version: 1.9.5
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libiconv: ">=1.16,<2.0.0a0"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.9.5-h583eb01_0.tar.bz2"
-    hash:
-      md5: a94d4fb8005f9d8d286e06bbb1bec448
-      sha256: f8379387abdb1c51ec72165fbd7e2c54b83c40224ea9eed825a18895ab60273f
-    optional: false
-    category: main
-  - name: gcc_impl_linux-64
-    version: 11.3.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      binutils_impl_linux-64: ">=2.39"
-      libgcc-devel_linux-64: "==11.3.0 h210ce93_19"
-      libgcc-ng: ">=11.3.0"
-      libgomp: ">=11.3.0"
-      libsanitizer: "==11.3.0 h239ccf8_19"
-      libstdcxx-ng: ">=11.3.0"
-      sysroot_linux-64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-11.3.0-hab1b70f_19.tar.bz2"
-    hash:
-      md5: 89ac16d36e66ccb9ca5d34c9217e5799
-      sha256: 51c6e39148c9da4a9889d34f0daebdf961ca93f032b1e86f621a67ecff2bd915
-    optional: false
-    category: main
-  - name: jack
-    version: 1.9.22
-    manager: conda
-    platform: linux-64
-    dependencies:
-      alsa-lib: ">=1.2.8,<1.2.9.0a0"
-      libdb: ">=6.2.32,<6.3.0a0"
-      libgcc-ng: ">=12"
-      libopus: ">=1.3.1,<2.0a0"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/jack-1.9.22-h11f4161_0.conda"
-    hash:
-      md5: 504fa9e712b99494a9cf4630e3ca7d78
-      sha256: 9f173c6633f7ef049b05cd92a9fc028402972ddc44a56d5bb51d8879d73bbde7
-    optional: false
-    category: main
-  - name: libblas
-    version: 3.9.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libopenblas: ">=0.3.21,<1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-16_linux64_openblas.tar.bz2"
-    hash:
-      md5: d9b7a8639171f6c6fa0a983edabcfe2b
-      sha256: 4e4c60d3fe0b95ffb25911dace509e3532979f5deef4364141c533c5ca82dd39
-    optional: false
-    category: main
-  - name: libbrotlidec
-    version: 1.0.9
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libbrotlicommon: "==1.0.9 h166bdaf_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.0.9-h166bdaf_8.tar.bz2"
-    hash:
-      md5: 4ae4d7795d33e02bd20f6b23d91caf82
-      sha256: d88ba07c3be27c89cb4975cc7edf63ee7b1c62d01f70d5c3f7efeb987c82b052
-    optional: false
-    category: main
-  - name: libbrotlienc
-    version: 1.0.9
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libbrotlicommon: "==1.0.9 h166bdaf_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.0.9-h166bdaf_8.tar.bz2"
-    hash:
-      md5: 04bac51ba35ea023dc48af73c1c88c25
-      sha256: a0468858b2f647f51509a32040e93512818a8f9980f20b3554cccac747bcc4be
-    optional: false
-    category: main
-  - name: libcap
-    version: "2.66"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      attr: ">=2.5.1,<2.6.0a0"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libcap-2.66-ha37c62d_0.tar.bz2"
-    hash:
-      md5: 2d7665abd0997f1a6d4b7596bc27b657
-      sha256: db113b0bacb45533ec6f5c13a548054af8bd0ca2f7583e8bc5989f17e1e1638b
-    optional: false
-    category: main
-  - name: libedit
-    version: 3.1.20191231
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=7.5.0"
-      ncurses: ">=6.2,<7.0.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2"
-    hash:
-      md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
-      sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
-    optional: false
-    category: main
-  - name: libevent
-    version: 2.1.10
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-      openssl: ">=3.0.0,<4.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.10-h28343ad_4.tar.bz2"
-    hash:
-      md5: 4a049fc560e00e43151dc51368915fdd
-      sha256: 31ac7124c92628cd1c6bea368e38d7f43f8ec68d88128ecdc177773e6d00c60a
-    optional: false
-    category: main
-  - name: libflac
-    version: 1.4.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      gettext: ">=0.21.1,<1.0a0"
-      libgcc-ng: ">=12"
-      libogg: ">=1.3.4,<1.4.0a0"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.2-h27087fc_0.tar.bz2"
-    hash:
-      md5: 7daf72d8e2a8e848e11d63ed6d1026e0
-      sha256: 095cfa4e2df8622b8f9eebec3c60710ea0f4732c64cd24769ccf9ed63fd45545
-    optional: false
-    category: main
-  - name: libgpg-error
-    version: "1.46"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      gettext: ">=0.21.1,<1.0a0"
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.46-h620e276_0.conda"
-    hash:
-      md5: 27e745f6f2e4b757e95dd7225fbe6bdb
-      sha256: a2e3df80a5713b4143f7d276a9354d78f2b2927b22831dc24c3246a82674aaba
-    optional: false
-    category: main
-  - name: libpng
-    version: 1.6.39
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda"
-    hash:
-      md5: e1c890aebdebbfbf87e2c917187b4416
-      sha256: a32b36d34e4f2490b99bddbc77d01a674d304f667f0e62c89e02c961addef462
-    optional: false
-    category: main
-  - name: libsqlite
-    version: 3.40.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.40.0-h753d276_0.tar.bz2"
-    hash:
-      md5: 2e5f9a37d487e1019fd4d8113adb2f9f
-      sha256: 6008a0b914bd1a3510a3dba38eada93aa0349ebca3a21e5fa276833c8205bf49
+      md5: ceb7466afcb5be47530ffe9aae8650ae
+      sha256: 58b4f6e27b921ff9171e64b3e382cc644d7da70d5da4e3815b7ceae4b4b452e0
     optional: false
     category: main
   - name: libvorbis
@@ -1067,6 +6684,64 @@ package:
       sha256: 53080d72388a57b3c31ad5805c93a7328e46ff22fab7c44ad2a86d712740af33
     optional: false
     category: main
+  - name: libwebp-base
+    version: 1.2.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.2.4-h166bdaf_0.tar.bz2"
+    hash:
+      md5: ac2ccf7323d21f2994e4d1f5da664f37
+      sha256: 221f2e138dd264b7394b88f08884d93825d38800a51415059e813c02467abfd1
+    optional: false
+    category: main
+  - name: libwebp-base
+    version: 1.2.4
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.2.4-h4e544f5_0.tar.bz2"
+    hash:
+      md5: 9c307c3dba834b9529f6dcd95db543ed
+      sha256: 831824c213e80a43a0a85318e5967a88a1adbf344b24ed5c4ee9ead8b696f170
+    optional: false
+    category: main
+  - name: libwebp-base
+    version: 1.2.4
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libwebp-base-1.2.4-hb283c62_0.tar.bz2"
+    hash:
+      md5: 9d042b84b56f3d719a24cd2837fa5ff8
+      sha256: 49a4ec09882f4cc1895c6ba2733fb34fa25cfdb8ee087041254a5ad04cd6a125
+    optional: false
+    category: main
+  - name: libwebp-base
+    version: 1.2.4
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.2.4-h775f41a_0.tar.bz2"
+    hash:
+      md5: 28807bef802a354f9c164e7ab242c5cb
+      sha256: ca3eb817054ac2942802b6b51dc671ab2af6564da329bebcb2538cdb31b59fa1
+    optional: false
+    category: main
+  - name: libwebp-base
+    version: 1.2.4
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.2.4-h57fd34a_0.tar.bz2"
+    hash:
+      md5: 23f90b9f28c585445c52184a3388d01d
+      sha256: 43e9557894d07ddbba76fdacf321ca84f2c6da5a649a32a6a91f23e2761d1df4
+    optional: false
+    category: main
   - name: libxcb
     version: "1.13"
     manager: conda
@@ -1080,6 +6755,78 @@ package:
     hash:
       md5: b3653fdc58d03face9724f602218a904
       sha256: 8d5d24cbeda9282dd707edd3156e5fde2e3f3fe86c802fa7ce08c8f1e803bfd9
+    optional: false
+    category: main
+  - name: libxcb
+    version: "1.13"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+      pthread-stubs: "*"
+      xorg-libxau: "*"
+      xorg-libxdmcp: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.13-h3557bc0_1004.tar.bz2"
+    hash:
+      md5: cc973f5f452272c397546eac588cddb3
+      sha256: cf726d6b13e93636312722aff04831a77aa8721b63feb6fc12d3604fe209ff94
+    optional: false
+    category: main
+  - name: libxcb
+    version: "1.13"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+      pthread-stubs: "*"
+      xorg-libxau: "*"
+      xorg-libxdmcp: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libxcb-1.13-h4e0d66e_1004.tar.bz2"
+    hash:
+      md5: f963aaccf057bb6b3f7c4279b6795c50
+      sha256: 99e80c223ed09dda97af0cf067678259ebf21790cb20f8a9ebe07da68ae24d1e
+    optional: false
+    category: main
+  - name: libxcb
+    version: "1.13"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      pthread-stubs: "*"
+      xorg-libxau: "*"
+      xorg-libxdmcp: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.13-h0d85af4_1004.tar.bz2"
+    hash:
+      md5: eb7860935e14aec936065cbc21a1a962
+      sha256: 00e962ea91deae3dbed221c960c3bffab4172d87bc883b615298333fe336a5c6
+    optional: false
+    category: main
+  - name: libxcb
+    version: "1.13"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      pthread-stubs: "*"
+      xorg-libxau: "*"
+      xorg-libxdmcp: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.13-h9b22ae9_1004.tar.bz2"
+    hash:
+      md5: 6b3457a192f8091cb413962f65740ac4
+      sha256: a89b1e46650c01a8791c201c108d6d49a0a5604dd24ddb18902057bbd90f7dbb
+    optional: false
+    category: main
+  - name: libxkbcommon
+    version: 1.0.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=7.5.0"
+      libstdcxx-ng: ">=7.5.0"
+      libxml2: ">=2.9.10,<2.11.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.0.3-he3ba5ed_0.tar.bz2"
+    hash:
+      md5: f9dbabc7e01c459ed7a1d1d64b206e9b
+      sha256: 64d37e16c694714ca08a96f9864a35ba9ee38b8e222f8ee646e10976250d966d
     optional: false
     category: main
   - name: libxml2
@@ -1098,934 +6845,123 @@ package:
       sha256: b30713fb4477ff4f722280d956593e7e7a2cb705b7444dcc278de447432b43b1
     optional: false
     category: main
-  - name: mysql-common
-    version: 8.0.32
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      openssl: ">=3.0.7,<4.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.32-ha901b37_0.conda"
-    hash:
-      md5: 6a39818710235826181e104aada40c75
-      sha256: d7da5c1cc47656394933146ab30f6f3433553e8265ea1a4254bce441ab678199
-    optional: false
-    category: main
-  - name: openblas
-    version: 0.3.21
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libgfortran-ng: "*"
-      libgfortran5: ">=10.4.0"
-      libopenblas: "==0.3.21 pthreads_h78a6416_3"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/openblas-0.3.21-pthreads_h320a7e8_3.tar.bz2"
-    hash:
-      md5: 29155b9196b9d78022f11d86733e25a7
-      sha256: b9986da11c136f4171ce94df6fe5940b529f38b9f13f2746817913071aa51151
-    optional: false
-    category: main
-  - name: pcre2
-    version: "10.40"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      bzip2: ">=1.0.8,<2.0a0"
-      libgcc-ng: ">=12"
-      libzlib: ">=1.2.12,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2"
-    hash:
-      md5: 69e2c796349cd9b273890bee0febfe1b
-      sha256: 7a29ec847556eed4faa1646010baae371ced69059a4ade43851367a076d6108a
-    optional: false
-    category: main
-  - name: readline
-    version: 8.1.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      ncurses: ">=6.3,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/readline-8.1.2-h0f457ee_0.tar.bz2"
-    hash:
-      md5: db2ebbe2943aae81ed051a6a9af8e0fa
-      sha256: f5f383193bdbe01c41cb0d6f99fec68e820875e842e6e8b392dbe1a9b6c43ed8
-    optional: false
-    category: main
-  - name: tk
-    version: 8.6.12
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-      libzlib: ">=1.2.11,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.12-h27826a3_0.tar.bz2"
-    hash:
-      md5: 5b8c42eb62e9fc961af70bdd6a26e168
-      sha256: 032fd769aad9d4cad40ba261ab222675acb7ec951a8832455fce18ef33fa8df0
-    optional: false
-    category: main
-  - name: xorg-libsm
-    version: 1.2.3
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-      libuuid: ">=2.32.1,<3.0a0"
-      xorg-libice: 1.0.*
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.3-hd9c2040_1000.tar.bz2"
-    hash:
-      md5: 9e856f78d5c80d5a78f61e72d1d473a3
-      sha256: bdb350539521ddc1f30cc721b6604eced8ef72a0ec146e378bfe89e2be17ab35
-    optional: false
-    category: main
-  - name: zlib
+  - name: libzlib
     version: 1.2.13
     manager: conda
     platform: linux-64
     dependencies:
       libgcc-ng: ">=12"
-      libzlib: "==1.2.13 h166bdaf_4"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h166bdaf_4.tar.bz2"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h166bdaf_4.tar.bz2"
     hash:
-      md5: 4b11e365c0275b808be78b30f904e295
-      sha256: 282ce274ebe6da1fbd52efbb61bd5a93dec0365b14d64566e6819d1691b75300
+      md5: f3f9de449d32ca9b9c66a22863c96f41
+      sha256: 22f3663bcf294d349327e60e464a51cd59664a71b8ed70c28a9f512d10bc77dd
     optional: false
     category: main
-  - name: zstd
-    version: 1.5.2
+  - name: libzlib
+    version: 1.2.13
     manager: conda
-    platform: linux-64
+    platform: linux-aarch64
     dependencies:
       libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.2-h3eb15da_6.conda"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h4e544f5_4.tar.bz2"
     hash:
-      md5: 6b63daed8feeca47be78f323e793d555
-      sha256: fbe49a8c8df83c2eccb37c5863ad98baeb29796ec96f2c503783d7b89bf80c98
+      md5: 88596b6277fe6d39f046983aae6044db
+      sha256: 9803ac96dbdbc27df9c149e06d4436b778c468bd0e6e023fbcb49a6fe9c404b4
     optional: false
     category: main
-  - name: brotli-bin
-    version: 1.0.9
+  - name: libzlib
+    version: 1.2.13
     manager: conda
-    platform: linux-64
-    dependencies:
-      libbrotlidec: "==1.0.9 h166bdaf_8"
-      libbrotlienc: "==1.0.9 h166bdaf_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.0.9-h166bdaf_8.tar.bz2"
-    hash:
-      md5: e5613f2bc717e9945840ff474419b8e4
-      sha256: ab1994e03bdd88e4b27f9f802ac18e45ed29b92cce25e1fd86da43b89734950f
-    optional: false
-    category: main
-  - name: freetype
-    version: 2.12.1
-    manager: conda
-    platform: linux-64
+    platform: linux-ppc64le
     dependencies:
       libgcc-ng: ">=12"
-      libpng: ">=1.6.39,<1.7.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-hca18f0e_1.conda"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libzlib-1.2.13-hb283c62_4.tar.bz2"
     hash:
-      md5: e1232042de76d24539a436d37597eb06
-      sha256: 1eb913727b54e9aa63c6d9a1177db4e2894cee97c5f26910a2b61899d5ac904f
+      md5: af99cdd23d3761a569840663bdf0dc0d
+      sha256: 62073ba865b49db36dc14ffeaa2985711bce65d720b853e3aa4cce0a9e5439d8
     optional: false
     category: main
-  - name: gcc
-    version: 11.3.0
+  - name: libzlib
+    version: 1.2.13
     manager: conda
-    platform: linux-64
-    dependencies:
-      gcc_impl_linux-64: 11.3.0.*
-    url: "https://conda.anaconda.org/conda-forge/linux-64/gcc-11.3.0-h02d0930_11.tar.bz2"
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-hfd90126_4.tar.bz2"
     hash:
-      md5: 6037ebe5f1e3054519ce78b11eec9cd4
-      sha256: 1946d6c3ea7e98231de51d506c978c00ae97c7b27379ab34a368218d014758c8
+      md5: 35eb3fce8d51ed3c1fd4122bad48250b
+      sha256: 0d954350222cc12666a1f4852dbc9bcf4904d8e467d29505f2b04ded6518f890
     optional: false
     category: main
-  - name: gcc_linux-64
-    version: 11.3.0
+  - name: libzlib
+    version: 1.2.13
     manager: conda
-    platform: linux-64
-    dependencies:
-      binutils_linux-64: "==2.39 h5fc0e48_11"
-      gcc_impl_linux-64: 11.3.0.*
-      sysroot_linux-64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-11.3.0-he6f903b_11.tar.bz2"
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h03a7124_4.tar.bz2"
     hash:
-      md5: 25f76cb82e483ce96d118b9edffd12c9
-      sha256: c0041b6f805b6b3c01bfb51232b606c9a50a8e0154d17bbf61af36d62c600f00
+      md5: 780852dc54c4c07e64b276a97f89c162
+      sha256: a1bf4a1c107838fea4570a7f1750306d65d84fcf2913d4e0d30b4db785e8f223
     optional: false
     category: main
-  - name: gfortran_impl_linux-64
-    version: 11.3.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      gcc_impl_linux-64: ">=11.3.0"
-      libgcc-ng: ">=4.9"
-      libgfortran5: ">=11.3.0"
-      libstdcxx-ng: ">=4.9"
-      sysroot_linux-64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/gfortran_impl_linux-64-11.3.0-he34c6f7_19.tar.bz2"
-    hash:
-      md5: 3de873ee757f1a2e583416a3583f84c4
-      sha256: 3263c7b7d4c9d0c0a25e92ca201b7c014c00257cecf08ac28953dfda43c93803
-    optional: false
-    category: main
-  - name: gxx_impl_linux-64
-    version: 11.3.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      gcc_impl_linux-64: "==11.3.0 hab1b70f_19"
-      libstdcxx-devel_linux-64: "==11.3.0 h210ce93_19"
-      sysroot_linux-64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-11.3.0-hab1b70f_19.tar.bz2"
-    hash:
-      md5: b73564a352e64bb5f2c9bfd3cd6dd127
-      sha256: b86a4d15050c8ad5b8a4273c55f468847d891ceb08f3702408c3a0e921a5b5ea
-    optional: false
-    category: main
-  - name: krb5
-    version: 1.20.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      keyutils: ">=1.6.1,<2.0a0"
-      libedit: ">=3.1.20191231,<4.0a0"
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      openssl: ">=3.0.7,<4.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/krb5-1.20.1-h81ceb04_0.conda"
-    hash:
-      md5: 89a41adce7106749573d883b2f657d78
-      sha256: 51a346807ce981e1450eb04c3566415b05eed705bc9e6c98c198ec62367b7c62
-    optional: false
-    category: main
-  - name: libcblas
-    version: 3.9.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libblas: "==3.9.0 16_linux64_openblas"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-16_linux64_openblas.tar.bz2"
-    hash:
-      md5: 20bae26d0a1db73f758fc3754cab4719
-      sha256: e4ceab90a49cb3ac1af20177016dc92066aa278eded19646bb928d261b98367f
-    optional: false
-    category: main
-  - name: libgcrypt
-    version: 1.10.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-      libgpg-error: ">=1.44,<2.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.1-h166bdaf_0.tar.bz2"
-    hash:
-      md5: f967fc95089cd247ceed56eda31de3a9
-      sha256: 8fd7e6db1021cd9298d9896233454de204116840eb66a06fcb712e1015ff132a
-    optional: false
-    category: main
-  - name: libglib
-    version: 2.74.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      gettext: ">=0.21.1,<1.0a0"
-      libffi: ">=3.4,<4.0a0"
-      libgcc-ng: ">=12"
-      libiconv: ">=1.17,<2.0a0"
-      libstdcxx-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      pcre2: ">=10.40,<10.41.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libglib-2.74.1-h606061b_1.tar.bz2"
-    hash:
-      md5: ed5349aa96776e00b34eccecf4a948fe
-      sha256: 3cbad3d63cff2dd9ac1dc9cce54fd3d657f3aff53df41bfe5bae9d760562a5af
-    optional: false
-    category: main
-  - name: liblapack
-    version: 3.9.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libblas: "==3.9.0 16_linux64_openblas"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-16_linux64_openblas.tar.bz2"
-    hash:
-      md5: 955d993f41f9354bf753d29864ea20ad
-      sha256: f5f30b8049dfa368599e5a08a4f35cb1966af0abc539d1fd1f50d93db76a74e6
-    optional: false
-    category: main
-  - name: libllvm15
+  - name: llvm-openmp
     version: 15.0.7
     manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      libxml2: ">=2.10.3,<2.11.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      zstd: ">=1.5.2,<1.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hadd5161_0.conda"
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-15.0.7-h61d9ccf_0.conda"
     hash:
-      md5: 70cbb0c2033665f2a7339bf0ec51a67f
-      sha256: 3fb9a9cfd2f5c79e8116c67f95d5a9b790ec66807ae0d8cebefc26fda9f836a7
+      md5: 3faa9933dff6e96333b5ca5274674b63
+      sha256: cc1586b43b757890b7d1cd24e1582345a36c40acd6cb6f9d9affb91de3c62015
     optional: false
     category: main
-  - name: libsndfile
-    version: 1.2.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      lame: ">=3.100,<3.101.0a0"
-      libflac: ">=1.4.2,<1.5.0a0"
-      libgcc-ng: ">=12"
-      libogg: ">=1.3.4,<1.4.0a0"
-      libopus: ">=1.3.1,<2.0a0"
-      libstdcxx-ng: ">=12"
-      libvorbis: ">=1.3.7,<1.4.0a0"
-      mpg123: ">=1.31.1,<1.32.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.0-hb75c966_0.conda"
-    hash:
-      md5: c648d19cd9c8625898d5d370414de7c7
-      sha256: 52ab2460d626d1cc95092daa4f7191f84d4950aeb9925484135f96af6b6391d8
-    optional: false
-    category: main
-  - name: libtiff
-    version: 4.5.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      jpeg: ">=9e,<10a"
-      lerc: ">=4.0.0,<5.0a0"
-      libdeflate: ">=1.17,<1.18.0a0"
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      libwebp-base: ">=1.2.4,<2.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      xz: ">=5.2.6,<6.0a0"
-      zstd: ">=1.5.2,<1.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.5.0-h6adf6a1_2.conda"
-    hash:
-      md5: 2e648a34072eb39d7c4fc2a9981c5f0c
-      sha256: e3e18d91fb282b61288d4fd2574dfa31f7ae90ef2737f96722fb6ad3257862ee
-    optional: false
-    category: main
-  - name: libxkbcommon
-    version: 1.0.3
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=7.5.0"
-      libstdcxx-ng: ">=7.5.0"
-      libxml2: ">=2.9.10,<2.11.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.0.3-he3ba5ed_0.tar.bz2"
-    hash:
-      md5: f9dbabc7e01c459ed7a1d1d64b206e9b
-      sha256: 64d37e16c694714ca08a96f9864a35ba9ee38b8e222f8ee646e10976250d966d
-    optional: false
-    category: main
-  - name: mysql-libs
-    version: 8.0.32
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      mysql-common: "==8.0.32 ha901b37_0"
-      openssl: ">=3.0.7,<4.0a0"
-      zstd: ">=1.5.2,<1.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.32-hd7da12d_0.conda"
-    hash:
-      md5: b05d7ea8b76f1172d5fe4f30e03277ea
-      sha256: 903174761ce605d98410747e0072757da5278d57309148ef175af490aa791f38
-    optional: false
-    category: main
-  - name: nss
-    version: "3.88"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      __glibc: ">=2.17,<3.0.a0"
-      libgcc-ng: ">=12"
-      libsqlite: ">=3.40.0,<4.0a0"
-      libstdcxx-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      nspr: ">=4.35,<5.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/nss-3.88-he45b914_0.conda"
-    hash:
-      md5: d7a81dfb99ad8fbb88872fb7ec646e6c
-      sha256: a589e916119db06742da1307c3438a5c733cf01006470158c7aae8f2859f6e90
-    optional: false
-    category: main
-  - name: python
-    version: 3.9.16
-    manager: conda
-    platform: linux-64
-    dependencies:
-      bzip2: ">=1.0.8,<2.0a0"
-      ld_impl_linux-64: ">=2.36.1"
-      libffi: ">=3.4,<4.0a0"
-      libgcc-ng: ">=12"
-      libnsl: ">=2.0.0,<2.1.0a0"
-      libsqlite: ">=3.40.0,<4.0a0"
-      libuuid: ">=2.32.1,<3.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      ncurses: ">=6.3,<7.0a0"
-      openssl: ">=3.0.7,<4.0a0"
-      pip: "*"
-      readline: ">=8.1.2,<9.0a0"
-      tk: ">=8.6.12,<8.7.0a0"
-      tzdata: "*"
-      xz: ">=5.2.6,<6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/python-3.9.16-h2782a2a_0_cpython.conda"
-    hash:
-      md5: 95c9b7c96a7fd7342e0c9d0a917b8f78
-      sha256: 00bcb28a294aa78bf9d2a2ecaae8cb887188eae710f9197d823d36fb8a5d9767
-    optional: false
-    category: main
-  - name: xcb-util
-    version: 0.4.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libxcb: ">=1.13,<1.14.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-h166bdaf_0.tar.bz2"
-    hash:
-      md5: 384e7fcb3cd162ba3e4aed4b687df566
-      sha256: 292dee40f8390aea0e6a0abbf2f255f179c777326831ed9e1ad7db53665c8562
-    optional: false
-    category: main
-  - name: xcb-util-keysyms
-    version: 0.4.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libxcb: ">=1.13,<1.14.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h166bdaf_0.tar.bz2"
-    hash:
-      md5: 637054603bb7594302e3bf83f0a99879
-      sha256: 6a2c0f38b360a2fda57b2349d2cbeeb7583576a4914a3e4ce17977601ac87613
-    optional: false
-    category: main
-  - name: xcb-util-renderutil
-    version: 0.3.9
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libxcb: ">=1.13,<1.14.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-h166bdaf_0.tar.bz2"
-    hash:
-      md5: 732e22f1741bccea861f5668cf7342a7
-      sha256: 19d27b7af8fb8047e044de2b87244337343c51fe7caa0fbaa9c53c2215787188
-    optional: false
-    category: main
-  - name: xcb-util-wm
-    version: 0.4.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libxcb: ">=1.13,<1.14.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h166bdaf_0.tar.bz2"
-    hash:
-      md5: 0a8e20a8aef954390b9481a527421a8c
-      sha256: a76af35297f233982b58de1f55f1900d8a8ae44018a55d2a94f3084ab97d6c80
-    optional: false
-    category: main
-  - name: xorg-libx11
-    version: 1.7.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-      libxcb: 1.*
-      xorg-kbproto: "*"
-      xorg-xproto: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.7.2-h7f98852_0.tar.bz2"
-    hash:
-      md5: 12a61e640b8894504326aadafccbb790
-      sha256: ec4641131e3afcb4b34614a5fa298efb34f54c2b2960bf9a73a8d202140d47c4
-    optional: false
-    category: main
-  - name: alabaster
-    version: 0.7.13
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 06006184e203b61d3525f90de394471e
-      sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
-    optional: false
-    category: main
-  - name: appdirs
-    version: 1.4.4
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 5f095bc6454094e96f146491fd03633b
-      sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
-    optional: false
-    category: main
-  - name: attrs
-    version: 22.2.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/attrs-22.2.0-pyh71513ae_0.conda"
-    hash:
-      md5: 8b76db7818a4e401ed4486c4c1635cd9
-      sha256: 3a58d4a4933fa8735471c782d35326ab78e0bcfce84756408515f82a94e4dec4
-    optional: false
-    category: main
-  - name: backcall
-    version: 0.2.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 6006a6d08a3fa99268a2681c7fb55213
-      sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
-    optional: false
-    category: main
-  - name: backports
-    version: "1.0"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda"
-    hash:
-      md5: 54ca2e08b3220c148a1d8329c2678e02
-      sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-    optional: false
-    category: main
-  - name: backports.zoneinfo
-    version: 0.2.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/backports.zoneinfo-0.2.1-py39hf3d152e_7.tar.bz2"
-    hash:
-      md5: b1a72c73acf3527aa5c1e2eed594fa25
-      sha256: 1e9ca141550b6b515dec4ff32a7ca32948f6ac01e0fec207d8a14a7170b2973c
-    optional: false
-    category: main
-  - name: brotli
-    version: 1.0.9
-    manager: conda
-    platform: linux-64
-    dependencies:
-      brotli-bin: "==1.0.9 h166bdaf_8"
-      libbrotlidec: "==1.0.9 h166bdaf_8"
-      libbrotlienc: "==1.0.9 h166bdaf_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/brotli-1.0.9-h166bdaf_8.tar.bz2"
-    hash:
-      md5: 2ff08978892a3e8b954397c461f18418
-      sha256: 74c0fa22ea7c62d2c8f7a7aea03a3bd4919f7f3940ef5b027ce0dfb5feb38c06
-    optional: false
-    category: main
-  - name: c-compiler
-    version: 1.5.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      binutils: "*"
-      gcc: "*"
-      gcc_linux-64: 11.*
-    url: "https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.5.2-h0b41bf4_0.conda"
-    hash:
-      md5: 69afb4e35be6366c2c1f9ed7f49bc3e6
-      sha256: fe4c0080648c3448939919ddc49339cd8e250124b69a518e66ef6989794fa58a
-    optional: false
-    category: main
-  - name: certifi
-    version: 2022.12.7
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/certifi-2022.12.7-pyhd8ed1ab_0.conda"
-    hash:
-      md5: fb9addc3db06e56abe03e0e9f21a63e6
-      sha256: 5e22af4776700200fab2c1df41a2188ab9cfe90a50c4f388592bb978562c88ec
-    optional: false
-    category: main
-  - name: charset-normalizer
-    version: 2.1.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c1d5b294fbf9a795dec349a6f4d8be8e
-      sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
-    optional: false
-    category: main
-  - name: click
-    version: 8.1.3
-    manager: conda
-    platform: linux-64
-    dependencies:
-      __unix: "*"
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2"
-    hash:
-      md5: 20e4087407c7cb04a40817114b333dbf
-      sha256: 23676470b591b100393bb0f6c46fe10624dcbefc696a6a9f42932ed8816ef0ea
-    optional: false
-    category: main
-  - name: colorama
-    version: 0.4.6
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 3faab06a954c2a04039983f2c4a50d99
-      sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-    optional: false
-    category: main
-  - name: cycler
-    version: 0.11.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: a50559fad0affdbb33729a68669ca1cb
-      sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
-    optional: false
-    category: main
-  - name: cython
-    version: 0.29.33
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/cython-0.29.33-py39h227be39_0.conda"
-    hash:
-      md5: 34bab6ef3e8cdf86fe78c46a984d3217
-      sha256: 908715a56fe7633df894464c59c3799d88300772fc62011fa96593ce4ad92ef4
-    optional: false
-    category: main
-  - name: dbus
-    version: 1.13.6
-    manager: conda
-    platform: linux-64
-    dependencies:
-      expat: ">=2.4.2,<3.0a0"
-      libgcc-ng: ">=9.4.0"
-      libglib: ">=2.70.2,<3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2"
-    hash:
-      md5: ecfff944ba3960ecb334b9a2663d708d
-      sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
-    optional: false
-    category: main
-  - name: decorator
-    version: 5.1.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 43afe5ab04e35e17ba28649471dd7364
-      sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-    optional: false
-    category: main
-  - name: docutils
-    version: "0.19"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/docutils-0.19-py39hf3d152e_1.tar.bz2"
-    hash:
-      md5: adb733ec2ee669f6d010758d054da60f
-      sha256: 826ae2374fc37a9bb29dd3c7783ba11ffa1e215660a60144e7f759c49686b1af
-    optional: false
-    category: main
-  - name: exceptiongroup
-    version: 1.1.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: a385c3e8968b4cf8fbc426ace915fd1a
-      sha256: cf668360331552b2903e440cda1b4e47062c3f3775342e4a278ef4d141c28d1d
-    optional: false
-    category: main
-  - name: execnet
-    version: 1.9.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: "==2.7|>=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/execnet-1.9.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 0e521f7a5e60d508b121d38b04874fb2
-      sha256: 1900bbc1764d01405e55be2e369d1b830fb435eb0f27c57033372c60f34c675c
-    optional: false
-    category: main
-  - name: executing
-    version: 1.2.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 4c1bc140e2be5c8ba6e3acab99e25c50
-      sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
-    optional: false
-    category: main
-  - name: fontconfig
-    version: 2.14.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      expat: ">=2.5.0,<3.0a0"
-      freetype: ">=2.12.1,<3.0a0"
-      libgcc-ng: ">=12"
-      libuuid: ">=2.32.1,<3.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda"
-    hash:
-      md5: 0f69b688f52ff6da70bccb7ff7001d1d
-      sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
-    optional: false
-    category: main
-  - name: gfortran
-    version: 11.3.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      gcc: 11.3.0.*
-      gcc_impl_linux-64: 11.3.0.*
-      gfortran_impl_linux-64: 11.3.0.*
-    url: "https://conda.anaconda.org/conda-forge/linux-64/gfortran-11.3.0-ha859ce3_11.tar.bz2"
-    hash:
-      md5: 9a6a0c6fc4d192fddc7347a0ca31a329
-      sha256: 9ec8753064dc7379958788952346fc1f0caa18affe093cac62c8a8e267f5f38e
-    optional: false
-    category: main
-  - name: gfortran_linux-64
-    version: 11.3.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      binutils_linux-64: "==2.39 h5fc0e48_11"
-      gcc_linux-64: "==11.3.0 he6f903b_11"
-      gfortran_impl_linux-64: 11.3.0.*
-      sysroot_linux-64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/gfortran_linux-64-11.3.0-h3c55166_11.tar.bz2"
-    hash:
-      md5: f70b169eb69320d71f193758b7df67e8
-      sha256: 7c3bc99fc0d32647681f9b8ce44f137f16ae5ec37f040b66506c6634c299f071
-    optional: false
-    category: main
-  - name: glib-tools
-    version: 2.74.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libglib: "==2.74.1 h606061b_1"
-      libstdcxx-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.74.1-h6239696_1.tar.bz2"
-    hash:
-      md5: 5f442e6bc9d89ba236eb25a25c5c2815
-      sha256: 029533e2e1cb03a80ae07a0a1a6bdd76b524e8f551d82e832a4d846a77b615c9
-    optional: false
-    category: main
-  - name: gxx
-    version: 11.3.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      gcc: 11.3.0.*
-      gxx_impl_linux-64: 11.3.0.*
-    url: "https://conda.anaconda.org/conda-forge/linux-64/gxx-11.3.0-h02d0930_11.tar.bz2"
-    hash:
-      md5: e47dd4b4e577f03bb6aab18f48be5419
-      sha256: 3614201ab2f09f27429b7faea7dcd9e24e089a325bca878f76cdd0dca4676520
-    optional: false
-    category: main
-  - name: gxx_linux-64
-    version: 11.3.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      binutils_linux-64: "==2.39 h5fc0e48_11"
-      gcc_linux-64: "==11.3.0 he6f903b_11"
-      gxx_impl_linux-64: 11.3.0.*
-      sysroot_linux-64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-11.3.0-hc203a17_11.tar.bz2"
-    hash:
-      md5: 15fbc9079f191d468403639a6515652c
-      sha256: 7be17e1fdb200e8b9afe8f4e88b3b821740be6024e433565abda94e5d021c9cb
-    optional: false
-    category: main
-  - name: idna
-    version: "3.4"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 34272b248891bddccc64479f9a7fffed
-      sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
-    optional: false
-    category: main
-  - name: imagesize
-    version: 1.4.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.4"
-    url: "https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 7de5386c8fea29e76b303f37dde4c352
-      sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
-    optional: false
-    category: main
-  - name: iniconfig
-    version: 2.0.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f800d2da156d08e289b14e87e43c1ae5
-      sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-    optional: false
-    category: main
-  - name: kiwisolver
-    version: 1.4.4
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.4-py39hf939315_1.tar.bz2"
-    hash:
-      md5: 41679a052a8ce841c74df1ebc802e411
-      sha256: eb28254cc7029e702d0059536d986b010221de62f9c8588a5a83e95a00b4e74d
-    optional: false
-    category: main
-  - name: lcms2
-    version: "2.14"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      jpeg: ">=9e,<10a"
-      libgcc-ng: ">=12"
-      libtiff: ">=4.5.0,<4.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.14-hfd0df8a_1.conda"
-    hash:
-      md5: c2566c2ea5f153ddd6bf4acaf7547d97
-      sha256: 632f191ac65bc673f8fcef9947e2c8431b0db6ca357ceebde3bdc4ed187af814
-    optional: false
-    category: main
-  - name: libclang13
+  - name: llvm-openmp
     version: 15.0.7
     manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-15.0.7-h7cfbb63_0.conda"
+    hash:
+      md5: 358164e15a9320f11b84a53fb8d8e446
+      sha256: 6cc4cf021fc1f06df3b97598bf9583fe7a04fad6a4eef9882558f7932f362bc0
+    optional: false
+    category: main
+  - name: llvm-tools
+    version: 14.0.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libllvm14: "==14.0.6 h5b596cc_1"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-14.0.6-h5b596cc_1.tar.bz2"
+    hash:
+      md5: d99491efd3d672b3496e9fc9273da7c0
+      sha256: 70be9ae375316ed616dae92c614763bd930d64765cf256d0f1aa50e3dcdafc58
+    optional: false
+    category: main
+  - name: llvm-tools
+    version: 14.0.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libllvm14: "==14.0.6 hf6e71e7_1"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-14.0.6-hf6e71e7_1.tar.bz2"
+    hash:
+      md5: e97dcf92f03537c52aa2dcdcaf6ef75c
+      sha256: 91dc605c32d6b76189c34757c27319800e78fd865d0652acdd5b18ac999988af
+    optional: false
+    category: main
+  - name: lz4-c
+    version: 1.9.4
+    manager: conda
     platform: linux-64
     dependencies:
       libgcc-ng: ">=12"
-      libllvm15: ">=15.0.7,<15.1.0a0"
       libstdcxx-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h3e3d535_1.conda"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda"
     hash:
-      md5: a3a0f7a6f0885f5e1e0ec691566afb77
-      sha256: e48481c37d02aefeddcfac20d48cf13b838c5f7b9018300fa7eac404d30f3d7f
-    optional: false
-    category: main
-  - name: libcups
-    version: 2.3.3
-    manager: conda
-    platform: linux-64
-    dependencies:
-      krb5: ">=1.20.1,<1.21.0a0"
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h36d4200_3.conda"
-    hash:
-      md5: c9f4416a34bc91e0eb029f912c68f81f
-      sha256: 0ccd610207807f53328f137b2adc99c413f8e1dcd1302f0325412796a94eaaf7
-    optional: false
-    category: main
-  - name: libpq
-    version: "15.2"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      krb5: ">=1.20.1,<1.21.0a0"
-      libgcc-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      openssl: ">=3.0.8,<4.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libpq-15.2-hb675445_0.conda"
-    hash:
-      md5: 4654b17eccaba55b8581d6b9c77f53cc
-      sha256: 5693c492ca0280e62edd114d91b7aa9c81fa60276b594f31d18a852636603f9e
-    optional: false
-    category: main
-  - name: libsystemd0
-    version: "252"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      __glibc: ">=2.17,<3.0.a0"
-      libcap: ">=2.66,<2.67.0a0"
-      libgcc-ng: ">=12"
-      libgcrypt: ">=1.10.1,<2.0a0"
-      lz4-c: ">=1.9.3,<1.10.0a0"
-      xz: ">=5.2.6,<6.0a0"
-      zstd: ">=1.5.2,<1.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-252-h2a991cd_0.tar.bz2"
-    hash:
-      md5: 3c5ae9f61f663b3d5e1bf7f7da0c85f5
-      sha256: a181e25a04207179da598a5a89747a026642341e193dca125620f5f4e268804a
+      md5: 318b08df404f9c9be5712aaa5a6f0bb0
+      sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
     optional: false
     category: main
   - name: markupsafe
@@ -2042,1086 +6978,134 @@ package:
       sha256: da31fe95611393bb7dd3dee309a89328448570fd8a3205c2c55c03eb73688b61
     optional: false
     category: main
-  - name: munkres
-    version: 1.1.4
+  - name: markupsafe
+    version: 2.1.2
     manager: conda
-    platform: linux-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 2ba8498c1018c1e9c61eb99b973dfe19
-      sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
-    optional: false
-    category: main
-  - name: mypy_extensions
-    version: 1.0.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda"
-    hash:
-      md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-      sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-    optional: false
-    category: main
-  - name: numpy
-    version: 1.24.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libblas: ">=3.9.0,<4.0a0"
-      libcblas: ">=3.9.0,<4.0a0"
-      libgcc-ng: ">=12"
-      liblapack: ">=3.9.0,<4.0a0"
-      libstdcxx-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.2-py39h7360e5f_0.conda"
-    hash:
-      md5: 757070dc7cc33003254888808cd34f1e
-      sha256: c0418aa18f4fd37d3ac786058bfa29cca0b5b8eca95a2e0ae2fdd13aefc81ad6
-    optional: false
-    category: main
-  - name: openjpeg
-    version: 2.5.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libpng: ">=1.6.39,<1.7.0a0"
-      libstdcxx-ng: ">=12"
-      libtiff: ">=4.5.0,<4.6.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-hfec8fc6_2.conda"
-    hash:
-      md5: 5ce6a42505c6e9e6151c54c3ec8d68ea
-      sha256: 3cbfb1fe9bb492dcb672f98f0ddc7b4e029f51f77101d9c301caa3acaea8cba2
-    optional: false
-    category: main
-  - name: packaging
-    version: "23.0"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/packaging-23.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 1ff2e3ca41f0ce16afec7190db28288b
-      sha256: 00288f5e5e841711e8b8fef1f1242c858d8ef99ccbe5d7e0df4789d5d8d40645
-    optional: false
-    category: main
-  - name: parso
-    version: 0.8.3
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 17a565a0c3899244e938cdf417e7b094
-      sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
-    optional: false
-    category: main
-  - name: pickleshare
-    version: 0.7.5
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2"
-    hash:
-      md5: 415f0ebb6198cc2801c73438a9fb5761
-      sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-    optional: false
-    category: main
-  - name: pluggy
-    version: 1.0.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2"
-    hash:
-      md5: 7d301a0d25f424d96175f810935f0da9
-      sha256: c25e1757e4e90638bb1e778aba3ee5f3c01fae9752e3c3929f9be7d367f6c7f3
-    optional: false
-    category: main
-  - name: ply
-    version: "3.11"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/ply-3.11-py_1.tar.bz2"
-    hash:
-      md5: 7205635cd71531943440fbfe3b6b5727
-      sha256: 2cd6fae8f9cbc806b7f828f006ae4a83c23fac917cacfd73c37ce322d4324e53
-    optional: false
-    category: main
-  - name: psutil
-    version: 5.9.4
-    manager: conda
-    platform: linux-64
+    platform: linux-aarch64
     dependencies:
       libgcc-ng: ">=12"
       python: ">=3.9,<3.10.0a0"
       python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.4-py39hb9d737c_0.tar.bz2"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/markupsafe-2.1.2-py39h599bc27_0.conda"
     hash:
-      md5: 12184951da572828fb986b06ffb63eed
-      sha256: 515cf2cfc0504eb5758fa9ddfabc1dcbd7182da7650828aac97c9eee35597c84
+      md5: 13af483192015190404fede49f1a306e
+      sha256: 4eb2683d7391a984b0f32e9f9fb20c2708b6a674b0e6d901cd80ccb61b491052
     optional: false
     category: main
-  - name: ptyprocess
-    version: 0.7.0
+  - name: markupsafe
+    version: 2.1.2
     manager: conda
-    platform: linux-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2"
-    hash:
-      md5: 359eeb6536da0e687af562ed265ec263
-      sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
-    optional: false
-    category: main
-  - name: pure_eval
-    version: 0.2.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6784285c7e55cb7212efabc79e4c2883
-      sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
-    optional: false
-    category: main
-  - name: pycodestyle
-    version: 2.7.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: 2.7.*|>=3.5
-    url: "https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.7.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 0234673eb2ecfbdf4e54574ab4d95f81
-      sha256: 5c6aa7a724551d7768930b30bd77e531580f6ddd68a391094e799a21a82b9492
-    optional: false
-    category: main
-  - name: pycparser
-    version: "2.21"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: 2.7.*|>=3.4
-    url: "https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 076becd9e05608f8dc72757d5f3a91ff
-      sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
-    optional: false
-    category: main
-  - name: pyparsing
-    version: 3.0.9
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: e8fbc1b54b25f4b08281467bc13b70cc
-      sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
-    optional: false
-    category: main
-  - name: pysocks
-    version: 1.7.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      __unix: "*"
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2"
-    hash:
-      md5: 2a7de29fb590ca14b5243c4c812c8025
-      sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
-    optional: false
-    category: main
-  - name: pytz
-    version: 2022.7.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytz-2022.7.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f59d49a7b464901cf714b9e7984d01a2
-      sha256: 93cfc7a92099e26b0575a343da4a667b52371cc38e4dee4ee264dc041ef77bac
-    optional: false
-    category: main
-  - name: setuptools
-    version: 59.2.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/setuptools-59.2.0-py39hf3d152e_0.tar.bz2"
-    hash:
-      md5: 37ef3543fa46bf5d587f23d72b88fbf7
-      sha256: 7e74640590ebe3379bb33c0aed17efa8c305c016b85e987d1e864a40a29743aa
-    optional: false
-    category: main
-  - name: six
-    version: 1.16.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2"
-    hash:
-      md5: e5f25f8dbc060e9a8d912e432202afc2
-      sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
-    optional: false
-    category: main
-  - name: smmap
-    version: 3.0.5
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/smmap-3.0.5-pyh44b312d_0.tar.bz2"
-    hash:
-      md5: 3a8dc70789709aa315325d5df06fb7e4
-      sha256: 091de70ee6bfe063e0c0f77336975d124fd1e3f49b9c58d97c0c7b3d287c0002
-    optional: false
-    category: main
-  - name: snowballstemmer
-    version: 2.2.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 4d22a9315e78c6827f806065957d566e
-      sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
-    optional: false
-    category: main
-  - name: sortedcontainers
-    version: 2.4.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6d6552722448103793743dabfbda532d
-      sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
-    optional: false
-    category: main
-  - name: soupsieve
-    version: 2.3.2.post1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 146f4541d643d48fc8a75cacf69f03ae
-      sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
-    optional: false
-    category: main
-  - name: sphinxcontrib-applehelp
-    version: 1.0.4
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.4-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 5a31a7d564f551d0e6dff52fd8cb5b16
-      sha256: 802810d8321d55e5666806d565e72949eabf77ad510fe2758ce1da2441675ef1
-    optional: false
-    category: main
-  - name: sphinxcontrib-devhelp
-    version: 1.0.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.2-py_0.tar.bz2"
-    hash:
-      md5: 68e01cac9d38d0e717cd5c87bc3d2cc9
-      sha256: 66cca7eccb7f92eee53f9f5a552e3e1d643daa3a1ebd03c185e2819e5c491576
-    optional: false
-    category: main
-  - name: sphinxcontrib-htmlhelp
-    version: 2.0.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 6c8c4d6eb2325e59290ac6dbbeacd5f0
-      sha256: aeff20be994e6f9520a91fc177a33cb3e4d0911cdf8d27e575d001f00afa33fd
-    optional: false
-    category: main
-  - name: sphinxcontrib-jsmath
-    version: 1.0.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-py_0.tar.bz2"
-    hash:
-      md5: 67cd9d9c0382d37479b4d306c369a2d4
-      sha256: a42415fc789e9f6ae2e18f07ac143d2e9ce73a35a55ecf1dd1b3d055dd1e6dbe
-    optional: false
-    category: main
-  - name: sphinxcontrib-qthelp
-    version: 1.0.3
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2"
-    hash:
-      md5: d01180388e6d1838c3e1ad029590aa7a
-      sha256: 35d8f01fc798d38b72ae003c040d2dee650d315f904268a1f793d4d59460d1e2
-    optional: false
-    category: main
-  - name: sphinxcontrib-serializinghtml
-    version: 1.1.5
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2"
-    hash:
-      md5: 9ff55a0901cf952f05c654394de76bf7
-      sha256: 890bbf815cff114ddbb618b9876d492fce07d02956c1d7b3d46cb7f835f563f6
-    optional: false
-    category: main
-  - name: toml
-    version: 0.10.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: f832c45a477c78bebd107098db465095
-      sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
-    optional: false
-    category: main
-  - name: tomli
-    version: 2.0.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 5844808ffab9ebdb694585b50ba02a96
-      sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-    optional: false
-    category: main
-  - name: tornado
-    version: "6.2"
-    manager: conda
-    platform: linux-64
+    platform: linux-ppc64le
     dependencies:
       libgcc-ng: ">=12"
       python: ">=3.9,<3.10.0a0"
       python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/tornado-6.2-py39hb9d737c_1.tar.bz2"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/markupsafe-2.1.2-py39h3c7ea95_0.conda"
     hash:
-      md5: 8a7d309b08cff6386fe384aa10dd3748
-      sha256: 67c3eef0531caf75a81945844288f363cd3b7b029829bd91ed0994bf6b231f34
+      md5: 4b35b03829dc7cd269f7c0bb8b741fea
+      sha256: 27403dd13b41d2590f52645745d8daf5269fe415b99208d79935c8f5ff8c7911
     optional: false
     category: main
-  - name: traitlets
-    version: 5.9.0
+  - name: markupsafe
+    version: 2.1.2
     manager: conda
-    platform: linux-64
+    platform: osx-64
     dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: d0b4f5c87cd35ac3fb3d47b223263a64
-      sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
-    optional: false
-    category: main
-  - name: typing_extensions
-    version: 4.4.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.4.0-pyha770c72_0.tar.bz2"
-    hash:
-      md5: 2d93b130d148d7fc77e583677792fc6a
-      sha256: 70c57b5ac94cd32e78f1a2fa2c38572bfac85b901a6a99aa254a9e8e126c132d
-    optional: false
-    category: main
-  - name: unicodedata2
-    version: 15.0.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
       python: ">=3.9,<3.10.0a0"
       python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.0.0-py39hb9d737c_0.tar.bz2"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.2-py39ha30fb19_0.conda"
     hash:
-      md5: 230d65004135bf312504a1bbcb0c7a08
-      sha256: 03c2cf05d1f4f2b01fc1e3ced22d5f331f2f233e335c4a4cd11a31fea1fccc0c
+      md5: 3b7b34916156e45ec52df74efc3db6e4
+      sha256: d5aa88cdd75728fe101f83d0c4a7ab36634044f890e9e41aceb7454500e8af2b
     optional: false
     category: main
-  - name: wheel
-    version: 0.38.4
+  - name: markupsafe
+    version: 2.1.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.2-py39h02fc5c5_0.conda"
+    hash:
+      md5: 525d6fb3283d4b90cd9f92c9811214af
+      sha256: 33f4eb17d29fe5983f27ac193e1dd071857447649a6a4197f1bb0310f1928f57
+    optional: false
+    category: main
+  - name: matplotlib
+    version: 3.6.3
     manager: conda
     platform: linux-64
     dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c829cfb8cb826acb9de0ac1a2df0a940
-      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-    optional: false
-    category: main
-  - name: xcb-util-image
-    version: 0.4.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libxcb: ">=1.13,<1.14.0a0"
-      xcb-util: ">=0.4.0,<0.5.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h166bdaf_0.tar.bz2"
-    hash:
-      md5: c9b568bd804cb2903c6be6f5f68182e4
-      sha256: 6db358d4afa0eb1225e24871f6c64c1b6c433f203babdd43508b0d61252467d1
-    optional: false
-    category: main
-  - name: xorg-libxext
-    version: 1.3.4
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-      xorg-libx11: ">=1.7.0,<2.0a0"
-      xorg-xextproto: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h7f98852_1.tar.bz2"
-    hash:
-      md5: 536cc5db4d0a3ba0630541aec064b5e4
-      sha256: cf47ccbf49d46189d7bdadeac1387c826be82deb92ce6badbb03baae4b67ed26
-    optional: false
-    category: main
-  - name: xorg-libxrender
-    version: 0.9.10
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-      xorg-libx11: ">=1.7.0,<2.0a0"
-      xorg-renderproto: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.10-h7f98852_1003.tar.bz2"
-    hash:
-      md5: f59c1242cc1dd93e72c2ee2b360979eb
-      sha256: 7d907ed9e2ec5af5d7498fb3ab744accc298914ae31497ab6dcc6ef8bd134d00
-    optional: false
-    category: main
-  - name: zipp
-    version: 3.13.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/zipp-3.13.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 41b09d997939e83b231c4557a90c3b13
-      sha256: 0a9a545b8dc46c847658ebfa636257ea5993a355419c1d3b2f14810730ee0a82
-    optional: false
-    category: main
-  - name: asttokens
-    version: 2.2.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.5"
-      six: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: bf7f54dd0f25c3f06ecb82a07341841a
-      sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
-    optional: false
-    category: main
-  - name: babel
-    version: 2.11.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-      pytz: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/babel-2.11.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 2ea70fde8d581ba9425a761609eed6ba
-      sha256: 21a8403d886136c0a80f965ae5387fa1693b19ddd69023bcd0e844f2510d7e2f
-    optional: false
-    category: main
-  - name: backports.functools_lru_cache
-    version: 1.6.4
-    manager: conda
-    platform: linux-64
-    dependencies:
-      backports: "*"
-      python: ">=3.6"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c5b3edc62d6309088f4970b3eaaa65a6
-      sha256: fdea00d4b79990f3fe938e2716bc32bd895eb5c44b6c75b8261db095a1b33c16
-    optional: false
-    category: main
-  - name: beautifulsoup4
-    version: 4.11.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-      soupsieve: ">=1.2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.11.2-pyha770c72_0.conda"
-    hash:
-      md5: 88b59f6989f0ed5ab3433af0b82555e1
-      sha256: deb43944425b3ec7fdfd5e6620cf97a4ed888a279237f90cd67a338d123efd15
-    optional: false
-    category: main
-  - name: cairo
-    version: 1.16.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      fontconfig: ">=2.13.96,<3.0a0"
-      fonts-conda-ecosystem: "*"
-      freetype: ">=2.12.1,<3.0a0"
-      icu: ">=70.1,<71.0a0"
-      libgcc-ng: ">=12"
-      libglib: ">=2.72.1,<3.0a0"
-      libpng: ">=1.6.38,<1.7.0a0"
-      libxcb: ">=1.13,<1.14.0a0"
-      libzlib: ">=1.2.12,<1.3.0a0"
-      pixman: ">=0.40.0,<1.0a0"
-      xorg-libice: "*"
-      xorg-libsm: "*"
-      xorg-libx11: "*"
-      xorg-libxext: "*"
-      xorg-libxrender: "*"
-      zlib: ">=1.2.12,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/cairo-1.16.0-ha61ee94_1014.tar.bz2"
-    hash:
-      md5: d1a88f3ed5b52e1024b80d4bcd26a7a0
-      sha256: f062cf56e6e50d3ad4b425ebb3765ca9138c6ebc52e6a42d1377de8bc8d954f6
-    optional: false
-    category: main
-  - name: cffi
-    version: 1.15.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libffi: ">=3.4,<4.0a0"
-      libgcc-ng: ">=12"
-      pycparser: "*"
+      matplotlib-base: ">=3.6.3,<3.6.4.0a0"
+      pyqt: ">=5"
       python: ">=3.9,<3.10.0a0"
       python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/cffi-1.15.1-py39he91dace_3.conda"
+      tornado: ">=5"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.6.3-py39hf3d152e_0.conda"
     hash:
-      md5: 20080319ef73fbad74dcd6d62f2a3ffe
-      sha256: 485a8f65c58c26c7d48bfea20ed1d6f1493f3329dd2c9c0a888a1c2b7c2365c5
+      md5: dbef5ffeeca5c5112cc3be8f03e6d1a5
+      sha256: b1d70dba47ea0e901084fd4d32b506772063b38a99e1c39c1b0fef4c06e7deef
     optional: false
     category: main
-  - name: contourpy
-    version: 1.0.7
+  - name: matplotlib
+    version: 3.6.3
     manager: conda
-    platform: linux-64
+    platform: linux-aarch64
     dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      numpy: ">=1.16"
+      matplotlib-base: ">=3.6.3,<3.6.4.0a0"
       python: ">=3.9,<3.10.0a0"
       python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.0.7-py39h4b4f3f3_0.conda"
+      tornado: ">=5"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.6.3-py39ha65689a_0.conda"
     hash:
-      md5: c5387f3fb1f5b8b71e1c865fc55f4951
-      sha256: 74a767b73686caf0bb1d1186cd62a54f01e03ad5432eaaf0a7babad7634c4067
+      md5: 1af8933de795cb23f0a28cba529c544d
+      sha256: 7adde98e60579550ed3fe3f40f5877b135bacd6b74f59e4d3df25f504033e99f
     optional: false
     category: main
-  - name: coverage
-    version: 7.1.0
+  - name: matplotlib
+    version: 3.6.3
     manager: conda
-    platform: linux-64
+    platform: linux-ppc64le
     dependencies:
-      libgcc-ng: ">=12"
+      matplotlib-base: ">=3.6.3,<3.6.4.0a0"
       python: ">=3.9,<3.10.0a0"
       python_abi: 3.9.* *_cp39
-      tomli: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/coverage-7.1.0-py39h72bdee0_0.conda"
+      tornado: ">=5"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/matplotlib-3.6.3-py39hc1b9086_0.conda"
     hash:
-      md5: 915b100b564875cceb85cbeab61fd678
-      sha256: 074f44d601cae7c972183e915e7ea53ea433c59a43cb0c8964bb4d897e514512
+      md5: 773e37213cd47be018f3cd225b9694a5
+      sha256: 9d85a0fd853509efc0c2a63e10e56a968069d23552fa8391b667cf52fb6b7c03
     optional: false
     category: main
-  - name: cxx-compiler
-    version: 1.5.2
+  - name: matplotlib
+    version: 3.6.3
     manager: conda
-    platform: linux-64
+    platform: osx-64
     dependencies:
-      c-compiler: "==1.5.2 h0b41bf4_0"
-      gxx: "*"
-      gxx_linux-64: 11.*
-    url: "https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.5.2-hf52228f_0.conda"
-    hash:
-      md5: 6b3b19e359824b97df7145c8c878c8be
-      sha256: c6916082ea28b905dd59d4b6b5b07be413a3a5a814193df43c28101e4d29a7fc
-    optional: false
-    category: main
-  - name: fonttools
-    version: 4.38.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      brotli: "*"
-      libgcc-ng: ">=12"
-      munkres: "*"
+      matplotlib-base: ">=3.6.3,<3.6.4.0a0"
       python: ">=3.9,<3.10.0a0"
       python_abi: 3.9.* *_cp39
-      unicodedata2: ">=14.0.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.38.0-py39hb9d737c_1.tar.bz2"
+      tornado: ">=5"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.6.3-py39h6e9494a_0.conda"
     hash:
-      md5: 3f2d104f2fefdd5e8a205dd3aacbf1d7
-      sha256: 55dff2dd401ef1d6fc4a27cf8e74af899c609519d35eafff3b097d7fc1836d83
+      md5: 255526eb4dbca981a03b25f0267f2a62
+      sha256: bb324a483b9cb30a09bfefe18cb4e42199201940be0ed82f3c0fbdb26ef2950d
     optional: false
     category: main
-  - name: fortran-compiler
-    version: 1.5.2
+  - name: matplotlib
+    version: 3.6.3
     manager: conda
-    platform: linux-64
+    platform: osx-arm64
     dependencies:
-      binutils: "*"
-      c-compiler: "==1.5.2 h0b41bf4_0"
-      gfortran: "*"
-      gfortran_linux-64: 11.*
-    url: "https://conda.anaconda.org/conda-forge/linux-64/fortran-compiler-1.5.2-hdb1a99f_0.conda"
-    hash:
-      md5: 265323e1bd53709aeb739c9b1794b398
-      sha256: 985733294fe9b3dc6f126ee95b4b934e097060ca0c12fe469812596a4763228e
-    optional: false
-    category: main
-  - name: gitdb
-    version: 4.0.10
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.4"
-      smmap: ">=3.0.1,<4"
-    url: "https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.10-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 3706d2f3d7cb5dae600c833345a76132
-      sha256: 0003ab2b971913380633c711bf49a54dcf06e179986c725b0925854b58878377
-    optional: false
-    category: main
-  - name: glib
-    version: 2.74.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      gettext: ">=0.21.1,<1.0a0"
-      glib-tools: "==2.74.1 h6239696_1"
-      libgcc-ng: ">=12"
-      libglib: "==2.74.1 h606061b_1"
-      libstdcxx-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/glib-2.74.1-h6239696_1.tar.bz2"
-    hash:
-      md5: f3220a9e9d3abcbfca43419a219df7e4
-      sha256: bc3f1d84e976a62ae8388e3b44f260d867beb7a307c18147048a8301a3c12e47
-    optional: false
-    category: main
-  - name: hypothesis
-    version: 6.68.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      attrs: ">=19.2.0"
-      backports.zoneinfo: ">=0.2.1"
-      click: ">=7.0"
-      exceptiongroup: ">=1.0.0rc8"
-      python: ">=3.8"
-      setuptools: "*"
-      sortedcontainers: ">=2.1.0,<3.0.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.68.1-pyha770c72_0.conda"
-    hash:
-      md5: 3c044b3b920eb287f8c095c7f086ba64
-      sha256: e3a29c1303b563e450e0f706e4d78a281d1aa519d3e1094fc642305bceff72e1
-    optional: false
-    category: main
-  - name: importlib-metadata
-    version: 6.0.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.8"
-      zipp: ">=0.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.0.0-pyha770c72_0.conda"
-    hash:
-      md5: 691644becbcdca9f73243450b1c63e62
-      sha256: 0062e6ae1719395c25f0b60a21215470b4ea67514fed8a9330869da8604acfca
-    optional: false
-    category: main
-  - name: jedi
-    version: 0.18.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      parso: ">=0.8.0,<0.9.0"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
-      sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
-    optional: false
-    category: main
-  - name: jinja2
-    version: 3.1.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      markupsafe: ">=2.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: c8490ed5c70966d232fdd389d0dbed37
-      sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-    optional: false
-    category: main
-  - name: libclang
-    version: 15.0.7
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libclang13: "==15.0.7 default_h3e3d535_1"
-      libgcc-ng: ">=12"
-      libllvm15: ">=15.0.7,<15.1.0a0"
-      libstdcxx-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_had23c3d_1.conda"
-    hash:
-      md5: 36c65ed73b7c92589bd9562ef8a6023d
-      sha256: eba3ed760c72c992a04d86455556ecb90c0e1e3688defcac44b28a848d71651c
-    optional: false
-    category: main
-  - name: matplotlib-inline
-    version: 0.1.6
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-      traitlets: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: b21613793fcc81d944c76c9f2864a7de
-      sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-    optional: false
-    category: main
-  - name: meson
-    version: 1.0.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      ninja: ">=1.8.2"
-      python: ">=3.5.2"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/meson-1.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 4de573313958b8da6c526fdd354fffc8
-      sha256: 57dc7634aa05f3944314e6b56b2f37e6fb1a52b33de9ca153aee5d9adf83a5d7
-    optional: false
-    category: main
-  - name: mypy
-    version: "0.981"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      mypy_extensions: ">=0.4.3"
-      psutil: ">=4.0"
+      matplotlib-base: ">=3.6.3,<3.6.4.0a0"
       python: ">=3.9,<3.10.0a0"
       python_abi: 3.9.* *_cp39
-      tomli: ">=1.1.0"
-      typing_extensions: ">=3.10"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/mypy-0.981-py39hb9d737c_0.tar.bz2"
+      tornado: ">=5"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.6.3-py39hdf13c20_0.conda"
     hash:
-      md5: 726060f54d0a1ae07577a34dda31a868
-      sha256: 0cbf2e4018d7694517268c258a7b53b73c4c3a57490352a0792e08b96d8b637f
-    optional: false
-    category: main
-  - name: pexpect
-    version: 4.8.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      ptyprocess: ">=0.5"
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2"
-    hash:
-      md5: 330448ce4403cc74990ac07c555942a1
-      sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
-    optional: false
-    category: main
-  - name: pillow
-    version: 9.4.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      freetype: ">=2.12.1,<3.0a0"
-      jpeg: ">=9e,<10a"
-      lcms2: ">=2.14,<3.0a0"
-      libgcc-ng: ">=12"
-      libtiff: ">=4.5.0,<4.6.0a0"
-      libwebp-base: ">=1.2.4,<2.0a0"
-      libxcb: ">=1.13,<1.14.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      openjpeg: ">=2.5.0,<3.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tk: ">=8.6.12,<8.7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/pillow-9.4.0-py39h2320bf1_1.conda"
-    hash:
-      md5: d2f79132b9c8e416058a4cd84ef27b3d
-      sha256: 77348588ae7cc8034b63e8a71b6695ba22761e1c531678e724cf06a12be3d1e2
-    optional: false
-    category: main
-  - name: pip
-    version: "23.0"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-      setuptools: "*"
-      wheel: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 85b35999162ec95f9f999bac15279c02
-      sha256: bbffec284bd0e154363e845121f43007e7e64c80412ff13be21909be907b697d
-    optional: false
-    category: main
-  - name: pulseaudio
-    version: "16.1"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      alsa-lib: ">=1.2.8,<1.2.9.0a0"
-      dbus: ">=1.13.6,<2.0a0"
-      fftw: ">=3.3.10,<4.0a0"
-      gstreamer-orc: ">=0.4.33,<0.5.0a0"
-      jack: ">=1.9.21,<1.10.0a0"
-      libcap: ">=2.66,<2.67.0a0"
-      libgcc-ng: ">=12"
-      libglib: ">=2.74.1,<3.0a0"
-      libsndfile: ">=1.2.0,<1.3.0a0"
-      libsystemd0: ">=252"
-      libtool: ">=2.4.7,<3.0a0"
-      libudev1: ">=252"
-      openssl: ">=3.0.7,<4.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-16.1-ha8d29e2_1.conda"
-    hash:
-      md5: dbfc2a8d63a43a11acf4c704e1ef9d0c
-      sha256: aa2aa5b5e2430a3c3d8b24574e5e270c47026740cb706e9be31df81b0627afa6
-    optional: false
-    category: main
-  - name: pygments
-    version: 2.14.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pygments-2.14.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: c78cd16b11cd6a295484bd6c8f24bea1
-      sha256: e8710e24f60b6a97289468f47914e53610101755088bc237621cc1980edbfcd9
-    optional: false
-    category: main
-  - name: pyproject-metadata
-    version: 0.7.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      packaging: ">=19.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyproject-metadata-0.7.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: dcb27826ffc94d5f04e241322239983b
-      sha256: 9ec35cffa163f587aeb52d1603df8374659e3be30dbc6db0e980ecb797f21fee
-    optional: false
-    category: main
-  - name: pytest
-    version: 7.2.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      attrs: ">=19.2.0"
-      colorama: "*"
-      exceptiongroup: "*"
-      iniconfig: "*"
-      packaging: "*"
-      pluggy: ">=0.12,<2.0"
-      python: ">=3.8"
-      tomli: ">=1.0.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f0be05afc9c9ab45e273c088e00c258b
-      sha256: d298dfe6c53555c9fb5662f5f936e621cddd3b0a7031789375b82a1ee3b3a96b
-    optional: false
-    category: main
-  - name: python-dateutil
-    version: 2.8.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-      six: ">=1.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: dd999d1cc9f79e67dbb855c8924c7984
-      sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-    optional: false
-    category: main
-  - name: sip
-    version: 6.7.7
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      packaging: "*"
-      ply: "*"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      toml: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.7-py39h227be39_0.conda"
-    hash:
-      md5: 7d9a35091552af3655151f164ddd64a3
-      sha256: cbd7ddbe101dfe7d7241c5334e08c56fd9000400a099a2144ba95f63f90b9b45
-    optional: false
-    category: main
-  - name: typing-extensions
-    version: 4.4.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      typing_extensions: "==4.4.0 pyha770c72_0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.4.0-hd8ed1ab_0.tar.bz2"
-    hash:
-      md5: be969210b61b897775a0de63cd9e9026
-      sha256: 6f129b1bc18d111dcf3abaec6fcf6cbee00f1b77bb42d0f0bc8d85f8faa65cf0
-    optional: false
-    category: main
-  - name: brotlipy
-    version: 0.7.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      cffi: ">=1.0.0"
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/brotlipy-0.7.0-py39hb9d737c_1005.tar.bz2"
-    hash:
-      md5: a639fdd9428d8b25f8326a3838d54045
-      sha256: 293229afcd31e81626e5cfe0478be402b35d29b73aa421a49470645debda5019
-    optional: false
-    category: main
-  - name: compilers
-    version: 1.5.2
-    manager: conda
-    platform: linux-64
-    dependencies:
-      c-compiler: "==1.5.2 h0b41bf4_0"
-      cxx-compiler: "==1.5.2 hf52228f_0"
-      fortran-compiler: "==1.5.2 hdb1a99f_0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/compilers-1.5.2-ha770c72_0.conda"
-    hash:
-      md5: f95226244ee1c487cf53272f971323f4
-      sha256: 8ca9a7581c9522fa299782e28ac1e196f67df72b2f01c1e6ed09a2d3a77ec310
-    optional: false
-    category: main
-  - name: cryptography
-    version: 39.0.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      cffi: ">=1.12"
-      libgcc-ng: ">=12"
-      openssl: ">=3.0.8,<4.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-64/cryptography-39.0.1-py39h079d5ae_0.conda"
-    hash:
-      md5: 3245013812dfbff6a22e57533ac6f69d
-      sha256: 4349d5416c718c331454b957e0a077500fb4fb9e8f3b7eadb8777a3842021818
-    optional: false
-    category: main
-  - name: gitpython
-    version: 3.1.30
-    manager: conda
-    platform: linux-64
-    dependencies:
-      gitdb: ">=4.0.1,<5"
-      python: ">=3.7"
-      typing_extensions: ">=3.7.4.3"
-    url: "https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.30-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 0c217ab2f5ef6925e4e52c70b57cfc4a
-      sha256: 2ccd8aa401701947398a087b1aa11042b1b088e7331fed574b7ec9909bee09d6
-    optional: false
-    category: main
-  - name: gstreamer
-    version: 1.22.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      __glibc: ">=2.17,<3.0.a0"
-      gettext: ">=0.21.1,<1.0a0"
-      glib: ">=2.74.1,<3.0a0"
-      libgcc-ng: ">=12"
-      libglib: ">=2.74.1,<3.0a0"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.0-h25f0c4b_0.conda"
-    hash:
-      md5: d764367398de61c0d5531dd912e6cc96
-      sha256: ebf7839171f7ae6228c9650b13f551da9812486bbb6cd5e78985574b82dc6bbc
-    optional: false
-    category: main
-  - name: harfbuzz
-    version: 6.0.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      cairo: ">=1.16.0,<2.0a0"
-      freetype: ">=2.12.1,<3.0a0"
-      graphite2: "*"
-      icu: ">=70.1,<71.0a0"
-      libgcc-ng: ">=12"
-      libglib: ">=2.74.1,<3.0a0"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-6.0.0-h8e241bc_0.conda"
-    hash:
-      md5: 448fe40d2fed88ccf4d9ded37cbb2b38
-      sha256: f300fcb390253d6d63346ee71e56f82bc830783d1682ac933fe9ac86f39da942
+      md5: dc01380d1f0fd2946d0b2b822acf18d6
+      sha256: d78938af23d11a6535ffa5bd75be4c43f81079b9d659869781a0d454ca19ff1c
     optional: false
     category: main
   - name: matplotlib-base
@@ -3151,6 +7135,246 @@ package:
       sha256: 70a6cc23b22ea0afdf73605d344062983282e1b2e7c8f9d2b0d70bdf93ba771a
     optional: false
     category: main
+  - name: matplotlib-base
+    version: 3.6.3
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      certifi: ">=2020.6.20"
+      contourpy: ">=1.0.1"
+      cycler: ">=0.10"
+      fonttools: ">=4.22.0"
+      freetype: ">=2.12.1,<3.0a0"
+      kiwisolver: ">=1.0.1"
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      numpy: ">=1.20.3,<2.0a0"
+      packaging: ">=20.0"
+      pillow: ">=6.2.0"
+      pyparsing: ">=2.3.1"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python-dateutil: ">=2.7"
+      python_abi: 3.9.* *_cp39
+      tk: ">=8.6.12,<8.7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.6.3-py39h2983639_0.conda"
+    hash:
+      md5: 9e1496189564d3740c20d3aff999a0ee
+      sha256: 4b51e606ad1e698820d72a247f12eb0c2858e52c87b7b51530f0f386a5672b4b
+    optional: false
+    category: main
+  - name: matplotlib-base
+    version: 3.6.3
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      certifi: ">=2020.6.20"
+      contourpy: ">=1.0.1"
+      cycler: ">=0.10"
+      fonttools: ">=4.22.0"
+      freetype: ">=2.12.1,<3.0a0"
+      kiwisolver: ">=1.0.1"
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      numpy: ">=1.20.3,<2.0a0"
+      packaging: ">=20.0"
+      pillow: ">=6.2.0"
+      pyparsing: ">=2.3.1"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python-dateutil: ">=2.7"
+      python_abi: 3.9.* *_cp39
+      tk: ">=8.6.12,<8.7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/matplotlib-base-3.6.3-py39h5497c37_0.conda"
+    hash:
+      md5: 269461bf8080174eb1efc68961abc45a
+      sha256: f439e829ea1775ad93638858597b435aed3d36aaa4b06e93197334272c900e99
+    optional: false
+    category: main
+  - name: matplotlib-base
+    version: 3.6.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=10.12"
+      certifi: ">=2020.6.20"
+      contourpy: ">=1.0.1"
+      cycler: ">=0.10"
+      fonttools: ">=4.22.0"
+      freetype: ">=2.12.1,<3.0a0"
+      kiwisolver: ">=1.0.1"
+      libcxx: ">=14.0.6"
+      numpy: ">=1.20.3,<2.0a0"
+      packaging: ">=20.0"
+      pillow: ">=6.2.0"
+      pyparsing: ">=2.3.1"
+      python: ">=3.9,<3.10.0a0"
+      python-dateutil: ">=2.7"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.6.3-py39hb2f573b_0.conda"
+    hash:
+      md5: 2852034caacfeaa91d7258c5712887e2
+      sha256: cbf4ca345fbce7bdebbdfc9175f9969af4bb6afb97f73450bf81b90d63389dda
+    optional: false
+    category: main
+  - name: matplotlib-base
+    version: 3.6.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      certifi: ">=2020.6.20"
+      contourpy: ">=1.0.1"
+      cycler: ">=0.10"
+      fonttools: ">=4.22.0"
+      freetype: ">=2.12.1,<3.0a0"
+      kiwisolver: ">=1.0.1"
+      libcxx: ">=14.0.6"
+      numpy: ">=1.20.3,<2.0a0"
+      packaging: ">=20.0"
+      pillow: ">=6.2.0"
+      pyparsing: ">=2.3.1"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python-dateutil: ">=2.7"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.6.3-py39h35e9e80_0.conda"
+    hash:
+      md5: 6699bbc7c73575331a5dc91f83fffc47
+      sha256: 3df1794307e98ed49b8c3f8ca14c87b220b79ed56e4fcb7c74b0604ef35b36e0
+    optional: false
+    category: main
+  - name: matplotlib-inline
+    version: 0.1.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+      traitlets: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: b21613793fcc81d944c76c9f2864a7de
+      sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+    optional: false
+    category: main
+  - name: matplotlib-inline
+    version: 0.1.6
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+      traitlets: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: b21613793fcc81d944c76c9f2864a7de
+      sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+    optional: false
+    category: main
+  - name: matplotlib-inline
+    version: 0.1.6
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+      traitlets: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: b21613793fcc81d944c76c9f2864a7de
+      sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+    optional: false
+    category: main
+  - name: matplotlib-inline
+    version: 0.1.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+      traitlets: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: b21613793fcc81d944c76c9f2864a7de
+      sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+    optional: false
+    category: main
+  - name: matplotlib-inline
+    version: 0.1.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+      traitlets: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: b21613793fcc81d944c76c9f2864a7de
+      sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
+    optional: false
+    category: main
+  - name: meson
+    version: 1.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      ninja: ">=1.8.2"
+      python: ">=3.5.2"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/meson-1.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 4de573313958b8da6c526fdd354fffc8
+      sha256: 57dc7634aa05f3944314e6b56b2f37e6fb1a52b33de9ca153aee5d9adf83a5d7
+    optional: false
+    category: main
+  - name: meson
+    version: 1.0.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      ninja: ">=1.8.2"
+      python: ">=3.5.2"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/meson-1.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 4de573313958b8da6c526fdd354fffc8
+      sha256: 57dc7634aa05f3944314e6b56b2f37e6fb1a52b33de9ca153aee5d9adf83a5d7
+    optional: false
+    category: main
+  - name: meson
+    version: 1.0.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      ninja: ">=1.8.2"
+      python: ">=3.5.2"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/meson-1.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 4de573313958b8da6c526fdd354fffc8
+      sha256: 57dc7634aa05f3944314e6b56b2f37e6fb1a52b33de9ca153aee5d9adf83a5d7
+    optional: false
+    category: main
+  - name: meson
+    version: 1.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      ninja: ">=1.8.2"
+      python: ">=3.5.2"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/meson-1.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 4de573313958b8da6c526fdd354fffc8
+      sha256: 57dc7634aa05f3944314e6b56b2f37e6fb1a52b33de9ca153aee5d9adf83a5d7
+    optional: false
+    category: main
+  - name: meson
+    version: 1.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      ninja: ">=1.8.2"
+      python: ">=3.5.2"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/meson-1.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 4de573313958b8da6c526fdd354fffc8
+      sha256: 57dc7634aa05f3944314e6b56b2f37e6fb1a52b33de9ca153aee5d9adf83a5d7
+    optional: false
+    category: main
   - name: meson-python
     version: 0.12.0
     manager: conda
@@ -3168,6 +7392,1024 @@ package:
     hash:
       md5: dc566efe9c7af4eb305402b5c6121ca3
       sha256: 2ea6e9b843e7d93283f2bd442f20bc973cf8141ef1876c9fe4353e473265a4da
+    optional: false
+    category: main
+  - name: meson-python
+    version: 0.12.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      colorama: "*"
+      meson: ">=0.63.3"
+      ninja: "*"
+      pyproject-metadata: ">=0.6.1"
+      python: ">=3.7"
+      tomli: ">=1.0.0"
+      typing-extensions: ">=3.7.4"
+      wheel: ">=0.36.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/meson-python-0.12.0-pyh71feb2d_0.conda"
+    hash:
+      md5: dc566efe9c7af4eb305402b5c6121ca3
+      sha256: 2ea6e9b843e7d93283f2bd442f20bc973cf8141ef1876c9fe4353e473265a4da
+    optional: false
+    category: main
+  - name: meson-python
+    version: 0.12.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      colorama: "*"
+      meson: ">=0.63.3"
+      ninja: "*"
+      pyproject-metadata: ">=0.6.1"
+      python: ">=3.7"
+      tomli: ">=1.0.0"
+      typing-extensions: ">=3.7.4"
+      wheel: ">=0.36.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/meson-python-0.12.0-pyh71feb2d_0.conda"
+    hash:
+      md5: dc566efe9c7af4eb305402b5c6121ca3
+      sha256: 2ea6e9b843e7d93283f2bd442f20bc973cf8141ef1876c9fe4353e473265a4da
+    optional: false
+    category: main
+  - name: meson-python
+    version: 0.12.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      colorama: "*"
+      meson: ">=0.63.3"
+      ninja: "*"
+      pyproject-metadata: ">=0.6.1"
+      python: ">=3.7"
+      tomli: ">=1.0.0"
+      typing-extensions: ">=3.7.4"
+      wheel: ">=0.36.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/meson-python-0.12.0-pyh71feb2d_0.conda"
+    hash:
+      md5: dc566efe9c7af4eb305402b5c6121ca3
+      sha256: 2ea6e9b843e7d93283f2bd442f20bc973cf8141ef1876c9fe4353e473265a4da
+    optional: false
+    category: main
+  - name: meson-python
+    version: 0.12.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      colorama: "*"
+      meson: ">=0.63.3"
+      ninja: "*"
+      pyproject-metadata: ">=0.6.1"
+      python: ">=3.7"
+      tomli: ">=1.0.0"
+      typing-extensions: ">=3.7.4"
+      wheel: ">=0.36.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/meson-python-0.12.0-pyh71feb2d_0.conda"
+    hash:
+      md5: dc566efe9c7af4eb305402b5c6121ca3
+      sha256: 2ea6e9b843e7d93283f2bd442f20bc973cf8141ef1876c9fe4353e473265a4da
+    optional: false
+    category: main
+  - name: mpc
+    version: 1.3.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      gmp: ">=6.2.1,<7.0a0"
+      mpfr: ">=4.1.0,<5.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h81bd1dd_0.conda"
+    hash:
+      md5: c752c0eb6c250919559172c011e5f65b
+      sha256: 2ae945a15c8a984d581dcfb974ad3b5d877a6527de2c95a3363e6b4490b2f312
+    optional: false
+    category: main
+  - name: mpc
+    version: 1.3.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      gmp: ">=6.2.1,<7.0a0"
+      mpfr: ">=4.1.0,<5.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h91ba8db_0.conda"
+    hash:
+      md5: 362af269d860ae49580f8f032a68b0df
+      sha256: 6d8d4f8befca279f022c1c212241ad6672cb347181452555414e277484ad534c
+    optional: false
+    category: main
+  - name: mpfr
+    version: 4.1.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      gmp: ">=6.2.1,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.1.0-h0f52abe_1.tar.bz2"
+    hash:
+      md5: afe26b08c2d2265b4d663d199000e5da
+      sha256: 68e2d7c06f438f7179b9b0c6f826a33a29c6580233a1e60fa71d4da260d70b8f
+    optional: false
+    category: main
+  - name: mpfr
+    version: 4.1.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      gmp: ">=6.2.0,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.1.0-h6d7a090_1.tar.bz2"
+    hash:
+      md5: c37f296f76cfb61d4f91613da93789e6
+      sha256: bf44598be1fe9f6310ac0ebcd91dd6b51d4d19fe085c96b4da8297f2fc868f86
+    optional: false
+    category: main
+  - name: mpg123
+    version: 1.31.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.31.2-hcb278e6_0.conda"
+    hash:
+      md5: 08efb1e1813f1a151b7a945b972a049b
+      sha256: cc8cb2097e96d2420dd698951ab524b6c8268fa691d370020a0eae3e65197c04
+    optional: false
+    category: main
+  - name: munkres
+    version: 1.1.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 2ba8498c1018c1e9c61eb99b973dfe19
+      sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+    optional: false
+    category: main
+  - name: munkres
+    version: 1.1.4
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 2ba8498c1018c1e9c61eb99b973dfe19
+      sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+    optional: false
+    category: main
+  - name: munkres
+    version: 1.1.4
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 2ba8498c1018c1e9c61eb99b973dfe19
+      sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+    optional: false
+    category: main
+  - name: munkres
+    version: 1.1.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 2ba8498c1018c1e9c61eb99b973dfe19
+      sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+    optional: false
+    category: main
+  - name: munkres
+    version: 1.1.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2"
+    hash:
+      md5: 2ba8498c1018c1e9c61eb99b973dfe19
+      sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
+    optional: false
+    category: main
+  - name: mypy
+    version: "0.981"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      mypy_extensions: ">=0.4.3"
+      psutil: ">=4.0"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      tomli: ">=1.1.0"
+      typing_extensions: ">=3.10"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/mypy-0.981-py39hb9d737c_0.tar.bz2"
+    hash:
+      md5: 726060f54d0a1ae07577a34dda31a868
+      sha256: 0cbf2e4018d7694517268c258a7b53b73c4c3a57490352a0792e08b96d8b637f
+    optional: false
+    category: main
+  - name: mypy
+    version: "0.981"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      mypy_extensions: ">=0.4.3"
+      psutil: ">=4.0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+      tomli: ">=1.1.0"
+      typing_extensions: ">=3.10"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/mypy-0.981-py39h0fd3b05_0.tar.bz2"
+    hash:
+      md5: 356d846032061ddec0beb97de9fb4570
+      sha256: ca216a2d2022060c3a51fe3bb9b73e250797da3c874bd766f3e4b4223f362495
+    optional: false
+    category: main
+  - name: mypy
+    version: "0.981"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      mypy_extensions: ">=0.4.3"
+      psutil: ">=4.0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+      tomli: ">=1.1.0"
+      typing_extensions: ">=3.10"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/mypy-0.981-py39h98ec90c_0.tar.bz2"
+    hash:
+      md5: 456fb0f78d0244ff31c8095cc042e0d4
+      sha256: d0c049919ecf4642373a1447cfb8c2f056e59bbe0df4c11051b1a5e53f27d9e7
+    optional: false
+    category: main
+  - name: mypy
+    version: "0.981"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      mypy_extensions: ">=0.4.3"
+      psutil: ">=4.0"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      tomli: ">=1.1.0"
+      typing_extensions: ">=3.10"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/mypy-0.981-py39ha30fb19_0.tar.bz2"
+    hash:
+      md5: b6580642702195bf97ea22c5913a82b9
+      sha256: df7bdee4a6f7376bccfede1570bd3338011137d4ba63520b90b56e642ee5f782
+    optional: false
+    category: main
+  - name: mypy
+    version: "0.981"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      mypy_extensions: ">=0.4.3"
+      psutil: ">=4.0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+      tomli: ">=1.1.0"
+      typing_extensions: ">=3.10"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/mypy-0.981-py39h02fc5c5_0.tar.bz2"
+    hash:
+      md5: c9d491f73cc761dcd0f12de0b40c83c5
+      sha256: b5537747d9947a0d868d1b814ddc536b9392d4697587d111113c2b685204d524
+    optional: false
+    category: main
+  - name: mypy_extensions
+    version: 1.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda"
+    hash:
+      md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+      sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+    optional: false
+    category: main
+  - name: mypy_extensions
+    version: 1.0.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda"
+    hash:
+      md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+      sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+    optional: false
+    category: main
+  - name: mypy_extensions
+    version: 1.0.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda"
+    hash:
+      md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+      sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+    optional: false
+    category: main
+  - name: mypy_extensions
+    version: 1.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda"
+    hash:
+      md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+      sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+    optional: false
+    category: main
+  - name: mypy_extensions
+    version: 1.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda"
+    hash:
+      md5: 4eccaeba205f0aed9ac3a9ea58568ca3
+      sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
+    optional: false
+    category: main
+  - name: mysql-common
+    version: 8.0.32
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      openssl: ">=3.0.7,<4.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.32-ha901b37_0.conda"
+    hash:
+      md5: 6a39818710235826181e104aada40c75
+      sha256: d7da5c1cc47656394933146ab30f6f3433553e8265ea1a4254bce441ab678199
+    optional: false
+    category: main
+  - name: mysql-libs
+    version: 8.0.32
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      mysql-common: "==8.0.32 ha901b37_0"
+      openssl: ">=3.0.7,<4.0a0"
+      zstd: ">=1.5.2,<1.6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.32-hd7da12d_0.conda"
+    hash:
+      md5: b05d7ea8b76f1172d5fe4f30e03277ea
+      sha256: 903174761ce605d98410747e0072757da5278d57309148ef175af490aa791f38
+    optional: false
+    category: main
+  - name: ncurses
+    version: "6.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=10.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.3-h27087fc_1.tar.bz2"
+    hash:
+      md5: 4acfc691e64342b9dae57cf2adc63238
+      sha256: b801e8cf4b2c9a30bce5616746c6c2a4e36427f045b46d9fc08a4ed40a9f7065
+    optional: false
+    category: main
+  - name: ncurses
+    version: "6.3"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=10.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.3-headf329_1.tar.bz2"
+    hash:
+      md5: 486b68148e121bc8bbadc3cefae4c04f
+      sha256: d410d840cb39175d7edc388690b93b2e3d7613c2e2f5c64b96582dc8b55b2319
+    optional: false
+    category: main
+  - name: ncurses
+    version: "6.3"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=10.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ncurses-6.3-hab78ccb_1.tar.bz2"
+    hash:
+      md5: 775403ae6d617d309d874f9bff20e670
+      sha256: 37761927f381de5741d7f176dddc1c3b60876f44db10f7d636ad1133381d1a94
+    optional: false
+    category: main
+  - name: ncurses
+    version: "6.3"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.3-h96cf925_1.tar.bz2"
+    hash:
+      md5: 76217ebfbb163ff2770a261f955a5861
+      sha256: 9794a23d03586c99cac49d4ae3d5337faaa6bfc256b31d2662ff4ad5972be143
+    optional: false
+    category: main
+  - name: ncurses
+    version: "6.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.3-h07bb92c_1.tar.bz2"
+    hash:
+      md5: db86e5a978380a13f5559f97afdfe99d
+      sha256: 50ba7c13dd7d05569e7caa98a13a3684450f8547b4965a1e86b54e2f1240debe
+    optional: false
+    category: main
+  - name: ninja
+    version: 1.11.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=10.3.0"
+      libstdcxx-ng: ">=10.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.0-h924138e_0.tar.bz2"
+    hash:
+      md5: 18c563c26253a21c1aa9d662e874b0cd
+      sha256: 1d3659abc4e3dfa9c8c03a664f6d0323503b75a4506fb9d28f28448be5540fc5
+    optional: false
+    category: main
+  - name: ninja
+    version: 1.11.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=10.3.0"
+      libstdcxx-ng: ">=10.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.11.0-hdd96247_0.tar.bz2"
+    hash:
+      md5: 836cf12c1e2acba999080766059b20ad
+      sha256: 56123a84b506452186a1604597f424e3bf366e71fceec113e6292a73bafa2d7e
+    optional: false
+    category: main
+  - name: ninja
+    version: 1.11.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=10.3.0"
+      libstdcxx-ng: ">=10.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ninja-1.11.0-h06f31f1_0.tar.bz2"
+    hash:
+      md5: 75122717f0e5f294b581a9d7e93b7bb9
+      sha256: fa399deab6926f00c01fb49e3095b341ae53edfa940258b96d65a390a27d4691
+    optional: false
+    category: main
+  - name: ninja
+    version: 1.11.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=13.0.1"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.0-h1b54a9f_0.tar.bz2"
+    hash:
+      md5: 02e4d7a0d1cda051ddf5e83725c4b2a6
+      sha256: c7c7de719893c28b3e35fd3afa2ca7f6bf03022df5cf2398e1806c881ce41775
+    optional: false
+    category: main
+  - name: ninja
+    version: 1.11.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=13.0.1"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.0-hf86a087_0.tar.bz2"
+    hash:
+      md5: 1544c2828bb4b2a55997cd77627720ea
+      sha256: fe04151afa66d9bce6025066201692929aa195fe77fc62505f9b183720de03cb
+    optional: false
+    category: main
+  - name: nomkl
+    version: "1.0"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2"
+    hash:
+      md5: 9a66894dfd07c4510beb6b3f9672ccc0
+      sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
+    optional: false
+    category: main
+  - name: nomkl
+    version: "1.0"
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2"
+    hash:
+      md5: 9a66894dfd07c4510beb6b3f9672ccc0
+      sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
+    optional: false
+    category: main
+  - name: nomkl
+    version: "1.0"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2"
+    hash:
+      md5: 9a66894dfd07c4510beb6b3f9672ccc0
+      sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
+    optional: false
+    category: main
+  - name: nomkl
+    version: "1.0"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2"
+    hash:
+      md5: 9a66894dfd07c4510beb6b3f9672ccc0
+      sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
+    optional: false
+    category: main
+  - name: nomkl
+    version: "1.0"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2"
+    hash:
+      md5: 9a66894dfd07c4510beb6b3f9672ccc0
+      sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
+    optional: false
+    category: main
+  - name: nspr
+    version: "4.35"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda"
+    hash:
+      md5: da0ec11a6454ae19bff5b02ed881a2b1
+      sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
+    optional: false
+    category: main
+  - name: nss
+    version: "3.88"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc-ng: ">=12"
+      libsqlite: ">=3.40.0,<4.0a0"
+      libstdcxx-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      nspr: ">=4.35,<5.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/nss-3.88-he45b914_0.conda"
+    hash:
+      md5: d7a81dfb99ad8fbb88872fb7ec646e6c
+      sha256: a589e916119db06742da1307c3438a5c733cf01006470158c7aae8f2859f6e90
+    optional: false
+    category: main
+  - name: numpy
+    version: 1.24.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libblas: ">=3.9.0,<4.0a0"
+      libcblas: ">=3.9.0,<4.0a0"
+      libgcc-ng: ">=12"
+      liblapack: ">=3.9.0,<4.0a0"
+      libstdcxx-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/numpy-1.24.2-py39h7360e5f_0.conda"
+    hash:
+      md5: 757070dc7cc33003254888808cd34f1e
+      sha256: c0418aa18f4fd37d3ac786058bfa29cca0b5b8eca95a2e0ae2fdd13aefc81ad6
+    optional: false
+    category: main
+  - name: numpy
+    version: 1.24.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libblas: ">=3.9.0,<4.0a0"
+      libcblas: ">=3.9.0,<4.0a0"
+      libgcc-ng: ">=12"
+      liblapack: ">=3.9.0,<4.0a0"
+      libstdcxx-ng: ">=12"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.24.2-py39hafab3e7_0.conda"
+    hash:
+      md5: e8d27fa9b6e02d6fba071d9c555d7962
+      sha256: 9e527264dc80f537796e72c408f335de71842a00b8cad5abfd4d1f9150b2bca9
+    optional: false
+    category: main
+  - name: numpy
+    version: 1.24.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libblas: ">=3.9.0,<4.0a0"
+      libcblas: ">=3.9.0,<4.0a0"
+      libgcc-ng: ">=12"
+      liblapack: ">=3.9.0,<4.0a0"
+      libstdcxx-ng: ">=12"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/numpy-1.24.2-py39h27d966d_0.conda"
+    hash:
+      md5: 01161f20e96598201f9a9360b4b5f39e
+      sha256: 16dd1b6975ca3eda91d53b5d1e72f8b0297c3765fc53d156697d29150926a614
+    optional: false
+    category: main
+  - name: numpy
+    version: 1.24.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libblas: ">=3.9.0,<4.0a0"
+      libcblas: ">=3.9.0,<4.0a0"
+      libcxx: ">=14.0.6"
+      liblapack: ">=3.9.0,<4.0a0"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/numpy-1.24.2-py39h6ee2318_0.conda"
+    hash:
+      md5: 9b49051072af22354aee82b524f808ff
+      sha256: 6c4acf04c482a33b7c4a1661ed50c6927f683418b9b61b29f16711f77480485e
+    optional: false
+    category: main
+  - name: numpy
+    version: 1.24.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libblas: ">=3.9.0,<4.0a0"
+      libcblas: ">=3.9.0,<4.0a0"
+      libcxx: ">=14.0.6"
+      liblapack: ">=3.9.0,<4.0a0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.24.2-py39hff61c6a_0.conda"
+    hash:
+      md5: 894fca4ee0ea0bfef6ebca15d6d8196e
+      sha256: 6c0ed2591695627ff4789d14def1868afa43395c7af0db4c97878a6abc27e5e5
+    optional: false
+    category: main
+  - name: numpydoc
+    version: 1.4.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      jinja2: ">=2.10"
+      python: ">=3.7"
+      sphinx: ">=1.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.4.0-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: 0aac89c61a466b0f9c4fd0ec44d81f1d
+      sha256: 11a892cc1678a23d169909e553447fb7e312d6baaa314fdcd719f6abff1c7da6
+    optional: false
+    category: main
+  - name: numpydoc
+    version: 1.4.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      jinja2: ">=2.10"
+      python: ">=3.7"
+      sphinx: ">=1.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.4.0-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: 0aac89c61a466b0f9c4fd0ec44d81f1d
+      sha256: 11a892cc1678a23d169909e553447fb7e312d6baaa314fdcd719f6abff1c7da6
+    optional: false
+    category: main
+  - name: numpydoc
+    version: 1.4.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      jinja2: ">=2.10"
+      python: ">=3.7"
+      sphinx: ">=1.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.4.0-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: 0aac89c61a466b0f9c4fd0ec44d81f1d
+      sha256: 11a892cc1678a23d169909e553447fb7e312d6baaa314fdcd719f6abff1c7da6
+    optional: false
+    category: main
+  - name: numpydoc
+    version: 1.4.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      jinja2: ">=2.10"
+      python: ">=3.7"
+      sphinx: ">=1.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.4.0-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: 0aac89c61a466b0f9c4fd0ec44d81f1d
+      sha256: 11a892cc1678a23d169909e553447fb7e312d6baaa314fdcd719f6abff1c7da6
+    optional: false
+    category: main
+  - name: numpydoc
+    version: 1.4.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      jinja2: ">=2.10"
+      python: ">=3.7"
+      sphinx: ">=1.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.4.0-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: 0aac89c61a466b0f9c4fd0ec44d81f1d
+      sha256: 11a892cc1678a23d169909e553447fb7e312d6baaa314fdcd719f6abff1c7da6
+    optional: false
+    category: main
+  - name: openblas
+    version: 0.3.21
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libgfortran-ng: "*"
+      libgfortran5: ">=10.4.0"
+      libopenblas: "==0.3.21 pthreads_h78a6416_3"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/openblas-0.3.21-pthreads_h320a7e8_3.tar.bz2"
+    hash:
+      md5: 29155b9196b9d78022f11d86733e25a7
+      sha256: b9986da11c136f4171ce94df6fe5940b529f38b9f13f2746817913071aa51151
+    optional: false
+    category: main
+  - name: openblas
+    version: 0.3.21
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libgfortran-ng: "*"
+      libgfortran5: ">=10.4.0"
+      libopenblas: "==0.3.21 pthreads_h6cb6f83_3"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/openblas-0.3.21-pthreads_h2d9dd7e_3.tar.bz2"
+    hash:
+      md5: 17a824cf9bbf0e31998d2c1a2140204c
+      sha256: b782a114740e74a42e8ac77e57de4ed6d35aad30ec6a07106826e1a1e3d0c274
+    optional: false
+    category: main
+  - name: openblas
+    version: 0.3.21
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libgfortran-ng: "*"
+      libgfortran5: ">=10.4.0"
+      libopenblas: "==0.3.21 pthreads_h60f2977_3"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/openblas-0.3.21-pthreads_h5960496_3.tar.bz2"
+    hash:
+      md5: cd3637b6090fb6415c0abd53feb35c71
+      sha256: 0e4f4656d5a0f582013bb41313eed5bb64ef4f79ff1d127b2926a6356ae0c64b
+    optional: false
+    category: main
+  - name: openblas
+    version: 0.3.21
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libgfortran: 5.*
+      libgfortran5: ">=11.3.0"
+      libopenblas: "==0.3.21 openmp_h429af6e_3"
+      llvm-openmp: ">=14.0.4"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/openblas-0.3.21-openmp_hbefa662_3.tar.bz2"
+    hash:
+      md5: f0ad8b67cf731e7e375e497305d7cee5
+      sha256: 8aaf3165d6b443c48f3a1b2b34330c361801d04ac668d43be5475472c6a4e25f
+    optional: false
+    category: main
+  - name: openblas
+    version: 0.3.21
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libgfortran: 5.*
+      libgfortran5: ">=11.3.0"
+      libopenblas: "==0.3.21 openmp_hc731615_3"
+      llvm-openmp: ">=14.0.4"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/openblas-0.3.21-openmp_hf78f355_3.tar.bz2"
+    hash:
+      md5: ff5b9fccd5f48f6d1b14c9e3859417b9
+      sha256: 536b88e3a11a6d075a182506d969b98efee9d7481caf7daf9bc11ed33cdcbf0f
+    optional: false
+    category: main
+  - name: openjpeg
+    version: 2.5.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libpng: ">=1.6.39,<1.7.0a0"
+      libstdcxx-ng: ">=12"
+      libtiff: ">=4.5.0,<4.6.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-hfec8fc6_2.conda"
+    hash:
+      md5: 5ce6a42505c6e9e6151c54c3ec8d68ea
+      sha256: 3cbfb1fe9bb492dcb672f98f0ddc7b4e029f51f77101d9c301caa3acaea8cba2
+    optional: false
+    category: main
+  - name: openjpeg
+    version: 2.5.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libpng: ">=1.6.39,<1.7.0a0"
+      libstdcxx-ng: ">=12"
+      libtiff: ">=4.5.0,<4.6.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.0-h9508984_2.conda"
+    hash:
+      md5: 3d56d402a845c243f8c2dd3c8e836029
+      sha256: 6cb45c526e9577313081a7d020a278fbdfd91e6df14f42a327276ec1a29a5045
+    optional: false
+    category: main
+  - name: openjpeg
+    version: 2.5.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libpng: ">=1.6.39,<1.7.0a0"
+      libstdcxx-ng: ">=12"
+      libtiff: ">=4.5.0,<4.6.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/openjpeg-2.5.0-hbcaec15_2.conda"
+    hash:
+      md5: 6d3258c9f7aa73ef7534f6bcbfd493c1
+      sha256: 853ad1d97ce95219b41f3fb481dc2a562d83c6808008ff3b154f0452cb21a8ba
+    optional: false
+    category: main
+  - name: openjpeg
+    version: 2.5.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=14.0.6"
+      libpng: ">=1.6.39,<1.7.0a0"
+      libtiff: ">=4.5.0,<4.6.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-h13ac156_2.conda"
+    hash:
+      md5: 299a29af9ac9f550ad459d655739280b
+      sha256: 2375eafbd5241d8249fb467e2a8e190646e8798c33059c72efa60f197cdf4944
+    optional: false
+    category: main
+  - name: openjpeg
+    version: 2.5.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=14.0.6"
+      libpng: ">=1.6.39,<1.7.0a0"
+      libtiff: ">=4.5.0,<4.6.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-hbc2ba62_2.conda"
+    hash:
+      md5: c3e184f0810a4614863569488b1ac709
+      sha256: 2bb159e385e633a08cc164f50b4e39fa465b85f54c376a5c20aa15f57ef407b3
+    optional: false
+    category: main
+  - name: openssl
+    version: 3.0.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      ca-certificates: "*"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/openssl-3.0.8-h0b41bf4_0.conda"
+    hash:
+      md5: e043403cd18faf815bf7705ab6c1e092
+      sha256: cd981c5c18463bc7a164fcf45c5cf697d58852b780b4dfa5e83c18c1fda6d7cd
+    optional: false
+    category: main
+  - name: openssl
+    version: 3.0.8
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      ca-certificates: "*"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.0.8-hb4cce97_0.conda"
+    hash:
+      md5: 268fe30a14a3f40fe54da04fc053fd2d
+      sha256: 19d10fdaee08ab2b5506cdce4399922c5c7d012be7ca7ca93c521748bade3e90
+    optional: false
+    category: main
+  - name: openssl
+    version: 3.0.8
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      ca-certificates: "*"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/openssl-3.0.8-h4194056_0.conda"
+    hash:
+      md5: e952dfc7249a48558697f61b41859864
+      sha256: 62200f7fa9acb5d9cee24b373695e78ef1d7373bdfd77a50b80e57864b536436
+    optional: false
+    category: main
+  - name: openssl
+    version: 3.0.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      ca-certificates: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/openssl-3.0.8-hfd90126_0.conda"
+    hash:
+      md5: 4239d01834a13512079046ea216b6657
+      sha256: 750ebd464414b7c4ea5aaa704788f7238a356c0a54ce76b018af246cdb65bf08
+    optional: false
+    category: main
+  - name: openssl
+    version: 3.0.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      ca-certificates: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.0.8-h03a7124_0.conda"
+    hash:
+      md5: accdc6784b8ae5dd618a9e76f4c3af36
+      sha256: 6d58b0412c4c27669da02368a303f4c4abc1b0edda5f27b2f8155299ab2b45a5
+    optional: false
+    category: main
+  - name: packaging
+    version: "23.0"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/packaging-23.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 1ff2e3ca41f0ce16afec7190db28288b
+      sha256: 00288f5e5e841711e8b8fef1f1242c858d8ef99ccbe5d7e0df4789d5d8d40645
+    optional: false
+    category: main
+  - name: packaging
+    version: "23.0"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/packaging-23.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 1ff2e3ca41f0ce16afec7190db28288b
+      sha256: 00288f5e5e841711e8b8fef1f1242c858d8ef99ccbe5d7e0df4789d5d8d40645
+    optional: false
+    category: main
+  - name: packaging
+    version: "23.0"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/packaging-23.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 1ff2e3ca41f0ce16afec7190db28288b
+      sha256: 00288f5e5e841711e8b8fef1f1242c858d8ef99ccbe5d7e0df4789d5d8d40645
+    optional: false
+    category: main
+  - name: packaging
+    version: "23.0"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/packaging-23.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 1ff2e3ca41f0ce16afec7190db28288b
+      sha256: 00288f5e5e841711e8b8fef1f1242c858d8ef99ccbe5d7e0df4789d5d8d40645
+    optional: false
+    category: main
+  - name: packaging
+    version: "23.0"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/packaging-23.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 1ff2e3ca41f0ce16afec7190db28288b
+      sha256: 00288f5e5e841711e8b8fef1f1242c858d8ef99ccbe5d7e0df4789d5d8d40645
     optional: false
     category: main
   - name: pandas
@@ -3188,6 +8430,1499 @@ package:
       sha256: a71fb9584f2b58e260fa565d5f27af763f21ed2afeede79e7d848620691bd765
     optional: false
     category: main
+  - name: pandas
+    version: 1.5.3
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      numpy: ">=1.20.3,<2.0a0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python-dateutil: ">=2.8.1"
+      python_abi: 3.9.* *_cp39
+      pytz: ">=2020.1"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-1.5.3-py39h1e1c27f_0.conda"
+    hash:
+      md5: 13b3d2c17a216d189837df6a2caefb5d
+      sha256: eeece380a252712eaebbcc12d73abbe7542ff3e25b560afac0f1766f9a1b854b
+    optional: false
+    category: main
+  - name: pandas
+    version: 1.5.3
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      numpy: ">=1.20.3,<2.0a0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python-dateutil: ">=2.8.1"
+      python_abi: 3.9.* *_cp39
+      pytz: ">=2020.1"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/pandas-1.5.3-py39h3cc8c3b_0.conda"
+    hash:
+      md5: e158babd99fc5079be0d87e52cef7466
+      sha256: 2c61728511be17f464b673d48713a26703a64ca4a6ad402465a2d805c1ad3089
+    optional: false
+    category: main
+  - name: pandas
+    version: 1.5.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=14.0.6"
+      numpy: ">=1.20.3,<2.0a0"
+      python: ">=3.9,<3.10.0a0"
+      python-dateutil: ">=2.8.1"
+      python_abi: 3.9.* *_cp39
+      pytz: ">=2020.1"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/pandas-1.5.3-py39hecff1ad_0.conda"
+    hash:
+      md5: e7d2a20902a36eea13dea9b0021fbfb4
+      sha256: 2fcd5f5ad098fe73089c3d5970f155df75c329cffbdf08c3ad52b2515224fe6a
+    optional: false
+    category: main
+  - name: pandas
+    version: 1.5.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=14.0.6"
+      numpy: ">=1.20.3,<2.0a0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python-dateutil: ">=2.8.1"
+      python_abi: 3.9.* *_cp39
+      pytz: ">=2020.1"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/pandas-1.5.3-py39hde7b980_0.conda"
+    hash:
+      md5: 694bdfe194977ddb7588e05f57ce295c
+      sha256: 1906573ea1ab24667c120984c840b9550a2fab8eba699ae659a49824661fc30c
+    optional: false
+    category: main
+  - name: parso
+    version: 0.8.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 17a565a0c3899244e938cdf417e7b094
+      sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+    optional: false
+    category: main
+  - name: parso
+    version: 0.8.3
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 17a565a0c3899244e938cdf417e7b094
+      sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+    optional: false
+    category: main
+  - name: parso
+    version: 0.8.3
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 17a565a0c3899244e938cdf417e7b094
+      sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+    optional: false
+    category: main
+  - name: parso
+    version: 0.8.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 17a565a0c3899244e938cdf417e7b094
+      sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+    optional: false
+    category: main
+  - name: parso
+    version: 0.8.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 17a565a0c3899244e938cdf417e7b094
+      sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+    optional: false
+    category: main
+  - name: pcre2
+    version: "10.40"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      bzip2: ">=1.0.8,<2.0a0"
+      libgcc-ng: ">=12"
+      libzlib: ">=1.2.12,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2"
+    hash:
+      md5: 69e2c796349cd9b273890bee0febfe1b
+      sha256: 7a29ec847556eed4faa1646010baae371ced69059a4ade43851367a076d6108a
+    optional: false
+    category: main
+  - name: pcre2
+    version: "10.40"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      bzip2: ">=1.0.8,<2.0a0"
+      libzlib: ">=1.2.12,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.40-hb34f9b4_0.tar.bz2"
+    hash:
+      md5: 721b7288270bafc83586b0f01c2a67f2
+      sha256: 93503b5e05470ccc87f696c0fdf0d47938e0305b5047eacb85c15d78dcf641fe
+    optional: false
+    category: main
+  - name: pexpect
+    version: 4.8.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      ptyprocess: ">=0.5"
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2"
+    hash:
+      md5: 330448ce4403cc74990ac07c555942a1
+      sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
+    optional: false
+    category: main
+  - name: pexpect
+    version: 4.8.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      ptyprocess: ">=0.5"
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2"
+    hash:
+      md5: 330448ce4403cc74990ac07c555942a1
+      sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
+    optional: false
+    category: main
+  - name: pexpect
+    version: 4.8.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      ptyprocess: ">=0.5"
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2"
+    hash:
+      md5: 330448ce4403cc74990ac07c555942a1
+      sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
+    optional: false
+    category: main
+  - name: pexpect
+    version: 4.8.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      ptyprocess: ">=0.5"
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2"
+    hash:
+      md5: 330448ce4403cc74990ac07c555942a1
+      sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
+    optional: false
+    category: main
+  - name: pexpect
+    version: 4.8.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      ptyprocess: ">=0.5"
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2"
+    hash:
+      md5: 330448ce4403cc74990ac07c555942a1
+      sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
+    optional: false
+    category: main
+  - name: pickleshare
+    version: 0.7.5
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2"
+    hash:
+      md5: 415f0ebb6198cc2801c73438a9fb5761
+      sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+    optional: false
+    category: main
+  - name: pickleshare
+    version: 0.7.5
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2"
+    hash:
+      md5: 415f0ebb6198cc2801c73438a9fb5761
+      sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+    optional: false
+    category: main
+  - name: pickleshare
+    version: 0.7.5
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2"
+    hash:
+      md5: 415f0ebb6198cc2801c73438a9fb5761
+      sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+    optional: false
+    category: main
+  - name: pickleshare
+    version: 0.7.5
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2"
+    hash:
+      md5: 415f0ebb6198cc2801c73438a9fb5761
+      sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+    optional: false
+    category: main
+  - name: pickleshare
+    version: 0.7.5
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2"
+    hash:
+      md5: 415f0ebb6198cc2801c73438a9fb5761
+      sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
+    optional: false
+    category: main
+  - name: pillow
+    version: 9.4.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      freetype: ">=2.12.1,<3.0a0"
+      jpeg: ">=9e,<10a"
+      lcms2: ">=2.14,<3.0a0"
+      libgcc-ng: ">=12"
+      libtiff: ">=4.5.0,<4.6.0a0"
+      libwebp-base: ">=1.2.4,<2.0a0"
+      libxcb: ">=1.13,<1.14.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      openjpeg: ">=2.5.0,<3.0a0"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      tk: ">=8.6.12,<8.7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/pillow-9.4.0-py39h2320bf1_1.conda"
+    hash:
+      md5: d2f79132b9c8e416058a4cd84ef27b3d
+      sha256: 77348588ae7cc8034b63e8a71b6695ba22761e1c531678e724cf06a12be3d1e2
+    optional: false
+    category: main
+  - name: pillow
+    version: 9.4.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      freetype: ">=2.12.1,<3.0a0"
+      jpeg: ">=9e,<10a"
+      lcms2: ">=2.14,<3.0a0"
+      libgcc-ng: ">=12"
+      libtiff: ">=4.5.0,<4.6.0a0"
+      libwebp-base: ">=1.2.4,<2.0a0"
+      libxcb: ">=1.13,<1.14.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      openjpeg: ">=2.5.0,<3.0a0"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      tk: ">=8.6.12,<8.7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-9.4.0-py39h72365ce_1.conda"
+    hash:
+      md5: 0cd1a724352e4916a84339500506f61e
+      sha256: f230a8e3bf559c49163b3adbd64075d3eef7274e98b97800662cb6678746847f
+    optional: false
+    category: main
+  - name: pillow
+    version: 9.4.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      freetype: ">=2.12.1,<3.0a0"
+      jpeg: ">=9e,<10a"
+      lcms2: ">=2.14,<3.0a0"
+      libgcc-ng: ">=12"
+      libtiff: ">=4.5.0,<4.6.0a0"
+      libwebp-base: ">=1.2.4,<2.0a0"
+      libxcb: ">=1.13,<1.14.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      openjpeg: ">=2.5.0,<3.0a0"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      tk: ">=8.6.12,<8.7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/pillow-9.4.0-py39h845a511_1.conda"
+    hash:
+      md5: c0534e2f92c834acc9d4e8205c418764
+      sha256: a24c5f4c66ee54f7fdf7d370a6102b3d47ecbd8d1e0df190ce128605703c9ede
+    optional: false
+    category: main
+  - name: pillow
+    version: 9.4.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      freetype: ">=2.12.1,<3.0a0"
+      jpeg: ">=9e,<10a"
+      lcms2: ">=2.14,<3.0a0"
+      libtiff: ">=4.5.0,<4.6.0a0"
+      libwebp-base: ">=1.2.4,<2.0a0"
+      libxcb: ">=1.13,<1.14.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      openjpeg: ">=2.5.0,<3.0a0"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      tk: ">=8.6.12,<8.7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/pillow-9.4.0-py39h7f5cd59_1.conda"
+    hash:
+      md5: d2f1bdaa85fd34020259533efeeb40bb
+      sha256: b7a6d9e50a212215f76666789b0e9c155756d90e27678b4a8720fc6825621648
+    optional: false
+    category: main
+  - name: pillow
+    version: 9.4.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      freetype: ">=2.12.1,<3.0a0"
+      jpeg: ">=9e,<10a"
+      lcms2: ">=2.14,<3.0a0"
+      libtiff: ">=4.5.0,<4.6.0a0"
+      libwebp-base: ">=1.2.4,<2.0a0"
+      libxcb: ">=1.13,<1.14.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      openjpeg: ">=2.5.0,<3.0a0"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+      tk: ">=8.6.12,<8.7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/pillow-9.4.0-py39h8bd98a6_1.conda"
+    hash:
+      md5: 90500f863712b55483294662f1f5f5f1
+      sha256: 3005f4fc32c370c380abc692c027a1391ab8248798153cb2eca62dfc569912f7
+    optional: false
+    category: main
+  - name: pip
+    version: "23.0"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+      setuptools: "*"
+      wheel: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 85b35999162ec95f9f999bac15279c02
+      sha256: bbffec284bd0e154363e845121f43007e7e64c80412ff13be21909be907b697d
+    optional: false
+    category: main
+  - name: pip
+    version: "23.0"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+      setuptools: "*"
+      wheel: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 85b35999162ec95f9f999bac15279c02
+      sha256: bbffec284bd0e154363e845121f43007e7e64c80412ff13be21909be907b697d
+    optional: false
+    category: main
+  - name: pip
+    version: "23.0"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+      setuptools: "*"
+      wheel: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 85b35999162ec95f9f999bac15279c02
+      sha256: bbffec284bd0e154363e845121f43007e7e64c80412ff13be21909be907b697d
+    optional: false
+    category: main
+  - name: pip
+    version: "23.0"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+      setuptools: "*"
+      wheel: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 85b35999162ec95f9f999bac15279c02
+      sha256: bbffec284bd0e154363e845121f43007e7e64c80412ff13be21909be907b697d
+    optional: false
+    category: main
+  - name: pip
+    version: "23.0"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+      setuptools: "*"
+      wheel: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 85b35999162ec95f9f999bac15279c02
+      sha256: bbffec284bd0e154363e845121f43007e7e64c80412ff13be21909be907b697d
+    optional: false
+    category: main
+  - name: pixman
+    version: 0.40.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=7.5.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/pixman-0.40.0-h36c2ea0_0.tar.bz2"
+    hash:
+      md5: 660e72c82f2e75a6b3fe6a6e75c79f19
+      sha256: 6a0630fff84b5a683af6185a6c67adc8bdfa2043047fcb251add0d352ef60e79
+    optional: false
+    category: main
+  - name: pkg-config
+    version: 0.29.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=7.5.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/pkg-config-0.29.2-h36c2ea0_1008.tar.bz2"
+    hash:
+      md5: fbef41ff6a4c8140c30057466a1cdd47
+      sha256: 8b35a077ceccdf6888f1e82bd3ea281175014aefdc2d4cf63d7a4c7e169c125c
+    optional: false
+    category: main
+  - name: pkg-config
+    version: 0.29.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=7.5.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hb9de7d4_1008.tar.bz2"
+    hash:
+      md5: 1d0a81d5da1378d9b989383556c20eac
+      sha256: 0d6af1ebd78e231281f570ad7ddd1e2789e485c94fba6b5cef4e8ad23ff7f3bf
+    optional: false
+    category: main
+  - name: pkg-config
+    version: 0.29.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=8.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/pkg-config-0.29.2-h339bb43_1008.tar.bz2"
+    hash:
+      md5: 473f492aa9dff1b35454c461ab1a823e
+      sha256: 0fb80b8894dd8914dd62fe5b096fcd7bb514bd3846d4d7c068ffc21411e73150
+    optional: false
+    category: main
+  - name: pkg-config
+    version: 0.29.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libiconv: ">=1.16,<2.0.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-ha3d46e9_1008.tar.bz2"
+    hash:
+      md5: 352bc6fb446a7ca608c61b33c1d5eb98
+      sha256: f60d1c03c7d10e8926e767981872fdd6002d2094925df598a53c58261524c151
+    optional: false
+    category: main
+  - name: pkg-config
+    version: 0.29.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libglib: ">=2.70.2,<3.0a0"
+      libiconv: ">=1.16,<2.0.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hab62308_1008.tar.bz2"
+    hash:
+      md5: 8d173d52214679033079d1b0582075aa
+      sha256: e59e69111709d097f9938e72ba19811ec1ef36aababdbed77bd7c767f15639e0
+    optional: false
+    category: main
+  - name: pluggy
+    version: 1.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2"
+    hash:
+      md5: 7d301a0d25f424d96175f810935f0da9
+      sha256: c25e1757e4e90638bb1e778aba3ee5f3c01fae9752e3c3929f9be7d367f6c7f3
+    optional: false
+    category: main
+  - name: pluggy
+    version: 1.0.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2"
+    hash:
+      md5: 7d301a0d25f424d96175f810935f0da9
+      sha256: c25e1757e4e90638bb1e778aba3ee5f3c01fae9752e3c3929f9be7d367f6c7f3
+    optional: false
+    category: main
+  - name: pluggy
+    version: 1.0.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2"
+    hash:
+      md5: 7d301a0d25f424d96175f810935f0da9
+      sha256: c25e1757e4e90638bb1e778aba3ee5f3c01fae9752e3c3929f9be7d367f6c7f3
+    optional: false
+    category: main
+  - name: pluggy
+    version: 1.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2"
+    hash:
+      md5: 7d301a0d25f424d96175f810935f0da9
+      sha256: c25e1757e4e90638bb1e778aba3ee5f3c01fae9752e3c3929f9be7d367f6c7f3
+    optional: false
+    category: main
+  - name: pluggy
+    version: 1.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2"
+    hash:
+      md5: 7d301a0d25f424d96175f810935f0da9
+      sha256: c25e1757e4e90638bb1e778aba3ee5f3c01fae9752e3c3929f9be7d367f6c7f3
+    optional: false
+    category: main
+  - name: ply
+    version: "3.11"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/ply-3.11-py_1.tar.bz2"
+    hash:
+      md5: 7205635cd71531943440fbfe3b6b5727
+      sha256: 2cd6fae8f9cbc806b7f828f006ae4a83c23fac917cacfd73c37ce322d4324e53
+    optional: false
+    category: main
+  - name: pooch
+    version: 1.6.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      appdirs: ">=1.3.0"
+      packaging: ">=20.0"
+      python: ">=3.6"
+      requests: ">=2.19.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pooch-1.6.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6429e1d1091c51f626b5dcfdd38bf429
+      sha256: 1f0548105de86fb2eb6fbb8d3d6cc2004079b8442d232258108687d6cc91eb73
+    optional: false
+    category: main
+  - name: pooch
+    version: 1.6.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      appdirs: ">=1.3.0"
+      packaging: ">=20.0"
+      python: ">=3.6"
+      requests: ">=2.19.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pooch-1.6.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6429e1d1091c51f626b5dcfdd38bf429
+      sha256: 1f0548105de86fb2eb6fbb8d3d6cc2004079b8442d232258108687d6cc91eb73
+    optional: false
+    category: main
+  - name: pooch
+    version: 1.6.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      appdirs: ">=1.3.0"
+      packaging: ">=20.0"
+      python: ">=3.6"
+      requests: ">=2.19.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pooch-1.6.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6429e1d1091c51f626b5dcfdd38bf429
+      sha256: 1f0548105de86fb2eb6fbb8d3d6cc2004079b8442d232258108687d6cc91eb73
+    optional: false
+    category: main
+  - name: pooch
+    version: 1.6.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      appdirs: ">=1.3.0"
+      packaging: ">=20.0"
+      python: ">=3.6"
+      requests: ">=2.19.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pooch-1.6.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6429e1d1091c51f626b5dcfdd38bf429
+      sha256: 1f0548105de86fb2eb6fbb8d3d6cc2004079b8442d232258108687d6cc91eb73
+    optional: false
+    category: main
+  - name: pooch
+    version: 1.6.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      appdirs: ">=1.3.0"
+      packaging: ">=20.0"
+      python: ">=3.6"
+      requests: ">=2.19.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pooch-1.6.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6429e1d1091c51f626b5dcfdd38bf429
+      sha256: 1f0548105de86fb2eb6fbb8d3d6cc2004079b8442d232258108687d6cc91eb73
+    optional: false
+    category: main
+  - name: prompt-toolkit
+    version: 3.0.36
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+      wcwidth: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda"
+    hash:
+      md5: 4d79ec192e0bfd530a254006d123b9a6
+      sha256: 6bd3626799c9467d7aa8ed5f95043e4cea614a1329580980ddcf40cfed3ee860
+    optional: false
+    category: main
+  - name: prompt-toolkit
+    version: 3.0.36
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+      wcwidth: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda"
+    hash:
+      md5: 4d79ec192e0bfd530a254006d123b9a6
+      sha256: 6bd3626799c9467d7aa8ed5f95043e4cea614a1329580980ddcf40cfed3ee860
+    optional: false
+    category: main
+  - name: prompt-toolkit
+    version: 3.0.36
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+      wcwidth: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda"
+    hash:
+      md5: 4d79ec192e0bfd530a254006d123b9a6
+      sha256: 6bd3626799c9467d7aa8ed5f95043e4cea614a1329580980ddcf40cfed3ee860
+    optional: false
+    category: main
+  - name: prompt-toolkit
+    version: 3.0.36
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+      wcwidth: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda"
+    hash:
+      md5: 4d79ec192e0bfd530a254006d123b9a6
+      sha256: 6bd3626799c9467d7aa8ed5f95043e4cea614a1329580980ddcf40cfed3ee860
+    optional: false
+    category: main
+  - name: prompt-toolkit
+    version: 3.0.36
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+      wcwidth: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda"
+    hash:
+      md5: 4d79ec192e0bfd530a254006d123b9a6
+      sha256: 6bd3626799c9467d7aa8ed5f95043e4cea614a1329580980ddcf40cfed3ee860
+    optional: false
+    category: main
+  - name: psutil
+    version: 5.9.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.4-py39hb9d737c_0.tar.bz2"
+    hash:
+      md5: 12184951da572828fb986b06ffb63eed
+      sha256: 515cf2cfc0504eb5758fa9ddfabc1dcbd7182da7650828aac97c9eee35597c84
+    optional: false
+    category: main
+  - name: psutil
+    version: 5.9.4
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-5.9.4-py39h0fd3b05_0.tar.bz2"
+    hash:
+      md5: 2d6fcae2ae9953db962dc3fc1ef456a4
+      sha256: e2bb7645fc1875ee0a54f6af2f9355162e4f70b8e11cb2913c43f082d3ef65ee
+    optional: false
+    category: main
+  - name: psutil
+    version: 5.9.4
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/psutil-5.9.4-py39h98ec90c_0.tar.bz2"
+    hash:
+      md5: 5bd05c9eb882774901835d43e4c2c365
+      sha256: d0bde2a78f967ba275a969a2d5b722d0792ac710c45c5ac74ee7b85f3cf6bb05
+    optional: false
+    category: main
+  - name: psutil
+    version: 5.9.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.4-py39ha30fb19_0.tar.bz2"
+    hash:
+      md5: fde4dae8cd4d545d53e20d371ffd4c77
+      sha256: 4e81064087ca1938c04d8e9dd1e8be92f686a56f7ebf0da5371beea9fc5f2a24
+    optional: false
+    category: main
+  - name: psutil
+    version: 5.9.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.4-py39h02fc5c5_0.tar.bz2"
+    hash:
+      md5: bf7577af58a627d4f3c454965b246f18
+      sha256: 6c99579a51949c5a74d627c06058fa8a21a54bf088538b06061388ecf56fbe88
+    optional: false
+    category: main
+  - name: pthread-stubs
+    version: "0.4"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=7.5.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2"
+    hash:
+      md5: 22dad4df6e8630e8dff2428f6f6a7036
+      sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
+    optional: false
+    category: main
+  - name: pthread-stubs
+    version: "0.4"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=7.5.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-hb9de7d4_1001.tar.bz2"
+    hash:
+      md5: d0183ec6ce0b5aaa3486df25fa5f0ded
+      sha256: f1d7ff5e06cc515ec82010537813c796369f8e9dde46ce3f4fa1a9f70bc7db7d
+    optional: false
+    category: main
+  - name: pthread-stubs
+    version: "0.4"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=8.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/pthread-stubs-0.4-h339bb43_1001.tar.bz2"
+    hash:
+      md5: 3c08a226d34a1ac3472fdfec4bd9217f
+      sha256: e6509a0eddb850203bdfc5a01d1ea4a28af732335c99848ec5e27db1f543326f
+    optional: false
+    category: main
+  - name: pthread-stubs
+    version: "0.4"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2"
+    hash:
+      md5: addd19059de62181cd11ae8f4ef26084
+      sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
+    optional: false
+    category: main
+  - name: pthread-stubs
+    version: "0.4"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2"
+    hash:
+      md5: d3f26c6494d4105d4ecb85203d687102
+      sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
+    optional: false
+    category: main
+  - name: ptyprocess
+    version: 0.7.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2"
+    hash:
+      md5: 359eeb6536da0e687af562ed265ec263
+      sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+    optional: false
+    category: main
+  - name: ptyprocess
+    version: 0.7.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2"
+    hash:
+      md5: 359eeb6536da0e687af562ed265ec263
+      sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+    optional: false
+    category: main
+  - name: ptyprocess
+    version: 0.7.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2"
+    hash:
+      md5: 359eeb6536da0e687af562ed265ec263
+      sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+    optional: false
+    category: main
+  - name: ptyprocess
+    version: 0.7.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2"
+    hash:
+      md5: 359eeb6536da0e687af562ed265ec263
+      sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+    optional: false
+    category: main
+  - name: ptyprocess
+    version: 0.7.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2"
+    hash:
+      md5: 359eeb6536da0e687af562ed265ec263
+      sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
+    optional: false
+    category: main
+  - name: pulseaudio
+    version: "16.1"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      alsa-lib: ">=1.2.8,<1.2.9.0a0"
+      dbus: ">=1.13.6,<2.0a0"
+      fftw: ">=3.3.10,<4.0a0"
+      gstreamer-orc: ">=0.4.33,<0.5.0a0"
+      jack: ">=1.9.21,<1.10.0a0"
+      libcap: ">=2.66,<2.67.0a0"
+      libgcc-ng: ">=12"
+      libglib: ">=2.74.1,<3.0a0"
+      libsndfile: ">=1.2.0,<1.3.0a0"
+      libsystemd0: ">=252"
+      libtool: ">=2.4.7,<3.0a0"
+      libudev1: ">=252"
+      openssl: ">=3.0.7,<4.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-16.1-ha8d29e2_1.conda"
+    hash:
+      md5: dbfc2a8d63a43a11acf4c704e1ef9d0c
+      sha256: aa2aa5b5e2430a3c3d8b24574e5e270c47026740cb706e9be31df81b0627afa6
+    optional: false
+    category: main
+  - name: pure_eval
+    version: 0.2.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6784285c7e55cb7212efabc79e4c2883
+      sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+    optional: false
+    category: main
+  - name: pure_eval
+    version: 0.2.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6784285c7e55cb7212efabc79e4c2883
+      sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+    optional: false
+    category: main
+  - name: pure_eval
+    version: 0.2.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6784285c7e55cb7212efabc79e4c2883
+      sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+    optional: false
+    category: main
+  - name: pure_eval
+    version: 0.2.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6784285c7e55cb7212efabc79e4c2883
+      sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+    optional: false
+    category: main
+  - name: pure_eval
+    version: 0.2.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6784285c7e55cb7212efabc79e4c2883
+      sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
+    optional: false
+    category: main
+  - name: pycodestyle
+    version: 2.7.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: 2.7.*|>=3.5
+    url: "https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.7.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 0234673eb2ecfbdf4e54574ab4d95f81
+      sha256: 5c6aa7a724551d7768930b30bd77e531580f6ddd68a391094e799a21a82b9492
+    optional: false
+    category: main
+  - name: pycodestyle
+    version: 2.7.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: 2.7.*|>=3.5
+    url: "https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.7.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 0234673eb2ecfbdf4e54574ab4d95f81
+      sha256: 5c6aa7a724551d7768930b30bd77e531580f6ddd68a391094e799a21a82b9492
+    optional: false
+    category: main
+  - name: pycodestyle
+    version: 2.7.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: 2.7.*|>=3.5
+    url: "https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.7.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 0234673eb2ecfbdf4e54574ab4d95f81
+      sha256: 5c6aa7a724551d7768930b30bd77e531580f6ddd68a391094e799a21a82b9492
+    optional: false
+    category: main
+  - name: pycodestyle
+    version: 2.7.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: 2.7.*|>=3.5
+    url: "https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.7.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 0234673eb2ecfbdf4e54574ab4d95f81
+      sha256: 5c6aa7a724551d7768930b30bd77e531580f6ddd68a391094e799a21a82b9492
+    optional: false
+    category: main
+  - name: pycodestyle
+    version: 2.7.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: 2.7.*|>=3.5
+    url: "https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.7.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 0234673eb2ecfbdf4e54574ab4d95f81
+      sha256: 5c6aa7a724551d7768930b30bd77e531580f6ddd68a391094e799a21a82b9492
+    optional: false
+    category: main
+  - name: pycparser
+    version: "2.21"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: 2.7.*|>=3.4
+    url: "https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 076becd9e05608f8dc72757d5f3a91ff
+      sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+    optional: false
+    category: main
+  - name: pycparser
+    version: "2.21"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: 2.7.*|>=3.4
+    url: "https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 076becd9e05608f8dc72757d5f3a91ff
+      sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+    optional: false
+    category: main
+  - name: pycparser
+    version: "2.21"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: 2.7.*|>=3.4
+    url: "https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 076becd9e05608f8dc72757d5f3a91ff
+      sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+    optional: false
+    category: main
+  - name: pycparser
+    version: "2.21"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: 2.7.*|>=3.4
+    url: "https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 076becd9e05608f8dc72757d5f3a91ff
+      sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+    optional: false
+    category: main
+  - name: pycparser
+    version: "2.21"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: 2.7.*|>=3.4
+    url: "https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 076becd9e05608f8dc72757d5f3a91ff
+      sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+    optional: false
+    category: main
+  - name: pydata-sphinx-theme
+    version: 0.9.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      beautifulsoup4: "*"
+      docutils: "!=0.17.0"
+      packaging: "*"
+      python: ">=3.7"
+      sphinx: ">=4.0.2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.9.0-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: ed5f1236283219a21207813d387b44bd
+      sha256: 11d56e0953a8f880d265d18eb3b3adc2f0ba182a33409088141dc84e22dba50c
+    optional: false
+    category: main
+  - name: pydata-sphinx-theme
+    version: 0.9.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      beautifulsoup4: "*"
+      docutils: "!=0.17.0"
+      packaging: "*"
+      python: ">=3.7"
+      sphinx: ">=4.0.2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.9.0-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: ed5f1236283219a21207813d387b44bd
+      sha256: 11d56e0953a8f880d265d18eb3b3adc2f0ba182a33409088141dc84e22dba50c
+    optional: false
+    category: main
+  - name: pydata-sphinx-theme
+    version: 0.9.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      beautifulsoup4: "*"
+      docutils: "!=0.17.0"
+      packaging: "*"
+      python: ">=3.7"
+      sphinx: ">=4.0.2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.9.0-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: ed5f1236283219a21207813d387b44bd
+      sha256: 11d56e0953a8f880d265d18eb3b3adc2f0ba182a33409088141dc84e22dba50c
+    optional: false
+    category: main
+  - name: pydata-sphinx-theme
+    version: 0.9.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      beautifulsoup4: "*"
+      docutils: "!=0.17.0"
+      packaging: "*"
+      python: ">=3.7"
+      sphinx: ">=4.0.2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.9.0-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: ed5f1236283219a21207813d387b44bd
+      sha256: 11d56e0953a8f880d265d18eb3b3adc2f0ba182a33409088141dc84e22dba50c
+    optional: false
+    category: main
+  - name: pydata-sphinx-theme
+    version: 0.9.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      beautifulsoup4: "*"
+      docutils: "!=0.17.0"
+      packaging: "*"
+      python: ">=3.7"
+      sphinx: ">=4.0.2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.9.0-pyhd8ed1ab_1.tar.bz2"
+    hash:
+      md5: ed5f1236283219a21207813d387b44bd
+      sha256: 11d56e0953a8f880d265d18eb3b3adc2f0ba182a33409088141dc84e22dba50c
+    optional: false
+    category: main
+  - name: pygments
+    version: 2.14.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pygments-2.14.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: c78cd16b11cd6a295484bd6c8f24bea1
+      sha256: e8710e24f60b6a97289468f47914e53610101755088bc237621cc1980edbfcd9
+    optional: false
+    category: main
+  - name: pygments
+    version: 2.14.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pygments-2.14.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: c78cd16b11cd6a295484bd6c8f24bea1
+      sha256: e8710e24f60b6a97289468f47914e53610101755088bc237621cc1980edbfcd9
+    optional: false
+    category: main
+  - name: pygments
+    version: 2.14.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pygments-2.14.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: c78cd16b11cd6a295484bd6c8f24bea1
+      sha256: e8710e24f60b6a97289468f47914e53610101755088bc237621cc1980edbfcd9
+    optional: false
+    category: main
+  - name: pygments
+    version: 2.14.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pygments-2.14.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: c78cd16b11cd6a295484bd6c8f24bea1
+      sha256: e8710e24f60b6a97289468f47914e53610101755088bc237621cc1980edbfcd9
+    optional: false
+    category: main
+  - name: pygments
+    version: 2.14.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+      setuptools: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pygments-2.14.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: c78cd16b11cd6a295484bd6c8f24bea1
+      sha256: e8710e24f60b6a97289468f47914e53610101755088bc237621cc1980edbfcd9
+    optional: false
+    category: main
+  - name: pyopenssl
+    version: 23.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      cryptography: ">=38.0.0,<40"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: d41957700e83bbb925928764cb7f8878
+      sha256: adbf8951f22bfa950b9e24394df1ef1d2b2d7dfb194d91c7f42bc11900695785
+    optional: false
+    category: main
+  - name: pyopenssl
+    version: 23.0.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      cryptography: ">=38.0.0,<40"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: d41957700e83bbb925928764cb7f8878
+      sha256: adbf8951f22bfa950b9e24394df1ef1d2b2d7dfb194d91c7f42bc11900695785
+    optional: false
+    category: main
+  - name: pyopenssl
+    version: 23.0.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      cryptography: ">=38.0.0,<40"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: d41957700e83bbb925928764cb7f8878
+      sha256: adbf8951f22bfa950b9e24394df1ef1d2b2d7dfb194d91c7f42bc11900695785
+    optional: false
+    category: main
+  - name: pyopenssl
+    version: 23.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      cryptography: ">=38.0.0,<40"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: d41957700e83bbb925928764cb7f8878
+      sha256: adbf8951f22bfa950b9e24394df1ef1d2b2d7dfb194d91c7f42bc11900695785
+    optional: false
+    category: main
+  - name: pyopenssl
+    version: 23.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      cryptography: ">=38.0.0,<40"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.0.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: d41957700e83bbb925928764cb7f8878
+      sha256: adbf8951f22bfa950b9e24394df1ef1d2b2d7dfb194d91c7f42bc11900695785
+    optional: false
+    category: main
+  - name: pyparsing
+    version: 3.0.9
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: e8fbc1b54b25f4b08281467bc13b70cc
+      sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+    optional: false
+    category: main
+  - name: pyparsing
+    version: 3.0.9
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: e8fbc1b54b25f4b08281467bc13b70cc
+      sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+    optional: false
+    category: main
+  - name: pyparsing
+    version: 3.0.9
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: e8fbc1b54b25f4b08281467bc13b70cc
+      sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+    optional: false
+    category: main
+  - name: pyparsing
+    version: 3.0.9
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: e8fbc1b54b25f4b08281467bc13b70cc
+      sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+    optional: false
+    category: main
+  - name: pyparsing
+    version: 3.0.9
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: e8fbc1b54b25f4b08281467bc13b70cc
+      sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
+    optional: false
+    category: main
+  - name: pyproject-metadata
+    version: 0.7.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      packaging: ">=19.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyproject-metadata-0.7.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: dcb27826ffc94d5f04e241322239983b
+      sha256: 9ec35cffa163f587aeb52d1603df8374659e3be30dbc6db0e980ecb797f21fee
+    optional: false
+    category: main
+  - name: pyproject-metadata
+    version: 0.7.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      packaging: ">=19.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyproject-metadata-0.7.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: dcb27826ffc94d5f04e241322239983b
+      sha256: 9ec35cffa163f587aeb52d1603df8374659e3be30dbc6db0e980ecb797f21fee
+    optional: false
+    category: main
+  - name: pyproject-metadata
+    version: 0.7.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      packaging: ">=19.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyproject-metadata-0.7.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: dcb27826ffc94d5f04e241322239983b
+      sha256: 9ec35cffa163f587aeb52d1603df8374659e3be30dbc6db0e980ecb797f21fee
+    optional: false
+    category: main
+  - name: pyproject-metadata
+    version: 0.7.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      packaging: ">=19.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyproject-metadata-0.7.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: dcb27826ffc94d5f04e241322239983b
+      sha256: 9ec35cffa163f587aeb52d1603df8374659e3be30dbc6db0e980ecb797f21fee
+    optional: false
+    category: main
+  - name: pyproject-metadata
+    version: 0.7.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      packaging: ">=19.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pyproject-metadata-0.7.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: dcb27826ffc94d5f04e241322239983b
+      sha256: 9ec35cffa163f587aeb52d1603df8374659e3be30dbc6db0e980ecb797f21fee
+    optional: false
+    category: main
+  - name: pyqt
+    version: 5.15.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      pyqt5-sip: "==12.11.0 py39h227be39_3"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      qt-main: ">=5.15.6,<5.16.0a0"
+      sip: ">=6.7.5,<6.8.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.7-py39h5c7b992_3.conda"
+    hash:
+      md5: 19e30314fe824605750da905febb8ee6
+      sha256: 1dfa1bff6d1334682790063c889198671b477a95c71a3d73ff656b4d88ea542b
+    optional: false
+    category: main
   - name: pyqt5-sip
     version: 12.11.0
     manager: conda
@@ -3206,10 +9941,230 @@ package:
       sha256: aff0befab89f536c4540dba017543d1616862b2d51350cb6d2875c294bd1b199
     optional: false
     category: main
+  - name: pysocks
+    version: 1.7.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __unix: "*"
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2"
+    hash:
+      md5: 2a7de29fb590ca14b5243c4c812c8025
+      sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+    optional: false
+    category: main
+  - name: pysocks
+    version: 1.7.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      __unix: "*"
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2"
+    hash:
+      md5: 2a7de29fb590ca14b5243c4c812c8025
+      sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+    optional: false
+    category: main
+  - name: pysocks
+    version: 1.7.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      __unix: "*"
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2"
+    hash:
+      md5: 2a7de29fb590ca14b5243c4c812c8025
+      sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+    optional: false
+    category: main
+  - name: pysocks
+    version: 1.7.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __unix: "*"
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2"
+    hash:
+      md5: 2a7de29fb590ca14b5243c4c812c8025
+      sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+    optional: false
+    category: main
+  - name: pysocks
+    version: 1.7.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __unix: "*"
+      python: ">=3.8"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2"
+    hash:
+      md5: 2a7de29fb590ca14b5243c4c812c8025
+      sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
+    optional: false
+    category: main
+  - name: pytest
+    version: 7.2.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      attrs: ">=19.2.0"
+      colorama: "*"
+      exceptiongroup: "*"
+      iniconfig: "*"
+      packaging: "*"
+      pluggy: ">=0.12,<2.0"
+      python: ">=3.8"
+      tomli: ">=1.0.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f0be05afc9c9ab45e273c088e00c258b
+      sha256: d298dfe6c53555c9fb5662f5f936e621cddd3b0a7031789375b82a1ee3b3a96b
+    optional: false
+    category: main
+  - name: pytest
+    version: 7.2.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      attrs: ">=19.2.0"
+      colorama: "*"
+      exceptiongroup: "*"
+      iniconfig: "*"
+      packaging: "*"
+      pluggy: ">=0.12,<2.0"
+      python: ">=3.8"
+      tomli: ">=1.0.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f0be05afc9c9ab45e273c088e00c258b
+      sha256: d298dfe6c53555c9fb5662f5f936e621cddd3b0a7031789375b82a1ee3b3a96b
+    optional: false
+    category: main
+  - name: pytest
+    version: 7.2.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      attrs: ">=19.2.0"
+      colorama: "*"
+      exceptiongroup: "*"
+      iniconfig: "*"
+      packaging: "*"
+      pluggy: ">=0.12,<2.0"
+      python: ">=3.8"
+      tomli: ">=1.0.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f0be05afc9c9ab45e273c088e00c258b
+      sha256: d298dfe6c53555c9fb5662f5f936e621cddd3b0a7031789375b82a1ee3b3a96b
+    optional: false
+    category: main
+  - name: pytest
+    version: 7.2.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      attrs: ">=19.2.0"
+      colorama: "*"
+      exceptiongroup: "*"
+      iniconfig: "*"
+      packaging: "*"
+      pluggy: ">=0.12,<2.0"
+      python: ">=3.8"
+      tomli: ">=1.0.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f0be05afc9c9ab45e273c088e00c258b
+      sha256: d298dfe6c53555c9fb5662f5f936e621cddd3b0a7031789375b82a1ee3b3a96b
+    optional: false
+    category: main
+  - name: pytest
+    version: 7.2.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      attrs: ">=19.2.0"
+      colorama: "*"
+      exceptiongroup: "*"
+      iniconfig: "*"
+      packaging: "*"
+      pluggy: ">=0.12,<2.0"
+      python: ">=3.8"
+      tomli: ">=1.0.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f0be05afc9c9ab45e273c088e00c258b
+      sha256: d298dfe6c53555c9fb5662f5f936e621cddd3b0a7031789375b82a1ee3b3a96b
+    optional: false
+    category: main
   - name: pytest-cov
     version: 4.0.0
     manager: conda
     platform: linux-64
+    dependencies:
+      coverage: ">=5.2.1"
+      pytest: ">=4.6"
+      python: ">=3.6"
+      toml: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.0.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c9e3f8bfdb9bfc34aa1836a6ed4b25d7
+      sha256: 2e00bbdb00b2514faba50ddcb6ecf1d6e4f2d5af346f9cd1240aacb1b61dccb6
+    optional: false
+    category: main
+  - name: pytest-cov
+    version: 4.0.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      coverage: ">=5.2.1"
+      pytest: ">=4.6"
+      python: ">=3.6"
+      toml: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.0.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c9e3f8bfdb9bfc34aa1836a6ed4b25d7
+      sha256: 2e00bbdb00b2514faba50ddcb6ecf1d6e4f2d5af346f9cd1240aacb1b61dccb6
+    optional: false
+    category: main
+  - name: pytest-cov
+    version: 4.0.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      coverage: ">=5.2.1"
+      pytest: ">=4.6"
+      python: ">=3.6"
+      toml: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.0.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c9e3f8bfdb9bfc34aa1836a6ed4b25d7
+      sha256: 2e00bbdb00b2514faba50ddcb6ecf1d6e4f2d5af346f9cd1240aacb1b61dccb6
+    optional: false
+    category: main
+  - name: pytest-cov
+    version: 4.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      coverage: ">=5.2.1"
+      pytest: ">=4.6"
+      python: ">=3.6"
+      toml: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.0.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c9e3f8bfdb9bfc34aa1836a6ed4b25d7
+      sha256: 2e00bbdb00b2514faba50ddcb6ecf1d6e4f2d5af346f9cd1240aacb1b61dccb6
+    optional: false
+    category: main
+  - name: pytest-cov
+    version: 4.0.0
+    manager: conda
+    platform: osx-arm64
     dependencies:
       coverage: ">=5.2.1"
       pytest: ">=4.6"
@@ -3235,104 +10190,362 @@ package:
       sha256: aa81f80bf0a2f53423ab80137ca4fc201473884725a2983a0d79b2e420c2a671
     optional: false
     category: main
-  - name: stack_data
-    version: 0.6.2
+  - name: pytest-xdist
+    version: 3.2.0
     manager: conda
-    platform: linux-64
+    platform: linux-aarch64
     dependencies:
-      asttokens: "*"
-      executing: "*"
-      pure_eval: "*"
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda"
+      execnet: ">=1.1"
+      pytest: ">=6.2.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.2.0-pyhd8ed1ab_0.conda"
     hash:
-      md5: e7df0fdd404616638df5ece6e69ba7af
-      sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+      md5: 70ab87b96126f35d1e68de2ad9fb6423
+      sha256: aa81f80bf0a2f53423ab80137ca4fc201473884725a2983a0d79b2e420c2a671
     optional: false
     category: main
-  - name: wcwidth
-    version: 0.2.6
+  - name: pytest-xdist
+    version: 3.2.0
     manager: conda
-    platform: linux-64
+    platform: linux-ppc64le
     dependencies:
-      backports.functools_lru_cache: "*"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda"
+      execnet: ">=1.1"
+      pytest: ">=6.2.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.2.0-pyhd8ed1ab_0.conda"
     hash:
-      md5: 078979d33523cb477bd1916ce41aacc9
-      sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
+      md5: 70ab87b96126f35d1e68de2ad9fb6423
+      sha256: aa81f80bf0a2f53423ab80137ca4fc201473884725a2983a0d79b2e420c2a671
     optional: false
     category: main
-  - name: gst-plugins-base
-    version: 1.22.0
+  - name: pytest-xdist
+    version: 3.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      execnet: ">=1.1"
+      pytest: ">=6.2.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.2.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 70ab87b96126f35d1e68de2ad9fb6423
+      sha256: aa81f80bf0a2f53423ab80137ca4fc201473884725a2983a0d79b2e420c2a671
+    optional: false
+    category: main
+  - name: pytest-xdist
+    version: 3.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      execnet: ">=1.1"
+      pytest: ">=6.2.0"
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.2.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 70ab87b96126f35d1e68de2ad9fb6423
+      sha256: aa81f80bf0a2f53423ab80137ca4fc201473884725a2983a0d79b2e420c2a671
+    optional: false
+    category: main
+  - name: python
+    version: 3.9.16
     manager: conda
     platform: linux-64
     dependencies:
-      __glibc: ">=2.17,<3.0.a0"
-      alsa-lib: ">=1.2.8,<1.2.9.0a0"
-      gettext: ">=0.21.1,<1.0a0"
-      gstreamer: "==1.22.0 h25f0c4b_0"
+      bzip2: ">=1.0.8,<2.0a0"
+      ld_impl_linux-64: ">=2.36.1"
+      libffi: ">=3.4,<4.0a0"
       libgcc-ng: ">=12"
-      libglib: ">=2.74.1,<3.0a0"
-      libopus: ">=1.3.1,<2.0a0"
-      libpng: ">=1.6.39,<1.7.0a0"
-      libstdcxx-ng: ">=12"
-      libvorbis: ">=1.3.7,<1.4.0a0"
-      libxcb: ">=1.13,<1.14.0a0"
+      libnsl: ">=2.0.0,<2.1.0a0"
+      libsqlite: ">=3.40.0,<4.0a0"
+      libuuid: ">=2.32.1,<3.0a0"
       libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.0-h4243ec0_0.conda"
+      ncurses: ">=6.3,<7.0a0"
+      openssl: ">=3.0.7,<4.0a0"
+      pip: "*"
+      readline: ">=8.1.2,<9.0a0"
+      tk: ">=8.6.12,<8.7.0a0"
+      tzdata: "*"
+      xz: ">=5.2.6,<6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/python-3.9.16-h2782a2a_0_cpython.conda"
     hash:
-      md5: 81c20b15d2281a1ea48eac5b4eee8cfa
-      sha256: dfa2794ea19248f13a1eb067727c70d11e8bba228b82a4bee18ad6a26fdc99fe
+      md5: 95c9b7c96a7fd7342e0c9d0a917b8f78
+      sha256: 00bcb28a294aa78bf9d2a2ecaae8cb887188eae710f9197d823d36fb8a5d9767
     optional: false
     category: main
-  - name: prompt-toolkit
-    version: 3.0.36
+  - name: python
+    version: 3.9.16
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      bzip2: ">=1.0.8,<2.0a0"
+      ld_impl_linux-aarch64: ">=2.36.1"
+      libffi: ">=3.4,<4.0a0"
+      libgcc-ng: ">=12"
+      libnsl: ">=2.0.0,<2.1.0a0"
+      libsqlite: ">=3.40.0,<4.0a0"
+      libuuid: ">=2.32.1,<3.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      ncurses: ">=6.3,<7.0a0"
+      openssl: ">=3.0.7,<4.0a0"
+      pip: "*"
+      readline: ">=8.1.2,<9.0a0"
+      tk: ">=8.6.12,<8.7.0a0"
+      tzdata: "*"
+      xz: ">=5.2.6,<6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.9.16-hb363c5e_0_cpython.conda"
+    hash:
+      md5: 0a7ef29549eaef817898062eeeefebd3
+      sha256: 776e0ad572f4c7c9de53e5f6aaa435eb37162f041866f04fd496d3c91e3c2f47
+    optional: false
+    category: main
+  - name: python
+    version: 3.9.16
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      bzip2: ">=1.0.8,<2.0a0"
+      ld_impl_linux-ppc64le: ">=2.36.1"
+      libffi: ">=3.4,<4.0a0"
+      libgcc-ng: ">=12"
+      libnsl: ">=2.0.0,<2.1.0a0"
+      libsqlite: ">=3.39.4,<4.0a0"
+      libuuid: ">=2.32.1,<3.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      ncurses: ">=6.3,<7.0a0"
+      openssl: ">=3.0.7,<4.0a0"
+      pip: "*"
+      readline: ">=8.1.2,<9.0a0"
+      tk: ">=8.6.12,<8.7.0a0"
+      tzdata: "*"
+      xz: ">=5.2.6,<6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/python-3.9.16-h342c621_0_cpython.conda"
+    hash:
+      md5: f5a45d99a97a1a92e41178b4fc787644
+      sha256: ed87de2a117baa5341e85ef80b509aea3cce2c0c94c376003cb9c7f77610ff62
+    optional: false
+    category: main
+  - name: python
+    version: 3.9.16
+    manager: conda
+    platform: osx-64
+    dependencies:
+      bzip2: ">=1.0.8,<2.0a0"
+      libffi: ">=3.4,<4.0a0"
+      libsqlite: ">=3.40.0,<4.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      ncurses: ">=6.3,<7.0a0"
+      openssl: ">=3.0.7,<4.0a0"
+      pip: "*"
+      readline: ">=8.1.2,<9.0a0"
+      tk: ">=8.6.12,<8.7.0a0"
+      tzdata: "*"
+      xz: ">=5.2.6,<6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/python-3.9.16-h709bd14_0_cpython.conda"
+    hash:
+      md5: 37f637999bb01d0474492ed14660c34b
+      sha256: ffff69cde5bce4fadaf1b6fb551d3ffa1f0f8a6dfdc95ec114f9aac02758a71a
+    optional: false
+    category: main
+  - name: python
+    version: 3.9.16
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      bzip2: ">=1.0.8,<2.0a0"
+      libffi: ">=3.4,<4.0a0"
+      libsqlite: ">=3.40.0,<4.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      ncurses: ">=6.3,<7.0a0"
+      openssl: ">=3.0.7,<4.0a0"
+      pip: "*"
+      readline: ">=8.1.2,<9.0a0"
+      tk: ">=8.6.12,<8.7.0a0"
+      tzdata: "*"
+      xz: ">=5.2.6,<6.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.16-hea58f1e_0_cpython.conda"
+    hash:
+      md5: d2dfc4fe1da1624e020334b1000c6a3d
+      sha256: 90596405b18cf38e0ae2eebb81fc41da836081f3488ae9f3571a9199664a6032
+    optional: false
+    category: main
+  - name: python-dateutil
+    version: 2.8.2
     manager: conda
     platform: linux-64
     dependencies:
       python: ">=3.6"
-      wcwidth: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda"
+      six: ">=1.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2"
     hash:
-      md5: 4d79ec192e0bfd530a254006d123b9a6
-      sha256: 6bd3626799c9467d7aa8ed5f95043e4cea614a1329580980ddcf40cfed3ee860
+      md5: dd999d1cc9f79e67dbb855c8924c7984
+      sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
     optional: false
     category: main
-  - name: pyopenssl
-    version: 23.0.0
+  - name: python-dateutil
+    version: 2.8.2
     manager: conda
-    platform: linux-64
+    platform: linux-aarch64
     dependencies:
-      cryptography: ">=38.0.0,<40"
       python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.0.0-pyhd8ed1ab_0.conda"
+      six: ">=1.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2"
     hash:
-      md5: d41957700e83bbb925928764cb7f8878
-      sha256: adbf8951f22bfa950b9e24394df1ef1d2b2d7dfb194d91c7f42bc11900695785
+      md5: dd999d1cc9f79e67dbb855c8924c7984
+      sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
     optional: false
     category: main
-  - name: ipython
-    version: 8.10.0
+  - name: python-dateutil
+    version: 2.8.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+      six: ">=1.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: dd999d1cc9f79e67dbb855c8924c7984
+      sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+    optional: false
+    category: main
+  - name: python-dateutil
+    version: 2.8.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+      six: ">=1.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: dd999d1cc9f79e67dbb855c8924c7984
+      sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+    optional: false
+    category: main
+  - name: python-dateutil
+    version: 2.8.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+      six: ">=1.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: dd999d1cc9f79e67dbb855c8924c7984
+      sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
+    optional: false
+    category: main
+  - name: python_abi
+    version: "3.9"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.9-3_cp39.conda"
+    hash:
+      md5: 0dd193187d54e585cac7eab942a8847e
+      sha256: 89e8c4436dd04d8b4a0c13c508e930be56973a480a9714171969de953bdafd3a
+    optional: false
+    category: main
+  - name: python_abi
+    version: "3.9"
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.9-3_cp39.conda"
+    hash:
+      md5: b6f330b045cf3425945d536a6b5cd240
+      sha256: f9ea2e91bd871899b5c2682e6ef78523b68769a62ea86af86894cfc5d37d1f0a
+    optional: false
+    category: main
+  - name: python_abi
+    version: "3.9"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/python_abi-3.9-3_cp39.conda"
+    hash:
+      md5: 4f09b636d43728c2906cf03a18a4e8f6
+      sha256: 3321ab95a62cefe8b305da972b8780647fd8063e96ee331e2b6c9070353272c2
+    optional: false
+    category: main
+  - name: python_abi
+    version: "3.9"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.9-3_cp39.conda"
+    hash:
+      md5: 021e2768e8eaf24ee8e25aec64d305a1
+      sha256: b02e179f015b042510da8ba256c86f5cfb34058a96ec1c548f33f9f8bcdbb78c
+    optional: false
+    category: main
+  - name: python_abi
+    version: "3.9"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.9-3_cp39.conda"
+    hash:
+      md5: f8fb5fb65327a2429b084833c8ff1dbc
+      sha256: 9434a23c734685db9a5017206dae58f141e2edddec2ee9e1ec10a3fdefa55c0f
+    optional: false
+    category: main
+  - name: pytz
+    version: 2022.7.1
     manager: conda
     platform: linux-64
     dependencies:
-      __linux: "*"
-      backcall: "*"
-      decorator: "*"
-      jedi: ">=0.16"
-      matplotlib-inline: "*"
-      pexpect: ">4.3"
-      pickleshare: "*"
-      prompt-toolkit: ">=3.0.30,<3.1.0"
-      pygments: ">=2.4.0"
-      python: ">=3.8"
-      stack_data: "*"
-      traitlets: ">=5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/ipython-8.10.0-pyh41d4057_0.conda"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytz-2022.7.1-pyhd8ed1ab_0.conda"
     hash:
-      md5: 4703355103974293bbd8a32449b3ff28
-      sha256: 350847af23f964a1002c712547e26a1e144e5bbc1662016263c5fb8fc963dcff
+      md5: f59d49a7b464901cf714b9e7984d01a2
+      sha256: 93cfc7a92099e26b0575a343da4a667b52371cc38e4dee4ee264dc041ef77bac
+    optional: false
+    category: main
+  - name: pytz
+    version: 2022.7.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytz-2022.7.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f59d49a7b464901cf714b9e7984d01a2
+      sha256: 93cfc7a92099e26b0575a343da4a667b52371cc38e4dee4ee264dc041ef77bac
+    optional: false
+    category: main
+  - name: pytz
+    version: 2022.7.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytz-2022.7.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f59d49a7b464901cf714b9e7984d01a2
+      sha256: 93cfc7a92099e26b0575a343da4a667b52371cc38e4dee4ee264dc041ef77bac
+    optional: false
+    category: main
+  - name: pytz
+    version: 2022.7.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytz-2022.7.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f59d49a7b464901cf714b9e7984d01a2
+      sha256: 93cfc7a92099e26b0575a343da4a667b52371cc38e4dee4ee264dc041ef77bac
+    optional: false
+    category: main
+  - name: pytz
+    version: 2022.7.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pytz-2022.7.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: f59d49a7b464901cf714b9e7984d01a2
+      sha256: 93cfc7a92099e26b0575a343da4a667b52371cc38e4dee4ee264dc041ef77bac
     optional: false
     category: main
   - name: qt-main
@@ -3384,40 +10597,67 @@ package:
       sha256: fd0b6b8365fd4d0e86476a3047ba6a281eea0bdfef770df83b897fd73e959dd9
     optional: false
     category: main
-  - name: urllib3
-    version: 1.26.14
-    manager: conda
-    platform: linux-64
-    dependencies:
-      brotlipy: ">=0.6.0"
-      certifi: "*"
-      cryptography: ">=1.3.4"
-      idna: ">=2.0.0"
-      pyopenssl: ">=0.14"
-      pysocks: ">=1.5.6,<2.0,!=1.5.7"
-      python: "<4.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.14-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 01f33ad2e0aaf6b5ba4add50dad5ad29
-      sha256: f2f09c44e47946ce631dbc9a8a79bb463ac0f4122aaafdbcc51f200a1e420ca6
-    optional: false
-    category: main
-  - name: pyqt
-    version: 5.15.7
+  - name: readline
+    version: 8.1.2
     manager: conda
     platform: linux-64
     dependencies:
       libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      pyqt5-sip: "==12.11.0 py39h227be39_3"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      qt-main: ">=5.15.6,<5.16.0a0"
-      sip: ">=6.7.5,<6.8.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.7-py39h5c7b992_3.conda"
+      ncurses: ">=6.3,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/readline-8.1.2-h0f457ee_0.tar.bz2"
     hash:
-      md5: 19e30314fe824605750da905febb8ee6
-      sha256: 1dfa1bff6d1334682790063c889198671b477a95c71a3d73ff656b4d88ea542b
+      md5: db2ebbe2943aae81ed051a6a9af8e0fa
+      sha256: f5f383193bdbe01c41cb0d6f99fec68e820875e842e6e8b392dbe1a9b6c43ed8
+    optional: false
+    category: main
+  - name: readline
+    version: 8.1.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      ncurses: ">=6.3,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.1.2-h38e3740_0.tar.bz2"
+    hash:
+      md5: 3cdbfb7d7b63ae2c2d35bb167d257ecd
+      sha256: a33bb6e4c93599fb97eb19db0dcca602a90475f2da3c01c14add19b908178fcd
+    optional: false
+    category: main
+  - name: readline
+    version: 8.1.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      ncurses: ">=6.3,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/readline-8.1.2-h6828edc_0.tar.bz2"
+    hash:
+      md5: a8b0d567fd553734fc0fd0ab2447526a
+      sha256: 37e57caeeb181929648aa898487909b8badad20aa9fb49ab603446cccdb743db
+    optional: false
+    category: main
+  - name: readline
+    version: 8.1.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      ncurses: ">=6.3,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/readline-8.1.2-h3899abd_0.tar.bz2"
+    hash:
+      md5: 89fa404901fa8fb7d4f4e07083b8d635
+      sha256: c65dc1200a252832db49bdd6836c512a0eaafe97aa914b9f8358b15eebb1d94b
+    optional: false
+    category: main
+  - name: readline
+    version: 8.1.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      ncurses: ">=6.3,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.1.2-h46ed386_0.tar.bz2"
+    hash:
+      md5: dc790f296d94409efb3f22af84ee968d
+      sha256: 2d2a65fcdd91361ea7e40c03eeec18ff7a453c32f6589a1fce64717f6cd7c7b6
     optional: false
     category: main
   - name: requests
@@ -3436,111 +10676,68 @@ package:
       sha256: 22c081b4cdd023a514400413f50efdf2c378f56f2a5ea9d65666aacf4696490a
     optional: false
     category: main
-  - name: matplotlib
-    version: 3.6.3
+  - name: requests
+    version: 2.28.2
     manager: conda
-    platform: linux-64
+    platform: linux-aarch64
     dependencies:
-      matplotlib-base: ">=3.6.3,<3.6.4.0a0"
-      pyqt: ">=5"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tornado: ">=5"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.6.3-py39hf3d152e_0.conda"
+      certifi: ">=2017.4.17"
+      charset-normalizer: ">=2,<3"
+      idna: ">=2.5,<4"
+      python: ">=3.7,<4.0"
+      urllib3: ">=1.21.1,<1.27"
+    url: "https://conda.anaconda.org/conda-forge/noarch/requests-2.28.2-pyhd8ed1ab_0.conda"
     hash:
-      md5: dbef5ffeeca5c5112cc3be8f03e6d1a5
-      sha256: b1d70dba47ea0e901084fd4d32b506772063b38a99e1c39c1b0fef4c06e7deef
+      md5: 11d178fc55199482ee48d6812ea83983
+      sha256: 22c081b4cdd023a514400413f50efdf2c378f56f2a5ea9d65666aacf4696490a
     optional: false
     category: main
-  - name: pooch
-    version: 1.6.0
+  - name: requests
+    version: 2.28.2
     manager: conda
-    platform: linux-64
+    platform: linux-ppc64le
     dependencies:
-      appdirs: ">=1.3.0"
-      packaging: ">=20.0"
-      python: ">=3.6"
-      requests: ">=2.19.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pooch-1.6.0-pyhd8ed1ab_0.tar.bz2"
+      certifi: ">=2017.4.17"
+      charset-normalizer: ">=2,<3"
+      idna: ">=2.5,<4"
+      python: ">=3.7,<4.0"
+      urllib3: ">=1.21.1,<1.27"
+    url: "https://conda.anaconda.org/conda-forge/noarch/requests-2.28.2-pyhd8ed1ab_0.conda"
     hash:
-      md5: 6429e1d1091c51f626b5dcfdd38bf429
-      sha256: 1f0548105de86fb2eb6fbb8d3d6cc2004079b8442d232258108687d6cc91eb73
+      md5: 11d178fc55199482ee48d6812ea83983
+      sha256: 22c081b4cdd023a514400413f50efdf2c378f56f2a5ea9d65666aacf4696490a
     optional: false
     category: main
-  - name: sphinx
-    version: 5.3.0
+  - name: requests
+    version: 2.28.2
     manager: conda
-    platform: linux-64
+    platform: osx-64
     dependencies:
-      alabaster: ">=0.7,<0.8"
-      babel: ">=2.9"
-      colorama: ">=0.4.5"
-      docutils: ">=0.14,<0.20"
-      imagesize: ">=1.3"
-      importlib-metadata: ">=4.8"
-      jinja2: ">=3.0"
-      packaging: ">=21.0"
-      pygments: ">=2.12"
-      python: ">=3.7"
-      requests: ">=2.5.0"
-      snowballstemmer: ">=2.0"
-      sphinxcontrib-applehelp: "*"
-      sphinxcontrib-devhelp: "*"
-      sphinxcontrib-htmlhelp: ">=2.0.0"
-      sphinxcontrib-jsmath: "*"
-      sphinxcontrib-qthelp: "*"
-      sphinxcontrib-serializinghtml: ">=1.1.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-5.3.0-pyhd8ed1ab_0.tar.bz2"
+      certifi: ">=2017.4.17"
+      charset-normalizer: ">=2,<3"
+      idna: ">=2.5,<4"
+      python: ">=3.7,<4.0"
+      urllib3: ">=1.21.1,<1.27"
+    url: "https://conda.anaconda.org/conda-forge/noarch/requests-2.28.2-pyhd8ed1ab_0.conda"
     hash:
-      md5: f9e1fcfe235d655900bfeb6aee426472
-      sha256: f11fd5fb4ae2c65f41ae86e7408e3ab44844898d928264aa9e89929fffc685c8
+      md5: 11d178fc55199482ee48d6812ea83983
+      sha256: 22c081b4cdd023a514400413f50efdf2c378f56f2a5ea9d65666aacf4696490a
     optional: false
     category: main
-  - name: breathe
-    version: 4.34.0
+  - name: requests
+    version: 2.28.2
     manager: conda
-    platform: linux-64
+    platform: osx-arm64
     dependencies:
-      docutils: ">=0.12"
-      jinja2: ">=2.7.3"
-      markupsafe: ">=0.23"
-      pygments: ">=1.6"
-      python: ">=3.6"
-      sphinx: ">=4.0,<6.0.0a"
-    url: "https://conda.anaconda.org/conda-forge/noarch/breathe-4.34.0-pyhd8ed1ab_0.tar.bz2"
+      certifi: ">=2017.4.17"
+      charset-normalizer: ">=2,<3"
+      idna: ">=2.5,<4"
+      python: ">=3.7,<4.0"
+      urllib3: ">=1.21.1,<1.27"
+    url: "https://conda.anaconda.org/conda-forge/noarch/requests-2.28.2-pyhd8ed1ab_0.conda"
     hash:
-      md5: a2a04f8e8c2d91adb08ff929b4d73654
-      sha256: 40f86cd741a443363e8928d5d36ba3a49071aaffc26c5a7b24a8167c5bcbba81
-    optional: false
-    category: main
-  - name: numpydoc
-    version: 1.4.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      jinja2: ">=2.10"
-      python: ">=3.7"
-      sphinx: ">=1.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.4.0-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: 0aac89c61a466b0f9c4fd0ec44d81f1d
-      sha256: 11a892cc1678a23d169909e553447fb7e312d6baaa314fdcd719f6abff1c7da6
-    optional: false
-    category: main
-  - name: pydata-sphinx-theme
-    version: 0.9.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      beautifulsoup4: "*"
-      docutils: "!=0.17.0"
-      packaging: "*"
-      python: ">=3.7"
-      sphinx: ">=4.0.2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.9.0-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: ed5f1236283219a21207813d387b44bd
-      sha256: 11d56e0953a8f880d265d18eb3b3adc2f0ba182a33409088141dc84e22dba50c
+      md5: 11d178fc55199482ee48d6812ea83983
+      sha256: 22c081b4cdd023a514400413f50efdf2c378f56f2a5ea9d65666aacf4696490a
     optional: false
     category: main
   - name: scipy
@@ -3565,2378 +10762,6 @@ package:
       sha256: d9191b5aa96255c5e6a176a795e304e0806aa31366baa0101e6c242c474341d2
     optional: false
     category: main
-  - name: sphinx-design
-    version: 0.3.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.6"
-      sphinx: ">=4,<6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-design-0.3.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 83d1a712e6d2bab6b298b1d2f42ad355
-      sha256: 6b193a483a02bbc7a785dcd28614b4c082d1795fec0a1c48690d8d7a0a876e20
-    optional: false
-    category: main
-  - name: ca-certificates
-    version: 2022.12.7
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2022.12.7-h4fd8a4c_0.conda"
-    hash:
-      md5: 2450fbcaf65634e0d071e47e2b8487b4
-      sha256: bb4e6340d55775738a5867a16071658c294d46cceff7f652f65d8dc6a495a578
-    optional: false
-    category: main
-  - name: kernel-headers_linux-aarch64
-    version: 4.18.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_13.tar.bz2"
-    hash:
-      md5: a9385e5b11a076c40d75915986f498d7
-      sha256: 14e227d98193550f9da275e58e27de104ab569849f1ce16b810fae4d7b351d49
-    optional: false
-    category: main
-  - name: ld_impl_linux-aarch64
-    version: "2.39"
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.39-h16cd69b_1.conda"
-    hash:
-      md5: 9daf385ebefaea92087d3a315e398964
-      sha256: aae71464a25bc5f32db5211621798a0725fc910a6a2a19a6161dbfcb0a7b1e35
-    optional: false
-    category: main
-  - name: libgcc-devel_linux-aarch64
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-devel_linux-aarch64-11.3.0-h02014c4_19.tar.bz2"
-    hash:
-      md5: dde2aeef8efee13089f2fbb2bdb4879e
-      sha256: 40f1288935150ab0b524c030d852aa67826db379ff61350c817006b9ce1b2b97
-    optional: false
-    category: main
-  - name: libgfortran5
-    version: 12.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-12.2.0-hf695500_19.tar.bz2"
-    hash:
-      md5: bc890809e1f807b51bf04dfbee70ddf5
-      sha256: e0496081c3a26c578abd0e292317c80159ebfbd5bb1ecca446894b9adf39abd7
-    optional: false
-    category: main
-  - name: libgomp
-    version: 12.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-12.2.0-h607ecd0_19.tar.bz2"
-    hash:
-      md5: 65b9cb876525dcb2e74a90cf02c6762a
-      sha256: d802eaceaf6f77fb8cb2e990aacf9b3eaa83361b16369a760fc1585841d7885c
-    optional: false
-    category: main
-  - name: libstdcxx-devel_linux-aarch64
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-devel_linux-aarch64-11.3.0-h02014c4_19.tar.bz2"
-    hash:
-      md5: 1951ddce2b043a2597eb8317f6fee950
-      sha256: 83a35253ac31c38d502bcff450457a86a9cd175f164cabc82400ea07ad2679be
-    optional: false
-    category: main
-  - name: libstdcxx-ng
-    version: 12.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-12.2.0-hc13a102_19.tar.bz2"
-    hash:
-      md5: 981741cd4321edd5c504b48f74fe91f2
-      sha256: db906f0ad19acc6aefcd5409a7a72fea76302f72013dce7593467ae07dbf54f3
-    optional: false
-    category: main
-  - name: nomkl
-    version: "1.0"
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2"
-    hash:
-      md5: 9a66894dfd07c4510beb6b3f9672ccc0
-      sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
-    optional: false
-    category: main
-  - name: python_abi
-    version: "3.9"
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.9-3_cp39.conda"
-    hash:
-      md5: b6f330b045cf3425945d536a6b5cd240
-      sha256: f9ea2e91bd871899b5c2682e6ef78523b68769a62ea86af86894cfc5d37d1f0a
-    optional: false
-    category: main
-  - name: tzdata
-    version: 2022g
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
-    hash:
-      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
-      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
-    optional: false
-    category: main
-  - name: _openmp_mutex
-    version: "4.5"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgomp: ">=7.5.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2"
-    hash:
-      md5: 6168d71addc746e8f2b8d57dfd2edcea
-      sha256: 3702bef2f0a4d38bd8288bbe54aace623602a1343c2cfbefd3fa188e015bebf0
-    optional: false
-    category: main
-  - name: libgfortran-ng
-    version: 12.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgfortran5: "==12.2.0 hf695500_19"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-12.2.0-he9431aa_19.tar.bz2"
-    hash:
-      md5: b5b34211bbf681bd3e7a5a4d80cce77b
-      sha256: 3ac162edf354bfa46076f52f3bff3a8ac10e626ebb9ed5e01aad954ebd386829
-    optional: false
-    category: main
-  - name: sysroot_linux-aarch64
-    version: "2.17"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      kernel-headers_linux-aarch64: "==4.18.0 h5b4a56d_13"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h43d7e78_13.tar.bz2"
-    hash:
-      md5: 6d8f1fd1e675ba478041892112887949
-      sha256: 932f7f8947c206ad4707a18c3bebbe217efdef67fd2cf9e0e94f5ccf0edeee38
-    optional: false
-    category: main
-  - name: binutils_impl_linux-aarch64
-    version: "2.39"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      ld_impl_linux-aarch64: "==2.39 h16cd69b_1"
-      sysroot_linux-aarch64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.39-h48546ad_1.conda"
-    hash:
-      md5: 74724e155402aa2391b99fe919b6af17
-      sha256: dbdcca1fc9601ebc035d61283ceb317fe9b006dc7a9aa65d696769e9c74c5580
-    optional: false
-    category: main
-  - name: libgcc-ng
-    version: 12.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      _openmp_mutex: ">=4.5"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-12.2.0-h607ecd0_19.tar.bz2"
-    hash:
-      md5: 8456a29b6d9fc3123ccb9a966b6b2c49
-      sha256: 0dd30553f6f38b011c9c81471a50f85e98a79e4dd672fdc1fc97904b54b5419b
-    optional: false
-    category: main
-  - name: binutils
-    version: "2.39"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      binutils_impl_linux-aarch64: ">=2.39,<2.40.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.39-h64c2a2e_1.conda"
-    hash:
-      md5: 9c096a144d04d6701d5ecc530e711934
-      sha256: 0f37fe063a6111c38272abef6c42b881c7fe71958313638701206c0e8669b2ae
-    optional: false
-    category: main
-  - name: binutils_linux-aarch64
-    version: "2.39"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      binutils_impl_linux-aarch64: 2.39.*
-      sysroot_linux-aarch64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.39-h489c705_11.tar.bz2"
-    hash:
-      md5: 4b7f9e2048a3b75aca16b9612d7f49c7
-      sha256: 21da410295e7e42e7459fa633a72c213b19c88d12a95c6b08599935e975694c4
-    optional: false
-    category: main
-  - name: bzip2
-    version: 1.0.8
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-hf897c2e_4.tar.bz2"
-    hash:
-      md5: 2d787570a729e273a4e75775ddf3348a
-      sha256: 3aeb6ab92aa0351722497b2d2a735dc20921cf6c60d9196c04b7a2b9ece198d2
-    optional: false
-    category: main
-  - name: jpeg
-    version: 9e
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/jpeg-9e-h2a766a3_3.conda"
-    hash:
-      md5: 9530170a461f31c2c04753fc664eb6b0
-      sha256: 9a99054cdd1b67bc3319b863d17045045455cfb3ff1a3cb166f2f2a206aedf4d
-    optional: false
-    category: main
-  - name: lerc
-    version: 4.0.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2"
-    hash:
-      md5: 1a0ffc65e03ce81559dbcb0695ad1476
-      sha256: 2d09ef9b7796d83364957e420b41c32d94e628c3f0520b61c332518a7b5cd586
-    optional: false
-    category: main
-  - name: libbrotlicommon
-    version: 1.0.9
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.0.9-h4e544f5_8.tar.bz2"
-    hash:
-      md5: 3cedc3935cfaa2a5303daa25fb12cb1d
-      sha256: 8eedfeb9097042f1005d4764bda83de0eda907e55d77408654367760ad46053d
-    optional: false
-    category: main
-  - name: libdeflate
-    version: "1.17"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.17-hb4cce97_0.conda"
-    hash:
-      md5: 0a26f36963967687f4cab7c4a017a189
-      sha256: 3602858d16549239f036ccb8763e6b0e4a027f2f28e0b2d9d8e65fbbb34a9ded
-    optional: false
-    category: main
-  - name: libffi
-    version: 3.4.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2"
-    hash:
-      md5: dddd85f4d52121fab0a8b099c5e06501
-      sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
-    optional: false
-    category: main
-  - name: libiconv
-    version: "1.17"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h9cdd2b7_0.tar.bz2"
-    hash:
-      md5: efc27cfbc82a027f65c02c661832ecfc
-      sha256: e3c95d751ea71a638f781e82b1498e914e1d11536ea52fc354fecb2e65d3a7d3
-    optional: false
-    category: main
-  - name: libnsl
-    version: 2.0.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.0-hf897c2e_0.tar.bz2"
-    hash:
-      md5: 36fdbc05c9d9145ece86f5a63c3f352e
-      sha256: 182dbc318b7ab3ab10bc5a9d3ca161b143ae8db6df8aa11b65140009e322e642
-    optional: false
-    category: main
-  - name: libopenblas
-    version: 0.3.21
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libgfortran-ng: "*"
-      libgfortran5: ">=10.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.21-pthreads_h6cb6f83_3.tar.bz2"
-    hash:
-      md5: bc66302748a788c3bce59999ed6d737d
-      sha256: 78a93de015d389597d9bdd470ffcfa3901d4b39b85d6516f242ff71d18dc6607
-    optional: false
-    category: main
-  - name: libsanitizer
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=11.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-11.3.0-hdddb281_19.tar.bz2"
-    hash:
-      md5: bd023c6dd60bd0102ce12e1e0257265b
-      sha256: e1e263d2fc39c329d97b50a20a355e641a37ab7fe724133ffdfedb32ab53cf4d
-    optional: false
-    category: main
-  - name: libuuid
-    version: 2.32.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.32.1-hf897c2e_1000.tar.bz2"
-    hash:
-      md5: e038da5ef9095b0d79aac14a311394e7
-      sha256: 8f7eead3723c32631b252aea336bb39fbbde433b8d0c5a75745f03eaa980447d
-    optional: false
-    category: main
-  - name: libwebp-base
-    version: 1.2.4
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.2.4-h4e544f5_0.tar.bz2"
-    hash:
-      md5: 9c307c3dba834b9529f6dcd95db543ed
-      sha256: 831824c213e80a43a0a85318e5967a88a1adbf344b24ed5c4ee9ead8b696f170
-    optional: false
-    category: main
-  - name: libzlib
-    version: 1.2.13
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h4e544f5_4.tar.bz2"
-    hash:
-      md5: 88596b6277fe6d39f046983aae6044db
-      sha256: 9803ac96dbdbc27df9c149e06d4436b778c468bd0e6e023fbcb49a6fe9c404b4
-    optional: false
-    category: main
-  - name: ncurses
-    version: "6.3"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.3-headf329_1.tar.bz2"
-    hash:
-      md5: 486b68148e121bc8bbadc3cefae4c04f
-      sha256: d410d840cb39175d7edc388690b93b2e3d7613c2e2f5c64b96582dc8b55b2319
-    optional: false
-    category: main
-  - name: ninja
-    version: 1.11.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-      libstdcxx-ng: ">=10.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.11.0-hdd96247_0.tar.bz2"
-    hash:
-      md5: 836cf12c1e2acba999080766059b20ad
-      sha256: 56123a84b506452186a1604597f424e3bf366e71fceec113e6292a73bafa2d7e
-    optional: false
-    category: main
-  - name: openssl
-    version: 3.0.8
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      ca-certificates: "*"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.0.8-hb4cce97_0.conda"
-    hash:
-      md5: 268fe30a14a3f40fe54da04fc053fd2d
-      sha256: 19d10fdaee08ab2b5506cdce4399922c5c7d012be7ca7ca93c521748bade3e90
-    optional: false
-    category: main
-  - name: pkg-config
-    version: 0.29.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=7.5.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/pkg-config-0.29.2-hb9de7d4_1008.tar.bz2"
-    hash:
-      md5: 1d0a81d5da1378d9b989383556c20eac
-      sha256: 0d6af1ebd78e231281f570ad7ddd1e2789e485c94fba6b5cef4e8ad23ff7f3bf
-    optional: false
-    category: main
-  - name: pthread-stubs
-    version: "0.4"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=7.5.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-hb9de7d4_1001.tar.bz2"
-    hash:
-      md5: d0183ec6ce0b5aaa3486df25fa5f0ded
-      sha256: f1d7ff5e06cc515ec82010537813c796369f8e9dde46ce3f4fa1a9f70bc7db7d
-    optional: false
-    category: main
-  - name: xorg-libxau
-    version: 1.0.9
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.9-h3557bc0_0.tar.bz2"
-    hash:
-      md5: e0c187f5ce240897762bbb89a8a407cc
-      sha256: 898553ead60af45e3b8b2a7be1b21b0df8ce3c20d5772490c05188cce5ec8b55
-    optional: false
-    category: main
-  - name: xorg-libxdmcp
-    version: 1.1.3
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h3557bc0_0.tar.bz2"
-    hash:
-      md5: a6c9016ae1ca5c47a3603ed4cd65fedd
-      sha256: 2aad9a0b57796170b8fb40317598fd79cfc7ae27fa7fb68c417d815e44499d59
-    optional: false
-    category: main
-  - name: xz
-    version: 5.2.6
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2"
-    hash:
-      md5: 83baad393a31d59c20b63ba4da6592df
-      sha256: 93f58a7b393adf41fa007ac8c55978765e957e90cd31877ece1e5a343cb98220
-    optional: false
-    category: main
-  - name: doxygen
-    version: 1.9.5
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libiconv: ">=1.16,<2.0.0a0"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/doxygen-1.9.5-h04155f4_0.tar.bz2"
-    hash:
-      md5: 8b648aebf430cde9aa32cc55a51dc3b2
-      sha256: 4ccd5a8f2434ba04fcda419e690dec233f381432e23adceb0f2fe11029b67770
-    optional: false
-    category: main
-  - name: gcc_impl_linux-aarch64
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      binutils_impl_linux-aarch64: ">=2.39"
-      libgcc-devel_linux-aarch64: "==11.3.0 h02014c4_19"
-      libgcc-ng: ">=11.3.0"
-      libgomp: ">=11.3.0"
-      libsanitizer: "==11.3.0 hdddb281_19"
-      libstdcxx-ng: ">=11.3.0"
-      sysroot_linux-aarch64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-11.3.0-h771ed3b_19.tar.bz2"
-    hash:
-      md5: 3b89b2222e3ade690a36e419e85d4988
-      sha256: 9f83e3b05644fd28a681ec9a98a75662299a0643cb5c3697025a6450d19000ae
-    optional: false
-    category: main
-  - name: libblas
-    version: 3.9.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libopenblas: ">=0.3.21,<1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-16_linuxaarch64_openblas.tar.bz2"
-    hash:
-      md5: 188f02883567d5b7f96c7aa12e7007c9
-      sha256: 6fdf73da8b717f207979f77660646ca2d7e17671482435f281b676ac27eb288e
-    optional: false
-    category: main
-  - name: libbrotlidec
-    version: 1.0.9
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libbrotlicommon: "==1.0.9 h4e544f5_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.0.9-h4e544f5_8.tar.bz2"
-    hash:
-      md5: 319956380b383ec9f6a46d585599c028
-      sha256: 5c735e238743bda58f44fcb5bef564dc5262c0ea0219ccdb8cbcb168c98a58e0
-    optional: false
-    category: main
-  - name: libbrotlienc
-    version: 1.0.9
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libbrotlicommon: "==1.0.9 h4e544f5_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.0.9-h4e544f5_8.tar.bz2"
-    hash:
-      md5: 56a0a025208af24e2b43b2bbeee79802
-      sha256: 2f6617b2ac53ab440d50a062d08e39cb207dc3ac36a5abe61efe0fa11d2205a1
-    optional: false
-    category: main
-  - name: libpng
-    version: 1.6.39
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.39-hf9034f9_0.conda"
-    hash:
-      md5: 5ec9052384a6ac85e9111e9ac7c5ec4c
-      sha256: a43ab7cb0a66febe26e33b75e4aef6ce4ce532f69e6336e24ce00235ed000fd9
-    optional: false
-    category: main
-  - name: libsqlite
-    version: 3.40.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.40.0-hf9034f9_0.tar.bz2"
-    hash:
-      md5: 9afb0d5dbaa403858a660cd0b4a31d29
-      sha256: 15e4a4bef065f73c2aae630c0408fd6108f5915d4640c7d97578f2e07b3f5d11
-    optional: false
-    category: main
-  - name: libxcb
-    version: "1.13"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-      pthread-stubs: "*"
-      xorg-libxau: "*"
-      xorg-libxdmcp: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.13-h3557bc0_1004.tar.bz2"
-    hash:
-      md5: cc973f5f452272c397546eac588cddb3
-      sha256: cf726d6b13e93636312722aff04831a77aa8721b63feb6fc12d3604fe209ff94
-    optional: false
-    category: main
-  - name: openblas
-    version: 0.3.21
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libgfortran-ng: "*"
-      libgfortran5: ">=10.4.0"
-      libopenblas: "==0.3.21 pthreads_h6cb6f83_3"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/openblas-0.3.21-pthreads_h2d9dd7e_3.tar.bz2"
-    hash:
-      md5: 17a824cf9bbf0e31998d2c1a2140204c
-      sha256: b782a114740e74a42e8ac77e57de4ed6d35aad30ec6a07106826e1a1e3d0c274
-    optional: false
-    category: main
-  - name: readline
-    version: 8.1.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      ncurses: ">=6.3,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.1.2-h38e3740_0.tar.bz2"
-    hash:
-      md5: 3cdbfb7d7b63ae2c2d35bb167d257ecd
-      sha256: a33bb6e4c93599fb97eb19db0dcca602a90475f2da3c01c14add19b908178fcd
-    optional: false
-    category: main
-  - name: tk
-    version: 8.6.12
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-      libzlib: ">=1.2.11,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.12-hd8af866_0.tar.bz2"
-    hash:
-      md5: 7894e82ff743bd96c76585ddebe28e2a
-      sha256: d659316c9e502fb0e1b9a284fb0f0c00e273bff787e9385ab14be9af13dcd0d2
-    optional: false
-    category: main
-  - name: zstd
-    version: 1.5.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.2-h44f6412_6.conda"
-    hash:
-      md5: 6d0d1cd6d184129eabb96bb220afb5b2
-      sha256: d06afa18c6789d29f1d74990d0b2b68ada43665a419deb617d6440368bd951fc
-    optional: false
-    category: main
-  - name: brotli-bin
-    version: 1.0.9
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libbrotlidec: "==1.0.9 h4e544f5_8"
-      libbrotlienc: "==1.0.9 h4e544f5_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-bin-1.0.9-h4e544f5_8.tar.bz2"
-    hash:
-      md5: 0980429a0148a53edd0f1f207ec28a39
-      sha256: 30214484976cc0a6f37c6e2473578d4602d66d01acf3ccfd2f97238cbb91621b
-    optional: false
-    category: main
-  - name: freetype
-    version: 2.12.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libpng: ">=1.6.39,<1.7.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hbbbf32d_1.conda"
-    hash:
-      md5: e0891290982420d67651589c8584eec3
-      sha256: f574138dd4fcec3acbd87df049bb9161af95ad194120cf322d884fdf0df477b5
-    optional: false
-    category: main
-  - name: gcc
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      gcc_impl_linux-aarch64: 11.3.0.*
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-11.3.0-he2d1185_11.tar.bz2"
-    hash:
-      md5: 72f1c88a327e40a7bdf030be352e9f49
-      sha256: 70ee0c88cec738b6b5932b0e5c72b8d929aa3e167e9cb34823aed40d02a7e233
-    optional: false
-    category: main
-  - name: gcc_linux-aarch64
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      binutils_linux-aarch64: "==2.39 h489c705_11"
-      gcc_impl_linux-aarch64: 11.3.0.*
-      sysroot_linux-aarch64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-11.3.0-h2cafa97_11.tar.bz2"
-    hash:
-      md5: 4cdc6d5a965f658b823d4d5829422e8a
-      sha256: 35232fa113d8cb3b15217e3b6ff00d0fbc3dff33c742a2851919b73a2cf010e1
-    optional: false
-    category: main
-  - name: gfortran_impl_linux-aarch64
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      gcc_impl_linux-aarch64: ">=11.3.0"
-      libgcc-ng: ">=4.9"
-      libgfortran5: ">=11.3.0"
-      libstdcxx-ng: ">=4.9"
-      sysroot_linux-aarch64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_impl_linux-aarch64-11.3.0-h0a651b8_19.tar.bz2"
-    hash:
-      md5: fc45cd438909a1e5e5d39565bd3b3ecd
-      sha256: 9baf7d7c29ee9dc62638c74414253ad1b5fd2140e108a5d8fb582520ca3d981f
-    optional: false
-    category: main
-  - name: gxx_impl_linux-aarch64
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      gcc_impl_linux-aarch64: "==11.3.0 h771ed3b_19"
-      libstdcxx-devel_linux-aarch64: "==11.3.0 h02014c4_19"
-      sysroot_linux-aarch64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-11.3.0-h771ed3b_19.tar.bz2"
-    hash:
-      md5: 567374f76eeac7b755e5d5873459fe98
-      sha256: c58c38263c10700cd3af75ce9a847a14dea67fe18cf9948059bb8a6e95dd641a
-    optional: false
-    category: main
-  - name: libcblas
-    version: 3.9.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libblas: "==3.9.0 16_linuxaarch64_openblas"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-16_linuxaarch64_openblas.tar.bz2"
-    hash:
-      md5: 520a3ecbebc63239c27dd6f70c2ababe
-      sha256: c1d4fa9a99475647c7904009c026fe7f9c0b3159b2f7d2bcecac102751104302
-    optional: false
-    category: main
-  - name: liblapack
-    version: 3.9.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libblas: "==3.9.0 16_linuxaarch64_openblas"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-16_linuxaarch64_openblas.tar.bz2"
-    hash:
-      md5: 62990b2d1efc22d0beb394e893d39541
-      sha256: 80a809ce2c965b27d8b8b90753ab01d467b9bf2a66467ca98fc363e4a41da5ec
-    optional: false
-    category: main
-  - name: libtiff
-    version: 4.5.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      jpeg: ">=9e,<10a"
-      lerc: ">=4.0.0,<5.0a0"
-      libdeflate: ">=1.17,<1.18.0a0"
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      libwebp-base: ">=1.2.4,<2.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      xz: ">=5.2.6,<6.0a0"
-      zstd: ">=1.5.2,<1.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.5.0-h4c1066a_2.conda"
-    hash:
-      md5: 45b240c8ce410ecc8f82cd085279dce9
-      sha256: a0e7bf098114756ef6e675414dde37b24c508816d3e525ba27d271cfbea0ab68
-    optional: false
-    category: main
-  - name: python
-    version: 3.9.16
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      bzip2: ">=1.0.8,<2.0a0"
-      ld_impl_linux-aarch64: ">=2.36.1"
-      libffi: ">=3.4,<4.0a0"
-      libgcc-ng: ">=12"
-      libnsl: ">=2.0.0,<2.1.0a0"
-      libsqlite: ">=3.40.0,<4.0a0"
-      libuuid: ">=2.32.1,<3.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      ncurses: ">=6.3,<7.0a0"
-      openssl: ">=3.0.7,<4.0a0"
-      pip: "*"
-      readline: ">=8.1.2,<9.0a0"
-      tk: ">=8.6.12,<8.7.0a0"
-      tzdata: "*"
-      xz: ">=5.2.6,<6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.9.16-hb363c5e_0_cpython.conda"
-    hash:
-      md5: 0a7ef29549eaef817898062eeeefebd3
-      sha256: 776e0ad572f4c7c9de53e5f6aaa435eb37162f041866f04fd496d3c91e3c2f47
-    optional: false
-    category: main
-  - name: alabaster
-    version: 0.7.13
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 06006184e203b61d3525f90de394471e
-      sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
-    optional: false
-    category: main
-  - name: appdirs
-    version: 1.4.4
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 5f095bc6454094e96f146491fd03633b
-      sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
-    optional: false
-    category: main
-  - name: attrs
-    version: 22.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/attrs-22.2.0-pyh71513ae_0.conda"
-    hash:
-      md5: 8b76db7818a4e401ed4486c4c1635cd9
-      sha256: 3a58d4a4933fa8735471c782d35326ab78e0bcfce84756408515f82a94e4dec4
-    optional: false
-    category: main
-  - name: backcall
-    version: 0.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 6006a6d08a3fa99268a2681c7fb55213
-      sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
-    optional: false
-    category: main
-  - name: backports
-    version: "1.0"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda"
-    hash:
-      md5: 54ca2e08b3220c148a1d8329c2678e02
-      sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-    optional: false
-    category: main
-  - name: backports.zoneinfo
-    version: 0.2.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/backports.zoneinfo-0.2.1-py39h4420490_7.tar.bz2"
-    hash:
-      md5: 81f95bd3b0e4370ac3aef6e19eef8763
-      sha256: 340b8c181416f6811c80601d8cdd8a8ba9d0540e31e3bde1f901e8e71d7c56d8
-    optional: false
-    category: main
-  - name: brotli
-    version: 1.0.9
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      brotli-bin: "==1.0.9 h4e544f5_8"
-      libbrotlidec: "==1.0.9 h4e544f5_8"
-      libbrotlienc: "==1.0.9 h4e544f5_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/brotli-1.0.9-h4e544f5_8.tar.bz2"
-    hash:
-      md5: 259d82bd990ba225508389509634b157
-      sha256: e775343c34d04c6e27b4967b6edeac4793c9f0bd6c843990497c72798f49808f
-    optional: false
-    category: main
-  - name: c-compiler
-    version: 1.5.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      binutils: "*"
-      gcc: "*"
-      gcc_linux-aarch64: 11.*
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.5.2-hb4cce97_0.conda"
-    hash:
-      md5: ea29c067379169a815018c1c94a05b9e
-      sha256: 3c63e0126e5a21e62bff541253a6c235b7130e984f39b2fa6acc3773d744ff23
-    optional: false
-    category: main
-  - name: certifi
-    version: 2022.12.7
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/certifi-2022.12.7-pyhd8ed1ab_0.conda"
-    hash:
-      md5: fb9addc3db06e56abe03e0e9f21a63e6
-      sha256: 5e22af4776700200fab2c1df41a2188ab9cfe90a50c4f388592bb978562c88ec
-    optional: false
-    category: main
-  - name: charset-normalizer
-    version: 2.1.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c1d5b294fbf9a795dec349a6f4d8be8e
-      sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
-    optional: false
-    category: main
-  - name: click
-    version: 8.1.3
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      __unix: "*"
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2"
-    hash:
-      md5: 20e4087407c7cb04a40817114b333dbf
-      sha256: 23676470b591b100393bb0f6c46fe10624dcbefc696a6a9f42932ed8816ef0ea
-    optional: false
-    category: main
-  - name: colorama
-    version: 0.4.6
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 3faab06a954c2a04039983f2c4a50d99
-      sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-    optional: false
-    category: main
-  - name: cycler
-    version: 0.11.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: a50559fad0affdbb33729a68669ca1cb
-      sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
-    optional: false
-    category: main
-  - name: cython
-    version: 0.29.33
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/cython-0.29.33-py39hdcdd789_0.conda"
-    hash:
-      md5: 7a94705550f5c09d4a3b069f0488caed
-      sha256: 9e7162fd241d306a0274c970dc266c9684747b1b31bfee795572ceb232b004bf
-    optional: false
-    category: main
-  - name: decorator
-    version: 5.1.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 43afe5ab04e35e17ba28649471dd7364
-      sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-    optional: false
-    category: main
-  - name: docutils
-    version: "0.19"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/docutils-0.19-py39ha65689a_1.tar.bz2"
-    hash:
-      md5: fd0d3cb6620a155e9a1bbb5f0d5f2456
-      sha256: 01587e209ffd4f7b9f7ef9988068a9ef6a008f405c397c60a48a95584c30a4a8
-    optional: false
-    category: main
-  - name: exceptiongroup
-    version: 1.1.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: a385c3e8968b4cf8fbc426ace915fd1a
-      sha256: cf668360331552b2903e440cda1b4e47062c3f3775342e4a278ef4d141c28d1d
-    optional: false
-    category: main
-  - name: execnet
-    version: 1.9.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: "==2.7|>=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/execnet-1.9.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 0e521f7a5e60d508b121d38b04874fb2
-      sha256: 1900bbc1764d01405e55be2e369d1b830fb435eb0f27c57033372c60f34c675c
-    optional: false
-    category: main
-  - name: executing
-    version: 1.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 4c1bc140e2be5c8ba6e3acab99e25c50
-      sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
-    optional: false
-    category: main
-  - name: gfortran
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      gcc: 11.3.0.*
-      gcc_impl_linux-aarch64: 11.3.0.*
-      gfortran_impl_linux-aarch64: 11.3.0.*
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran-11.3.0-h6b6addb_11.tar.bz2"
-    hash:
-      md5: e918df1fe2a391d9b715a79a5232ea2f
-      sha256: b6556bd72c554d55ca0cd8f1ab2281838e2a8b817d4276c61f7f1be5546b4edf
-    optional: false
-    category: main
-  - name: gfortran_linux-aarch64
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      binutils_linux-aarch64: "==2.39 h489c705_11"
-      gcc_linux-aarch64: "==11.3.0 h2cafa97_11"
-      gfortran_impl_linux-aarch64: 11.3.0.*
-      sysroot_linux-aarch64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gfortran_linux-aarch64-11.3.0-hff98631_11.tar.bz2"
-    hash:
-      md5: a7be589b27f26b2c447a4c703c588244
-      sha256: 5ca1326e20b37b2e91dd2d7553a0be569623f96d60fdd740354b2a93be2c948e
-    optional: false
-    category: main
-  - name: gxx
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      gcc: 11.3.0.*
-      gxx_impl_linux-aarch64: 11.3.0.*
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-11.3.0-he2d1185_11.tar.bz2"
-    hash:
-      md5: 0730f39c40a80d5003c5f8bddd514777
-      sha256: bf2a6e358a7256f4d9d65b72c914112b6f1bd4de47d8d2dee5fd62e57d7823ca
-    optional: false
-    category: main
-  - name: gxx_linux-aarch64
-    version: 11.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      binutils_linux-aarch64: "==2.39 h489c705_11"
-      gcc_linux-aarch64: "==11.3.0 h2cafa97_11"
-      gxx_impl_linux-aarch64: 11.3.0.*
-      sysroot_linux-aarch64: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-11.3.0-h7ccc656_11.tar.bz2"
-    hash:
-      md5: 7b4ebbdadc6c61ce3e98fb2d5605f5dc
-      sha256: 229f44d96f37b471e5b7b26f7c617a09636dc6f258c13cbdf322ca27f0e6b2f0
-    optional: false
-    category: main
-  - name: idna
-    version: "3.4"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 34272b248891bddccc64479f9a7fffed
-      sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
-    optional: false
-    category: main
-  - name: imagesize
-    version: 1.4.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.4"
-    url: "https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 7de5386c8fea29e76b303f37dde4c352
-      sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
-    optional: false
-    category: main
-  - name: iniconfig
-    version: 2.0.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f800d2da156d08e289b14e87e43c1ae5
-      sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-    optional: false
-    category: main
-  - name: kiwisolver
-    version: 1.4.4
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/kiwisolver-1.4.4-py39h110580c_1.tar.bz2"
-    hash:
-      md5: 9c045502f6ab8c89bfda6be3c389e503
-      sha256: 9bf3781b4f46988b7e97d9fbaeab666340d3818d162d362b11529809349c9741
-    optional: false
-    category: main
-  - name: lcms2
-    version: "2.14"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      jpeg: ">=9e,<10a"
-      libgcc-ng: ">=12"
-      libtiff: ">=4.5.0,<4.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.14-h7576be9_1.conda"
-    hash:
-      md5: 33f4117db8c2b9ff0888cedd74b2f8e9
-      sha256: 1210de1fbb82cc73fb81f8db3e5ea26071855f3695198fe45fd4382c33aaf1c2
-    optional: false
-    category: main
-  - name: markupsafe
-    version: 2.1.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/markupsafe-2.1.2-py39h599bc27_0.conda"
-    hash:
-      md5: 13af483192015190404fede49f1a306e
-      sha256: 4eb2683d7391a984b0f32e9f9fb20c2708b6a674b0e6d901cd80ccb61b491052
-    optional: false
-    category: main
-  - name: munkres
-    version: 1.1.4
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 2ba8498c1018c1e9c61eb99b973dfe19
-      sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
-    optional: false
-    category: main
-  - name: mypy_extensions
-    version: 1.0.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda"
-    hash:
-      md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-      sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-    optional: false
-    category: main
-  - name: numpy
-    version: 1.24.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libblas: ">=3.9.0,<4.0a0"
-      libcblas: ">=3.9.0,<4.0a0"
-      libgcc-ng: ">=12"
-      liblapack: ">=3.9.0,<4.0a0"
-      libstdcxx-ng: ">=12"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.24.2-py39hafab3e7_0.conda"
-    hash:
-      md5: e8d27fa9b6e02d6fba071d9c555d7962
-      sha256: 9e527264dc80f537796e72c408f335de71842a00b8cad5abfd4d1f9150b2bca9
-    optional: false
-    category: main
-  - name: openjpeg
-    version: 2.5.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libpng: ">=1.6.39,<1.7.0a0"
-      libstdcxx-ng: ">=12"
-      libtiff: ">=4.5.0,<4.6.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.0-h9508984_2.conda"
-    hash:
-      md5: 3d56d402a845c243f8c2dd3c8e836029
-      sha256: 6cb45c526e9577313081a7d020a278fbdfd91e6df14f42a327276ec1a29a5045
-    optional: false
-    category: main
-  - name: packaging
-    version: "23.0"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/packaging-23.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 1ff2e3ca41f0ce16afec7190db28288b
-      sha256: 00288f5e5e841711e8b8fef1f1242c858d8ef99ccbe5d7e0df4789d5d8d40645
-    optional: false
-    category: main
-  - name: parso
-    version: 0.8.3
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 17a565a0c3899244e938cdf417e7b094
-      sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
-    optional: false
-    category: main
-  - name: pickleshare
-    version: 0.7.5
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2"
-    hash:
-      md5: 415f0ebb6198cc2801c73438a9fb5761
-      sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-    optional: false
-    category: main
-  - name: pluggy
-    version: 1.0.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2"
-    hash:
-      md5: 7d301a0d25f424d96175f810935f0da9
-      sha256: c25e1757e4e90638bb1e778aba3ee5f3c01fae9752e3c3929f9be7d367f6c7f3
-    optional: false
-    category: main
-  - name: psutil
-    version: 5.9.4
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-5.9.4-py39h0fd3b05_0.tar.bz2"
-    hash:
-      md5: 2d6fcae2ae9953db962dc3fc1ef456a4
-      sha256: e2bb7645fc1875ee0a54f6af2f9355162e4f70b8e11cb2913c43f082d3ef65ee
-    optional: false
-    category: main
-  - name: ptyprocess
-    version: 0.7.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2"
-    hash:
-      md5: 359eeb6536da0e687af562ed265ec263
-      sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
-    optional: false
-    category: main
-  - name: pure_eval
-    version: 0.2.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6784285c7e55cb7212efabc79e4c2883
-      sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
-    optional: false
-    category: main
-  - name: pycodestyle
-    version: 2.7.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: 2.7.*|>=3.5
-    url: "https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.7.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 0234673eb2ecfbdf4e54574ab4d95f81
-      sha256: 5c6aa7a724551d7768930b30bd77e531580f6ddd68a391094e799a21a82b9492
-    optional: false
-    category: main
-  - name: pycparser
-    version: "2.21"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: 2.7.*|>=3.4
-    url: "https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 076becd9e05608f8dc72757d5f3a91ff
-      sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
-    optional: false
-    category: main
-  - name: pyparsing
-    version: 3.0.9
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: e8fbc1b54b25f4b08281467bc13b70cc
-      sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
-    optional: false
-    category: main
-  - name: pysocks
-    version: 1.7.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      __unix: "*"
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2"
-    hash:
-      md5: 2a7de29fb590ca14b5243c4c812c8025
-      sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
-    optional: false
-    category: main
-  - name: pytz
-    version: 2022.7.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytz-2022.7.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f59d49a7b464901cf714b9e7984d01a2
-      sha256: 93cfc7a92099e26b0575a343da4a667b52371cc38e4dee4ee264dc041ef77bac
-    optional: false
-    category: main
-  - name: setuptools
-    version: 59.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/setuptools-59.2.0-py39ha65689a_0.tar.bz2"
-    hash:
-      md5: d16c2492792df4ceab4c32d426e49f00
-      sha256: 4cc2357f91ebe448287026240be37e717fd5a82cbc1d49fd5ef3ae721672e5e7
-    optional: false
-    category: main
-  - name: six
-    version: 1.16.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2"
-    hash:
-      md5: e5f25f8dbc060e9a8d912e432202afc2
-      sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
-    optional: false
-    category: main
-  - name: smmap
-    version: 3.0.5
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/smmap-3.0.5-pyh44b312d_0.tar.bz2"
-    hash:
-      md5: 3a8dc70789709aa315325d5df06fb7e4
-      sha256: 091de70ee6bfe063e0c0f77336975d124fd1e3f49b9c58d97c0c7b3d287c0002
-    optional: false
-    category: main
-  - name: snowballstemmer
-    version: 2.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 4d22a9315e78c6827f806065957d566e
-      sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
-    optional: false
-    category: main
-  - name: sortedcontainers
-    version: 2.4.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6d6552722448103793743dabfbda532d
-      sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
-    optional: false
-    category: main
-  - name: soupsieve
-    version: 2.3.2.post1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 146f4541d643d48fc8a75cacf69f03ae
-      sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
-    optional: false
-    category: main
-  - name: sphinxcontrib-applehelp
-    version: 1.0.4
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.4-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 5a31a7d564f551d0e6dff52fd8cb5b16
-      sha256: 802810d8321d55e5666806d565e72949eabf77ad510fe2758ce1da2441675ef1
-    optional: false
-    category: main
-  - name: sphinxcontrib-devhelp
-    version: 1.0.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.2-py_0.tar.bz2"
-    hash:
-      md5: 68e01cac9d38d0e717cd5c87bc3d2cc9
-      sha256: 66cca7eccb7f92eee53f9f5a552e3e1d643daa3a1ebd03c185e2819e5c491576
-    optional: false
-    category: main
-  - name: sphinxcontrib-htmlhelp
-    version: 2.0.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 6c8c4d6eb2325e59290ac6dbbeacd5f0
-      sha256: aeff20be994e6f9520a91fc177a33cb3e4d0911cdf8d27e575d001f00afa33fd
-    optional: false
-    category: main
-  - name: sphinxcontrib-jsmath
-    version: 1.0.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-py_0.tar.bz2"
-    hash:
-      md5: 67cd9d9c0382d37479b4d306c369a2d4
-      sha256: a42415fc789e9f6ae2e18f07ac143d2e9ce73a35a55ecf1dd1b3d055dd1e6dbe
-    optional: false
-    category: main
-  - name: sphinxcontrib-qthelp
-    version: 1.0.3
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2"
-    hash:
-      md5: d01180388e6d1838c3e1ad029590aa7a
-      sha256: 35d8f01fc798d38b72ae003c040d2dee650d315f904268a1f793d4d59460d1e2
-    optional: false
-    category: main
-  - name: sphinxcontrib-serializinghtml
-    version: 1.1.5
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2"
-    hash:
-      md5: 9ff55a0901cf952f05c654394de76bf7
-      sha256: 890bbf815cff114ddbb618b9876d492fce07d02956c1d7b3d46cb7f835f563f6
-    optional: false
-    category: main
-  - name: toml
-    version: 0.10.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: f832c45a477c78bebd107098db465095
-      sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
-    optional: false
-    category: main
-  - name: tomli
-    version: 2.0.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 5844808ffab9ebdb694585b50ba02a96
-      sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-    optional: false
-    category: main
-  - name: tornado
-    version: "6.2"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/tornado-6.2-py39hb9a1dbb_1.tar.bz2"
-    hash:
-      md5: f5f4671e5e76b582263699cb4ab3172c
-      sha256: 432a7832582bdba4cadda30d82a1115d31de069e236573943f2c429b2b20c46f
-    optional: false
-    category: main
-  - name: traitlets
-    version: 5.9.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: d0b4f5c87cd35ac3fb3d47b223263a64
-      sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
-    optional: false
-    category: main
-  - name: typing_extensions
-    version: 4.4.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.4.0-pyha770c72_0.tar.bz2"
-    hash:
-      md5: 2d93b130d148d7fc77e583677792fc6a
-      sha256: 70c57b5ac94cd32e78f1a2fa2c38572bfac85b901a6a99aa254a9e8e126c132d
-    optional: false
-    category: main
-  - name: unicodedata2
-    version: 15.0.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-15.0.0-py39h0fd3b05_0.tar.bz2"
-    hash:
-      md5: 835f1a9631e600e0176593e95e85f73f
-      sha256: 06d0dd905a8b4555b729d8c5568a8339a385476890d3b3fc2134ec08d0cfc484
-    optional: false
-    category: main
-  - name: wheel
-    version: 0.38.4
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c829cfb8cb826acb9de0ac1a2df0a940
-      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-    optional: false
-    category: main
-  - name: zipp
-    version: 3.13.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/zipp-3.13.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 41b09d997939e83b231c4557a90c3b13
-      sha256: 0a9a545b8dc46c847658ebfa636257ea5993a355419c1d3b2f14810730ee0a82
-    optional: false
-    category: main
-  - name: asttokens
-    version: 2.2.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.5"
-      six: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: bf7f54dd0f25c3f06ecb82a07341841a
-      sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
-    optional: false
-    category: main
-  - name: babel
-    version: 2.11.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-      pytz: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/babel-2.11.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 2ea70fde8d581ba9425a761609eed6ba
-      sha256: 21a8403d886136c0a80f965ae5387fa1693b19ddd69023bcd0e844f2510d7e2f
-    optional: false
-    category: main
-  - name: backports.functools_lru_cache
-    version: 1.6.4
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      backports: "*"
-      python: ">=3.6"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c5b3edc62d6309088f4970b3eaaa65a6
-      sha256: fdea00d4b79990f3fe938e2716bc32bd895eb5c44b6c75b8261db095a1b33c16
-    optional: false
-    category: main
-  - name: beautifulsoup4
-    version: 4.11.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-      soupsieve: ">=1.2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.11.2-pyha770c72_0.conda"
-    hash:
-      md5: 88b59f6989f0ed5ab3433af0b82555e1
-      sha256: deb43944425b3ec7fdfd5e6620cf97a4ed888a279237f90cd67a338d123efd15
-    optional: false
-    category: main
-  - name: cffi
-    version: 1.15.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libffi: ">=3.4,<4.0a0"
-      libgcc-ng: ">=12"
-      pycparser: "*"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/cffi-1.15.1-py39hb26bf21_3.conda"
-    hash:
-      md5: dee0362c4fde8edce396183fd6390d6e
-      sha256: 0a3690929b3a22c4e2db8001293509e38b5d90eb2ff57d5d71456e81c9c0f8eb
-    optional: false
-    category: main
-  - name: contourpy
-    version: 1.0.7
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      numpy: ">=1.16"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/contourpy-1.0.7-py39hd9a2fea_0.conda"
-    hash:
-      md5: efa783bf5c2b30aba3cf22599fe0274e
-      sha256: 0da3e468f4ee6cc3d708e32ab4d1e4d6e8ed899168693e3e33570d1e8ce927d9
-    optional: false
-    category: main
-  - name: coverage
-    version: 7.1.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tomli: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/coverage-7.1.0-py39h599bc27_0.conda"
-    hash:
-      md5: 642b33264c733811d45640fc5d035a5c
-      sha256: 7d02e1632234311db52c247b7d59ea8173cc06ac43943147a5291be62885a6c3
-    optional: false
-    category: main
-  - name: cxx-compiler
-    version: 1.5.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      c-compiler: "==1.5.2 hb4cce97_0"
-      gxx: "*"
-      gxx_linux-aarch64: 11.*
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.5.2-h4c384f3_0.conda"
-    hash:
-      md5: 8ce6c4bc31f879baedd1f726f430fa6a
-      sha256: a2560d134c72f29f193ec195f25e774a6855c8bc1588427abfdfbb52c6769620
-    optional: false
-    category: main
-  - name: fonttools
-    version: 4.38.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      brotli: "*"
-      libgcc-ng: ">=12"
-      munkres: "*"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-      unicodedata2: ">=14.0.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/fonttools-4.38.0-py39h0fd3b05_1.tar.bz2"
-    hash:
-      md5: c4eda904dc52f53c948d64d20662525f
-      sha256: f8160177436c15a924a539f3074d36ad10960b0243340a1b9d79633432fff65e
-    optional: false
-    category: main
-  - name: fortran-compiler
-    version: 1.5.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      binutils: "*"
-      c-compiler: "==1.5.2 hb4cce97_0"
-      gfortran: "*"
-      gfortran_linux-aarch64: 11.*
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/fortran-compiler-1.5.2-h878be85_0.conda"
-    hash:
-      md5: 0fc27753a4f9b39286bd58ce8870605e
-      sha256: e9d8407d1a4030b3faef9a7278cea55de3343f2507680ef673d32dff14d9060b
-    optional: false
-    category: main
-  - name: gitdb
-    version: 4.0.10
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.4"
-      smmap: ">=3.0.1,<4"
-    url: "https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.10-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 3706d2f3d7cb5dae600c833345a76132
-      sha256: 0003ab2b971913380633c711bf49a54dcf06e179986c725b0925854b58878377
-    optional: false
-    category: main
-  - name: hypothesis
-    version: 6.68.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      attrs: ">=19.2.0"
-      backports.zoneinfo: ">=0.2.1"
-      click: ">=7.0"
-      exceptiongroup: ">=1.0.0rc8"
-      python: ">=3.8"
-      setuptools: "*"
-      sortedcontainers: ">=2.1.0,<3.0.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.68.1-pyha770c72_0.conda"
-    hash:
-      md5: 3c044b3b920eb287f8c095c7f086ba64
-      sha256: e3a29c1303b563e450e0f706e4d78a281d1aa519d3e1094fc642305bceff72e1
-    optional: false
-    category: main
-  - name: importlib-metadata
-    version: 6.0.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.8"
-      zipp: ">=0.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.0.0-pyha770c72_0.conda"
-    hash:
-      md5: 691644becbcdca9f73243450b1c63e62
-      sha256: 0062e6ae1719395c25f0b60a21215470b4ea67514fed8a9330869da8604acfca
-    optional: false
-    category: main
-  - name: jedi
-    version: 0.18.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      parso: ">=0.8.0,<0.9.0"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
-      sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
-    optional: false
-    category: main
-  - name: jinja2
-    version: 3.1.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      markupsafe: ">=2.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: c8490ed5c70966d232fdd389d0dbed37
-      sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-    optional: false
-    category: main
-  - name: matplotlib-inline
-    version: 0.1.6
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-      traitlets: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: b21613793fcc81d944c76c9f2864a7de
-      sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-    optional: false
-    category: main
-  - name: meson
-    version: 1.0.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      ninja: ">=1.8.2"
-      python: ">=3.5.2"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/meson-1.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 4de573313958b8da6c526fdd354fffc8
-      sha256: 57dc7634aa05f3944314e6b56b2f37e6fb1a52b33de9ca153aee5d9adf83a5d7
-    optional: false
-    category: main
-  - name: mypy
-    version: "0.981"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      mypy_extensions: ">=0.4.3"
-      psutil: ">=4.0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-      tomli: ">=1.1.0"
-      typing_extensions: ">=3.10"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/mypy-0.981-py39h0fd3b05_0.tar.bz2"
-    hash:
-      md5: 356d846032061ddec0beb97de9fb4570
-      sha256: ca216a2d2022060c3a51fe3bb9b73e250797da3c874bd766f3e4b4223f362495
-    optional: false
-    category: main
-  - name: pexpect
-    version: 4.8.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      ptyprocess: ">=0.5"
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2"
-    hash:
-      md5: 330448ce4403cc74990ac07c555942a1
-      sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
-    optional: false
-    category: main
-  - name: pillow
-    version: 9.4.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      freetype: ">=2.12.1,<3.0a0"
-      jpeg: ">=9e,<10a"
-      lcms2: ">=2.14,<3.0a0"
-      libgcc-ng: ">=12"
-      libtiff: ">=4.5.0,<4.6.0a0"
-      libwebp-base: ">=1.2.4,<2.0a0"
-      libxcb: ">=1.13,<1.14.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      openjpeg: ">=2.5.0,<3.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tk: ">=8.6.12,<8.7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-9.4.0-py39h72365ce_1.conda"
-    hash:
-      md5: 0cd1a724352e4916a84339500506f61e
-      sha256: f230a8e3bf559c49163b3adbd64075d3eef7274e98b97800662cb6678746847f
-    optional: false
-    category: main
-  - name: pip
-    version: "23.0"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-      setuptools: "*"
-      wheel: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 85b35999162ec95f9f999bac15279c02
-      sha256: bbffec284bd0e154363e845121f43007e7e64c80412ff13be21909be907b697d
-    optional: false
-    category: main
-  - name: pygments
-    version: 2.14.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pygments-2.14.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: c78cd16b11cd6a295484bd6c8f24bea1
-      sha256: e8710e24f60b6a97289468f47914e53610101755088bc237621cc1980edbfcd9
-    optional: false
-    category: main
-  - name: pyproject-metadata
-    version: 0.7.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      packaging: ">=19.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyproject-metadata-0.7.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: dcb27826ffc94d5f04e241322239983b
-      sha256: 9ec35cffa163f587aeb52d1603df8374659e3be30dbc6db0e980ecb797f21fee
-    optional: false
-    category: main
-  - name: pytest
-    version: 7.2.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      attrs: ">=19.2.0"
-      colorama: "*"
-      exceptiongroup: "*"
-      iniconfig: "*"
-      packaging: "*"
-      pluggy: ">=0.12,<2.0"
-      python: ">=3.8"
-      tomli: ">=1.0.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f0be05afc9c9ab45e273c088e00c258b
-      sha256: d298dfe6c53555c9fb5662f5f936e621cddd3b0a7031789375b82a1ee3b3a96b
-    optional: false
-    category: main
-  - name: python-dateutil
-    version: 2.8.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-      six: ">=1.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: dd999d1cc9f79e67dbb855c8924c7984
-      sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-    optional: false
-    category: main
-  - name: typing-extensions
-    version: 4.4.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      typing_extensions: "==4.4.0 pyha770c72_0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.4.0-hd8ed1ab_0.tar.bz2"
-    hash:
-      md5: be969210b61b897775a0de63cd9e9026
-      sha256: 6f129b1bc18d111dcf3abaec6fcf6cbee00f1b77bb42d0f0bc8d85f8faa65cf0
-    optional: false
-    category: main
-  - name: brotlipy
-    version: 0.7.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      cffi: ">=1.0.0"
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/brotlipy-0.7.0-py39h0fd3b05_1005.tar.bz2"
-    hash:
-      md5: 5d37ef329c084829d3ff5b172a08b8f9
-      sha256: b62b8ba3688978d1344a4ea639b4ab28988fac5318a9842af4e7b9f5feb8374d
-    optional: false
-    category: main
-  - name: compilers
-    version: 1.5.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      c-compiler: "==1.5.2 hb4cce97_0"
-      cxx-compiler: "==1.5.2 h4c384f3_0"
-      fortran-compiler: "==1.5.2 h878be85_0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/compilers-1.5.2-h8af1aa0_0.conda"
-    hash:
-      md5: 3505d3b81bd518ea3fd084f33f6d486f
-      sha256: 84c71456b39a9693d471c9b279073afa67c47611f5fdaa99b72f069f46454e96
-    optional: false
-    category: main
-  - name: cryptography
-    version: 39.0.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      cffi: ">=1.12"
-      libgcc-ng: ">=12"
-      openssl: ">=3.0.8,<4.0a0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/cryptography-39.0.1-py39h8a84b6a_0.conda"
-    hash:
-      md5: 836c852bcc8f60392bfe4f9305f541b7
-      sha256: a0918f5094edff472291dc2889431a17aaff4b0ee38ae321ff2ea5b420a4b42a
-    optional: false
-    category: main
-  - name: gitpython
-    version: 3.1.30
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      gitdb: ">=4.0.1,<5"
-      python: ">=3.7"
-      typing_extensions: ">=3.7.4.3"
-    url: "https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.30-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 0c217ab2f5ef6925e4e52c70b57cfc4a
-      sha256: 2ccd8aa401701947398a087b1aa11042b1b088e7331fed574b7ec9909bee09d6
-    optional: false
-    category: main
-  - name: matplotlib-base
-    version: 3.6.3
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      certifi: ">=2020.6.20"
-      contourpy: ">=1.0.1"
-      cycler: ">=0.10"
-      fonttools: ">=4.22.0"
-      freetype: ">=2.12.1,<3.0a0"
-      kiwisolver: ">=1.0.1"
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      numpy: ">=1.20.3,<2.0a0"
-      packaging: ">=20.0"
-      pillow: ">=6.2.0"
-      pyparsing: ">=2.3.1"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python-dateutil: ">=2.7"
-      python_abi: 3.9.* *_cp39
-      tk: ">=8.6.12,<8.7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-base-3.6.3-py39h2983639_0.conda"
-    hash:
-      md5: 9e1496189564d3740c20d3aff999a0ee
-      sha256: 4b51e606ad1e698820d72a247f12eb0c2858e52c87b7b51530f0f386a5672b4b
-    optional: false
-    category: main
-  - name: meson-python
-    version: 0.12.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      colorama: "*"
-      meson: ">=0.63.3"
-      ninja: "*"
-      pyproject-metadata: ">=0.6.1"
-      python: ">=3.7"
-      tomli: ">=1.0.0"
-      typing-extensions: ">=3.7.4"
-      wheel: ">=0.36.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/meson-python-0.12.0-pyh71feb2d_0.conda"
-    hash:
-      md5: dc566efe9c7af4eb305402b5c6121ca3
-      sha256: 2ea6e9b843e7d93283f2bd442f20bc973cf8141ef1876c9fe4353e473265a4da
-    optional: false
-    category: main
-  - name: pandas
-    version: 1.5.3
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      numpy: ">=1.20.3,<2.0a0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python-dateutil: ">=2.8.1"
-      python_abi: 3.9.* *_cp39
-      pytz: ">=2020.1"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-1.5.3-py39h1e1c27f_0.conda"
-    hash:
-      md5: 13b3d2c17a216d189837df6a2caefb5d
-      sha256: eeece380a252712eaebbcc12d73abbe7542ff3e25b560afac0f1766f9a1b854b
-    optional: false
-    category: main
-  - name: pytest-cov
-    version: 4.0.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      coverage: ">=5.2.1"
-      pytest: ">=4.6"
-      python: ">=3.6"
-      toml: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.0.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c9e3f8bfdb9bfc34aa1836a6ed4b25d7
-      sha256: 2e00bbdb00b2514faba50ddcb6ecf1d6e4f2d5af346f9cd1240aacb1b61dccb6
-    optional: false
-    category: main
-  - name: pytest-xdist
-    version: 3.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      execnet: ">=1.1"
-      pytest: ">=6.2.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.2.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 70ab87b96126f35d1e68de2ad9fb6423
-      sha256: aa81f80bf0a2f53423ab80137ca4fc201473884725a2983a0d79b2e420c2a671
-    optional: false
-    category: main
-  - name: stack_data
-    version: 0.6.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      asttokens: "*"
-      executing: "*"
-      pure_eval: "*"
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: e7df0fdd404616638df5ece6e69ba7af
-      sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-    optional: false
-    category: main
-  - name: wcwidth
-    version: 0.2.6
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      backports.functools_lru_cache: "*"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 078979d33523cb477bd1916ce41aacc9
-      sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
-    optional: false
-    category: main
-  - name: matplotlib
-    version: 3.6.3
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      matplotlib-base: ">=3.6.3,<3.6.4.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tornado: ">=5"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/matplotlib-3.6.3-py39ha65689a_0.conda"
-    hash:
-      md5: 1af8933de795cb23f0a28cba529c544d
-      sha256: 7adde98e60579550ed3fe3f40f5877b135bacd6b74f59e4d3df25f504033e99f
-    optional: false
-    category: main
-  - name: prompt-toolkit
-    version: 3.0.36
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-      wcwidth: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda"
-    hash:
-      md5: 4d79ec192e0bfd530a254006d123b9a6
-      sha256: 6bd3626799c9467d7aa8ed5f95043e4cea614a1329580980ddcf40cfed3ee860
-    optional: false
-    category: main
-  - name: pyopenssl
-    version: 23.0.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      cryptography: ">=38.0.0,<40"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: d41957700e83bbb925928764cb7f8878
-      sha256: adbf8951f22bfa950b9e24394df1ef1d2b2d7dfb194d91c7f42bc11900695785
-    optional: false
-    category: main
-  - name: ipython
-    version: 8.10.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      __linux: "*"
-      backcall: "*"
-      decorator: "*"
-      jedi: ">=0.16"
-      matplotlib-inline: "*"
-      pexpect: ">4.3"
-      pickleshare: "*"
-      prompt-toolkit: ">=3.0.30,<3.1.0"
-      pygments: ">=2.4.0"
-      python: ">=3.8"
-      stack_data: "*"
-      traitlets: ">=5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/ipython-8.10.0-pyh41d4057_0.conda"
-    hash:
-      md5: 4703355103974293bbd8a32449b3ff28
-      sha256: 350847af23f964a1002c712547e26a1e144e5bbc1662016263c5fb8fc963dcff
-    optional: false
-    category: main
-  - name: urllib3
-    version: 1.26.14
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      brotlipy: ">=0.6.0"
-      certifi: "*"
-      cryptography: ">=1.3.4"
-      idna: ">=2.0.0"
-      pyopenssl: ">=0.14"
-      pysocks: ">=1.5.6,<2.0,!=1.5.7"
-      python: "<4.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.14-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 01f33ad2e0aaf6b5ba4add50dad5ad29
-      sha256: f2f09c44e47946ce631dbc9a8a79bb463ac0f4122aaafdbcc51f200a1e420ca6
-    optional: false
-    category: main
-  - name: requests
-    version: 2.28.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      certifi: ">=2017.4.17"
-      charset-normalizer: ">=2,<3"
-      idna: ">=2.5,<4"
-      python: ">=3.7,<4.0"
-      urllib3: ">=1.21.1,<1.27"
-    url: "https://conda.anaconda.org/conda-forge/noarch/requests-2.28.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 11d178fc55199482ee48d6812ea83983
-      sha256: 22c081b4cdd023a514400413f50efdf2c378f56f2a5ea9d65666aacf4696490a
-    optional: false
-    category: main
-  - name: pooch
-    version: 1.6.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      appdirs: ">=1.3.0"
-      packaging: ">=20.0"
-      python: ">=3.6"
-      requests: ">=2.19.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pooch-1.6.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6429e1d1091c51f626b5dcfdd38bf429
-      sha256: 1f0548105de86fb2eb6fbb8d3d6cc2004079b8442d232258108687d6cc91eb73
-    optional: false
-    category: main
-  - name: sphinx
-    version: 5.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      alabaster: ">=0.7,<0.8"
-      babel: ">=2.9"
-      colorama: ">=0.4.5"
-      docutils: ">=0.14,<0.20"
-      imagesize: ">=1.3"
-      importlib-metadata: ">=4.8"
-      jinja2: ">=3.0"
-      packaging: ">=21.0"
-      pygments: ">=2.12"
-      python: ">=3.7"
-      requests: ">=2.5.0"
-      snowballstemmer: ">=2.0"
-      sphinxcontrib-applehelp: "*"
-      sphinxcontrib-devhelp: "*"
-      sphinxcontrib-htmlhelp: ">=2.0.0"
-      sphinxcontrib-jsmath: "*"
-      sphinxcontrib-qthelp: "*"
-      sphinxcontrib-serializinghtml: ">=1.1.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-5.3.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: f9e1fcfe235d655900bfeb6aee426472
-      sha256: f11fd5fb4ae2c65f41ae86e7408e3ab44844898d928264aa9e89929fffc685c8
-    optional: false
-    category: main
-  - name: breathe
-    version: 4.34.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      docutils: ">=0.12"
-      jinja2: ">=2.7.3"
-      markupsafe: ">=0.23"
-      pygments: ">=1.6"
-      python: ">=3.6"
-      sphinx: ">=4.0,<6.0.0a"
-    url: "https://conda.anaconda.org/conda-forge/noarch/breathe-4.34.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: a2a04f8e8c2d91adb08ff929b4d73654
-      sha256: 40f86cd741a443363e8928d5d36ba3a49071aaffc26c5a7b24a8167c5bcbba81
-    optional: false
-    category: main
-  - name: numpydoc
-    version: 1.4.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      jinja2: ">=2.10"
-      python: ">=3.7"
-      sphinx: ">=1.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.4.0-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: 0aac89c61a466b0f9c4fd0ec44d81f1d
-      sha256: 11a892cc1678a23d169909e553447fb7e312d6baaa314fdcd719f6abff1c7da6
-    optional: false
-    category: main
-  - name: pydata-sphinx-theme
-    version: 0.9.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      beautifulsoup4: "*"
-      docutils: "!=0.17.0"
-      packaging: "*"
-      python: ">=3.7"
-      sphinx: ">=4.0.2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.9.0-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: ed5f1236283219a21207813d387b44bd
-      sha256: 11d56e0953a8f880d265d18eb3b3adc2f0ba182a33409088141dc84e22dba50c
-    optional: false
-    category: main
   - name: scipy
     version: 1.10.0
     manager: conda
@@ -5957,2392 +10782,6 @@ package:
     hash:
       md5: c540ebeaba5c037beb48ce709738afcb
       sha256: e87204c9a98961e632a37f2ff779b1a3d5bd0477d0981f319e12d8d45f54b26d
-    optional: false
-    category: main
-  - name: sphinx-design
-    version: 0.3.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.6"
-      sphinx: ">=4,<6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-design-0.3.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 83d1a712e6d2bab6b298b1d2f42ad355
-      sha256: 6b193a483a02bbc7a785dcd28614b4c082d1795fec0a1c48690d8d7a0a876e20
-    optional: false
-    category: main
-  - name: _libgcc_mutex
-    version: "0.1"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/_libgcc_mutex-0.1-conda_forge.tar.bz2"
-    hash:
-      md5: e96f48755dc7c9f86c4aecf4cac40477
-      sha256: 5dd34b412e6274c0614d01a2f616844376ae873dfb8782c2c67d055779de6df6
-    optional: false
-    category: main
-  - name: ca-certificates
-    version: 2022.12.7
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ca-certificates-2022.12.7-h1084571_0.conda"
-    hash:
-      md5: e3becd49c6d0e94d1b67c9f9a4d50587
-      sha256: 82b77cb085c961b085fbbb5ea3920c1933bda08c2e1dd53685f6f21b16a336ac
-    optional: false
-    category: main
-  - name: kernel-headers_linux-ppc64le
-    version: 3.10.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-ppc64le-3.10.0-h23d7e6c_13.tar.bz2"
-    hash:
-      md5: 2c36c739b5b1827404dcc96860f9b7e1
-      sha256: 6752a00b9bf73087c90fbc3da9284745ec7fb5f960a132d3189c6a053d59cfb8
-    optional: false
-    category: main
-  - name: ld_impl_linux-ppc64le
-    version: "2.39"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ld_impl_linux-ppc64le-2.39-hea198f4_1.conda"
-    hash:
-      md5: c7db6cc5b9479df1ed884b6147601613
-      sha256: 20d6db1053ae4af65677fc4b4cf9b2d5884ce26ea6b38f7088a5ebad1de62746
-    optional: false
-    category: main
-  - name: libgcc-devel_linux-ppc64le
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-devel_linux-ppc64le-11.3.0-hcb32637_19.tar.bz2"
-    hash:
-      md5: e652f909e48f3e16a1f4c2a26aaa900b
-      sha256: f4270a73600fe1debf364cfc4b74aac4ca90a052abe9e302301ab62189fc255a
-    optional: false
-    category: main
-  - name: libgfortran5
-    version: 12.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgfortran5-12.2.0-hda65b67_19.tar.bz2"
-    hash:
-      md5: 62f0191db9d8e634ed676c0645aee79b
-      sha256: 6131391202198279f8a3744fa08e6f3f6513d8211799608410bca8fe6b76bf37
-    optional: false
-    category: main
-  - name: libstdcxx-devel_linux-ppc64le
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-devel_linux-ppc64le-11.3.0-hcb32637_19.tar.bz2"
-    hash:
-      md5: 7c528de8f0dddad1ef05aa11151f66d6
-      sha256: f4f4869b24af9d3f37ac15ced5efd51323a0b92886ba0a50fb79d199ba402dd2
-    optional: false
-    category: main
-  - name: libstdcxx-ng
-    version: 12.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libstdcxx-ng-12.2.0-h99369c6_19.tar.bz2"
-    hash:
-      md5: 7fd9892955253a7e5f49ae0e94703dd7
-      sha256: 6e630d9cbb4c0680757e4cbe86a09302125283afd791e997d0ae2fc7ce863384
-    optional: false
-    category: main
-  - name: nomkl
-    version: "1.0"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2"
-    hash:
-      md5: 9a66894dfd07c4510beb6b3f9672ccc0
-      sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
-    optional: false
-    category: main
-  - name: python_abi
-    version: "3.9"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/python_abi-3.9-3_cp39.conda"
-    hash:
-      md5: 4f09b636d43728c2906cf03a18a4e8f6
-      sha256: 3321ab95a62cefe8b305da972b8780647fd8063e96ee331e2b6c9070353272c2
-    optional: false
-    category: main
-  - name: tzdata
-    version: 2022g
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
-    hash:
-      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
-      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
-    optional: false
-    category: main
-  - name: libgfortran-ng
-    version: 12.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgfortran5: "==12.2.0 hda65b67_19"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgfortran-ng-12.2.0-hfdc3801_19.tar.bz2"
-    hash:
-      md5: 81d5153ea3ba783743ab08b859fc8e1f
-      sha256: 5221449383ddf2f73777337f788b7367ae2f035373ff1e9030ea98fe891c73ab
-    optional: false
-    category: main
-  - name: libgomp
-    version: 12.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      _libgcc_mutex: "==0.1 conda_forge"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgomp-12.2.0-hbc1322c_19.tar.bz2"
-    hash:
-      md5: 25647ac31b4d467fce690c6a561a58aa
-      sha256: 56a43985f648c358c6b3eb949863e393dbdb48d8f017315e03ff703031b8a951
-    optional: false
-    category: main
-  - name: sysroot_linux-ppc64le
-    version: "2.17"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      kernel-headers_linux-ppc64le: "==3.10.0 h23d7e6c_13"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-ppc64le-2.17-h395ec9b_13.tar.bz2"
-    hash:
-      md5: c8016c77c47a363566a72ff10a0233e0
-      sha256: 50b9204fe2d6b90a6e4092d4e5f60ed24561f7914bf2296f46dbd620631efcaa
-    optional: false
-    category: main
-  - name: _openmp_mutex
-    version: "4.5"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      _libgcc_mutex: "==0.1 conda_forge"
-      libgomp: ">=7.5.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/_openmp_mutex-4.5-2_gnu.tar.bz2"
-    hash:
-      md5: 3e41cbaba7e4988d15a24c4e85e6171b
-      sha256: 4c89c2067cf5e7b0fbbdc3200c3f7affa5896e14812acf10f51575be87ae0c05
-    optional: false
-    category: main
-  - name: binutils_impl_linux-ppc64le
-    version: "2.39"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      ld_impl_linux-ppc64le: "==2.39 hea198f4_1"
-      sysroot_linux-ppc64le: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/binutils_impl_linux-ppc64le-2.39-heb37b50_1.conda"
-    hash:
-      md5: d4fd843dce0edcc58c63e995b7837293
-      sha256: 91e5401f436aa2686f0dfa36066674f4e26e43efade059acaff3d5c4f25d90d1
-    optional: false
-    category: main
-  - name: binutils
-    version: "2.39"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      binutils_impl_linux-ppc64le: ">=2.39,<2.40.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/binutils-2.39-h7f02139_1.conda"
-    hash:
-      md5: 93ad8fe1ef01293548b6fc28169d40fe
-      sha256: 986d2a9388cb6176b91aacc7cda9f6d317a34e0f61d6d323fc121c3718bc9392
-    optional: false
-    category: main
-  - name: binutils_linux-ppc64le
-    version: "2.39"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      binutils_impl_linux-ppc64le: 2.39.*
-      sysroot_linux-ppc64le: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/binutils_linux-ppc64le-2.39-h5e55cfe_11.tar.bz2"
-    hash:
-      md5: cb19199c186994b286cbb1afb447a9d0
-      sha256: b6b696f484684ad58e9509cc9414fc65349ea9e6fdb6d84822e39b738fa34ed3
-    optional: false
-    category: main
-  - name: libgcc-ng
-    version: 12.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      _libgcc_mutex: "==0.1 conda_forge"
-      _openmp_mutex: ">=4.5"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-ng-12.2.0-hbc1322c_19.tar.bz2"
-    hash:
-      md5: 9ad34f95d6fb05300bbd0f553f3bece4
-      sha256: 335a2b7415cb5fbbf05459f6cfcca4dd8bafd43bcbe5bf6aa56bf66b7ed6bf42
-    optional: false
-    category: main
-  - name: bzip2
-    version: 1.0.8
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/bzip2-1.0.8-h4e0d66e_4.tar.bz2"
-    hash:
-      md5: 3cbc4e0eede8b25bc53b6a462815aceb
-      sha256: e0edf3c1804547239de9f678f9b650684d0f215e4c277e1d92c281f4d61559b8
-    optional: false
-    category: main
-  - name: jpeg
-    version: 9e
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/jpeg-9e-h4194056_3.conda"
-    hash:
-      md5: 90cc27ac2032b05e4131bc62d33635dd
-      sha256: 41ab5b1f339fb2ab0a8938081bf972111a7d730e106eec3987c718e093ab07a9
-    optional: false
-    category: main
-  - name: lerc
-    version: 4.0.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/lerc-4.0.0-hbbae597_0.tar.bz2"
-    hash:
-      md5: fc65ed3c14d2236d5917f11eaf2b949f
-      sha256: 694594f8344b02e0c18ae80d898b248a5afc228f8033fe0c57cb52d8c1839152
-    optional: false
-    category: main
-  - name: libbrotlicommon
-    version: 1.0.9
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libbrotlicommon-1.0.9-hb283c62_8.tar.bz2"
-    hash:
-      md5: 9981d8b1ed12d10234fa31973de47c10
-      sha256: 69a03504a38fb6b99322896de35df1b76ac34fd25d01d6fed4cb9de7cb18ceb0
-    optional: false
-    category: main
-  - name: libdeflate
-    version: "1.17"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libdeflate-1.17-h4194056_0.conda"
-    hash:
-      md5: 02f45219ac7b6b3d2af66fbbb2a7c8e5
-      sha256: aa28ce878cbe18757b4acca5341b91bab3531a42ddd092227ebc34c255781135
-    optional: false
-    category: main
-  - name: libffi
-    version: 3.4.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libffi-3.4.2-h4e0d66e_5.tar.bz2"
-    hash:
-      md5: 79c37a0a50ef77fea4ee5f6d257b8b3c
-      sha256: 178ca9f82e2144a8834dd01f9af3b4b9b5d482892675931edccff06aee524953
-    optional: false
-    category: main
-  - name: libiconv
-    version: "1.17"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libiconv-1.17-hb283c62_0.tar.bz2"
-    hash:
-      md5: 4c3d267837da62ef2b79d56729d3fe65
-      sha256: 39c0fb8eaec7b378d88b458376da90261afbdb076eb4c6dd11f51de69d36384f
-    optional: false
-    category: main
-  - name: libnsl
-    version: 2.0.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libnsl-2.0.0-h4e0d66e_0.tar.bz2"
-    hash:
-      md5: e6c718cb0e01f2af330da0a8dbd55b68
-      sha256: 2aa6cd044633586588c7105a3702788ee65b679801ab5d00b48d64265ae2f13c
-    optional: false
-    category: main
-  - name: libopenblas
-    version: 0.3.21
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libgfortran-ng: "*"
-      libgfortran5: ">=10.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libopenblas-0.3.21-pthreads_h60f2977_3.tar.bz2"
-    hash:
-      md5: 8d9a4d593fea2ccf376b5e459651dd87
-      sha256: 5b624bbe5f0de77e1979a508c57f55b052155eabf806756b0153d2f97a1d581c
-    optional: false
-    category: main
-  - name: libsanitizer
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=11.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libsanitizer-11.3.0-hc94946d_19.tar.bz2"
-    hash:
-      md5: e9d33799921c73fb1af2dfaba774b19e
-      sha256: b7da522d965117797d9e79e4c83494958cba00b6e5d2c0afba7bcf34385162de
-    optional: false
-    category: main
-  - name: libuuid
-    version: 2.32.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libuuid-2.32.1-h4e0d66e_1000.tar.bz2"
-    hash:
-      md5: ceb7466afcb5be47530ffe9aae8650ae
-      sha256: 58b4f6e27b921ff9171e64b3e382cc644d7da70d5da4e3815b7ceae4b4b452e0
-    optional: false
-    category: main
-  - name: libwebp-base
-    version: 1.2.4
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libwebp-base-1.2.4-hb283c62_0.tar.bz2"
-    hash:
-      md5: 9d042b84b56f3d719a24cd2837fa5ff8
-      sha256: 49a4ec09882f4cc1895c6ba2733fb34fa25cfdb8ee087041254a5ad04cd6a125
-    optional: false
-    category: main
-  - name: libzlib
-    version: 1.2.13
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libzlib-1.2.13-hb283c62_4.tar.bz2"
-    hash:
-      md5: af99cdd23d3761a569840663bdf0dc0d
-      sha256: 62073ba865b49db36dc14ffeaa2985711bce65d720b853e3aa4cce0a9e5439d8
-    optional: false
-    category: main
-  - name: ncurses
-    version: "6.3"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ncurses-6.3-hab78ccb_1.tar.bz2"
-    hash:
-      md5: 775403ae6d617d309d874f9bff20e670
-      sha256: 37761927f381de5741d7f176dddc1c3b60876f44db10f7d636ad1133381d1a94
-    optional: false
-    category: main
-  - name: ninja
-    version: 1.11.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-      libstdcxx-ng: ">=10.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ninja-1.11.0-h06f31f1_0.tar.bz2"
-    hash:
-      md5: 75122717f0e5f294b581a9d7e93b7bb9
-      sha256: fa399deab6926f00c01fb49e3095b341ae53edfa940258b96d65a390a27d4691
-    optional: false
-    category: main
-  - name: openssl
-    version: 3.0.8
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      ca-certificates: "*"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/openssl-3.0.8-h4194056_0.conda"
-    hash:
-      md5: e952dfc7249a48558697f61b41859864
-      sha256: 62200f7fa9acb5d9cee24b373695e78ef1d7373bdfd77a50b80e57864b536436
-    optional: false
-    category: main
-  - name: pkg-config
-    version: 0.29.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=8.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/pkg-config-0.29.2-h339bb43_1008.tar.bz2"
-    hash:
-      md5: 473f492aa9dff1b35454c461ab1a823e
-      sha256: 0fb80b8894dd8914dd62fe5b096fcd7bb514bd3846d4d7c068ffc21411e73150
-    optional: false
-    category: main
-  - name: pthread-stubs
-    version: "0.4"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=8.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/pthread-stubs-0.4-h339bb43_1001.tar.bz2"
-    hash:
-      md5: 3c08a226d34a1ac3472fdfec4bd9217f
-      sha256: e6509a0eddb850203bdfc5a01d1ea4a28af732335c99848ec5e27db1f543326f
-    optional: false
-    category: main
-  - name: xorg-libxau
-    version: 1.0.9
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/xorg-libxau-1.0.9-h4e0d66e_0.tar.bz2"
-    hash:
-      md5: 772615b637baddf37b1012ee28fbc70c
-      sha256: 6e83c6d5d74b20e759766cf34216a21d34d0efbd250fb8d865fbcbd51835c083
-    optional: false
-    category: main
-  - name: xorg-libxdmcp
-    version: 1.1.3
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/xorg-libxdmcp-1.1.3-h4e0d66e_0.tar.bz2"
-    hash:
-      md5: 95ac359ec2aea12a08fcbeb86bb48df6
-      sha256: 78d953c40eb0b68fa9db8aa059e1f5c899a1ba9b6ca34142400a0dd471d7088a
-    optional: false
-    category: main
-  - name: xz
-    version: 5.2.6
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/xz-5.2.6-hb283c62_0.tar.bz2"
-    hash:
-      md5: a411645e44054e333573ee5280fdb89b
-      sha256: d03eb2b53dc61ac97c88b3ca023cf19c2b83b97520725b3c2ec0bff2c47f4a98
-    optional: false
-    category: main
-  - name: doxygen
-    version: 1.9.5
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libiconv: ">=1.16,<2.0.0a0"
-      libstdcxx-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/doxygen-1.9.5-hc3812df_0.tar.bz2"
-    hash:
-      md5: 1bab180eb34c97ed9814436fecab3a0f
-      sha256: 4a22d0c893e52ef49dbfbc7f408ff4422aca8d41e40194cab623c580cbb50172
-    optional: false
-    category: main
-  - name: gcc_impl_linux-ppc64le
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      binutils_impl_linux-ppc64le: ">=2.39"
-      libgcc-devel_linux-ppc64le: "==11.3.0 hcb32637_19"
-      libgcc-ng: ">=11.3.0"
-      libgomp: ">=11.3.0"
-      libsanitizer: "==11.3.0 hc94946d_19"
-      libstdcxx-ng: ">=11.3.0"
-      sysroot_linux-ppc64le: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gcc_impl_linux-ppc64le-11.3.0-h8f9c6bb_19.tar.bz2"
-    hash:
-      md5: 0aeb44f45dbeb26ff69acf55562669de
-      sha256: b37216b165b1e914111f562fdc30c7c4f132a4ee2e093869f76ee4952aee46b5
-    optional: false
-    category: main
-  - name: libblas
-    version: 3.9.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libopenblas: ">=0.3.21,<1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libblas-3.9.0-16_linuxppc64le_openblas.tar.bz2"
-    hash:
-      md5: 762b1dc9aab318ee9ba7386d2418e165
-      sha256: 4a4ce4387841e3cf267b61907df06403ded365322fff3926f842f080957f82ee
-    optional: false
-    category: main
-  - name: libbrotlidec
-    version: 1.0.9
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libbrotlicommon: "==1.0.9 hb283c62_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libbrotlidec-1.0.9-hb283c62_8.tar.bz2"
-    hash:
-      md5: 66fb01acc327a224248ab33d16e4b8c0
-      sha256: 180aa63160d710e08855b3ff9b30f4321c5674913dd3f0b5c8f54cebdd669cc2
-    optional: false
-    category: main
-  - name: libbrotlienc
-    version: 1.0.9
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libbrotlicommon: "==1.0.9 hb283c62_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libbrotlienc-1.0.9-hb283c62_8.tar.bz2"
-    hash:
-      md5: 4c4ecee0aec784fe72e73935f5344676
-      sha256: bd6247e1ef777d697f546680242c9937dd43339c55077fef0964e6b1a2f2c5b7
-    optional: false
-    category: main
-  - name: libpng
-    version: 1.6.39
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libpng-1.6.39-hcc10993_0.conda"
-    hash:
-      md5: bcd557c46d754ede06e9a1554eb0c68c
-      sha256: fd374fc3c1900eeec3bdbdf4426795d8068e910b953fb9b35dffef86e8cd27ac
-    optional: false
-    category: main
-  - name: libsqlite
-    version: 3.39.4
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libzlib: ">=1.2.12,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libsqlite-3.39.4-hcc10993_0.tar.bz2"
-    hash:
-      md5: 49799ec532f260e4264705336d01310b
-      sha256: 93cdea9743cf1f86fdf9e9516061d5c68b9b5c43b99b7db1dd81d5b3452c4759
-    optional: false
-    category: main
-  - name: libxcb
-    version: "1.13"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-      pthread-stubs: "*"
-      xorg-libxau: "*"
-      xorg-libxdmcp: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libxcb-1.13-h4e0d66e_1004.tar.bz2"
-    hash:
-      md5: f963aaccf057bb6b3f7c4279b6795c50
-      sha256: 99e80c223ed09dda97af0cf067678259ebf21790cb20f8a9ebe07da68ae24d1e
-    optional: false
-    category: main
-  - name: openblas
-    version: 0.3.21
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libgfortran-ng: "*"
-      libgfortran5: ">=10.4.0"
-      libopenblas: "==0.3.21 pthreads_h60f2977_3"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/openblas-0.3.21-pthreads_h5960496_3.tar.bz2"
-    hash:
-      md5: cd3637b6090fb6415c0abd53feb35c71
-      sha256: 0e4f4656d5a0f582013bb41313eed5bb64ef4f79ff1d127b2926a6356ae0c64b
-    optional: false
-    category: main
-  - name: readline
-    version: 8.1.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      ncurses: ">=6.3,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/readline-8.1.2-h6828edc_0.tar.bz2"
-    hash:
-      md5: a8b0d567fd553734fc0fd0ab2447526a
-      sha256: 37e57caeeb181929648aa898487909b8badad20aa9fb49ab603446cccdb743db
-    optional: false
-    category: main
-  - name: tk
-    version: 8.6.12
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-      libzlib: ">=1.2.11,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/tk-8.6.12-h41c6715_0.tar.bz2"
-    hash:
-      md5: c0490995dc12b45388a01094f9959edd
-      sha256: 61ef67fe390109aa3423d30b96faddb97b054dfbcc0e6c8a3192331b13d14d92
-    optional: false
-    category: main
-  - name: zstd
-    version: 1.5.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/zstd-1.5.2-h7affb48_6.conda"
-    hash:
-      md5: ddc6eeb52a9d5e938f96d5dd246341ca
-      sha256: 7c927e9f2a67f0e546094ebee302acb0b3acde7a511b6a13e44155ef28f5b622
-    optional: false
-    category: main
-  - name: brotli-bin
-    version: 1.0.9
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libbrotlidec: "==1.0.9 hb283c62_8"
-      libbrotlienc: "==1.0.9 hb283c62_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/brotli-bin-1.0.9-hb283c62_8.tar.bz2"
-    hash:
-      md5: 3909235bac04f832ff9b02c764dbee23
-      sha256: 98fc147dcdfb2196b4e267a1fd0250934a9ad16fb4ce9dfb2466b4c51cd6123a
-    optional: false
-    category: main
-  - name: freetype
-    version: 2.12.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libpng: ">=1.6.39,<1.7.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/freetype-2.12.1-h90753b0_1.conda"
-    hash:
-      md5: 55076efce6db8419ba5b1b854f455c4a
-      sha256: a46c8d870bc41b15e0d8362911fe8fef4d7e6626bf23b1fc53e477788a149582
-    optional: false
-    category: main
-  - name: gcc
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      gcc_impl_linux-ppc64le: 11.3.0.*
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gcc-11.3.0-ha746174_11.tar.bz2"
-    hash:
-      md5: 6391f876f8572d2de23f5db0a8e863fa
-      sha256: a5373b326c9cef306250f9e159d1f55d37698bdf74a7b55e5b82dea463484e3f
-    optional: false
-    category: main
-  - name: gcc_linux-ppc64le
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      binutils_linux-ppc64le: "==2.39 h5e55cfe_11"
-      gcc_impl_linux-ppc64le: 11.3.0.*
-      sysroot_linux-ppc64le: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gcc_linux-ppc64le-11.3.0-h89f38ce_11.tar.bz2"
-    hash:
-      md5: 814568bab97f272b70b8970bda7d1734
-      sha256: 8e7691ff0b96738b6dc627564c000419e33239407879327e1af6309ec6638dbc
-    optional: false
-    category: main
-  - name: gfortran_impl_linux-ppc64le
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      gcc_impl_linux-ppc64le: ">=11.3.0"
-      libgcc-ng: ">=4.9"
-      libgfortran5: ">=11.3.0"
-      libstdcxx-ng: ">=4.9"
-      sysroot_linux-ppc64le: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gfortran_impl_linux-ppc64le-11.3.0-h230bcad_19.tar.bz2"
-    hash:
-      md5: e1dfcd199291fbe2535186c8ac26c38e
-      sha256: ea6822fe121d2236d6c1b604cf9566498dc2e5fdf2240cd3de4cb1cd98d0569e
-    optional: false
-    category: main
-  - name: gxx_impl_linux-ppc64le
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      gcc_impl_linux-ppc64le: "==11.3.0 h8f9c6bb_19"
-      libstdcxx-devel_linux-ppc64le: "==11.3.0 hcb32637_19"
-      sysroot_linux-ppc64le: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gxx_impl_linux-ppc64le-11.3.0-h8f9c6bb_19.tar.bz2"
-    hash:
-      md5: 6cae39b12f2baaf665838496d09f746e
-      sha256: d7ff5ce2eec8cf9b95d23c0fc8cf7a1eef64a7f7f2155369d8fd97ec42f20d4b
-    optional: false
-    category: main
-  - name: libcblas
-    version: 3.9.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libblas: "==3.9.0 16_linuxppc64le_openblas"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libcblas-3.9.0-16_linuxppc64le_openblas.tar.bz2"
-    hash:
-      md5: 7c92b1e5f94e656d9d2f4c6164c3dd7d
-      sha256: f1141c257846202190deebd326b37e6147168e40e2511dffae5db48089c4f201
-    optional: false
-    category: main
-  - name: liblapack
-    version: 3.9.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libblas: "==3.9.0 16_linuxppc64le_openblas"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/liblapack-3.9.0-16_linuxppc64le_openblas.tar.bz2"
-    hash:
-      md5: 6078295a03db891bce81100c41283109
-      sha256: a14d82536cea5d9f1bb64089f371f37172c7070ffe89274c4b38618e75143ba4
-    optional: false
-    category: main
-  - name: libtiff
-    version: 4.5.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      jpeg: ">=9e,<10a"
-      lerc: ">=4.0.0,<5.0a0"
-      libdeflate: ">=1.17,<1.18.0a0"
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      libwebp-base: ">=1.2.4,<2.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      xz: ">=5.2.6,<6.0a0"
-      zstd: ">=1.5.2,<1.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libtiff-4.5.0-h43527b7_2.conda"
-    hash:
-      md5: 0d6957963ed574ddd3f2fcf87a1e4169
-      sha256: 8d935040dcb5a3ecad23140947dd194069cb0cc5178b8104584e05c4155668fe
-    optional: false
-    category: main
-  - name: python
-    version: 3.9.16
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      bzip2: ">=1.0.8,<2.0a0"
-      ld_impl_linux-ppc64le: ">=2.36.1"
-      libffi: ">=3.4,<4.0a0"
-      libgcc-ng: ">=12"
-      libnsl: ">=2.0.0,<2.1.0a0"
-      libsqlite: ">=3.39.4,<4.0a0"
-      libuuid: ">=2.32.1,<3.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      ncurses: ">=6.3,<7.0a0"
-      openssl: ">=3.0.7,<4.0a0"
-      pip: "*"
-      readline: ">=8.1.2,<9.0a0"
-      tk: ">=8.6.12,<8.7.0a0"
-      tzdata: "*"
-      xz: ">=5.2.6,<6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/python-3.9.16-h342c621_0_cpython.conda"
-    hash:
-      md5: f5a45d99a97a1a92e41178b4fc787644
-      sha256: ed87de2a117baa5341e85ef80b509aea3cce2c0c94c376003cb9c7f77610ff62
-    optional: false
-    category: main
-  - name: alabaster
-    version: 0.7.13
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 06006184e203b61d3525f90de394471e
-      sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
-    optional: false
-    category: main
-  - name: appdirs
-    version: 1.4.4
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 5f095bc6454094e96f146491fd03633b
-      sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
-    optional: false
-    category: main
-  - name: attrs
-    version: 22.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/attrs-22.2.0-pyh71513ae_0.conda"
-    hash:
-      md5: 8b76db7818a4e401ed4486c4c1635cd9
-      sha256: 3a58d4a4933fa8735471c782d35326ab78e0bcfce84756408515f82a94e4dec4
-    optional: false
-    category: main
-  - name: backcall
-    version: 0.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 6006a6d08a3fa99268a2681c7fb55213
-      sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
-    optional: false
-    category: main
-  - name: backports
-    version: "1.0"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda"
-    hash:
-      md5: 54ca2e08b3220c148a1d8329c2678e02
-      sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-    optional: false
-    category: main
-  - name: backports.zoneinfo
-    version: 0.2.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/backports.zoneinfo-0.2.1-py39h0b1cf3c_7.tar.bz2"
-    hash:
-      md5: c1167f40e89755cc23c64c6f7fd3dbe3
-      sha256: f136781ac1b95d3565c2f2e5b32742d716e1b8bdd5d20d34b300a68a07f6fe2c
-    optional: false
-    category: main
-  - name: brotli
-    version: 1.0.9
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      brotli-bin: "==1.0.9 hb283c62_8"
-      libbrotlidec: "==1.0.9 hb283c62_8"
-      libbrotlienc: "==1.0.9 hb283c62_8"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/brotli-1.0.9-hb283c62_8.tar.bz2"
-    hash:
-      md5: f623f277928564629dc18ff3426ac984
-      sha256: 8c871a332088e2d1055042a21007426d863cc54e5b7416c9a55d20a6f0a1a236
-    optional: false
-    category: main
-  - name: c-compiler
-    version: 1.5.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      binutils: "*"
-      gcc: "*"
-      gcc_linux-ppc64le: 11.*
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/c-compiler-1.5.2-h4194056_0.conda"
-    hash:
-      md5: 906fd28502767b375b9456b4fd59bc4d
-      sha256: 929e32538223e861d1a4efabf95317278fa24602683852f86189bb03ff76aa62
-    optional: false
-    category: main
-  - name: certifi
-    version: 2022.12.7
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/certifi-2022.12.7-pyhd8ed1ab_0.conda"
-    hash:
-      md5: fb9addc3db06e56abe03e0e9f21a63e6
-      sha256: 5e22af4776700200fab2c1df41a2188ab9cfe90a50c4f388592bb978562c88ec
-    optional: false
-    category: main
-  - name: charset-normalizer
-    version: 2.1.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c1d5b294fbf9a795dec349a6f4d8be8e
-      sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
-    optional: false
-    category: main
-  - name: click
-    version: 8.1.3
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      __unix: "*"
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2"
-    hash:
-      md5: 20e4087407c7cb04a40817114b333dbf
-      sha256: 23676470b591b100393bb0f6c46fe10624dcbefc696a6a9f42932ed8816ef0ea
-    optional: false
-    category: main
-  - name: colorama
-    version: 0.4.6
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 3faab06a954c2a04039983f2c4a50d99
-      sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-    optional: false
-    category: main
-  - name: cycler
-    version: 0.11.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: a50559fad0affdbb33729a68669ca1cb
-      sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
-    optional: false
-    category: main
-  - name: cython
-    version: 0.29.33
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/cython-0.29.33-py39h89b8a7f_0.conda"
-    hash:
-      md5: ee427d1817a2e2f0683c77bdc0bc6ee9
-      sha256: 17ce872a2c27af5fcc84485e65072ce9549b516a14142acedd867edbfc1fc884
-    optional: false
-    category: main
-  - name: decorator
-    version: 5.1.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 43afe5ab04e35e17ba28649471dd7364
-      sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-    optional: false
-    category: main
-  - name: docutils
-    version: "0.19"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/docutils-0.19-py39hc1b9086_1.tar.bz2"
-    hash:
-      md5: b0c85fe5865a2d03afbd2b01ae03e69e
-      sha256: 490f080af53643f1e61fa042b69594079786a16c8889a151922642a3dec48377
-    optional: false
-    category: main
-  - name: exceptiongroup
-    version: 1.1.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: a385c3e8968b4cf8fbc426ace915fd1a
-      sha256: cf668360331552b2903e440cda1b4e47062c3f3775342e4a278ef4d141c28d1d
-    optional: false
-    category: main
-  - name: execnet
-    version: 1.9.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: "==2.7|>=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/execnet-1.9.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 0e521f7a5e60d508b121d38b04874fb2
-      sha256: 1900bbc1764d01405e55be2e369d1b830fb435eb0f27c57033372c60f34c675c
-    optional: false
-    category: main
-  - name: executing
-    version: 1.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 4c1bc140e2be5c8ba6e3acab99e25c50
-      sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
-    optional: false
-    category: main
-  - name: gfortran
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      gcc: 11.3.0.*
-      gcc_impl_linux-ppc64le: 11.3.0.*
-      gfortran_impl_linux-ppc64le: 11.3.0.*
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gfortran-11.3.0-h47285a8_11.tar.bz2"
-    hash:
-      md5: 6050ddfbd06be074a4a4b31973528c7f
-      sha256: 07de312619594359318edda76557fdede88c9cdb9df3869465decd4c8dc281b1
-    optional: false
-    category: main
-  - name: gfortran_linux-ppc64le
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      binutils_linux-ppc64le: "==2.39 h5e55cfe_11"
-      gcc_linux-ppc64le: "==11.3.0 h89f38ce_11"
-      gfortran_impl_linux-ppc64le: 11.3.0.*
-      sysroot_linux-ppc64le: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gfortran_linux-ppc64le-11.3.0-h7e72f06_11.tar.bz2"
-    hash:
-      md5: 5c1a3d92a26afe01e17ebcf99a1b3c11
-      sha256: 8ad5addbb3d147189aaa895c954e459dc278dc8da145e482c631038bbff2acee
-    optional: false
-    category: main
-  - name: gxx
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      gcc: 11.3.0.*
-      gxx_impl_linux-ppc64le: 11.3.0.*
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gxx-11.3.0-ha746174_11.tar.bz2"
-    hash:
-      md5: 203a2faa2e8aa3f329d0bf0c6ff351dd
-      sha256: 58b7742cdb4c6c4fa79f9c5e3a70fc4d01dc02cbb57d986a51ab90bd1e9b6a8a
-    optional: false
-    category: main
-  - name: gxx_linux-ppc64le
-    version: 11.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      binutils_linux-ppc64le: "==2.39 h5e55cfe_11"
-      gcc_linux-ppc64le: "==11.3.0 h89f38ce_11"
-      gxx_impl_linux-ppc64le: 11.3.0.*
-      sysroot_linux-ppc64le: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/gxx_linux-ppc64le-11.3.0-h3c74164_11.tar.bz2"
-    hash:
-      md5: a0f1353564cfcbf1310cfd9f744319c8
-      sha256: be7f130dba954b876a292ee0039efd0563a60621e6430f486d231775b35c05af
-    optional: false
-    category: main
-  - name: idna
-    version: "3.4"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 34272b248891bddccc64479f9a7fffed
-      sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
-    optional: false
-    category: main
-  - name: imagesize
-    version: 1.4.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.4"
-    url: "https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 7de5386c8fea29e76b303f37dde4c352
-      sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
-    optional: false
-    category: main
-  - name: iniconfig
-    version: 2.0.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f800d2da156d08e289b14e87e43c1ae5
-      sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-    optional: false
-    category: main
-  - name: kiwisolver
-    version: 1.4.4
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/kiwisolver-1.4.4-py39h2bf7372_1.tar.bz2"
-    hash:
-      md5: b2e6cbe5c430337f19676048e429d5c6
-      sha256: bd998a1dbaaaa9073ee6cfacbb8f28fcd1cec4817683272d9a09c8857276ef64
-    optional: false
-    category: main
-  - name: lcms2
-    version: "2.14"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      jpeg: ">=9e,<10a"
-      libgcc-ng: ">=12"
-      libtiff: ">=4.5.0,<4.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/lcms2-2.14-h4cdffb3_1.conda"
-    hash:
-      md5: 3dc2f029758b3692b6c0bca31e20f3f6
-      sha256: a5ba8adce3919b492527e638897bbf5843e75ea01358bac148f7d3c846c9f38b
-    optional: false
-    category: main
-  - name: markupsafe
-    version: 2.1.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/markupsafe-2.1.2-py39h3c7ea95_0.conda"
-    hash:
-      md5: 4b35b03829dc7cd269f7c0bb8b741fea
-      sha256: 27403dd13b41d2590f52645745d8daf5269fe415b99208d79935c8f5ff8c7911
-    optional: false
-    category: main
-  - name: munkres
-    version: 1.1.4
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 2ba8498c1018c1e9c61eb99b973dfe19
-      sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
-    optional: false
-    category: main
-  - name: mypy_extensions
-    version: 1.0.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda"
-    hash:
-      md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-      sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-    optional: false
-    category: main
-  - name: numpy
-    version: 1.24.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libblas: ">=3.9.0,<4.0a0"
-      libcblas: ">=3.9.0,<4.0a0"
-      libgcc-ng: ">=12"
-      liblapack: ">=3.9.0,<4.0a0"
-      libstdcxx-ng: ">=12"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/numpy-1.24.2-py39h27d966d_0.conda"
-    hash:
-      md5: 01161f20e96598201f9a9360b4b5f39e
-      sha256: 16dd1b6975ca3eda91d53b5d1e72f8b0297c3765fc53d156697d29150926a614
-    optional: false
-    category: main
-  - name: openjpeg
-    version: 2.5.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libpng: ">=1.6.39,<1.7.0a0"
-      libstdcxx-ng: ">=12"
-      libtiff: ">=4.5.0,<4.6.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/openjpeg-2.5.0-hbcaec15_2.conda"
-    hash:
-      md5: 6d3258c9f7aa73ef7534f6bcbfd493c1
-      sha256: 853ad1d97ce95219b41f3fb481dc2a562d83c6808008ff3b154f0452cb21a8ba
-    optional: false
-    category: main
-  - name: packaging
-    version: "23.0"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/packaging-23.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 1ff2e3ca41f0ce16afec7190db28288b
-      sha256: 00288f5e5e841711e8b8fef1f1242c858d8ef99ccbe5d7e0df4789d5d8d40645
-    optional: false
-    category: main
-  - name: parso
-    version: 0.8.3
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 17a565a0c3899244e938cdf417e7b094
-      sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
-    optional: false
-    category: main
-  - name: pickleshare
-    version: 0.7.5
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2"
-    hash:
-      md5: 415f0ebb6198cc2801c73438a9fb5761
-      sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-    optional: false
-    category: main
-  - name: pluggy
-    version: 1.0.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2"
-    hash:
-      md5: 7d301a0d25f424d96175f810935f0da9
-      sha256: c25e1757e4e90638bb1e778aba3ee5f3c01fae9752e3c3929f9be7d367f6c7f3
-    optional: false
-    category: main
-  - name: psutil
-    version: 5.9.4
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/psutil-5.9.4-py39h98ec90c_0.tar.bz2"
-    hash:
-      md5: 5bd05c9eb882774901835d43e4c2c365
-      sha256: d0bde2a78f967ba275a969a2d5b722d0792ac710c45c5ac74ee7b85f3cf6bb05
-    optional: false
-    category: main
-  - name: ptyprocess
-    version: 0.7.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2"
-    hash:
-      md5: 359eeb6536da0e687af562ed265ec263
-      sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
-    optional: false
-    category: main
-  - name: pure_eval
-    version: 0.2.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6784285c7e55cb7212efabc79e4c2883
-      sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
-    optional: false
-    category: main
-  - name: pycodestyle
-    version: 2.7.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: 2.7.*|>=3.5
-    url: "https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.7.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 0234673eb2ecfbdf4e54574ab4d95f81
-      sha256: 5c6aa7a724551d7768930b30bd77e531580f6ddd68a391094e799a21a82b9492
-    optional: false
-    category: main
-  - name: pycparser
-    version: "2.21"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: 2.7.*|>=3.4
-    url: "https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 076becd9e05608f8dc72757d5f3a91ff
-      sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
-    optional: false
-    category: main
-  - name: pyparsing
-    version: 3.0.9
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: e8fbc1b54b25f4b08281467bc13b70cc
-      sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
-    optional: false
-    category: main
-  - name: pysocks
-    version: 1.7.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      __unix: "*"
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2"
-    hash:
-      md5: 2a7de29fb590ca14b5243c4c812c8025
-      sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
-    optional: false
-    category: main
-  - name: pytz
-    version: 2022.7.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytz-2022.7.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f59d49a7b464901cf714b9e7984d01a2
-      sha256: 93cfc7a92099e26b0575a343da4a667b52371cc38e4dee4ee264dc041ef77bac
-    optional: false
-    category: main
-  - name: setuptools
-    version: 59.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/setuptools-59.2.0-py39hc1b9086_0.tar.bz2"
-    hash:
-      md5: 4617e1d24d2f1dff048a836d588fde54
-      sha256: ad9e51800a00e3252728011f818d0f227acac77388b1b73a0b8999c1a05944fd
-    optional: false
-    category: main
-  - name: six
-    version: 1.16.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2"
-    hash:
-      md5: e5f25f8dbc060e9a8d912e432202afc2
-      sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
-    optional: false
-    category: main
-  - name: smmap
-    version: 3.0.5
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/smmap-3.0.5-pyh44b312d_0.tar.bz2"
-    hash:
-      md5: 3a8dc70789709aa315325d5df06fb7e4
-      sha256: 091de70ee6bfe063e0c0f77336975d124fd1e3f49b9c58d97c0c7b3d287c0002
-    optional: false
-    category: main
-  - name: snowballstemmer
-    version: 2.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 4d22a9315e78c6827f806065957d566e
-      sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
-    optional: false
-    category: main
-  - name: sortedcontainers
-    version: 2.4.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6d6552722448103793743dabfbda532d
-      sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
-    optional: false
-    category: main
-  - name: soupsieve
-    version: 2.3.2.post1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 146f4541d643d48fc8a75cacf69f03ae
-      sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
-    optional: false
-    category: main
-  - name: sphinxcontrib-applehelp
-    version: 1.0.4
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.4-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 5a31a7d564f551d0e6dff52fd8cb5b16
-      sha256: 802810d8321d55e5666806d565e72949eabf77ad510fe2758ce1da2441675ef1
-    optional: false
-    category: main
-  - name: sphinxcontrib-devhelp
-    version: 1.0.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.2-py_0.tar.bz2"
-    hash:
-      md5: 68e01cac9d38d0e717cd5c87bc3d2cc9
-      sha256: 66cca7eccb7f92eee53f9f5a552e3e1d643daa3a1ebd03c185e2819e5c491576
-    optional: false
-    category: main
-  - name: sphinxcontrib-htmlhelp
-    version: 2.0.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 6c8c4d6eb2325e59290ac6dbbeacd5f0
-      sha256: aeff20be994e6f9520a91fc177a33cb3e4d0911cdf8d27e575d001f00afa33fd
-    optional: false
-    category: main
-  - name: sphinxcontrib-jsmath
-    version: 1.0.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-py_0.tar.bz2"
-    hash:
-      md5: 67cd9d9c0382d37479b4d306c369a2d4
-      sha256: a42415fc789e9f6ae2e18f07ac143d2e9ce73a35a55ecf1dd1b3d055dd1e6dbe
-    optional: false
-    category: main
-  - name: sphinxcontrib-qthelp
-    version: 1.0.3
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2"
-    hash:
-      md5: d01180388e6d1838c3e1ad029590aa7a
-      sha256: 35d8f01fc798d38b72ae003c040d2dee650d315f904268a1f793d4d59460d1e2
-    optional: false
-    category: main
-  - name: sphinxcontrib-serializinghtml
-    version: 1.1.5
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2"
-    hash:
-      md5: 9ff55a0901cf952f05c654394de76bf7
-      sha256: 890bbf815cff114ddbb618b9876d492fce07d02956c1d7b3d46cb7f835f563f6
-    optional: false
-    category: main
-  - name: toml
-    version: 0.10.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: f832c45a477c78bebd107098db465095
-      sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
-    optional: false
-    category: main
-  - name: tomli
-    version: 2.0.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 5844808ffab9ebdb694585b50ba02a96
-      sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-    optional: false
-    category: main
-  - name: tornado
-    version: "6.2"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/tornado-6.2-py39h9ca6cee_1.tar.bz2"
-    hash:
-      md5: de4ea4c74f01f9b64e7c7888f7d5c506
-      sha256: f4a3e920896c10dbe6247d0b0536acac4141ce28b6e8a1076c21b8563dd072c5
-    optional: false
-    category: main
-  - name: traitlets
-    version: 5.9.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: d0b4f5c87cd35ac3fb3d47b223263a64
-      sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
-    optional: false
-    category: main
-  - name: typing_extensions
-    version: 4.4.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.4.0-pyha770c72_0.tar.bz2"
-    hash:
-      md5: 2d93b130d148d7fc77e583677792fc6a
-      sha256: 70c57b5ac94cd32e78f1a2fa2c38572bfac85b901a6a99aa254a9e8e126c132d
-    optional: false
-    category: main
-  - name: unicodedata2
-    version: 15.0.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/unicodedata2-15.0.0-py39h98ec90c_0.tar.bz2"
-    hash:
-      md5: da1d94fc94f0136d8c23c64e6c66c9fb
-      sha256: 06b11396a68fc4d93105e4335da1b28b7465a53561a20c309dcecf1ad5795bcd
-    optional: false
-    category: main
-  - name: wheel
-    version: 0.38.4
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c829cfb8cb826acb9de0ac1a2df0a940
-      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-    optional: false
-    category: main
-  - name: zipp
-    version: 3.13.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/zipp-3.13.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 41b09d997939e83b231c4557a90c3b13
-      sha256: 0a9a545b8dc46c847658ebfa636257ea5993a355419c1d3b2f14810730ee0a82
-    optional: false
-    category: main
-  - name: asttokens
-    version: 2.2.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.5"
-      six: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: bf7f54dd0f25c3f06ecb82a07341841a
-      sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
-    optional: false
-    category: main
-  - name: babel
-    version: 2.11.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-      pytz: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/babel-2.11.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 2ea70fde8d581ba9425a761609eed6ba
-      sha256: 21a8403d886136c0a80f965ae5387fa1693b19ddd69023bcd0e844f2510d7e2f
-    optional: false
-    category: main
-  - name: backports.functools_lru_cache
-    version: 1.6.4
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      backports: "*"
-      python: ">=3.6"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c5b3edc62d6309088f4970b3eaaa65a6
-      sha256: fdea00d4b79990f3fe938e2716bc32bd895eb5c44b6c75b8261db095a1b33c16
-    optional: false
-    category: main
-  - name: beautifulsoup4
-    version: 4.11.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-      soupsieve: ">=1.2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.11.2-pyha770c72_0.conda"
-    hash:
-      md5: 88b59f6989f0ed5ab3433af0b82555e1
-      sha256: deb43944425b3ec7fdfd5e6620cf97a4ed888a279237f90cd67a338d123efd15
-    optional: false
-    category: main
-  - name: cffi
-    version: 1.15.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libffi: ">=3.4,<4.0a0"
-      libgcc-ng: ">=12"
-      pycparser: "*"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/cffi-1.15.1-py39h1929af6_3.conda"
-    hash:
-      md5: ff9e253220ea6ff14aea651d2328396f
-      sha256: b19050c387389ad2d0f817f3865a6a1f9706da40b53c6657d1fb8cb417457ff7
-    optional: false
-    category: main
-  - name: contourpy
-    version: 1.0.7
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      numpy: ">=1.16"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/contourpy-1.0.7-py39h9e1b185_0.conda"
-    hash:
-      md5: 13b641a7acb57ac3c52747d2cec170e2
-      sha256: 017e14b677471c076e978e9e8e625f2ff03e3d0cb88d1807b2b40501adf041e2
-    optional: false
-    category: main
-  - name: coverage
-    version: 7.1.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tomli: "*"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/coverage-7.1.0-py39h3c7ea95_0.conda"
-    hash:
-      md5: dd671f8adf5a91298fea2aa3f067c910
-      sha256: 5cd7aeb415ba5581cf10782b0d41b0b5e30ce236f074267944c21db57fa23569
-    optional: false
-    category: main
-  - name: cxx-compiler
-    version: 1.5.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      c-compiler: "==1.5.2 h4194056_0"
-      gxx: "*"
-      gxx_linux-ppc64le: 11.*
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/cxx-compiler-1.5.2-he01d56d_0.conda"
-    hash:
-      md5: b3e397799dcf3015c437a3d0ed17abfa
-      sha256: ce7f60cf80c215d740be900c17599fd635e504ce412f0cecb5918018a9724cc8
-    optional: false
-    category: main
-  - name: fonttools
-    version: 4.38.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      brotli: "*"
-      libgcc-ng: ">=12"
-      munkres: "*"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-      unicodedata2: ">=14.0.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/fonttools-4.38.0-py39h98ec90c_1.tar.bz2"
-    hash:
-      md5: 505389efe350445e400f250c35b3a300
-      sha256: ef5ce78150a726933e52a5e7f0886edf64eb2f0b9e2eb533d9f58ff5ae851671
-    optional: false
-    category: main
-  - name: fortran-compiler
-    version: 1.5.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      binutils: "*"
-      c-compiler: "==1.5.2 h4194056_0"
-      gfortran: "*"
-      gfortran_linux-ppc64le: 11.*
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/fortran-compiler-1.5.2-hc9fb769_0.conda"
-    hash:
-      md5: 0fd7f97c0c750664bd80c0ce33b64184
-      sha256: dddb38309e547593b9086eeeda9989b4032e89bbf27a87a3df65b0871df3725a
-    optional: false
-    category: main
-  - name: gitdb
-    version: 4.0.10
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.4"
-      smmap: ">=3.0.1,<4"
-    url: "https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.10-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 3706d2f3d7cb5dae600c833345a76132
-      sha256: 0003ab2b971913380633c711bf49a54dcf06e179986c725b0925854b58878377
-    optional: false
-    category: main
-  - name: hypothesis
-    version: 6.68.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      attrs: ">=19.2.0"
-      backports.zoneinfo: ">=0.2.1"
-      click: ">=7.0"
-      exceptiongroup: ">=1.0.0rc8"
-      python: ">=3.8"
-      setuptools: "*"
-      sortedcontainers: ">=2.1.0,<3.0.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.68.1-pyha770c72_0.conda"
-    hash:
-      md5: 3c044b3b920eb287f8c095c7f086ba64
-      sha256: e3a29c1303b563e450e0f706e4d78a281d1aa519d3e1094fc642305bceff72e1
-    optional: false
-    category: main
-  - name: importlib-metadata
-    version: 6.0.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.8"
-      zipp: ">=0.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.0.0-pyha770c72_0.conda"
-    hash:
-      md5: 691644becbcdca9f73243450b1c63e62
-      sha256: 0062e6ae1719395c25f0b60a21215470b4ea67514fed8a9330869da8604acfca
-    optional: false
-    category: main
-  - name: jedi
-    version: 0.18.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      parso: ">=0.8.0,<0.9.0"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
-      sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
-    optional: false
-    category: main
-  - name: jinja2
-    version: 3.1.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      markupsafe: ">=2.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: c8490ed5c70966d232fdd389d0dbed37
-      sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-    optional: false
-    category: main
-  - name: matplotlib-inline
-    version: 0.1.6
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-      traitlets: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: b21613793fcc81d944c76c9f2864a7de
-      sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-    optional: false
-    category: main
-  - name: meson
-    version: 1.0.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      ninja: ">=1.8.2"
-      python: ">=3.5.2"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/meson-1.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 4de573313958b8da6c526fdd354fffc8
-      sha256: 57dc7634aa05f3944314e6b56b2f37e6fb1a52b33de9ca153aee5d9adf83a5d7
-    optional: false
-    category: main
-  - name: mypy
-    version: "0.981"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      mypy_extensions: ">=0.4.3"
-      psutil: ">=4.0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-      tomli: ">=1.1.0"
-      typing_extensions: ">=3.10"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/mypy-0.981-py39h98ec90c_0.tar.bz2"
-    hash:
-      md5: 456fb0f78d0244ff31c8095cc042e0d4
-      sha256: d0c049919ecf4642373a1447cfb8c2f056e59bbe0df4c11051b1a5e53f27d9e7
-    optional: false
-    category: main
-  - name: pexpect
-    version: 4.8.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      ptyprocess: ">=0.5"
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2"
-    hash:
-      md5: 330448ce4403cc74990ac07c555942a1
-      sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
-    optional: false
-    category: main
-  - name: pillow
-    version: 9.4.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      freetype: ">=2.12.1,<3.0a0"
-      jpeg: ">=9e,<10a"
-      lcms2: ">=2.14,<3.0a0"
-      libgcc-ng: ">=12"
-      libtiff: ">=4.5.0,<4.6.0a0"
-      libwebp-base: ">=1.2.4,<2.0a0"
-      libxcb: ">=1.13,<1.14.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      openjpeg: ">=2.5.0,<3.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tk: ">=8.6.12,<8.7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/pillow-9.4.0-py39h845a511_1.conda"
-    hash:
-      md5: c0534e2f92c834acc9d4e8205c418764
-      sha256: a24c5f4c66ee54f7fdf7d370a6102b3d47ecbd8d1e0df190ce128605703c9ede
-    optional: false
-    category: main
-  - name: pip
-    version: "23.0"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-      setuptools: "*"
-      wheel: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 85b35999162ec95f9f999bac15279c02
-      sha256: bbffec284bd0e154363e845121f43007e7e64c80412ff13be21909be907b697d
-    optional: false
-    category: main
-  - name: pygments
-    version: 2.14.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pygments-2.14.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: c78cd16b11cd6a295484bd6c8f24bea1
-      sha256: e8710e24f60b6a97289468f47914e53610101755088bc237621cc1980edbfcd9
-    optional: false
-    category: main
-  - name: pyproject-metadata
-    version: 0.7.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      packaging: ">=19.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyproject-metadata-0.7.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: dcb27826ffc94d5f04e241322239983b
-      sha256: 9ec35cffa163f587aeb52d1603df8374659e3be30dbc6db0e980ecb797f21fee
-    optional: false
-    category: main
-  - name: pytest
-    version: 7.2.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      attrs: ">=19.2.0"
-      colorama: "*"
-      exceptiongroup: "*"
-      iniconfig: "*"
-      packaging: "*"
-      pluggy: ">=0.12,<2.0"
-      python: ">=3.8"
-      tomli: ">=1.0.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f0be05afc9c9ab45e273c088e00c258b
-      sha256: d298dfe6c53555c9fb5662f5f936e621cddd3b0a7031789375b82a1ee3b3a96b
-    optional: false
-    category: main
-  - name: python-dateutil
-    version: 2.8.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-      six: ">=1.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: dd999d1cc9f79e67dbb855c8924c7984
-      sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-    optional: false
-    category: main
-  - name: typing-extensions
-    version: 4.4.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      typing_extensions: "==4.4.0 pyha770c72_0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.4.0-hd8ed1ab_0.tar.bz2"
-    hash:
-      md5: be969210b61b897775a0de63cd9e9026
-      sha256: 6f129b1bc18d111dcf3abaec6fcf6cbee00f1b77bb42d0f0bc8d85f8faa65cf0
-    optional: false
-    category: main
-  - name: brotlipy
-    version: 0.7.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      cffi: ">=1.0.0"
-      libgcc-ng: ">=12"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/brotlipy-0.7.0-py39h98ec90c_1005.tar.bz2"
-    hash:
-      md5: d8c035f4b1b28f25bfbcc199aae52d3d
-      sha256: e534cdeef029b8fb255dd60336e2f6e6a81d011ce231517d5fe6dcd0440c4d08
-    optional: false
-    category: main
-  - name: compilers
-    version: 1.5.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      c-compiler: "==1.5.2 h4194056_0"
-      cxx-compiler: "==1.5.2 he01d56d_0"
-      fortran-compiler: "==1.5.2 hc9fb769_0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/compilers-1.5.2-ha3edaa6_0.conda"
-    hash:
-      md5: 46edabff80f1b3208e74cc858f733f5a
-      sha256: da5910e38483edcaf941c6d6c124274a900a899d55c91f82ca3324a68f99608b
-    optional: false
-    category: main
-  - name: cryptography
-    version: 39.0.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      cffi: ">=1.12"
-      libgcc-ng: ">=12"
-      openssl: ">=3.0.8,<4.0a0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/cryptography-39.0.1-py39h31bd36e_0.conda"
-    hash:
-      md5: 83f2e100cadaabaeae02f29dc3263f98
-      sha256: 4dd0c3fa9da6b1e542c812ac421b28bbff222906d79587855a8d8f51d64d81e5
-    optional: false
-    category: main
-  - name: gitpython
-    version: 3.1.30
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      gitdb: ">=4.0.1,<5"
-      python: ">=3.7"
-      typing_extensions: ">=3.7.4.3"
-    url: "https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.30-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 0c217ab2f5ef6925e4e52c70b57cfc4a
-      sha256: 2ccd8aa401701947398a087b1aa11042b1b088e7331fed574b7ec9909bee09d6
-    optional: false
-    category: main
-  - name: matplotlib-base
-    version: 3.6.3
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      certifi: ">=2020.6.20"
-      contourpy: ">=1.0.1"
-      cycler: ">=0.10"
-      fonttools: ">=4.22.0"
-      freetype: ">=2.12.1,<3.0a0"
-      kiwisolver: ">=1.0.1"
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      numpy: ">=1.20.3,<2.0a0"
-      packaging: ">=20.0"
-      pillow: ">=6.2.0"
-      pyparsing: ">=2.3.1"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python-dateutil: ">=2.7"
-      python_abi: 3.9.* *_cp39
-      tk: ">=8.6.12,<8.7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/matplotlib-base-3.6.3-py39h5497c37_0.conda"
-    hash:
-      md5: 269461bf8080174eb1efc68961abc45a
-      sha256: f439e829ea1775ad93638858597b435aed3d36aaa4b06e93197334272c900e99
-    optional: false
-    category: main
-  - name: meson-python
-    version: 0.12.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      colorama: "*"
-      meson: ">=0.63.3"
-      ninja: "*"
-      pyproject-metadata: ">=0.6.1"
-      python: ">=3.7"
-      tomli: ">=1.0.0"
-      typing-extensions: ">=3.7.4"
-      wheel: ">=0.36.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/meson-python-0.12.0-pyh71feb2d_0.conda"
-    hash:
-      md5: dc566efe9c7af4eb305402b5c6121ca3
-      sha256: 2ea6e9b843e7d93283f2bd442f20bc973cf8141ef1876c9fe4353e473265a4da
-    optional: false
-    category: main
-  - name: pandas
-    version: 1.5.3
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libstdcxx-ng: ">=12"
-      numpy: ">=1.20.3,<2.0a0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python-dateutil: ">=2.8.1"
-      python_abi: 3.9.* *_cp39
-      pytz: ">=2020.1"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/pandas-1.5.3-py39h3cc8c3b_0.conda"
-    hash:
-      md5: e158babd99fc5079be0d87e52cef7466
-      sha256: 2c61728511be17f464b673d48713a26703a64ca4a6ad402465a2d805c1ad3089
-    optional: false
-    category: main
-  - name: pytest-cov
-    version: 4.0.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      coverage: ">=5.2.1"
-      pytest: ">=4.6"
-      python: ">=3.6"
-      toml: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.0.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c9e3f8bfdb9bfc34aa1836a6ed4b25d7
-      sha256: 2e00bbdb00b2514faba50ddcb6ecf1d6e4f2d5af346f9cd1240aacb1b61dccb6
-    optional: false
-    category: main
-  - name: pytest-xdist
-    version: 3.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      execnet: ">=1.1"
-      pytest: ">=6.2.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.2.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 70ab87b96126f35d1e68de2ad9fb6423
-      sha256: aa81f80bf0a2f53423ab80137ca4fc201473884725a2983a0d79b2e420c2a671
-    optional: false
-    category: main
-  - name: stack_data
-    version: 0.6.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      asttokens: "*"
-      executing: "*"
-      pure_eval: "*"
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: e7df0fdd404616638df5ece6e69ba7af
-      sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-    optional: false
-    category: main
-  - name: wcwidth
-    version: 0.2.6
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      backports.functools_lru_cache: "*"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 078979d33523cb477bd1916ce41aacc9
-      sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
-    optional: false
-    category: main
-  - name: matplotlib
-    version: 3.6.3
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      matplotlib-base: ">=3.6.3,<3.6.4.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tornado: ">=5"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/matplotlib-3.6.3-py39hc1b9086_0.conda"
-    hash:
-      md5: 773e37213cd47be018f3cd225b9694a5
-      sha256: 9d85a0fd853509efc0c2a63e10e56a968069d23552fa8391b667cf52fb6b7c03
-    optional: false
-    category: main
-  - name: prompt-toolkit
-    version: 3.0.36
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-      wcwidth: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda"
-    hash:
-      md5: 4d79ec192e0bfd530a254006d123b9a6
-      sha256: 6bd3626799c9467d7aa8ed5f95043e4cea614a1329580980ddcf40cfed3ee860
-    optional: false
-    category: main
-  - name: pyopenssl
-    version: 23.0.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      cryptography: ">=38.0.0,<40"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: d41957700e83bbb925928764cb7f8878
-      sha256: adbf8951f22bfa950b9e24394df1ef1d2b2d7dfb194d91c7f42bc11900695785
-    optional: false
-    category: main
-  - name: ipython
-    version: 8.10.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      __linux: "*"
-      backcall: "*"
-      decorator: "*"
-      jedi: ">=0.16"
-      matplotlib-inline: "*"
-      pexpect: ">4.3"
-      pickleshare: "*"
-      prompt-toolkit: ">=3.0.30,<3.1.0"
-      pygments: ">=2.4.0"
-      python: ">=3.8"
-      stack_data: "*"
-      traitlets: ">=5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/ipython-8.10.0-pyh41d4057_0.conda"
-    hash:
-      md5: 4703355103974293bbd8a32449b3ff28
-      sha256: 350847af23f964a1002c712547e26a1e144e5bbc1662016263c5fb8fc963dcff
-    optional: false
-    category: main
-  - name: urllib3
-    version: 1.26.14
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      brotlipy: ">=0.6.0"
-      certifi: "*"
-      cryptography: ">=1.3.4"
-      idna: ">=2.0.0"
-      pyopenssl: ">=0.14"
-      pysocks: ">=1.5.6,<2.0,!=1.5.7"
-      python: "<4.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.14-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 01f33ad2e0aaf6b5ba4add50dad5ad29
-      sha256: f2f09c44e47946ce631dbc9a8a79bb463ac0f4122aaafdbcc51f200a1e420ca6
-    optional: false
-    category: main
-  - name: requests
-    version: 2.28.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      certifi: ">=2017.4.17"
-      charset-normalizer: ">=2,<3"
-      idna: ">=2.5,<4"
-      python: ">=3.7,<4.0"
-      urllib3: ">=1.21.1,<1.27"
-    url: "https://conda.anaconda.org/conda-forge/noarch/requests-2.28.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 11d178fc55199482ee48d6812ea83983
-      sha256: 22c081b4cdd023a514400413f50efdf2c378f56f2a5ea9d65666aacf4696490a
-    optional: false
-    category: main
-  - name: pooch
-    version: 1.6.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      appdirs: ">=1.3.0"
-      packaging: ">=20.0"
-      python: ">=3.6"
-      requests: ">=2.19.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pooch-1.6.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6429e1d1091c51f626b5dcfdd38bf429
-      sha256: 1f0548105de86fb2eb6fbb8d3d6cc2004079b8442d232258108687d6cc91eb73
-    optional: false
-    category: main
-  - name: sphinx
-    version: 5.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      alabaster: ">=0.7,<0.8"
-      babel: ">=2.9"
-      colorama: ">=0.4.5"
-      docutils: ">=0.14,<0.20"
-      imagesize: ">=1.3"
-      importlib-metadata: ">=4.8"
-      jinja2: ">=3.0"
-      packaging: ">=21.0"
-      pygments: ">=2.12"
-      python: ">=3.7"
-      requests: ">=2.5.0"
-      snowballstemmer: ">=2.0"
-      sphinxcontrib-applehelp: "*"
-      sphinxcontrib-devhelp: "*"
-      sphinxcontrib-htmlhelp: ">=2.0.0"
-      sphinxcontrib-jsmath: "*"
-      sphinxcontrib-qthelp: "*"
-      sphinxcontrib-serializinghtml: ">=1.1.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-5.3.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: f9e1fcfe235d655900bfeb6aee426472
-      sha256: f11fd5fb4ae2c65f41ae86e7408e3ab44844898d928264aa9e89929fffc685c8
-    optional: false
-    category: main
-  - name: breathe
-    version: 4.34.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      docutils: ">=0.12"
-      jinja2: ">=2.7.3"
-      markupsafe: ">=0.23"
-      pygments: ">=1.6"
-      python: ">=3.6"
-      sphinx: ">=4.0,<6.0.0a"
-    url: "https://conda.anaconda.org/conda-forge/noarch/breathe-4.34.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: a2a04f8e8c2d91adb08ff929b4d73654
-      sha256: 40f86cd741a443363e8928d5d36ba3a49071aaffc26c5a7b24a8167c5bcbba81
-    optional: false
-    category: main
-  - name: numpydoc
-    version: 1.4.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      jinja2: ">=2.10"
-      python: ">=3.7"
-      sphinx: ">=1.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.4.0-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: 0aac89c61a466b0f9c4fd0ec44d81f1d
-      sha256: 11a892cc1678a23d169909e553447fb7e312d6baaa314fdcd719f6abff1c7da6
-    optional: false
-    category: main
-  - name: pydata-sphinx-theme
-    version: 0.9.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      beautifulsoup4: "*"
-      docutils: "!=0.17.0"
-      packaging: "*"
-      python: ">=3.7"
-      sphinx: ">=4.0.2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.9.0-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: ed5f1236283219a21207813d387b44bd
-      sha256: 11d56e0953a8f880d265d18eb3b3adc2f0ba182a33409088141dc84e22dba50c
     optional: false
     category: main
   - name: scipy
@@ -8367,2369 +10806,6 @@ package:
       sha256: 8bd3869860945f3d4b3d136e06a431a58abca843cd3deed85824986daa9b5743
     optional: false
     category: main
-  - name: sphinx-design
-    version: 0.3.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.6"
-      sphinx: ">=4,<6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-design-0.3.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 83d1a712e6d2bab6b298b1d2f42ad355
-      sha256: 6b193a483a02bbc7a785dcd28614b4c082d1795fec0a1c48690d8d7a0a876e20
-    optional: false
-    category: main
-  - name: bzip2
-    version: 1.0.8
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2"
-    hash:
-      md5: 37edc4e6304ca87316e160f5ca0bd1b5
-      sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
-    optional: false
-    category: main
-  - name: ca-certificates
-    version: 2022.12.7
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2022.12.7-h033912b_0.conda"
-    hash:
-      md5: af2bdcd68f16ce030ca957cdeb83d88a
-      sha256: 898276d86de89fb034ecfae05103045d0a0d6a356ced1b6d1832cdbd07a8fc18
-    optional: false
-    category: main
-  - name: jpeg
-    version: 9e
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/jpeg-9e-hb7f2c08_3.conda"
-    hash:
-      md5: 6b55131ae9445ef38746dc6b080acda9
-      sha256: 1ef5f9b4d9817820224c92b016da210b1356250d7272e16901c547e156b3e615
-    optional: false
-    category: main
-  - name: libbrotlicommon
-    version: 1.0.9
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.0.9-hb7f2c08_8.tar.bz2"
-    hash:
-      md5: 37157d273eaf3bc7d6862104161d9ec9
-      sha256: c983101653f5bffea605c4423d84fd5ca28ee36b290cdb6207ec246e293f7d94
-    optional: false
-    category: main
-  - name: libcxx
-    version: 14.0.6
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libcxx-14.0.6-hccf4f1f_0.tar.bz2"
-    hash:
-      md5: 208a6a874b073277374de48a782f6b10
-      sha256: ebb75dd9f854b1f184a98d0b9128a3faed6cd2f05f83677e1f399c253580afe7
-    optional: false
-    category: main
-  - name: libdeflate
-    version: "1.17"
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.17-hac1461d_0.conda"
-    hash:
-      md5: e3894420cf8b6abbf6c4d3d9742fbb4a
-      sha256: b322e190fd6fe631e1f4836ef99cbfb8352c03c30b51cb5baa216f7c9124d82e
-    optional: false
-    category: main
-  - name: libffi
-    version: 3.4.2
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2"
-    hash:
-      md5: ccb34fb14960ad8b125962d3d79b31a9
-      sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
-    optional: false
-    category: main
-  - name: libgfortran-devel_osx-64
-    version: 11.3.0
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/libgfortran-devel_osx-64-11.3.0-h824d247_27.conda"
-    hash:
-      md5: 3729d4388eb5a801b148dd4802899dba
-      sha256: d93b662d07aeb99417be9b62ca511520865e691d1fc224a63e383727791ac3b7
-    optional: false
-    category: main
-  - name: libiconv
-    version: "1.17"
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2"
-    hash:
-      md5: 691d103d11180486154af49c037b7ed9
-      sha256: 4a3294037d595754f7da7c11a41f3922f995aaa333f3cb66f02d8afa032a7bc2
-    optional: false
-    category: main
-  - name: libwebp-base
-    version: 1.2.4
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.2.4-h775f41a_0.tar.bz2"
-    hash:
-      md5: 28807bef802a354f9c164e7ab242c5cb
-      sha256: ca3eb817054ac2942802b6b51dc671ab2af6564da329bebcb2538cdb31b59fa1
-    optional: false
-    category: main
-  - name: libzlib
-    version: 1.2.13
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-hfd90126_4.tar.bz2"
-    hash:
-      md5: 35eb3fce8d51ed3c1fd4122bad48250b
-      sha256: 0d954350222cc12666a1f4852dbc9bcf4904d8e467d29505f2b04ded6518f890
-    optional: false
-    category: main
-  - name: llvm-openmp
-    version: 15.0.7
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-15.0.7-h61d9ccf_0.conda"
-    hash:
-      md5: 3faa9933dff6e96333b5ca5274674b63
-      sha256: cc1586b43b757890b7d1cd24e1582345a36c40acd6cb6f9d9affb91de3c62015
-    optional: false
-    category: main
-  - name: ncurses
-    version: "6.3"
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.3-h96cf925_1.tar.bz2"
-    hash:
-      md5: 76217ebfbb163ff2770a261f955a5861
-      sha256: 9794a23d03586c99cac49d4ae3d5337faaa6bfc256b31d2662ff4ad5972be143
-    optional: false
-    category: main
-  - name: nomkl
-    version: "1.0"
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2"
-    hash:
-      md5: 9a66894dfd07c4510beb6b3f9672ccc0
-      sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
-    optional: false
-    category: main
-  - name: pthread-stubs
-    version: "0.4"
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2"
-    hash:
-      md5: addd19059de62181cd11ae8f4ef26084
-      sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
-    optional: false
-    category: main
-  - name: python_abi
-    version: "3.9"
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.9-3_cp39.conda"
-    hash:
-      md5: 021e2768e8eaf24ee8e25aec64d305a1
-      sha256: b02e179f015b042510da8ba256c86f5cfb34058a96ec1c548f33f9f8bcdbb78c
-    optional: false
-    category: main
-  - name: tzdata
-    version: 2022g
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
-    hash:
-      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
-      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
-    optional: false
-    category: main
-  - name: xorg-libxau
-    version: 1.0.9
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.9-h35c211d_0.tar.bz2"
-    hash:
-      md5: c5049997b2e98edfbcdd294582f66281
-      sha256: 6dcdbfcdb87c21cb615cd1a0a7fab7e657a443c771e80c771524f7d9b8443304
-    optional: false
-    category: main
-  - name: xorg-libxdmcp
-    version: 1.1.3
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2"
-    hash:
-      md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
-      sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
-    optional: false
-    category: main
-  - name: xz
-    version: 5.2.6
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2"
-    hash:
-      md5: a72f9d4ea13d55d745ff1ed594747f10
-      sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
-    optional: false
-    category: main
-  - name: doxygen
-    version: 1.9.5
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=14.0.4"
-      libiconv: ">=1.16,<2.0.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/doxygen-1.9.5-h6ca31d6_0.tar.bz2"
-    hash:
-      md5: 100e85351a872cfc6e5036329a10f589
-      sha256: 6900910a349b4a54fd42aa67c940c53efe137e0fe4160ec05aafb15dc9c6903e
-    optional: false
-    category: main
-  - name: gmp
-    version: 6.2.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=10.0.1"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/gmp-6.2.1-h2e338ed_0.tar.bz2"
-    hash:
-      md5: dedc96914428dae572a39e69ee2a392f
-      sha256: d6386708f6b7bcf790c57e985a5ca5636ec6ccaed0493b8ddea231aaeb8bfb00
-    optional: false
-    category: main
-  - name: isl
-    version: "0.25"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=13.0.1"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/isl-0.25-hb486fe8_0.tar.bz2"
-    hash:
-      md5: 45a9a46c78c0ea5c275b535f7923bde3
-      sha256: f0a10b2be179809d4444bee0a60d5aa286b306520d55897b29d22b9848ab71fb
-    optional: false
-    category: main
-  - name: lerc
-    version: 4.0.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=13.0.1"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2"
-    hash:
-      md5: f9d6a4c82889d5ecedec1d90eb673c55
-      sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
-    optional: false
-    category: main
-  - name: libbrotlidec
-    version: 1.0.9
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libbrotlicommon: "==1.0.9 hb7f2c08_8"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.0.9-hb7f2c08_8.tar.bz2"
-    hash:
-      md5: 7f952a036d9014b4dab96c6ea0f8c2a7
-      sha256: 52d8e8929b2476cf13fd397d88cefd911f805de00e77090fdc50b8fb11c372ca
-    optional: false
-    category: main
-  - name: libbrotlienc
-    version: 1.0.9
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libbrotlicommon: "==1.0.9 hb7f2c08_8"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.0.9-hb7f2c08_8.tar.bz2"
-    hash:
-      md5: b36a3bfe866d9127f25f286506982166
-      sha256: be7e794c6208e7e12982872922df13fbf020ab594d516b7bc306a384ac7d3ac6
-    optional: false
-    category: main
-  - name: libgfortran5
-    version: 11.3.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      llvm-openmp: ">=8.0.0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-11.3.0-h082f757_27.conda"
-    hash:
-      md5: f7602714b2be91be36f00fb75c45cb14
-      sha256: 78173905004e7d13501db619391b113f3b96f2c78ba3ed0273152d1340d6a818
-    optional: false
-    category: main
-  - name: libllvm14
-    version: 14.0.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=14"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libllvm14-14.0.6-h5b596cc_1.tar.bz2"
-    hash:
-      md5: c61f692b0e98efc1ef772fdf7d14e81a
-      sha256: 8e72bb60d707dfecca0cfb7378cbabe43de4537513a938fb0ab75ce58c5c7d91
-    optional: false
-    category: main
-  - name: libpng
-    version: 1.6.39
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda"
-    hash:
-      md5: 35e4928794c5391aec14ffdf1deaaee5
-      sha256: 5ad9f5e96e6770bfc8b0a826f48835e7f337c2d2e9512d76027a62f9c120b2a3
-    optional: false
-    category: main
-  - name: libsqlite
-    version: 3.40.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.40.0-ha978bb4_0.tar.bz2"
-    hash:
-      md5: ceb13b6726534b96e3b4e3dda91e9050
-      sha256: ae19f866188cc0c514fed754468460ae9e8dd763ebbd7b7afc4e818d71844297
-    optional: false
-    category: main
-  - name: libxcb
-    version: "1.13"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      pthread-stubs: "*"
-      xorg-libxau: "*"
-      xorg-libxdmcp: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.13-h0d85af4_1004.tar.bz2"
-    hash:
-      md5: eb7860935e14aec936065cbc21a1a962
-      sha256: 00e962ea91deae3dbed221c960c3bffab4172d87bc883b615298333fe336a5c6
-    optional: false
-    category: main
-  - name: ninja
-    version: 1.11.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=13.0.1"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.0-h1b54a9f_0.tar.bz2"
-    hash:
-      md5: 02e4d7a0d1cda051ddf5e83725c4b2a6
-      sha256: c7c7de719893c28b3e35fd3afa2ca7f6bf03022df5cf2398e1806c881ce41775
-    optional: false
-    category: main
-  - name: openssl
-    version: 3.0.8
-    manager: conda
-    platform: osx-64
-    dependencies:
-      ca-certificates: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/openssl-3.0.8-hfd90126_0.conda"
-    hash:
-      md5: 4239d01834a13512079046ea216b6657
-      sha256: 750ebd464414b7c4ea5aaa704788f7238a356c0a54ce76b018af246cdb65bf08
-    optional: false
-    category: main
-  - name: pkg-config
-    version: 0.29.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libiconv: ">=1.16,<2.0.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/pkg-config-0.29.2-ha3d46e9_1008.tar.bz2"
-    hash:
-      md5: 352bc6fb446a7ca608c61b33c1d5eb98
-      sha256: f60d1c03c7d10e8926e767981872fdd6002d2094925df598a53c58261524c151
-    optional: false
-    category: main
-  - name: readline
-    version: 8.1.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      ncurses: ">=6.3,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/readline-8.1.2-h3899abd_0.tar.bz2"
-    hash:
-      md5: 89fa404901fa8fb7d4f4e07083b8d635
-      sha256: c65dc1200a252832db49bdd6836c512a0eaafe97aa914b9f8358b15eebb1d94b
-    optional: false
-    category: main
-  - name: tapi
-    version: 1100.0.11
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=10.0.0.a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2"
-    hash:
-      md5: f9ff42ccf809a21ba6f8607f8de36108
-      sha256: 34b18ce8d1518b67e333ca1d3af733c3976ecbdf3a36b727f9b4dedddcc588fa
-    optional: false
-    category: main
-  - name: tk
-    version: 8.6.12
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libzlib: ">=1.2.11,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.12-h5dbffcc_0.tar.bz2"
-    hash:
-      md5: 8e9480d9c47061db2ed1b4ecce519a7f
-      sha256: 331aa1137a264fd9cc905f04f09a161c801fe504b93da08b4e6697bd7c9ae6a6
-    optional: false
-    category: main
-  - name: zlib
-    version: 1.2.13
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libzlib: "==1.2.13 hfd90126_4"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-hfd90126_4.tar.bz2"
-    hash:
-      md5: be90e6223c74ea253080abae19b3bdb1
-      sha256: 9db69bb5fc3e19093b550e25d1158cdf82f4f8eddc1f80f8d7d9de33eb8535a4
-    optional: false
-    category: main
-  - name: zstd
-    version: 1.5.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=14.0.6"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.2-hbc0c0cd_6.conda"
-    hash:
-      md5: 40a188783d3c425bdccc9ae9104acbb8
-      sha256: f845dafb0b488703ce81e25b6f27ed909ee9061b730c172e6b084fcf7156231f
-    optional: false
-    category: main
-  - name: brotli-bin
-    version: 1.0.9
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libbrotlidec: "==1.0.9 hb7f2c08_8"
-      libbrotlienc: "==1.0.9 hb7f2c08_8"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.0.9-hb7f2c08_8.tar.bz2"
-    hash:
-      md5: aac5ad0d8f747ef7f871508146df75d9
-      sha256: 36f79eb26da032c5d1ddc11e0bcac5526f249bf60d332e4743c8d48bb7334db0
-    optional: false
-    category: main
-  - name: freetype
-    version: 2.12.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libpng: ">=1.6.39,<1.7.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h3f81eb7_1.conda"
-    hash:
-      md5: 852224ea3e8991a8342228eab274840e
-      sha256: 0aea2b93d0da8bf022501857de93f2fc0e362fabcd83c4579be8d8f5bc3e17cb
-    optional: false
-    category: main
-  - name: libclang-cpp14
-    version: 14.0.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=13.0.1"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp14-14.0.6-default_h55ffa42_0.tar.bz2"
-    hash:
-      md5: 9b9bc2f878d47e6846e3d01ca0fcb921
-      sha256: 01f7c50ef3414ea00026e5845e6ac8f0395af8ea7d585e4977fd6d7aa3e215d0
-    optional: false
-    category: main
-  - name: libgfortran
-    version: 5.0.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libgfortran5: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-11_3_0_h97931a8_27.conda"
-    hash:
-      md5: 7d25335e67256924aa04de681e68e807
-      sha256: 834f1547a41fe53a23563b7702eb83b7156129a88460b5de701e8e019f7933a1
-    optional: false
-    category: main
-  - name: libtiff
-    version: 4.5.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      jpeg: ">=9e,<10a"
-      lerc: ">=4.0.0,<5.0a0"
-      libcxx: ">=14.0.6"
-      libdeflate: ">=1.17,<1.18.0a0"
-      libwebp-base: ">=1.2.4,<2.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      xz: ">=5.2.6,<6.0a0"
-      zstd: ">=1.5.2,<1.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.5.0-hee9004a_2.conda"
-    hash:
-      md5: 35f714269a801f7c3cb522aacd3c0e69
-      sha256: 03d00d6a3b1e569e9a8da66a9ad75a29c9c676dc7de6c16771abbb961abded2c
-    optional: false
-    category: main
-  - name: llvm-tools
-    version: 14.0.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libllvm14: "==14.0.6 h5b596cc_1"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-14.0.6-h5b596cc_1.tar.bz2"
-    hash:
-      md5: d99491efd3d672b3496e9fc9273da7c0
-      sha256: 70be9ae375316ed616dae92c614763bd930d64765cf256d0f1aa50e3dcdafc58
-    optional: false
-    category: main
-  - name: mpfr
-    version: 4.1.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      gmp: ">=6.2.1,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/mpfr-4.1.0-h0f52abe_1.tar.bz2"
-    hash:
-      md5: afe26b08c2d2265b4d663d199000e5da
-      sha256: 68e2d7c06f438f7179b9b0c6f826a33a29c6580233a1e60fa71d4da260d70b8f
-    optional: false
-    category: main
-  - name: python
-    version: 3.9.16
-    manager: conda
-    platform: osx-64
-    dependencies:
-      bzip2: ">=1.0.8,<2.0a0"
-      libffi: ">=3.4,<4.0a0"
-      libsqlite: ">=3.40.0,<4.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      ncurses: ">=6.3,<7.0a0"
-      openssl: ">=3.0.7,<4.0a0"
-      pip: "*"
-      readline: ">=8.1.2,<9.0a0"
-      tk: ">=8.6.12,<8.7.0a0"
-      tzdata: "*"
-      xz: ">=5.2.6,<6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/python-3.9.16-h709bd14_0_cpython.conda"
-    hash:
-      md5: 37f637999bb01d0474492ed14660c34b
-      sha256: ffff69cde5bce4fadaf1b6fb551d3ffa1f0f8a6dfdc95ec114f9aac02758a71a
-    optional: false
-    category: main
-  - name: sigtool
-    version: 0.1.3
-    manager: conda
-    platform: osx-64
-    dependencies:
-      openssl: ">=3.0.0,<4.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2"
-    hash:
-      md5: fbfb84b9de9a6939cb165c02c69b1865
-      sha256: 46fdeadf8f8d725819c4306838cdfd1099cd8fe3e17bd78862a5dfdcd6de61cf
-    optional: false
-    category: main
-  - name: alabaster
-    version: 0.7.13
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 06006184e203b61d3525f90de394471e
-      sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
-    optional: false
-    category: main
-  - name: appdirs
-    version: 1.4.4
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 5f095bc6454094e96f146491fd03633b
-      sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
-    optional: false
-    category: main
-  - name: appnope
-    version: 0.1.3
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 54ac328d703bff191256ffa1183126d1
-      sha256: b209a68ac55eb9ecad7042f0d4eedef5da924699f6cdf54ac1826869cfdae742
-    optional: false
-    category: main
-  - name: attrs
-    version: 22.2.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/attrs-22.2.0-pyh71513ae_0.conda"
-    hash:
-      md5: 8b76db7818a4e401ed4486c4c1635cd9
-      sha256: 3a58d4a4933fa8735471c782d35326ab78e0bcfce84756408515f82a94e4dec4
-    optional: false
-    category: main
-  - name: backcall
-    version: 0.2.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 6006a6d08a3fa99268a2681c7fb55213
-      sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
-    optional: false
-    category: main
-  - name: backports
-    version: "1.0"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda"
-    hash:
-      md5: 54ca2e08b3220c148a1d8329c2678e02
-      sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-    optional: false
-    category: main
-  - name: backports.zoneinfo
-    version: 0.2.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/backports.zoneinfo-0.2.1-py39h6e9494a_7.tar.bz2"
-    hash:
-      md5: 5727630b9e2234fbe5ba637c763a80c7
-      sha256: 4dda0fc050802b0ad30eda1a4b13ad82172627f1601fae9e36344e41de8be5e2
-    optional: false
-    category: main
-  - name: brotli
-    version: 1.0.9
-    manager: conda
-    platform: osx-64
-    dependencies:
-      brotli-bin: "==1.0.9 hb7f2c08_8"
-      libbrotlidec: "==1.0.9 hb7f2c08_8"
-      libbrotlienc: "==1.0.9 hb7f2c08_8"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/brotli-1.0.9-hb7f2c08_8.tar.bz2"
-    hash:
-      md5: 55f612fe4a9b5f6ac76348b6de94aaeb
-      sha256: 1272426370f1e8db1a8b245a7b522afe27413b09eab169990512a7676b802e3b
-    optional: false
-    category: main
-  - name: certifi
-    version: 2022.12.7
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/certifi-2022.12.7-pyhd8ed1ab_0.conda"
-    hash:
-      md5: fb9addc3db06e56abe03e0e9f21a63e6
-      sha256: 5e22af4776700200fab2c1df41a2188ab9cfe90a50c4f388592bb978562c88ec
-    optional: false
-    category: main
-  - name: charset-normalizer
-    version: 2.1.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c1d5b294fbf9a795dec349a6f4d8be8e
-      sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
-    optional: false
-    category: main
-  - name: clang-14
-    version: 14.0.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libclang-cpp14: "==14.0.6 default_h55ffa42_0"
-      libcxx: ">=13.0.1"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/clang-14-14.0.6-default_h55ffa42_0.tar.bz2"
-    hash:
-      md5: f4b08faae104f8a5483c06f7c6464b35
-      sha256: 8c421568bce373e71ade9768f0f7e3563eaec84cb2cd51a7f2e03c6c3bb7be94
-    optional: false
-    category: main
-  - name: click
-    version: 8.1.3
-    manager: conda
-    platform: osx-64
-    dependencies:
-      __unix: "*"
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2"
-    hash:
-      md5: 20e4087407c7cb04a40817114b333dbf
-      sha256: 23676470b591b100393bb0f6c46fe10624dcbefc696a6a9f42932ed8816ef0ea
-    optional: false
-    category: main
-  - name: colorama
-    version: 0.4.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 3faab06a954c2a04039983f2c4a50d99
-      sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-    optional: false
-    category: main
-  - name: cycler
-    version: 0.11.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: a50559fad0affdbb33729a68669ca1cb
-      sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
-    optional: false
-    category: main
-  - name: cython
-    version: 0.29.33
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=14.0.6"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/cython-0.29.33-py39h7a8716b_0.conda"
-    hash:
-      md5: 04be8513f2ce60858396afbd0353688a
-      sha256: 3ee611cc2d9793089ef54e20d7521655b2ef8017b4c56003f872ffdb16eafee2
-    optional: false
-    category: main
-  - name: decorator
-    version: 5.1.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 43afe5ab04e35e17ba28649471dd7364
-      sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-    optional: false
-    category: main
-  - name: docutils
-    version: "0.19"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/docutils-0.19-py39h6e9494a_1.tar.bz2"
-    hash:
-      md5: d9db9ab3a721b9f36017d6b93060b462
-      sha256: 232f045f5935309bd3c7901027a728c1dcfdab385e8ad104f54b6a70c315a219
-    optional: false
-    category: main
-  - name: exceptiongroup
-    version: 1.1.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: a385c3e8968b4cf8fbc426ace915fd1a
-      sha256: cf668360331552b2903e440cda1b4e47062c3f3775342e4a278ef4d141c28d1d
-    optional: false
-    category: main
-  - name: execnet
-    version: 1.9.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: "==2.7|>=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/execnet-1.9.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 0e521f7a5e60d508b121d38b04874fb2
-      sha256: 1900bbc1764d01405e55be2e369d1b830fb435eb0f27c57033372c60f34c675c
-    optional: false
-    category: main
-  - name: executing
-    version: 1.2.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 4c1bc140e2be5c8ba6e3acab99e25c50
-      sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
-    optional: false
-    category: main
-  - name: idna
-    version: "3.4"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 34272b248891bddccc64479f9a7fffed
-      sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
-    optional: false
-    category: main
-  - name: imagesize
-    version: 1.4.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.4"
-    url: "https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 7de5386c8fea29e76b303f37dde4c352
-      sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
-    optional: false
-    category: main
-  - name: iniconfig
-    version: 2.0.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f800d2da156d08e289b14e87e43c1ae5
-      sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-    optional: false
-    category: main
-  - name: kiwisolver
-    version: 1.4.4
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=14.0.4"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.4-py39h92daf61_1.tar.bz2"
-    hash:
-      md5: 7720e059630e25ab17ab12677e59c615
-      sha256: c397173c92ca77678d645bf8ef8064e81b821169db056217963f020acc09d42c
-    optional: false
-    category: main
-  - name: lcms2
-    version: "2.14"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      jpeg: ">=9e,<10a"
-      libtiff: ">=4.5.0,<4.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.14-h29502cd_1.conda"
-    hash:
-      md5: 1e42174021ffc69545f0814b9478dee3
-      sha256: 64efad232b892c2511ba56bbd821e0b1e2e80a7a8ccf3524c20b5f964793ce43
-    optional: false
-    category: main
-  - name: ld64_osx-64
-    version: "609"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: "*"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-      sigtool: "*"
-      tapi: ">=1100.0.11,<1101.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-hfd63004_11.conda"
-    hash:
-      md5: 8881d41cb8fa1104d4545c6b7ddc9671
-      sha256: 0c658f698bc12e0c7dc2def81c0b2a45aab810f5a11136dc99a5e944b47a3b97
-    optional: false
-    category: main
-  - name: libopenblas
-    version: 0.3.21
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libgfortran: 5.*
-      libgfortran5: ">=11.3.0"
-      llvm-openmp: ">=14.0.4"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.21-openmp_h429af6e_3.tar.bz2"
-    hash:
-      md5: 968c46aa7f4032c3f3873f3452ed4c34
-      sha256: a5a0b6ccef165ffb38e6a53e7b8808e33c77e081174315d2333ae93b593ae957
-    optional: false
-    category: main
-  - name: markupsafe
-    version: 2.1.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.2-py39ha30fb19_0.conda"
-    hash:
-      md5: 3b7b34916156e45ec52df74efc3db6e4
-      sha256: d5aa88cdd75728fe101f83d0c4a7ab36634044f890e9e41aceb7454500e8af2b
-    optional: false
-    category: main
-  - name: mpc
-    version: 1.3.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      gmp: ">=6.2.1,<7.0a0"
-      mpfr: ">=4.1.0,<5.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/mpc-1.3.1-h81bd1dd_0.conda"
-    hash:
-      md5: c752c0eb6c250919559172c011e5f65b
-      sha256: 2ae945a15c8a984d581dcfb974ad3b5d877a6527de2c95a3363e6b4490b2f312
-    optional: false
-    category: main
-  - name: munkres
-    version: 1.1.4
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 2ba8498c1018c1e9c61eb99b973dfe19
-      sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
-    optional: false
-    category: main
-  - name: mypy_extensions
-    version: 1.0.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda"
-    hash:
-      md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-      sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-    optional: false
-    category: main
-  - name: openjpeg
-    version: 2.5.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=14.0.6"
-      libpng: ">=1.6.39,<1.7.0a0"
-      libtiff: ">=4.5.0,<4.6.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-h13ac156_2.conda"
-    hash:
-      md5: 299a29af9ac9f550ad459d655739280b
-      sha256: 2375eafbd5241d8249fb467e2a8e190646e8798c33059c72efa60f197cdf4944
-    optional: false
-    category: main
-  - name: packaging
-    version: "23.0"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/packaging-23.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 1ff2e3ca41f0ce16afec7190db28288b
-      sha256: 00288f5e5e841711e8b8fef1f1242c858d8ef99ccbe5d7e0df4789d5d8d40645
-    optional: false
-    category: main
-  - name: parso
-    version: 0.8.3
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 17a565a0c3899244e938cdf417e7b094
-      sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
-    optional: false
-    category: main
-  - name: pickleshare
-    version: 0.7.5
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2"
-    hash:
-      md5: 415f0ebb6198cc2801c73438a9fb5761
-      sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-    optional: false
-    category: main
-  - name: pluggy
-    version: 1.0.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2"
-    hash:
-      md5: 7d301a0d25f424d96175f810935f0da9
-      sha256: c25e1757e4e90638bb1e778aba3ee5f3c01fae9752e3c3929f9be7d367f6c7f3
-    optional: false
-    category: main
-  - name: psutil
-    version: 5.9.4
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.4-py39ha30fb19_0.tar.bz2"
-    hash:
-      md5: fde4dae8cd4d545d53e20d371ffd4c77
-      sha256: 4e81064087ca1938c04d8e9dd1e8be92f686a56f7ebf0da5371beea9fc5f2a24
-    optional: false
-    category: main
-  - name: ptyprocess
-    version: 0.7.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2"
-    hash:
-      md5: 359eeb6536da0e687af562ed265ec263
-      sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
-    optional: false
-    category: main
-  - name: pure_eval
-    version: 0.2.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6784285c7e55cb7212efabc79e4c2883
-      sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
-    optional: false
-    category: main
-  - name: pycodestyle
-    version: 2.7.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: 2.7.*|>=3.5
-    url: "https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.7.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 0234673eb2ecfbdf4e54574ab4d95f81
-      sha256: 5c6aa7a724551d7768930b30bd77e531580f6ddd68a391094e799a21a82b9492
-    optional: false
-    category: main
-  - name: pycparser
-    version: "2.21"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: 2.7.*|>=3.4
-    url: "https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 076becd9e05608f8dc72757d5f3a91ff
-      sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
-    optional: false
-    category: main
-  - name: pyparsing
-    version: 3.0.9
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: e8fbc1b54b25f4b08281467bc13b70cc
-      sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
-    optional: false
-    category: main
-  - name: pysocks
-    version: 1.7.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      __unix: "*"
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2"
-    hash:
-      md5: 2a7de29fb590ca14b5243c4c812c8025
-      sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
-    optional: false
-    category: main
-  - name: pytz
-    version: 2022.7.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytz-2022.7.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f59d49a7b464901cf714b9e7984d01a2
-      sha256: 93cfc7a92099e26b0575a343da4a667b52371cc38e4dee4ee264dc041ef77bac
-    optional: false
-    category: main
-  - name: setuptools
-    version: 59.2.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/setuptools-59.2.0-py39h6e9494a_0.tar.bz2"
-    hash:
-      md5: a0954b685217e8b45fd677da613d4e95
-      sha256: 5f0850fae9a651bc448bc50af4550d93f8d966f168ef85a918e51eca6490d8ab
-    optional: false
-    category: main
-  - name: six
-    version: 1.16.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2"
-    hash:
-      md5: e5f25f8dbc060e9a8d912e432202afc2
-      sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
-    optional: false
-    category: main
-  - name: smmap
-    version: 3.0.5
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/smmap-3.0.5-pyh44b312d_0.tar.bz2"
-    hash:
-      md5: 3a8dc70789709aa315325d5df06fb7e4
-      sha256: 091de70ee6bfe063e0c0f77336975d124fd1e3f49b9c58d97c0c7b3d287c0002
-    optional: false
-    category: main
-  - name: snowballstemmer
-    version: 2.2.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 4d22a9315e78c6827f806065957d566e
-      sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
-    optional: false
-    category: main
-  - name: sortedcontainers
-    version: 2.4.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6d6552722448103793743dabfbda532d
-      sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
-    optional: false
-    category: main
-  - name: soupsieve
-    version: 2.3.2.post1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 146f4541d643d48fc8a75cacf69f03ae
-      sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
-    optional: false
-    category: main
-  - name: sphinxcontrib-applehelp
-    version: 1.0.4
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.4-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 5a31a7d564f551d0e6dff52fd8cb5b16
-      sha256: 802810d8321d55e5666806d565e72949eabf77ad510fe2758ce1da2441675ef1
-    optional: false
-    category: main
-  - name: sphinxcontrib-devhelp
-    version: 1.0.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.2-py_0.tar.bz2"
-    hash:
-      md5: 68e01cac9d38d0e717cd5c87bc3d2cc9
-      sha256: 66cca7eccb7f92eee53f9f5a552e3e1d643daa3a1ebd03c185e2819e5c491576
-    optional: false
-    category: main
-  - name: sphinxcontrib-htmlhelp
-    version: 2.0.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 6c8c4d6eb2325e59290ac6dbbeacd5f0
-      sha256: aeff20be994e6f9520a91fc177a33cb3e4d0911cdf8d27e575d001f00afa33fd
-    optional: false
-    category: main
-  - name: sphinxcontrib-jsmath
-    version: 1.0.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-py_0.tar.bz2"
-    hash:
-      md5: 67cd9d9c0382d37479b4d306c369a2d4
-      sha256: a42415fc789e9f6ae2e18f07ac143d2e9ce73a35a55ecf1dd1b3d055dd1e6dbe
-    optional: false
-    category: main
-  - name: sphinxcontrib-qthelp
-    version: 1.0.3
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2"
-    hash:
-      md5: d01180388e6d1838c3e1ad029590aa7a
-      sha256: 35d8f01fc798d38b72ae003c040d2dee650d315f904268a1f793d4d59460d1e2
-    optional: false
-    category: main
-  - name: sphinxcontrib-serializinghtml
-    version: 1.1.5
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2"
-    hash:
-      md5: 9ff55a0901cf952f05c654394de76bf7
-      sha256: 890bbf815cff114ddbb618b9876d492fce07d02956c1d7b3d46cb7f835f563f6
-    optional: false
-    category: main
-  - name: toml
-    version: 0.10.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: f832c45a477c78bebd107098db465095
-      sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
-    optional: false
-    category: main
-  - name: tomli
-    version: 2.0.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 5844808ffab9ebdb694585b50ba02a96
-      sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-    optional: false
-    category: main
-  - name: tornado
-    version: "6.2"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/tornado-6.2-py39ha30fb19_1.tar.bz2"
-    hash:
-      md5: 07917d8456ca9aa09acf950019bf53b2
-      sha256: 1536759eb5feb9fdf9e7974e9fce18a709f0e110a75caff72dd9d83c7192cd86
-    optional: false
-    category: main
-  - name: traitlets
-    version: 5.9.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: d0b4f5c87cd35ac3fb3d47b223263a64
-      sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
-    optional: false
-    category: main
-  - name: typing_extensions
-    version: 4.4.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.4.0-pyha770c72_0.tar.bz2"
-    hash:
-      md5: 2d93b130d148d7fc77e583677792fc6a
-      sha256: 70c57b5ac94cd32e78f1a2fa2c38572bfac85b901a6a99aa254a9e8e126c132d
-    optional: false
-    category: main
-  - name: unicodedata2
-    version: 15.0.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.0.0-py39ha30fb19_0.tar.bz2"
-    hash:
-      md5: 17876b4aebf783fb7bba980a79516892
-      sha256: 06ff21e0a28f5acee3719fd8c788c4dffbed408f463c933f7f892399039962fc
-    optional: false
-    category: main
-  - name: wheel
-    version: 0.38.4
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c829cfb8cb826acb9de0ac1a2df0a940
-      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-    optional: false
-    category: main
-  - name: zipp
-    version: 3.13.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/zipp-3.13.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 41b09d997939e83b231c4557a90c3b13
-      sha256: 0a9a545b8dc46c847658ebfa636257ea5993a355419c1d3b2f14810730ee0a82
-    optional: false
-    category: main
-  - name: asttokens
-    version: 2.2.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.5"
-      six: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: bf7f54dd0f25c3f06ecb82a07341841a
-      sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
-    optional: false
-    category: main
-  - name: babel
-    version: 2.11.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-      pytz: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/babel-2.11.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 2ea70fde8d581ba9425a761609eed6ba
-      sha256: 21a8403d886136c0a80f965ae5387fa1693b19ddd69023bcd0e844f2510d7e2f
-    optional: false
-    category: main
-  - name: backports.functools_lru_cache
-    version: 1.6.4
-    manager: conda
-    platform: osx-64
-    dependencies:
-      backports: "*"
-      python: ">=3.6"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c5b3edc62d6309088f4970b3eaaa65a6
-      sha256: fdea00d4b79990f3fe938e2716bc32bd895eb5c44b6c75b8261db095a1b33c16
-    optional: false
-    category: main
-  - name: beautifulsoup4
-    version: 4.11.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-      soupsieve: ">=1.2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.11.2-pyha770c72_0.conda"
-    hash:
-      md5: 88b59f6989f0ed5ab3433af0b82555e1
-      sha256: deb43944425b3ec7fdfd5e6620cf97a4ed888a279237f90cd67a338d123efd15
-    optional: false
-    category: main
-  - name: cctools_osx-64
-    version: 973.0.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      ld64_osx-64: ">=609,<610.0a0"
-      libcxx: "*"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      sigtool: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-hcc6d90d_11.conda"
-    hash:
-      md5: f1af817221bc31e7c770e1ea15374355
-      sha256: 35c805738300e15a77977849b540b2ba54d8cbc915cb531cf88240a8968fc00d
-    optional: false
-    category: main
-  - name: cffi
-    version: 1.15.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libffi: ">=3.4,<4.0a0"
-      pycparser: "*"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/cffi-1.15.1-py39h131948b_3.conda"
-    hash:
-      md5: 35c1b89ab4359002865052df70939c48
-      sha256: e099e8ce3f35906071035fef85cbca94bbbb90d18f231ba8cd1a88577c7d84b3
-    optional: false
-    category: main
-  - name: clang
-    version: 14.0.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      clang-14: "==14.0.6 default_h55ffa42_0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/clang-14.0.6-h694c41f_0.tar.bz2"
-    hash:
-      md5: 77667c3c75b88f12782f628d171ffeda
-      sha256: dc38927cc81c81c64ab632f3aaa4bb17ed776794b2bfd3fa3375b38ad768ace7
-    optional: false
-    category: main
-  - name: coverage
-    version: 7.1.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tomli: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/coverage-7.1.0-py39ha30fb19_0.conda"
-    hash:
-      md5: be24d2d5a14dd95d77376ca68df86e94
-      sha256: 7c3ee64099be5aa022f0126b5c5ace87cfb616a19fdcc7d88731ed432595fbc3
-    optional: false
-    category: main
-  - name: fonttools
-    version: 4.38.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      brotli: "*"
-      munkres: "*"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      unicodedata2: ">=14.0.0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.38.0-py39ha30fb19_1.tar.bz2"
-    hash:
-      md5: d4ef9879362c40c8c346a0b6cd79f2e0
-      sha256: 6875cb8e44e09332b59f276c3b32be05906206f8a19e773d8c765feeae6dac4b
-    optional: false
-    category: main
-  - name: gfortran_impl_osx-64
-    version: 11.3.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      gmp: ">=6.2.1,<7.0a0"
-      isl: ">=0.25,<0.26.0a0"
-      libcxx: ">=14.0.6"
-      libgfortran-devel_osx-64: 11.3.0.*
-      libgfortran5: ">=11.3.0"
-      libiconv: ">=1.17,<2.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      mpc: ">=1.2.1,<2.0a0"
-      mpfr: ">=4.1.0,<5.0a0"
-      zlib: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/gfortran_impl_osx-64-11.3.0-h1f927f5_27.conda"
-    hash:
-      md5: 0bb7f54e22a2136588b33e7b0bf24148
-      sha256: e8be46ff4aa486a808e3494cf6b44758cce199d2888d91553261f65bd02cf7f0
-    optional: false
-    category: main
-  - name: gitdb
-    version: 4.0.10
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.4"
-      smmap: ">=3.0.1,<4"
-    url: "https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.10-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 3706d2f3d7cb5dae600c833345a76132
-      sha256: 0003ab2b971913380633c711bf49a54dcf06e179986c725b0925854b58878377
-    optional: false
-    category: main
-  - name: hypothesis
-    version: 6.68.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      attrs: ">=19.2.0"
-      backports.zoneinfo: ">=0.2.1"
-      click: ">=7.0"
-      exceptiongroup: ">=1.0.0rc8"
-      python: ">=3.8"
-      setuptools: "*"
-      sortedcontainers: ">=2.1.0,<3.0.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.68.1-pyha770c72_0.conda"
-    hash:
-      md5: 3c044b3b920eb287f8c095c7f086ba64
-      sha256: e3a29c1303b563e450e0f706e4d78a281d1aa519d3e1094fc642305bceff72e1
-    optional: false
-    category: main
-  - name: importlib-metadata
-    version: 6.0.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.8"
-      zipp: ">=0.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.0.0-pyha770c72_0.conda"
-    hash:
-      md5: 691644becbcdca9f73243450b1c63e62
-      sha256: 0062e6ae1719395c25f0b60a21215470b4ea67514fed8a9330869da8604acfca
-    optional: false
-    category: main
-  - name: jedi
-    version: 0.18.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      parso: ">=0.8.0,<0.9.0"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
-      sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
-    optional: false
-    category: main
-  - name: jinja2
-    version: 3.1.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      markupsafe: ">=2.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: c8490ed5c70966d232fdd389d0dbed37
-      sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-    optional: false
-    category: main
-  - name: ld64
-    version: "609"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      ld64_osx-64: "==609 hfd63004_11"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/ld64-609-hc6ad406_11.conda"
-    hash:
-      md5: 9e14075f26a915bc6180b40789138adf
-      sha256: fd1d2aa9a08c52599fb03dbd65fe32e788f34bcd6d509f22eac7897233282d60
-    optional: false
-    category: main
-  - name: libblas
-    version: 3.9.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libopenblas: ">=0.3.21,<1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-16_osx64_openblas.tar.bz2"
-    hash:
-      md5: 644d63e9379867490b67bace400b2a0f
-      sha256: 7678dab49b552957ddfa1fc5ddf3a09963c788bca81adb0cd9626f6385e205c5
-    optional: false
-    category: main
-  - name: matplotlib-inline
-    version: 0.1.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-      traitlets: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: b21613793fcc81d944c76c9f2864a7de
-      sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-    optional: false
-    category: main
-  - name: meson
-    version: 1.0.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      ninja: ">=1.8.2"
-      python: ">=3.5.2"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/meson-1.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 4de573313958b8da6c526fdd354fffc8
-      sha256: 57dc7634aa05f3944314e6b56b2f37e6fb1a52b33de9ca153aee5d9adf83a5d7
-    optional: false
-    category: main
-  - name: mypy
-    version: "0.981"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      mypy_extensions: ">=0.4.3"
-      psutil: ">=4.0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tomli: ">=1.1.0"
-      typing_extensions: ">=3.10"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/mypy-0.981-py39ha30fb19_0.tar.bz2"
-    hash:
-      md5: b6580642702195bf97ea22c5913a82b9
-      sha256: df7bdee4a6f7376bccfede1570bd3338011137d4ba63520b90b56e642ee5f782
-    optional: false
-    category: main
-  - name: openblas
-    version: 0.3.21
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libgfortran: 5.*
-      libgfortran5: ">=11.3.0"
-      libopenblas: "==0.3.21 openmp_h429af6e_3"
-      llvm-openmp: ">=14.0.4"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/openblas-0.3.21-openmp_hbefa662_3.tar.bz2"
-    hash:
-      md5: f0ad8b67cf731e7e375e497305d7cee5
-      sha256: 8aaf3165d6b443c48f3a1b2b34330c361801d04ac668d43be5475472c6a4e25f
-    optional: false
-    category: main
-  - name: pexpect
-    version: 4.8.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      ptyprocess: ">=0.5"
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2"
-    hash:
-      md5: 330448ce4403cc74990ac07c555942a1
-      sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
-    optional: false
-    category: main
-  - name: pillow
-    version: 9.4.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      freetype: ">=2.12.1,<3.0a0"
-      jpeg: ">=9e,<10a"
-      lcms2: ">=2.14,<3.0a0"
-      libtiff: ">=4.5.0,<4.6.0a0"
-      libwebp-base: ">=1.2.4,<2.0a0"
-      libxcb: ">=1.13,<1.14.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      openjpeg: ">=2.5.0,<3.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tk: ">=8.6.12,<8.7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/pillow-9.4.0-py39h7f5cd59_1.conda"
-    hash:
-      md5: d2f1bdaa85fd34020259533efeeb40bb
-      sha256: b7a6d9e50a212215f76666789b0e9c155756d90e27678b4a8720fc6825621648
-    optional: false
-    category: main
-  - name: pip
-    version: "23.0"
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-      setuptools: "*"
-      wheel: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 85b35999162ec95f9f999bac15279c02
-      sha256: bbffec284bd0e154363e845121f43007e7e64c80412ff13be21909be907b697d
-    optional: false
-    category: main
-  - name: pygments
-    version: 2.14.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pygments-2.14.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: c78cd16b11cd6a295484bd6c8f24bea1
-      sha256: e8710e24f60b6a97289468f47914e53610101755088bc237621cc1980edbfcd9
-    optional: false
-    category: main
-  - name: pyproject-metadata
-    version: 0.7.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      packaging: ">=19.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyproject-metadata-0.7.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: dcb27826ffc94d5f04e241322239983b
-      sha256: 9ec35cffa163f587aeb52d1603df8374659e3be30dbc6db0e980ecb797f21fee
-    optional: false
-    category: main
-  - name: pytest
-    version: 7.2.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      attrs: ">=19.2.0"
-      colorama: "*"
-      exceptiongroup: "*"
-      iniconfig: "*"
-      packaging: "*"
-      pluggy: ">=0.12,<2.0"
-      python: ">=3.8"
-      tomli: ">=1.0.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f0be05afc9c9ab45e273c088e00c258b
-      sha256: d298dfe6c53555c9fb5662f5f936e621cddd3b0a7031789375b82a1ee3b3a96b
-    optional: false
-    category: main
-  - name: python-dateutil
-    version: 2.8.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-      six: ">=1.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: dd999d1cc9f79e67dbb855c8924c7984
-      sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-    optional: false
-    category: main
-  - name: typing-extensions
-    version: 4.4.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      typing_extensions: "==4.4.0 pyha770c72_0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.4.0-hd8ed1ab_0.tar.bz2"
-    hash:
-      md5: be969210b61b897775a0de63cd9e9026
-      sha256: 6f129b1bc18d111dcf3abaec6fcf6cbee00f1b77bb42d0f0bc8d85f8faa65cf0
-    optional: false
-    category: main
-  - name: brotlipy
-    version: 0.7.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      cffi: ">=1.0.0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/brotlipy-0.7.0-py39ha30fb19_1005.tar.bz2"
-    hash:
-      md5: 201d86c1f0b0132954fc72251b09df8a
-      sha256: 0204c1d5ab773e956233c0a6941f87faf7e9dc3fe30dec0d34f04091309859d8
-    optional: false
-    category: main
-  - name: cctools
-    version: 973.0.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      cctools_osx-64: "==973.0.1 hcc6d90d_11"
-      ld64: "==609 hc6ad406_11"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-h76f1dac_11.conda"
-    hash:
-      md5: 77d8192c013d7a4a355aee5b0ae1ae20
-      sha256: afe5a8d93ae1ecc09d98a15f6edea6b14e0f99fb3f64d4d04501461afb56ccd9
-    optional: false
-    category: main
-  - name: clangxx
-    version: 14.0.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      clang: "==14.0.6 h694c41f_0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/clangxx-14.0.6-default_h55ffa42_0.tar.bz2"
-    hash:
-      md5: 6a46064b0506895d090302433e70397b
-      sha256: 11b6d9f11aae45ac36a4d87d0f5367d00eda6f53c43bac38594024e25a366b04
-    optional: false
-    category: main
-  - name: cryptography
-    version: 39.0.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      cffi: ">=1.12"
-      openssl: ">=3.0.8,<4.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/cryptography-39.0.1-py39hbeae22c_0.conda"
-    hash:
-      md5: fac2793ec157233017912d190fa15f00
-      sha256: 3b98fbb4a457fb3136e832079b5cf112063bd3c91b655f640db0b455328b3767
-    optional: false
-    category: main
-  - name: gitpython
-    version: 3.1.30
-    manager: conda
-    platform: osx-64
-    dependencies:
-      gitdb: ">=4.0.1,<5"
-      python: ">=3.7"
-      typing_extensions: ">=3.7.4.3"
-    url: "https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.30-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 0c217ab2f5ef6925e4e52c70b57cfc4a
-      sha256: 2ccd8aa401701947398a087b1aa11042b1b088e7331fed574b7ec9909bee09d6
-    optional: false
-    category: main
-  - name: libcblas
-    version: 3.9.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libblas: "==3.9.0 16_osx64_openblas"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-16_osx64_openblas.tar.bz2"
-    hash:
-      md5: 28592eab0f05bcf9969789e87f754e11
-      sha256: 072a214ab1d596b99b985773bdb6f6e5f38774c7f73d70962700e0fc0d77d91f
-    optional: false
-    category: main
-  - name: liblapack
-    version: 3.9.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libblas: "==3.9.0 16_osx64_openblas"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-16_osx64_openblas.tar.bz2"
-    hash:
-      md5: 406ad426aade5578b90544cc2ed4a79b
-      sha256: 456a6e8bfc2e97846d9e157b5f51c23e0c4e9c922ccf7b2321be5362c835d35f
-    optional: false
-    category: main
-  - name: meson-python
-    version: 0.12.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      colorama: "*"
-      meson: ">=0.63.3"
-      ninja: "*"
-      pyproject-metadata: ">=0.6.1"
-      python: ">=3.7"
-      tomli: ">=1.0.0"
-      typing-extensions: ">=3.7.4"
-      wheel: ">=0.36.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/meson-python-0.12.0-pyh71feb2d_0.conda"
-    hash:
-      md5: dc566efe9c7af4eb305402b5c6121ca3
-      sha256: 2ea6e9b843e7d93283f2bd442f20bc973cf8141ef1876c9fe4353e473265a4da
-    optional: false
-    category: main
-  - name: pytest-cov
-    version: 4.0.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      coverage: ">=5.2.1"
-      pytest: ">=4.6"
-      python: ">=3.6"
-      toml: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.0.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c9e3f8bfdb9bfc34aa1836a6ed4b25d7
-      sha256: 2e00bbdb00b2514faba50ddcb6ecf1d6e4f2d5af346f9cd1240aacb1b61dccb6
-    optional: false
-    category: main
-  - name: pytest-xdist
-    version: 3.2.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      execnet: ">=1.1"
-      pytest: ">=6.2.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.2.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 70ab87b96126f35d1e68de2ad9fb6423
-      sha256: aa81f80bf0a2f53423ab80137ca4fc201473884725a2983a0d79b2e420c2a671
-    optional: false
-    category: main
-  - name: stack_data
-    version: 0.6.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      asttokens: "*"
-      executing: "*"
-      pure_eval: "*"
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: e7df0fdd404616638df5ece6e69ba7af
-      sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-    optional: false
-    category: main
-  - name: wcwidth
-    version: 0.2.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      backports.functools_lru_cache: "*"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 078979d33523cb477bd1916ce41aacc9
-      sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
-    optional: false
-    category: main
-  - name: compiler-rt_osx-64
-    version: 14.0.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      clang: 14.0.6.*
-      clangxx: 14.0.6.*
-    url: "https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-14.0.6-hab78ec2_0.tar.bz2"
-    hash:
-      md5: 4fdde3f4ed31722a1c811723f5db82f0
-      sha256: a8351d6a47a8a2cd8267862d36ad5a06f16955c68111140b8b147ee126433712
-    optional: false
-    category: main
-  - name: numpy
-    version: 1.24.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libblas: ">=3.9.0,<4.0a0"
-      libcblas: ">=3.9.0,<4.0a0"
-      libcxx: ">=14.0.6"
-      liblapack: ">=3.9.0,<4.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/numpy-1.24.2-py39h6ee2318_0.conda"
-    hash:
-      md5: 9b49051072af22354aee82b524f808ff
-      sha256: 6c4acf04c482a33b7c4a1661ed50c6927f683418b9b61b29f16711f77480485e
-    optional: false
-    category: main
-  - name: prompt-toolkit
-    version: 3.0.36
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-      wcwidth: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda"
-    hash:
-      md5: 4d79ec192e0bfd530a254006d123b9a6
-      sha256: 6bd3626799c9467d7aa8ed5f95043e4cea614a1329580980ddcf40cfed3ee860
-    optional: false
-    category: main
-  - name: pyopenssl
-    version: 23.0.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      cryptography: ">=38.0.0,<40"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: d41957700e83bbb925928764cb7f8878
-      sha256: adbf8951f22bfa950b9e24394df1ef1d2b2d7dfb194d91c7f42bc11900695785
-    optional: false
-    category: main
-  - name: compiler-rt
-    version: 14.0.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      clang: 14.0.6.*
-      clangxx: 14.0.6.*
-      compiler-rt_osx-64: 14.0.6.*
-    url: "https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-14.0.6-h613da45_0.tar.bz2"
-    hash:
-      md5: b44e0625319f9933e584dc3b96f5baf7
-      sha256: 2dea3b5efea587329320c70a335fa5666c3a814e70e76464734b90a40b70e8a8
-    optional: false
-    category: main
-  - name: contourpy
-    version: 1.0.7
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=14.0.6"
-      numpy: ">=1.16"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.0.7-py39h92daf61_0.conda"
-    hash:
-      md5: 3b50cfd6ea07613741693ba535fcefda
-      sha256: e62b248506d690eaea2de499555288665ca0508d54efe63690638f1b39e6e775
-    optional: false
-    category: main
-  - name: ipython
-    version: 8.10.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      __osx: "*"
-      appnope: "*"
-      backcall: "*"
-      decorator: "*"
-      jedi: ">=0.16"
-      matplotlib-inline: "*"
-      pexpect: ">4.3"
-      pickleshare: "*"
-      prompt-toolkit: ">=3.0.30,<3.1.0"
-      pygments: ">=2.4.0"
-      python: ">=3.8"
-      stack_data: "*"
-      traitlets: ">=5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/ipython-8.10.0-pyhd1c38e8_0.conda"
-    hash:
-      md5: e67b634578fefbb312cd6cfd34b63d86
-      sha256: 5951fbddbd8be803c38b75d7d34ff78d366e57e55a7afa2604be6fd0abacb882
-    optional: false
-    category: main
-  - name: pandas
-    version: 1.5.3
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libcxx: ">=14.0.6"
-      numpy: ">=1.20.3,<2.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python-dateutil: ">=2.8.1"
-      python_abi: 3.9.* *_cp39
-      pytz: ">=2020.1"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/pandas-1.5.3-py39hecff1ad_0.conda"
-    hash:
-      md5: e7d2a20902a36eea13dea9b0021fbfb4
-      sha256: 2fcd5f5ad098fe73089c3d5970f155df75c329cffbdf08c3ad52b2515224fe6a
-    optional: false
-    category: main
-  - name: urllib3
-    version: 1.26.14
-    manager: conda
-    platform: osx-64
-    dependencies:
-      brotlipy: ">=0.6.0"
-      certifi: "*"
-      cryptography: ">=1.3.4"
-      idna: ">=2.0.0"
-      pyopenssl: ">=0.14"
-      pysocks: ">=1.5.6,<2.0,!=1.5.7"
-      python: "<4.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.14-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 01f33ad2e0aaf6b5ba4add50dad5ad29
-      sha256: f2f09c44e47946ce631dbc9a8a79bb463ac0f4122aaafdbcc51f200a1e420ca6
-    optional: false
-    category: main
-  - name: clang_osx-64
-    version: 14.0.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      cctools_osx-64: "*"
-      clang: 14.0.6.*
-      compiler-rt: 14.0.6.*
-      ld64_osx-64: "*"
-      llvm-tools: 14.0.6.*
-    url: "https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-14.0.6-h3113cd8_4.conda"
-    hash:
-      md5: e1828ef1597292a9ea25627fdfacb9f3
-      sha256: 4cdce8a6e1b1ea671e6f10839548983f93f9c4ab86cb89acf439d414283162b5
-    optional: false
-    category: main
-  - name: matplotlib-base
-    version: 3.6.3
-    manager: conda
-    platform: osx-64
-    dependencies:
-      __osx: ">=10.12"
-      certifi: ">=2020.6.20"
-      contourpy: ">=1.0.1"
-      cycler: ">=0.10"
-      fonttools: ">=4.22.0"
-      freetype: ">=2.12.1,<3.0a0"
-      kiwisolver: ">=1.0.1"
-      libcxx: ">=14.0.6"
-      numpy: ">=1.20.3,<2.0a0"
-      packaging: ">=20.0"
-      pillow: ">=6.2.0"
-      pyparsing: ">=2.3.1"
-      python: ">=3.9,<3.10.0a0"
-      python-dateutil: ">=2.7"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.6.3-py39hb2f573b_0.conda"
-    hash:
-      md5: 2852034caacfeaa91d7258c5712887e2
-      sha256: cbf4ca345fbce7bdebbdfc9175f9969af4bb6afb97f73450bf81b90d63389dda
-    optional: false
-    category: main
-  - name: requests
-    version: 2.28.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      certifi: ">=2017.4.17"
-      charset-normalizer: ">=2,<3"
-      idna: ">=2.5,<4"
-      python: ">=3.7,<4.0"
-      urllib3: ">=1.21.1,<1.27"
-    url: "https://conda.anaconda.org/conda-forge/noarch/requests-2.28.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 11d178fc55199482ee48d6812ea83983
-      sha256: 22c081b4cdd023a514400413f50efdf2c378f56f2a5ea9d65666aacf4696490a
-    optional: false
-    category: main
-  - name: c-compiler
-    version: 1.5.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      cctools: ">=949.0.1"
-      clang_osx-64: 14.*
-      ld64: ">=530"
-      llvm-openmp: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.5.2-hbf74d83_0.conda"
-    hash:
-      md5: c1413ef5a20d658923e12dd3b566d8f3
-      sha256: 0f97b6cc2215f0789ffa2781eb8a6304efaf5c4592c4c619d6e0a63c23f2b877
-    optional: false
-    category: main
-  - name: clangxx_osx-64
-    version: 14.0.6
-    manager: conda
-    platform: osx-64
-    dependencies:
-      clang_osx-64: "==14.0.6 h3113cd8_4"
-      clangxx: 14.0.6.*
-      libcxx: ">=14.0.6"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-14.0.6-h6f97653_4.conda"
-    hash:
-      md5: f9f2cc37068e5f2f4332793640329fe3
-      sha256: 9da6a17e9ae0b51ecc2ab2f25f850a38902f696de1d05cf2ad9374146cfc1d3a
-    optional: false
-    category: main
-  - name: gfortran_osx-64
-    version: 11.3.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      cctools_osx-64: "*"
-      clang: "*"
-      clang_osx-64: "*"
-      gfortran_impl_osx-64: "==11.3.0"
-      ld64_osx-64: "*"
-      libgfortran: 5.*
-      libgfortran-devel_osx-64: "==11.3.0"
-      libgfortran5: ">=11.3.0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/gfortran_osx-64-11.3.0-h18f7dce_0.tar.bz2"
-    hash:
-      md5: 72320d23ed499315d1d1ac332b94bc66
-      sha256: 7abe5dd161c8e4cdb67ceefecf27906d208e46bdb86b71e444b71409fc0857a1
-    optional: false
-    category: main
-  - name: matplotlib
-    version: 3.6.3
-    manager: conda
-    platform: osx-64
-    dependencies:
-      matplotlib-base: ">=3.6.3,<3.6.4.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tornado: ">=5"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.6.3-py39h6e9494a_0.conda"
-    hash:
-      md5: 255526eb4dbca981a03b25f0267f2a62
-      sha256: bb324a483b9cb30a09bfefe18cb4e42199201940be0ed82f3c0fbdb26ef2950d
-    optional: false
-    category: main
-  - name: pooch
-    version: 1.6.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      appdirs: ">=1.3.0"
-      packaging: ">=20.0"
-      python: ">=3.6"
-      requests: ">=2.19.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pooch-1.6.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6429e1d1091c51f626b5dcfdd38bf429
-      sha256: 1f0548105de86fb2eb6fbb8d3d6cc2004079b8442d232258108687d6cc91eb73
-    optional: false
-    category: main
-  - name: sphinx
-    version: 5.3.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      alabaster: ">=0.7,<0.8"
-      babel: ">=2.9"
-      colorama: ">=0.4.5"
-      docutils: ">=0.14,<0.20"
-      imagesize: ">=1.3"
-      importlib-metadata: ">=4.8"
-      jinja2: ">=3.0"
-      packaging: ">=21.0"
-      pygments: ">=2.12"
-      python: ">=3.7"
-      requests: ">=2.5.0"
-      snowballstemmer: ">=2.0"
-      sphinxcontrib-applehelp: "*"
-      sphinxcontrib-devhelp: "*"
-      sphinxcontrib-htmlhelp: ">=2.0.0"
-      sphinxcontrib-jsmath: "*"
-      sphinxcontrib-qthelp: "*"
-      sphinxcontrib-serializinghtml: ">=1.1.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-5.3.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: f9e1fcfe235d655900bfeb6aee426472
-      sha256: f11fd5fb4ae2c65f41ae86e7408e3ab44844898d928264aa9e89929fffc685c8
-    optional: false
-    category: main
-  - name: breathe
-    version: 4.34.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      docutils: ">=0.12"
-      jinja2: ">=2.7.3"
-      markupsafe: ">=0.23"
-      pygments: ">=1.6"
-      python: ">=3.6"
-      sphinx: ">=4.0,<6.0.0a"
-    url: "https://conda.anaconda.org/conda-forge/noarch/breathe-4.34.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: a2a04f8e8c2d91adb08ff929b4d73654
-      sha256: 40f86cd741a443363e8928d5d36ba3a49071aaffc26c5a7b24a8167c5bcbba81
-    optional: false
-    category: main
-  - name: cxx-compiler
-    version: 1.5.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      c-compiler: "==1.5.2 hbf74d83_0"
-      clangxx_osx-64: 14.*
-    url: "https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.5.2-hb8565cd_0.conda"
-    hash:
-      md5: 349ae14723b98f76ea0fcb8e532b2ead
-      sha256: 91193c9029594d102217457ce8b4fe1cfd4a1e13e652451e94f851e91b45a147
-    optional: false
-    category: main
-  - name: gfortran
-    version: 11.3.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      cctools: "*"
-      gfortran_osx-64: "*"
-      ld64: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/gfortran-11.3.0-h2c809b3_0.tar.bz2"
-    hash:
-      md5: db5338d1fb1ad08498bdc1b42277a0d5
-      sha256: 4f5c1dc5323e888d4fa372eba6f4540b60f557963209502cfad569fdc3d47495
-    optional: false
-    category: main
-  - name: numpydoc
-    version: 1.4.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      jinja2: ">=2.10"
-      python: ">=3.7"
-      sphinx: ">=1.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.4.0-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: 0aac89c61a466b0f9c4fd0ec44d81f1d
-      sha256: 11a892cc1678a23d169909e553447fb7e312d6baaa314fdcd719f6abff1c7da6
-    optional: false
-    category: main
-  - name: pydata-sphinx-theme
-    version: 0.9.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      beautifulsoup4: "*"
-      docutils: "!=0.17.0"
-      packaging: "*"
-      python: ">=3.7"
-      sphinx: ">=4.0.2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.9.0-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: ed5f1236283219a21207813d387b44bd
-      sha256: 11d56e0953a8f880d265d18eb3b3adc2f0ba182a33409088141dc84e22dba50c
-    optional: false
-    category: main
   - name: scipy
     version: 1.10.0
     manager: conda
@@ -10749,2441 +10825,6 @@ package:
     hash:
       md5: fb37c05f4b9712410daa406ada94d631
       sha256: c44076aade55c5252c46c588692ceea2a98be6d2e44bc0bdafb00f3d7d56d622
-    optional: false
-    category: main
-  - name: sphinx-design
-    version: 0.3.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.6"
-      sphinx: ">=4,<6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-design-0.3.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 83d1a712e6d2bab6b298b1d2f42ad355
-      sha256: 6b193a483a02bbc7a785dcd28614b4c082d1795fec0a1c48690d8d7a0a876e20
-    optional: false
-    category: main
-  - name: fortran-compiler
-    version: 1.5.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      cctools: ">=949.0.1"
-      gfortran: "*"
-      gfortran_osx-64: 11.*
-      ld64: ">=530"
-      llvm-openmp: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/fortran-compiler-1.5.2-haad3a49_0.conda"
-    hash:
-      md5: 649a324b13eb77c6d5e98d36ea0c59f4
-      sha256: db482cbd1f8046a6d51c0af47d98f97e0c157bf9029bbc95b71c72972f3fa01f
-    optional: false
-    category: main
-  - name: compilers
-    version: 1.5.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      c-compiler: "==1.5.2 hbf74d83_0"
-      cxx-compiler: "==1.5.2 hb8565cd_0"
-      fortran-compiler: "==1.5.2 haad3a49_0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/compilers-1.5.2-h694c41f_0.conda"
-    hash:
-      md5: 1fdd3bc173dad6e7a0439962c7764ab8
-      sha256: fe35c96a228d9e245e9cc05fdff5078e8f31a9ae44bd320f5cb48e6ab0fca139
-    optional: false
-    category: main
-  - name: bzip2
-    version: 1.0.8
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2"
-    hash:
-      md5: fc76ace7b94fb1f694988ab1b14dd248
-      sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
-    optional: false
-    category: main
-  - name: ca-certificates
-    version: 2022.12.7
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2022.12.7-h4653dfc_0.conda"
-    hash:
-      md5: 7dc111916edc905957b7417a247583b6
-      sha256: a9634dc719fc9cd4c91cf8ad3167532e59051cace3e90ef2ba305a41c316784a
-    optional: false
-    category: main
-  - name: jpeg
-    version: 9e
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/jpeg-9e-h1a8c8d9_3.conda"
-    hash:
-      md5: ef1cce2ab799e0c2f32c3344125ff218
-      sha256: 7e21d03917fb535b39c3af0cc7b7115617556a4ca2fe13018c09407987883b34
-    optional: false
-    category: main
-  - name: libbrotlicommon
-    version: 1.0.9
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.0.9-h1a8c8d9_8.tar.bz2"
-    hash:
-      md5: 84eb0c3c995a865079080d092e4a3c06
-      sha256: 1bd70570aee08fe0274dd46879d0b4c36c662c18d3afc03c41c375c84658af88
-    optional: false
-    category: main
-  - name: libcxx
-    version: 14.0.6
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-14.0.6-h2692d47_0.tar.bz2"
-    hash:
-      md5: 716c4b72ff3808ade65748fd9b49cc44
-      sha256: 8e199c6956fad3abcbe9a1468c6219d9e95b64b898e9cf009b82d669c3bfdaf6
-    optional: false
-    category: main
-  - name: libdeflate
-    version: "1.17"
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.17-h1a8c8d9_0.conda"
-    hash:
-      md5: cae34d3f6ab02e0abf92ec3caaf0bd39
-      sha256: 9a1979b3f6dc155b8c48987cfae6b13ba19b3e176e4470b87f60011e806218f5
-    optional: false
-    category: main
-  - name: libffi
-    version: 3.4.2
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2"
-    hash:
-      md5: 086914b672be056eb70fd4285b6783b6
-      sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
-    optional: false
-    category: main
-  - name: libgfortran-devel_osx-arm64
-    version: 11.3.0
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/libgfortran-devel_osx-arm64-11.3.0-hfe9555d_27.conda"
-    hash:
-      md5: 28cf7c6b44b099d8cb4f801dc547cc5c
-      sha256: e0e304772a9c572081ee04b316327cec0659c77890db26548ea600ab9b20e1c8
-    optional: false
-    category: main
-  - name: libiconv
-    version: "1.17"
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2"
-    hash:
-      md5: 686f9c755574aa221f29fbcf36a67265
-      sha256: 2eb33065783b802f71d52bef6f15ce0fafea0adc8506f10ebd0d490244087bec
-    optional: false
-    category: main
-  - name: libwebp-base
-    version: 1.2.4
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.2.4-h57fd34a_0.tar.bz2"
-    hash:
-      md5: 23f90b9f28c585445c52184a3388d01d
-      sha256: 43e9557894d07ddbba76fdacf321ca84f2c6da5a649a32a6a91f23e2761d1df4
-    optional: false
-    category: main
-  - name: libzlib
-    version: 1.2.13
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h03a7124_4.tar.bz2"
-    hash:
-      md5: 780852dc54c4c07e64b276a97f89c162
-      sha256: a1bf4a1c107838fea4570a7f1750306d65d84fcf2913d4e0d30b4db785e8f223
-    optional: false
-    category: main
-  - name: llvm-openmp
-    version: 15.0.7
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-15.0.7-h7cfbb63_0.conda"
-    hash:
-      md5: 358164e15a9320f11b84a53fb8d8e446
-      sha256: 6cc4cf021fc1f06df3b97598bf9583fe7a04fad6a4eef9882558f7932f362bc0
-    optional: false
-    category: main
-  - name: ncurses
-    version: "6.3"
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.3-h07bb92c_1.tar.bz2"
-    hash:
-      md5: db86e5a978380a13f5559f97afdfe99d
-      sha256: 50ba7c13dd7d05569e7caa98a13a3684450f8547b4965a1e86b54e2f1240debe
-    optional: false
-    category: main
-  - name: nomkl
-    version: "1.0"
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/nomkl-1.0-h5ca1d4c_0.tar.bz2"
-    hash:
-      md5: 9a66894dfd07c4510beb6b3f9672ccc0
-      sha256: d38542a151a90417065c1a234866f97fd1ea82a81de75ecb725955ab78f88b4b
-    optional: false
-    category: main
-  - name: pthread-stubs
-    version: "0.4"
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2"
-    hash:
-      md5: d3f26c6494d4105d4ecb85203d687102
-      sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
-    optional: false
-    category: main
-  - name: python_abi
-    version: "3.9"
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.9-3_cp39.conda"
-    hash:
-      md5: f8fb5fb65327a2429b084833c8ff1dbc
-      sha256: 9434a23c734685db9a5017206dae58f141e2edddec2ee9e1ec10a3fdefa55c0f
-    optional: false
-    category: main
-  - name: tzdata
-    version: 2022g
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
-    hash:
-      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
-      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
-    optional: false
-    category: main
-  - name: xorg-libxau
-    version: 1.0.9
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.9-h27ca646_0.tar.bz2"
-    hash:
-      md5: e2fa1f5a28cf0ce02516baf910be132e
-      sha256: a5810ad0fae16b72ee7cbb22e009c926dd1cd95d82885896e7f20fe911f7195f
-    optional: false
-    category: main
-  - name: xorg-libxdmcp
-    version: 1.1.3
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2"
-    hash:
-      md5: 6738b13f7fadc18725965abdd4129c36
-      sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
-    optional: false
-    category: main
-  - name: xz
-    version: 5.2.6
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2"
-    hash:
-      md5: 39c6b54e94014701dd157f4f576ed211
-      sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
-    optional: false
-    category: main
-  - name: doxygen
-    version: 1.9.5
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=14.0.4"
-      libiconv: ">=1.16,<2.0.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/doxygen-1.9.5-hd78112f_0.tar.bz2"
-    hash:
-      md5: 0b5059999731cad5ca96b597f0b6c77b
-      sha256: 48a4bafdacca69e6ee38ea635d81e300bad86eda34869600fbdeff50ed74976f
-    optional: false
-    category: main
-  - name: gettext
-    version: 0.21.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libiconv: ">=1.17,<2.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2"
-    hash:
-      md5: 63d2ff6fddfa74e5458488fd311bf635
-      sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
-    optional: false
-    category: main
-  - name: gmp
-    version: 6.2.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=11.0.0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.2.1-h9f76cd9_0.tar.bz2"
-    hash:
-      md5: f8140773b6ca51bf32feec9b4290a8c5
-      sha256: 2fd12c3e78b6c632f7f34883b942b973bdd24302c74f2b9b78e776b654baf591
-    optional: false
-    category: main
-  - name: isl
-    version: "0.25"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=13.0.1"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/isl-0.25-h9a09cb3_0.tar.bz2"
-    hash:
-      md5: b0c90b63ffeb9e2d045be8f5bc64741c
-      sha256: 6c6b486de9db1c2c897b24f6b0eb9a1ecdaf355ede1ee2ccb0c1aaee4bd9ef59
-    optional: false
-    category: main
-  - name: lerc
-    version: 4.0.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=13.0.1"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2"
-    hash:
-      md5: de462d5aacda3b30721b512c5da4e742
-      sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
-    optional: false
-    category: main
-  - name: libbrotlidec
-    version: 1.0.9
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libbrotlicommon: "==1.0.9 h1a8c8d9_8"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.0.9-h1a8c8d9_8.tar.bz2"
-    hash:
-      md5: 640ea7b788cdd0420409bd8479f023f9
-      sha256: a0a52941eb59369a8b33b01b41bcf56efd313850c583f4814e2db59448439880
-    optional: false
-    category: main
-  - name: libbrotlienc
-    version: 1.0.9
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libbrotlicommon: "==1.0.9 h1a8c8d9_8"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.0.9-h1a8c8d9_8.tar.bz2"
-    hash:
-      md5: 572907b78be867937c258421bc0807a8
-      sha256: c5f65062cd41d5f5fd93eadd276885efbe7ce7c9346155852d4f5b619f8a166f
-    optional: false
-    category: main
-  - name: libgfortran5
-    version: 11.3.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      llvm-openmp: ">=8.0.0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-11.3.0-hdaf2cc0_27.conda"
-    hash:
-      md5: 4514d8c30cda679e66ca297965e4b043
-      sha256: 88325ae7043712ba02a616281d37bfbab63c4c9b2a7f18ef8410b13d84947350
-    optional: false
-    category: main
-  - name: libllvm14
-    version: 14.0.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=14"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libllvm14-14.0.6-hf6e71e7_1.tar.bz2"
-    hash:
-      md5: 2ec0ff9a370305311ce222bcb085b72d
-      sha256: e3b9eee8abc1e3c315094aa6452e01424e3da8aef8dd42093836183d55f5df4b
-    optional: false
-    category: main
-  - name: libpng
-    version: 1.6.39
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda"
-    hash:
-      md5: 0078e6327c13cfdeae6ff7601e360383
-      sha256: 21ab8409a8e66f9408b96428c0a36a9768faee9fe623c56614576f9e12962981
-    optional: false
-    category: main
-  - name: libsqlite
-    version: 3.40.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.40.0-h76d750c_0.tar.bz2"
-    hash:
-      md5: d090fcec993f4ef0a90e6df7f231a273
-      sha256: 5e8992b2099bb4767996e1bed70945ba39f61399ab912ba2a2770d12c165acb5
-    optional: false
-    category: main
-  - name: libxcb
-    version: "1.13"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      pthread-stubs: "*"
-      xorg-libxau: "*"
-      xorg-libxdmcp: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.13-h9b22ae9_1004.tar.bz2"
-    hash:
-      md5: 6b3457a192f8091cb413962f65740ac4
-      sha256: a89b1e46650c01a8791c201c108d6d49a0a5604dd24ddb18902057bbd90f7dbb
-    optional: false
-    category: main
-  - name: ninja
-    version: 1.11.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=13.0.1"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.0-hf86a087_0.tar.bz2"
-    hash:
-      md5: 1544c2828bb4b2a55997cd77627720ea
-      sha256: fe04151afa66d9bce6025066201692929aa195fe77fc62505f9b183720de03cb
-    optional: false
-    category: main
-  - name: openssl
-    version: 3.0.8
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      ca-certificates: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.0.8-h03a7124_0.conda"
-    hash:
-      md5: accdc6784b8ae5dd618a9e76f4c3af36
-      sha256: 6d58b0412c4c27669da02368a303f4c4abc1b0edda5f27b2f8155299ab2b45a5
-    optional: false
-    category: main
-  - name: pcre2
-    version: "10.40"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      bzip2: ">=1.0.8,<2.0a0"
-      libzlib: ">=1.2.12,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.40-hb34f9b4_0.tar.bz2"
-    hash:
-      md5: 721b7288270bafc83586b0f01c2a67f2
-      sha256: 93503b5e05470ccc87f696c0fdf0d47938e0305b5047eacb85c15d78dcf641fe
-    optional: false
-    category: main
-  - name: readline
-    version: 8.1.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      ncurses: ">=6.3,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.1.2-h46ed386_0.tar.bz2"
-    hash:
-      md5: dc790f296d94409efb3f22af84ee968d
-      sha256: 2d2a65fcdd91361ea7e40c03eeec18ff7a453c32f6589a1fce64717f6cd7c7b6
-    optional: false
-    category: main
-  - name: tapi
-    version: 1100.0.11
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=11.0.0.a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2"
-    hash:
-      md5: d83362e7d0513f35f454bc50b0ca591d
-      sha256: 1709265fbee693a9e8b4126b0a3e68a6c4718b05821c659279c1af051f2d40f3
-    optional: false
-    category: main
-  - name: tk
-    version: 8.6.12
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libzlib: ">=1.2.11,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.12-he1e0b03_0.tar.bz2"
-    hash:
-      md5: 2cb3d18eac154109107f093860bd545f
-      sha256: 9e43ec80045892e28233e4ca4d974e09d5837392127702fb952f3935b5e985a4
-    optional: false
-    category: main
-  - name: zlib
-    version: 1.2.13
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libzlib: "==1.2.13 h03a7124_4"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h03a7124_4.tar.bz2"
-    hash:
-      md5: 34161cff4e29cc45e536abf2f13fd6b4
-      sha256: 48844c5c911e2ef69571d6ef7181dcfae68df296c546662cb54057baed008949
-    optional: false
-    category: main
-  - name: zstd
-    version: 1.5.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=14.0.6"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.2-hf913c23_6.conda"
-    hash:
-      md5: 8f346953ef63bf5fb482488a659adcf3
-      sha256: 018989ba028e76abc332c246002e8f5975ff123c68f6116a30da8009b14ea88d
-    optional: false
-    category: main
-  - name: brotli-bin
-    version: 1.0.9
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libbrotlidec: "==1.0.9 h1a8c8d9_8"
-      libbrotlienc: "==1.0.9 h1a8c8d9_8"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.0.9-h1a8c8d9_8.tar.bz2"
-    hash:
-      md5: f212620a4f3606ff8f800b8b1077415a
-      sha256: d171637710bffc322b35198c03bcfd3d04f454433e845138e5120729f8941996
-    optional: false
-    category: main
-  - name: freetype
-    version: 2.12.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libpng: ">=1.6.39,<1.7.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hd633e50_1.conda"
-    hash:
-      md5: 33ea6326e26d1da25eb8dfa768195b82
-      sha256: 9f20ac782386cca6295cf02a07bbc6aedc4739330dc9caba242630602a9ab7f4
-    optional: false
-    category: main
-  - name: libclang-cpp14
-    version: 14.0.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=13.0.1"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp14-14.0.6-default_h81a5282_0.tar.bz2"
-    hash:
-      md5: 6cfc1343e167d250367983b1864adc04
-      sha256: 86a606d0d76cdae79d3d89c686313cda22ecbbde182b4e906759500078653d6b
-    optional: false
-    category: main
-  - name: libgfortran
-    version: 5.0.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libgfortran5: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-11_3_0_hd922786_27.conda"
-    hash:
-      md5: 61d66d1a81d08e3f82049aa279f4cd7f
-      sha256: fce7eb15948e1fec90508a4a7ca1fa350225f03e46c5a6e6df5b4f7b523db695
-    optional: false
-    category: main
-  - name: libglib
-    version: 2.74.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      gettext: ">=0.21.1,<1.0a0"
-      libcxx: ">=14.0.4"
-      libffi: ">=3.4,<4.0a0"
-      libiconv: ">=1.17,<2.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      pcre2: ">=10.40,<10.41.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.74.1-h4646484_1.tar.bz2"
-    hash:
-      md5: 4321cf67e46674567f419e95bae18522
-      sha256: c312e93652734424b30ed017743ea9e37a5efcdf42e14d3f78ca96cf64fd266d
-    optional: false
-    category: main
-  - name: libtiff
-    version: 4.5.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      jpeg: ">=9e,<10a"
-      lerc: ">=4.0.0,<5.0a0"
-      libcxx: ">=14.0.6"
-      libdeflate: ">=1.17,<1.18.0a0"
-      libwebp-base: ">=1.2.4,<2.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      xz: ">=5.2.6,<6.0a0"
-      zstd: ">=1.5.2,<1.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.5.0-h5dffbdd_2.conda"
-    hash:
-      md5: 8e08eae60de32c940096ee9b4da35685
-      sha256: 0207f4234571d393d2f790aedaa1e127dfcd9d7fe3fe886ebdf31c9e7b9f7ce2
-    optional: false
-    category: main
-  - name: llvm-tools
-    version: 14.0.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libllvm14: "==14.0.6 hf6e71e7_1"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-14.0.6-hf6e71e7_1.tar.bz2"
-    hash:
-      md5: e97dcf92f03537c52aa2dcdcaf6ef75c
-      sha256: 91dc605c32d6b76189c34757c27319800e78fd865d0652acdd5b18ac999988af
-    optional: false
-    category: main
-  - name: mpfr
-    version: 4.1.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      gmp: ">=6.2.0,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.1.0-h6d7a090_1.tar.bz2"
-    hash:
-      md5: c37f296f76cfb61d4f91613da93789e6
-      sha256: bf44598be1fe9f6310ac0ebcd91dd6b51d4d19fe085c96b4da8297f2fc868f86
-    optional: false
-    category: main
-  - name: python
-    version: 3.9.16
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      bzip2: ">=1.0.8,<2.0a0"
-      libffi: ">=3.4,<4.0a0"
-      libsqlite: ">=3.40.0,<4.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      ncurses: ">=6.3,<7.0a0"
-      openssl: ">=3.0.7,<4.0a0"
-      pip: "*"
-      readline: ">=8.1.2,<9.0a0"
-      tk: ">=8.6.12,<8.7.0a0"
-      tzdata: "*"
-      xz: ">=5.2.6,<6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.16-hea58f1e_0_cpython.conda"
-    hash:
-      md5: d2dfc4fe1da1624e020334b1000c6a3d
-      sha256: 90596405b18cf38e0ae2eebb81fc41da836081f3488ae9f3571a9199664a6032
-    optional: false
-    category: main
-  - name: sigtool
-    version: 0.1.3
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      openssl: ">=3.0.0,<4.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2"
-    hash:
-      md5: 4a2cac04f86a4540b8c9b8d8f597848f
-      sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
-    optional: false
-    category: main
-  - name: alabaster
-    version: 0.7.13
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/alabaster-0.7.13-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 06006184e203b61d3525f90de394471e
-      sha256: b2d160a050996950434c6e87a174fc01c4a937cbeffbdd20d1b46126b4478a95
-    optional: false
-    category: main
-  - name: appdirs
-    version: 1.4.4
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 5f095bc6454094e96f146491fd03633b
-      sha256: ae9fb8f68281f84482f2c234379aa12405a9e365151d43af20b3ae1f17312111
-    optional: false
-    category: main
-  - name: appnope
-    version: 0.1.3
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 54ac328d703bff191256ffa1183126d1
-      sha256: b209a68ac55eb9ecad7042f0d4eedef5da924699f6cdf54ac1826869cfdae742
-    optional: false
-    category: main
-  - name: attrs
-    version: 22.2.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/attrs-22.2.0-pyh71513ae_0.conda"
-    hash:
-      md5: 8b76db7818a4e401ed4486c4c1635cd9
-      sha256: 3a58d4a4933fa8735471c782d35326ab78e0bcfce84756408515f82a94e4dec4
-    optional: false
-    category: main
-  - name: backcall
-    version: 0.2.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 6006a6d08a3fa99268a2681c7fb55213
-      sha256: ee62d6434090c1327a48551734e06bd10e65a64ef7f3b6e68719500dab0e42b9
-    optional: false
-    category: main
-  - name: backports
-    version: "1.0"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda"
-    hash:
-      md5: 54ca2e08b3220c148a1d8329c2678e02
-      sha256: 711602276ae39276cb0faaca6fd0ac851fff0ca17151917569174841ef830bbd
-    optional: false
-    category: main
-  - name: backports.zoneinfo
-    version: 0.2.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/backports.zoneinfo-0.2.1-py39h2804cbe_7.tar.bz2"
-    hash:
-      md5: 53ed254446fa05b6c7efda9cabe03630
-      sha256: e149a5598cd38ee3db357a09d16384ea119d56be7d41decd10e078c8d326b28e
-    optional: false
-    category: main
-  - name: brotli
-    version: 1.0.9
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      brotli-bin: "==1.0.9 h1a8c8d9_8"
-      libbrotlidec: "==1.0.9 h1a8c8d9_8"
-      libbrotlienc: "==1.0.9 h1a8c8d9_8"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.0.9-h1a8c8d9_8.tar.bz2"
-    hash:
-      md5: e2a5e381ddd6529eb62e7710270b2ec5
-      sha256: f97debd05c2caeeefba22e0b71173f1fff99c1e5e66e6e9caa91c1c66eb59741
-    optional: false
-    category: main
-  - name: certifi
-    version: 2022.12.7
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/certifi-2022.12.7-pyhd8ed1ab_0.conda"
-    hash:
-      md5: fb9addc3db06e56abe03e0e9f21a63e6
-      sha256: 5e22af4776700200fab2c1df41a2188ab9cfe90a50c4f388592bb978562c88ec
-    optional: false
-    category: main
-  - name: charset-normalizer
-    version: 2.1.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-2.1.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c1d5b294fbf9a795dec349a6f4d8be8e
-      sha256: 9e6170fa7b65b5546377eddb602d5ff871110f84bebf101b7b8177ff64aab1cb
-    optional: false
-    category: main
-  - name: clang-14
-    version: 14.0.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libclang-cpp14: "==14.0.6 default_h81a5282_0"
-      libcxx: ">=13.0.1"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/clang-14-14.0.6-default_h81a5282_0.tar.bz2"
-    hash:
-      md5: ad7388bad4d7416ce2bbacddb2faa577
-      sha256: 20a8d11fca5be934d9d8990b688396c0a4be8bd8cc29be2e79be5e3e4baefbeb
-    optional: false
-    category: main
-  - name: click
-    version: 8.1.3
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      __unix: "*"
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/click-8.1.3-unix_pyhd8ed1ab_2.tar.bz2"
-    hash:
-      md5: 20e4087407c7cb04a40817114b333dbf
-      sha256: 23676470b591b100393bb0f6c46fe10624dcbefc696a6a9f42932ed8816ef0ea
-    optional: false
-    category: main
-  - name: colorama
-    version: 0.4.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 3faab06a954c2a04039983f2c4a50d99
-      sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
-    optional: false
-    category: main
-  - name: cycler
-    version: 0.11.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/cycler-0.11.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: a50559fad0affdbb33729a68669ca1cb
-      sha256: 3b594bc8aa0b9a51269d54c7a4ef6af777d7fad4bee16b05695e1124de6563f6
-    optional: false
-    category: main
-  - name: cython
-    version: 0.29.33
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=14.0.6"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cython-0.29.33-py39h23fbdae_0.conda"
-    hash:
-      md5: 39e8c4d178e2c54e910f8b59624fb796
-      sha256: 036c45bf33e0c167b4d518c649722290c1779a067b1f1c197e27b7f735d8af9b
-    optional: false
-    category: main
-  - name: decorator
-    version: 5.1.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 43afe5ab04e35e17ba28649471dd7364
-      sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
-    optional: false
-    category: main
-  - name: docutils
-    version: "0.19"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.19-py39h2804cbe_1.tar.bz2"
-    hash:
-      md5: 509daec50d39e5f31eb2992d2248752e
-      sha256: 910ef18f7b43aeef7a6cc51274c68895c64c28b7fa05979dae8917106d9f5cd7
-    optional: false
-    category: main
-  - name: exceptiongroup
-    version: 1.1.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: a385c3e8968b4cf8fbc426ace915fd1a
-      sha256: cf668360331552b2903e440cda1b4e47062c3f3775342e4a278ef4d141c28d1d
-    optional: false
-    category: main
-  - name: execnet
-    version: 1.9.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: "==2.7|>=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/execnet-1.9.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 0e521f7a5e60d508b121d38b04874fb2
-      sha256: 1900bbc1764d01405e55be2e369d1b830fb435eb0f27c57033372c60f34c675c
-    optional: false
-    category: main
-  - name: executing
-    version: 1.2.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 4c1bc140e2be5c8ba6e3acab99e25c50
-      sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
-    optional: false
-    category: main
-  - name: idna
-    version: "3.4"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 34272b248891bddccc64479f9a7fffed
-      sha256: 9887c35c374ec1847f167292d3fde023cb4c994a4ceeec283072b95440131f09
-    optional: false
-    category: main
-  - name: imagesize
-    version: 1.4.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.4"
-    url: "https://conda.anaconda.org/conda-forge/noarch/imagesize-1.4.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 7de5386c8fea29e76b303f37dde4c352
-      sha256: c2bfd7043e0c4c12d8b5593de666c1e81d67b83c474a0a79282cc5c4ef845460
-    optional: false
-    category: main
-  - name: iniconfig
-    version: 2.0.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f800d2da156d08e289b14e87e43c1ae5
-      sha256: 38740c939b668b36a50ef455b077e8015b8c9cf89860d421b3fff86048f49666
-    optional: false
-    category: main
-  - name: kiwisolver
-    version: 1.4.4
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=14.0.4"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.4-py39haaf3ac1_1.tar.bz2"
-    hash:
-      md5: 5f43e4d5437b93606167c640ea2d06c1
-      sha256: afe4759ca7572eb98361cd4c68ae3819a16d368c963d1134b926d2963434b3e6
-    optional: false
-    category: main
-  - name: lcms2
-    version: "2.14"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      jpeg: ">=9e,<10a"
-      libtiff: ">=4.5.0,<4.6.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.14-h481adae_1.conda"
-    hash:
-      md5: aad4fc7ce783e7d109576df5a9bb78c7
-      sha256: 65c0a292be935a5e499b1e782b7ddada93b16ec77fef7416e2846aa2b3e16f3b
-    optional: false
-    category: main
-  - name: ld64_osx-arm64
-    version: "609"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: "*"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-      sigtool: "*"
-      tapi: ">=1100.0.11,<1101.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-h7167370_11.conda"
-    hash:
-      md5: 5158e240a2318c11dba7e8493bf1b42b
-      sha256: 0a0a9d26eb1e14d1ff4b9ee7a05eb3f338f258dd2c78a6a649d7fe9037ae5f8c
-    optional: false
-    category: main
-  - name: libopenblas
-    version: 0.3.21
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libgfortran: 5.*
-      libgfortran5: ">=11.3.0"
-      llvm-openmp: ">=14.0.4"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.21-openmp_hc731615_3.tar.bz2"
-    hash:
-      md5: 2a980a5d8cc34ce70d339b983f9920de
-      sha256: 92e341be106c00adf1f1757ec9f9586a3848af94b434554c75dd7c5023f84ea2
-    optional: false
-    category: main
-  - name: markupsafe
-    version: 2.1.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.2-py39h02fc5c5_0.conda"
-    hash:
-      md5: 525d6fb3283d4b90cd9f92c9811214af
-      sha256: 33f4eb17d29fe5983f27ac193e1dd071857447649a6a4197f1bb0310f1928f57
-    optional: false
-    category: main
-  - name: mpc
-    version: 1.3.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      gmp: ">=6.2.1,<7.0a0"
-      mpfr: ">=4.1.0,<5.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/mpc-1.3.1-h91ba8db_0.conda"
-    hash:
-      md5: 362af269d860ae49580f8f032a68b0df
-      sha256: 6d8d4f8befca279f022c1c212241ad6672cb347181452555414e277484ad534c
-    optional: false
-    category: main
-  - name: munkres
-    version: 1.1.4
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2"
-    hash:
-      md5: 2ba8498c1018c1e9c61eb99b973dfe19
-      sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
-    optional: false
-    category: main
-  - name: mypy_extensions
-    version: 1.0.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda"
-    hash:
-      md5: 4eccaeba205f0aed9ac3a9ea58568ca3
-      sha256: f240217476e148e825420c6bc3a0c0efb08c0718b7042fae960400c02af858a3
-    optional: false
-    category: main
-  - name: openjpeg
-    version: 2.5.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=14.0.6"
-      libpng: ">=1.6.39,<1.7.0a0"
-      libtiff: ">=4.5.0,<4.6.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-hbc2ba62_2.conda"
-    hash:
-      md5: c3e184f0810a4614863569488b1ac709
-      sha256: 2bb159e385e633a08cc164f50b4e39fa465b85f54c376a5c20aa15f57ef407b3
-    optional: false
-    category: main
-  - name: packaging
-    version: "23.0"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/packaging-23.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 1ff2e3ca41f0ce16afec7190db28288b
-      sha256: 00288f5e5e841711e8b8fef1f1242c858d8ef99ccbe5d7e0df4789d5d8d40645
-    optional: false
-    category: main
-  - name: parso
-    version: 0.8.3
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 17a565a0c3899244e938cdf417e7b094
-      sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
-    optional: false
-    category: main
-  - name: pickleshare
-    version: 0.7.5
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2"
-    hash:
-      md5: 415f0ebb6198cc2801c73438a9fb5761
-      sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-    optional: false
-    category: main
-  - name: pkg-config
-    version: 0.29.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libglib: ">=2.70.2,<3.0a0"
-      libiconv: ">=1.16,<2.0.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hab62308_1008.tar.bz2"
-    hash:
-      md5: 8d173d52214679033079d1b0582075aa
-      sha256: e59e69111709d097f9938e72ba19811ec1ef36aababdbed77bd7c767f15639e0
-    optional: false
-    category: main
-  - name: pluggy
-    version: 1.0.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pluggy-1.0.0-pyhd8ed1ab_5.tar.bz2"
-    hash:
-      md5: 7d301a0d25f424d96175f810935f0da9
-      sha256: c25e1757e4e90638bb1e778aba3ee5f3c01fae9752e3c3929f9be7d367f6c7f3
-    optional: false
-    category: main
-  - name: psutil
-    version: 5.9.4
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.4-py39h02fc5c5_0.tar.bz2"
-    hash:
-      md5: bf7577af58a627d4f3c454965b246f18
-      sha256: 6c99579a51949c5a74d627c06058fa8a21a54bf088538b06061388ecf56fbe88
-    optional: false
-    category: main
-  - name: ptyprocess
-    version: 0.7.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2"
-    hash:
-      md5: 359eeb6536da0e687af562ed265ec263
-      sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
-    optional: false
-    category: main
-  - name: pure_eval
-    version: 0.2.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6784285c7e55cb7212efabc79e4c2883
-      sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
-    optional: false
-    category: main
-  - name: pycodestyle
-    version: 2.7.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: 2.7.*|>=3.5
-    url: "https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.7.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 0234673eb2ecfbdf4e54574ab4d95f81
-      sha256: 5c6aa7a724551d7768930b30bd77e531580f6ddd68a391094e799a21a82b9492
-    optional: false
-    category: main
-  - name: pycparser
-    version: "2.21"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: 2.7.*|>=3.4
-    url: "https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 076becd9e05608f8dc72757d5f3a91ff
-      sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
-    optional: false
-    category: main
-  - name: pyparsing
-    version: 3.0.9
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.0.9-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: e8fbc1b54b25f4b08281467bc13b70cc
-      sha256: 4acc7151cef5920d130f2e0a7615559cce8bfb037aeecb14d4d359ae3d9bc51b
-    optional: false
-    category: main
-  - name: pysocks
-    version: 1.7.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      __unix: "*"
-      python: ">=3.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2"
-    hash:
-      md5: 2a7de29fb590ca14b5243c4c812c8025
-      sha256: a42f826e958a8d22e65b3394f437af7332610e43ee313393d1cf143f0a2d274b
-    optional: false
-    category: main
-  - name: pytz
-    version: 2022.7.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytz-2022.7.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f59d49a7b464901cf714b9e7984d01a2
-      sha256: 93cfc7a92099e26b0575a343da4a667b52371cc38e4dee4ee264dc041ef77bac
-    optional: false
-    category: main
-  - name: setuptools
-    version: 59.2.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/setuptools-59.2.0-py39h2804cbe_0.tar.bz2"
-    hash:
-      md5: 71789b9ebc713ccc0ebae4ce8e07bf71
-      sha256: 83002349c6ae229f4ffa03ad2e3101121f1d47f1f04654c317d31e14528a4bfc
-    optional: false
-    category: main
-  - name: six
-    version: 1.16.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2"
-    hash:
-      md5: e5f25f8dbc060e9a8d912e432202afc2
-      sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
-    optional: false
-    category: main
-  - name: smmap
-    version: 3.0.5
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/smmap-3.0.5-pyh44b312d_0.tar.bz2"
-    hash:
-      md5: 3a8dc70789709aa315325d5df06fb7e4
-      sha256: 091de70ee6bfe063e0c0f77336975d124fd1e3f49b9c58d97c0c7b3d287c0002
-    optional: false
-    category: main
-  - name: snowballstemmer
-    version: 2.2.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 4d22a9315e78c6827f806065957d566e
-      sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
-    optional: false
-    category: main
-  - name: sortedcontainers
-    version: 2.4.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6d6552722448103793743dabfbda532d
-      sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
-    optional: false
-    category: main
-  - name: soupsieve
-    version: 2.3.2.post1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 146f4541d643d48fc8a75cacf69f03ae
-      sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
-    optional: false
-    category: main
-  - name: sphinxcontrib-applehelp
-    version: 1.0.4
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.4-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 5a31a7d564f551d0e6dff52fd8cb5b16
-      sha256: 802810d8321d55e5666806d565e72949eabf77ad510fe2758ce1da2441675ef1
-    optional: false
-    category: main
-  - name: sphinxcontrib-devhelp
-    version: 1.0.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.2-py_0.tar.bz2"
-    hash:
-      md5: 68e01cac9d38d0e717cd5c87bc3d2cc9
-      sha256: 66cca7eccb7f92eee53f9f5a552e3e1d643daa3a1ebd03c185e2819e5c491576
-    optional: false
-    category: main
-  - name: sphinxcontrib-htmlhelp
-    version: 2.0.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 6c8c4d6eb2325e59290ac6dbbeacd5f0
-      sha256: aeff20be994e6f9520a91fc177a33cb3e4d0911cdf8d27e575d001f00afa33fd
-    optional: false
-    category: main
-  - name: sphinxcontrib-jsmath
-    version: 1.0.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-py_0.tar.bz2"
-    hash:
-      md5: 67cd9d9c0382d37479b4d306c369a2d4
-      sha256: a42415fc789e9f6ae2e18f07ac143d2e9ce73a35a55ecf1dd1b3d055dd1e6dbe
-    optional: false
-    category: main
-  - name: sphinxcontrib-qthelp
-    version: 1.0.3
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2"
-    hash:
-      md5: d01180388e6d1838c3e1ad029590aa7a
-      sha256: 35d8f01fc798d38b72ae003c040d2dee650d315f904268a1f793d4d59460d1e2
-    optional: false
-    category: main
-  - name: sphinxcontrib-serializinghtml
-    version: 1.1.5
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2"
-    hash:
-      md5: 9ff55a0901cf952f05c654394de76bf7
-      sha256: 890bbf815cff114ddbb618b9876d492fce07d02956c1d7b3d46cb7f835f563f6
-    optional: false
-    category: main
-  - name: toml
-    version: 0.10.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=2.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: f832c45a477c78bebd107098db465095
-      sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
-    optional: false
-    category: main
-  - name: tomli
-    version: 2.0.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 5844808ffab9ebdb694585b50ba02a96
-      sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-    optional: false
-    category: main
-  - name: tornado
-    version: "6.2"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.2-py39h02fc5c5_1.tar.bz2"
-    hash:
-      md5: 54bb01d39f399f9e846530f824db4b03
-      sha256: a09467527b27668ac2e474750d499d298053e4a0a8e87b8333359494e9d36877
-    optional: false
-    category: main
-  - name: traitlets
-    version: 5.9.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: d0b4f5c87cd35ac3fb3d47b223263a64
-      sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
-    optional: false
-    category: main
-  - name: typing_extensions
-    version: 4.4.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.4.0-pyha770c72_0.tar.bz2"
-    hash:
-      md5: 2d93b130d148d7fc77e583677792fc6a
-      sha256: 70c57b5ac94cd32e78f1a2fa2c38572bfac85b901a6a99aa254a9e8e126c132d
-    optional: false
-    category: main
-  - name: unicodedata2
-    version: 15.0.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.0.0-py39h02fc5c5_0.tar.bz2"
-    hash:
-      md5: 1371c4d91f9c3edf170200a1374cb3e8
-      sha256: 3c0454fd960aca8f465db69beb281bbd8b4174e3df48871b625d43b037aea671
-    optional: false
-    category: main
-  - name: wheel
-    version: 0.38.4
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c829cfb8cb826acb9de0ac1a2df0a940
-      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-    optional: false
-    category: main
-  - name: zipp
-    version: 3.13.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/zipp-3.13.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 41b09d997939e83b231c4557a90c3b13
-      sha256: 0a9a545b8dc46c847658ebfa636257ea5993a355419c1d3b2f14810730ee0a82
-    optional: false
-    category: main
-  - name: asttokens
-    version: 2.2.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.5"
-      six: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: bf7f54dd0f25c3f06ecb82a07341841a
-      sha256: 7ed530efddd47a96c11197906b4008405b90e3bc2f4e0df722a36e0e6103fd9c
-    optional: false
-    category: main
-  - name: babel
-    version: 2.11.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-      pytz: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/babel-2.11.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 2ea70fde8d581ba9425a761609eed6ba
-      sha256: 21a8403d886136c0a80f965ae5387fa1693b19ddd69023bcd0e844f2510d7e2f
-    optional: false
-    category: main
-  - name: backports.functools_lru_cache
-    version: 1.6.4
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      backports: "*"
-      python: ">=3.6"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c5b3edc62d6309088f4970b3eaaa65a6
-      sha256: fdea00d4b79990f3fe938e2716bc32bd895eb5c44b6c75b8261db095a1b33c16
-    optional: false
-    category: main
-  - name: beautifulsoup4
-    version: 4.11.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-      soupsieve: ">=1.2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.11.2-pyha770c72_0.conda"
-    hash:
-      md5: 88b59f6989f0ed5ab3433af0b82555e1
-      sha256: deb43944425b3ec7fdfd5e6620cf97a4ed888a279237f90cd67a338d123efd15
-    optional: false
-    category: main
-  - name: cctools_osx-arm64
-    version: 973.0.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      ld64_osx-arm64: ">=609,<610.0a0"
-      libcxx: "*"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      sigtool: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-hef52d2f_11.conda"
-    hash:
-      md5: b4f37afd4ae6d094626d1cd10c4af0a8
-      sha256: 434e1ae972a0cd2980c414cb3d9bf2b31518c29dfd5e0124ad30aa6d9219a8f7
-    optional: false
-    category: main
-  - name: cffi
-    version: 1.15.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libffi: ">=3.4,<4.0a0"
-      pycparser: "*"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.15.1-py39h7e6b969_3.conda"
-    hash:
-      md5: 259002f955175cc89beb8477de5de291
-      sha256: 0fdb684286cb933d398d32f306a2dbbd605acafc4a0f85ebb3c54ff30d604b41
-    optional: false
-    category: main
-  - name: clang
-    version: 14.0.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      clang-14: "==14.0.6 default_h81a5282_0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/clang-14.0.6-hce30654_0.tar.bz2"
-    hash:
-      md5: 4b60f8635f0d1c6e143551fa82e91945
-      sha256: a001a0aee5076c7c64f0f695f171dcc59f23ce21dd61be94352f16598833a1d5
-    optional: false
-    category: main
-  - name: coverage
-    version: 7.1.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-      tomli: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.1.0-py39h02fc5c5_0.conda"
-    hash:
-      md5: abe9ca542c29c3b9963f5baaf64bf827
-      sha256: 57bcb6504fee2cc252ed2cec5e5aa07d10b8419f0b611078c56bc156dd7d66a1
-    optional: false
-    category: main
-  - name: fonttools
-    version: 4.38.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      brotli: "*"
-      munkres: "*"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-      unicodedata2: ">=14.0.0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.38.0-py39h02fc5c5_1.tar.bz2"
-    hash:
-      md5: bad1666f9a5aa9743e2be7b6818d752a
-      sha256: 7abe958b39d09b15ec6ec4847525d77a347e43fa05d480c95ce2453f4a394006
-    optional: false
-    category: main
-  - name: gfortran_impl_osx-arm64
-    version: 11.3.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      gmp: ">=6.2.1,<7.0a0"
-      isl: ">=0.25,<0.26.0a0"
-      libcxx: ">=14.0.6"
-      libgfortran-devel_osx-arm64: 11.3.0.*
-      libgfortran5: ">=11.3.0"
-      libiconv: ">=1.17,<2.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      mpc: ">=1.2.1,<2.0a0"
-      mpfr: ">=4.1.0,<5.0a0"
-      zlib: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/gfortran_impl_osx-arm64-11.3.0-h2a9d086_27.conda"
-    hash:
-      md5: 038e7f8ccaa6348bc5da9bd019e1bb61
-      sha256: bfe545a666ae47782e0a29eed499d006903f8b374e7c733ba6e559e99d7dc553
-    optional: false
-    category: main
-  - name: gitdb
-    version: 4.0.10
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.4"
-      smmap: ">=3.0.1,<4"
-    url: "https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.10-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 3706d2f3d7cb5dae600c833345a76132
-      sha256: 0003ab2b971913380633c711bf49a54dcf06e179986c725b0925854b58878377
-    optional: false
-    category: main
-  - name: hypothesis
-    version: 6.68.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      attrs: ">=19.2.0"
-      backports.zoneinfo: ">=0.2.1"
-      click: ">=7.0"
-      exceptiongroup: ">=1.0.0rc8"
-      python: ">=3.8"
-      setuptools: "*"
-      sortedcontainers: ">=2.1.0,<3.0.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.68.1-pyha770c72_0.conda"
-    hash:
-      md5: 3c044b3b920eb287f8c095c7f086ba64
-      sha256: e3a29c1303b563e450e0f706e4d78a281d1aa519d3e1094fc642305bceff72e1
-    optional: false
-    category: main
-  - name: importlib-metadata
-    version: 6.0.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.8"
-      zipp: ">=0.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.0.0-pyha770c72_0.conda"
-    hash:
-      md5: 691644becbcdca9f73243450b1c63e62
-      sha256: 0062e6ae1719395c25f0b60a21215470b4ea67514fed8a9330869da8604acfca
-    optional: false
-    category: main
-  - name: jedi
-    version: 0.18.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      parso: ">=0.8.0,<0.9.0"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/jedi-0.18.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: b5e695ef9c3f0d27d6cd96bf5adc9e07
-      sha256: abe63ae6e1b13f83500608d94004cb8d485b264083511d77f79253e775cd546c
-    optional: false
-    category: main
-  - name: jinja2
-    version: 3.1.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      markupsafe: ">=2.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: c8490ed5c70966d232fdd389d0dbed37
-      sha256: b045faba7130ab263db6a8fdc96b1a3de5fcf85c4a607c5f11a49e76851500b5
-    optional: false
-    category: main
-  - name: ld64
-    version: "609"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      ld64_osx-arm64: "==609 h7167370_11"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h619f069_11.conda"
-    hash:
-      md5: 00e421a01015e5246eca89480c6f7264
-      sha256: 2dafdecd71c4eb71524d1d9bc4df94bfd456144ddd7d88fec9813eced8993ee2
-    optional: false
-    category: main
-  - name: libblas
-    version: 3.9.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libopenblas: ">=0.3.21,<1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-16_osxarm64_openblas.tar.bz2"
-    hash:
-      md5: 53d6d5097f0d62e24db8c1979a21102e
-      sha256: 17dd67806f7e31981a1ac8abb63ed004eac416a1061c7737028f5af269430fa6
-    optional: false
-    category: main
-  - name: matplotlib-inline
-    version: 0.1.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-      traitlets: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: b21613793fcc81d944c76c9f2864a7de
-      sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-    optional: false
-    category: main
-  - name: meson
-    version: 1.0.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      ninja: ">=1.8.2"
-      python: ">=3.5.2"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/meson-1.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 4de573313958b8da6c526fdd354fffc8
-      sha256: 57dc7634aa05f3944314e6b56b2f37e6fb1a52b33de9ca153aee5d9adf83a5d7
-    optional: false
-    category: main
-  - name: mypy
-    version: "0.981"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      mypy_extensions: ">=0.4.3"
-      psutil: ">=4.0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-      tomli: ">=1.1.0"
-      typing_extensions: ">=3.10"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/mypy-0.981-py39h02fc5c5_0.tar.bz2"
-    hash:
-      md5: c9d491f73cc761dcd0f12de0b40c83c5
-      sha256: b5537747d9947a0d868d1b814ddc536b9392d4697587d111113c2b685204d524
-    optional: false
-    category: main
-  - name: openblas
-    version: 0.3.21
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libgfortran: 5.*
-      libgfortran5: ">=11.3.0"
-      libopenblas: "==0.3.21 openmp_hc731615_3"
-      llvm-openmp: ">=14.0.4"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/openblas-0.3.21-openmp_hf78f355_3.tar.bz2"
-    hash:
-      md5: ff5b9fccd5f48f6d1b14c9e3859417b9
-      sha256: 536b88e3a11a6d075a182506d969b98efee9d7481caf7daf9bc11ed33cdcbf0f
-    optional: false
-    category: main
-  - name: pexpect
-    version: 4.8.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      ptyprocess: ">=0.5"
-      python: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2"
-    hash:
-      md5: 330448ce4403cc74990ac07c555942a1
-      sha256: 07706c0417ead94f359ca7278f65452d3c396448777aba1da6a11fc351bdca9a
-    optional: false
-    category: main
-  - name: pillow
-    version: 9.4.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      freetype: ">=2.12.1,<3.0a0"
-      jpeg: ">=9e,<10a"
-      lcms2: ">=2.14,<3.0a0"
-      libtiff: ">=4.5.0,<4.6.0a0"
-      libwebp-base: ">=1.2.4,<2.0a0"
-      libxcb: ">=1.13,<1.14.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      openjpeg: ">=2.5.0,<3.0a0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-      tk: ">=8.6.12,<8.7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/pillow-9.4.0-py39h8bd98a6_1.conda"
-    hash:
-      md5: 90500f863712b55483294662f1f5f5f1
-      sha256: 3005f4fc32c370c380abc692c027a1391ab8248798153cb2eca62dfc569912f7
-    optional: false
-    category: main
-  - name: pip
-    version: "23.0"
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-      setuptools: "*"
-      wheel: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 85b35999162ec95f9f999bac15279c02
-      sha256: bbffec284bd0e154363e845121f43007e7e64c80412ff13be21909be907b697d
-    optional: false
-    category: main
-  - name: pygments
-    version: 2.14.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-      setuptools: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pygments-2.14.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: c78cd16b11cd6a295484bd6c8f24bea1
-      sha256: e8710e24f60b6a97289468f47914e53610101755088bc237621cc1980edbfcd9
-    optional: false
-    category: main
-  - name: pyproject-metadata
-    version: 0.7.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      packaging: ">=19.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyproject-metadata-0.7.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: dcb27826ffc94d5f04e241322239983b
-      sha256: 9ec35cffa163f587aeb52d1603df8374659e3be30dbc6db0e980ecb797f21fee
-    optional: false
-    category: main
-  - name: pytest
-    version: 7.2.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      attrs: ">=19.2.0"
-      colorama: "*"
-      exceptiongroup: "*"
-      iniconfig: "*"
-      packaging: "*"
-      pluggy: ">=0.12,<2.0"
-      python: ">=3.8"
-      tomli: ">=1.0.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-7.2.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: f0be05afc9c9ab45e273c088e00c258b
-      sha256: d298dfe6c53555c9fb5662f5f936e621cddd3b0a7031789375b82a1ee3b3a96b
-    optional: false
-    category: main
-  - name: python-dateutil
-    version: 2.8.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-      six: ">=1.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: dd999d1cc9f79e67dbb855c8924c7984
-      sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-    optional: false
-    category: main
-  - name: typing-extensions
-    version: 4.4.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      typing_extensions: "==4.4.0 pyha770c72_0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.4.0-hd8ed1ab_0.tar.bz2"
-    hash:
-      md5: be969210b61b897775a0de63cd9e9026
-      sha256: 6f129b1bc18d111dcf3abaec6fcf6cbee00f1b77bb42d0f0bc8d85f8faa65cf0
-    optional: false
-    category: main
-  - name: brotlipy
-    version: 0.7.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      cffi: ">=1.0.0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/brotlipy-0.7.0-py39h02fc5c5_1005.tar.bz2"
-    hash:
-      md5: cf0b1f6f29ee28e7b20d49cb66bae19e
-      sha256: d56a680b34d84144d396619eee5331493a9a611ee4ee21bd88a73bcac642abf4
-    optional: false
-    category: main
-  - name: cctools
-    version: 973.0.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      cctools_osx-arm64: "==973.0.1 hef52d2f_11"
-      ld64: "==609 h619f069_11"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-hcbb26d4_11.conda"
-    hash:
-      md5: fed06888f63eed25f43fdd6a475f9533
-      sha256: 2e24a64f78b0362431d1b2f92e1986b4696b08f33cd27b2b17f8e72aa56882dc
-    optional: false
-    category: main
-  - name: clangxx
-    version: 14.0.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      clang: "==14.0.6 hce30654_0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-14.0.6-default_hb7ecf47_0.tar.bz2"
-    hash:
-      md5: abb3bf7081791c101fcb2851c64900ca
-      sha256: 8b54e9ad48eac3d38c82ece984915f096be11d9279a0c59ccc0b9740e26ea58a
-    optional: false
-    category: main
-  - name: cryptography
-    version: 39.0.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      cffi: ">=1.12"
-      openssl: ">=3.0.8,<4.0a0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-39.0.1-py39he2a39a8_0.conda"
-    hash:
-      md5: 8a645fce995651a072a449b23a713954
-      sha256: d7a28a987198925ccc2a6f7d9b2e5e6da0fa97b5f18f844ff4aae1a2c57ec3f7
-    optional: false
-    category: main
-  - name: gitpython
-    version: 3.1.30
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      gitdb: ">=4.0.1,<5"
-      python: ">=3.7"
-      typing_extensions: ">=3.7.4.3"
-    url: "https://conda.anaconda.org/conda-forge/noarch/gitpython-3.1.30-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 0c217ab2f5ef6925e4e52c70b57cfc4a
-      sha256: 2ccd8aa401701947398a087b1aa11042b1b088e7331fed574b7ec9909bee09d6
-    optional: false
-    category: main
-  - name: libcblas
-    version: 3.9.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libblas: "==3.9.0 16_osxarm64_openblas"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-16_osxarm64_openblas.tar.bz2"
-    hash:
-      md5: c7cfc18378f00d3faf7f8a9a2553be3c
-      sha256: 99a04c6a273e76b01ace4f3a8f333b96a76b7351a155aaeba179e283da5c264e
-    optional: false
-    category: main
-  - name: liblapack
-    version: 3.9.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libblas: "==3.9.0 16_osxarm64_openblas"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-16_osxarm64_openblas.tar.bz2"
-    hash:
-      md5: 52d270c579bfca986d6cdd81eb5ed6e7
-      sha256: 87204cb0ff22f260b3aa5fc7c938157b471eb2bd287acf1ba7e61a67f86ba959
-    optional: false
-    category: main
-  - name: meson-python
-    version: 0.12.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      colorama: "*"
-      meson: ">=0.63.3"
-      ninja: "*"
-      pyproject-metadata: ">=0.6.1"
-      python: ">=3.7"
-      tomli: ">=1.0.0"
-      typing-extensions: ">=3.7.4"
-      wheel: ">=0.36.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/meson-python-0.12.0-pyh71feb2d_0.conda"
-    hash:
-      md5: dc566efe9c7af4eb305402b5c6121ca3
-      sha256: 2ea6e9b843e7d93283f2bd442f20bc973cf8141ef1876c9fe4353e473265a4da
-    optional: false
-    category: main
-  - name: pytest-cov
-    version: 4.0.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      coverage: ">=5.2.1"
-      pytest: ">=4.6"
-      python: ">=3.6"
-      toml: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.0.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c9e3f8bfdb9bfc34aa1836a6ed4b25d7
-      sha256: 2e00bbdb00b2514faba50ddcb6ecf1d6e4f2d5af346f9cd1240aacb1b61dccb6
-    optional: false
-    category: main
-  - name: pytest-xdist
-    version: 3.2.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      execnet: ">=1.1"
-      pytest: ">=6.2.0"
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.2.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 70ab87b96126f35d1e68de2ad9fb6423
-      sha256: aa81f80bf0a2f53423ab80137ca4fc201473884725a2983a0d79b2e420c2a671
-    optional: false
-    category: main
-  - name: stack_data
-    version: 0.6.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      asttokens: "*"
-      executing: "*"
-      pure_eval: "*"
-      python: ">=3.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: e7df0fdd404616638df5ece6e69ba7af
-      sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-    optional: false
-    category: main
-  - name: wcwidth
-    version: 0.2.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      backports.functools_lru_cache: "*"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 078979d33523cb477bd1916ce41aacc9
-      sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
-    optional: false
-    category: main
-  - name: compiler-rt_osx-arm64
-    version: 14.0.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      clang: 14.0.6.*
-      clangxx: 14.0.6.*
-    url: "https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-14.0.6-h48302dc_0.tar.bz2"
-    hash:
-      md5: ebcb473032038866101b70f9f270a9a2
-      sha256: f9f63e8779ff31368cc92ee668308c8e7e974f68457f62148c5663aa0136a42d
-    optional: false
-    category: main
-  - name: numpy
-    version: 1.24.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libblas: ">=3.9.0,<4.0a0"
-      libcblas: ">=3.9.0,<4.0a0"
-      libcxx: ">=14.0.6"
-      liblapack: ">=3.9.0,<4.0a0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.24.2-py39hff61c6a_0.conda"
-    hash:
-      md5: 894fca4ee0ea0bfef6ebca15d6d8196e
-      sha256: 6c0ed2591695627ff4789d14def1868afa43395c7af0db4c97878a6abc27e5e5
-    optional: false
-    category: main
-  - name: prompt-toolkit
-    version: 3.0.36
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.6"
-      wcwidth: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.36-pyha770c72_0.conda"
-    hash:
-      md5: 4d79ec192e0bfd530a254006d123b9a6
-      sha256: 6bd3626799c9467d7aa8ed5f95043e4cea614a1329580980ddcf40cfed3ee860
-    optional: false
-    category: main
-  - name: pyopenssl
-    version: 23.0.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      cryptography: ">=38.0.0,<40"
-      python: ">=3.6"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.0.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: d41957700e83bbb925928764cb7f8878
-      sha256: adbf8951f22bfa950b9e24394df1ef1d2b2d7dfb194d91c7f42bc11900695785
-    optional: false
-    category: main
-  - name: compiler-rt
-    version: 14.0.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      clang: 14.0.6.*
-      clangxx: 14.0.6.*
-      compiler-rt_osx-arm64: 14.0.6.*
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-14.0.6-h30b49de_0.tar.bz2"
-    hash:
-      md5: b88a5457fa7def557e5902046ab56b6e
-      sha256: 266578ae49450e6b4a778b454f8e7fd988676dd9146bb186093066ab1589ba06
-    optional: false
-    category: main
-  - name: contourpy
-    version: 1.0.7
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=14.0.6"
-      numpy: ">=1.16"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.0.7-py39haaf3ac1_0.conda"
-    hash:
-      md5: 221d648082c1ebdd89e6968441b5a9c5
-      sha256: 141e4de214f13537aee7acfa3ed49e43346af017d66030794cd0a4f62ceda9e6
-    optional: false
-    category: main
-  - name: ipython
-    version: 8.10.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      __osx: "*"
-      appnope: "*"
-      backcall: "*"
-      decorator: "*"
-      jedi: ">=0.16"
-      matplotlib-inline: "*"
-      pexpect: ">4.3"
-      pickleshare: "*"
-      prompt-toolkit: ">=3.0.30,<3.1.0"
-      pygments: ">=2.4.0"
-      python: ">=3.8"
-      stack_data: "*"
-      traitlets: ">=5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/ipython-8.10.0-pyhd1c38e8_0.conda"
-    hash:
-      md5: e67b634578fefbb312cd6cfd34b63d86
-      sha256: 5951fbddbd8be803c38b75d7d34ff78d366e57e55a7afa2604be6fd0abacb882
-    optional: false
-    category: main
-  - name: pandas
-    version: 1.5.3
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libcxx: ">=14.0.6"
-      numpy: ">=1.20.3,<2.0a0"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python-dateutil: ">=2.8.1"
-      python_abi: 3.9.* *_cp39
-      pytz: ">=2020.1"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/pandas-1.5.3-py39hde7b980_0.conda"
-    hash:
-      md5: 694bdfe194977ddb7588e05f57ce295c
-      sha256: 1906573ea1ab24667c120984c840b9550a2fab8eba699ae659a49824661fc30c
-    optional: false
-    category: main
-  - name: urllib3
-    version: 1.26.14
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      brotlipy: ">=0.6.0"
-      certifi: "*"
-      cryptography: ">=1.3.4"
-      idna: ">=2.0.0"
-      pyopenssl: ">=0.14"
-      pysocks: ">=1.5.6,<2.0,!=1.5.7"
-      python: "<4.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.14-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 01f33ad2e0aaf6b5ba4add50dad5ad29
-      sha256: f2f09c44e47946ce631dbc9a8a79bb463ac0f4122aaafdbcc51f200a1e420ca6
-    optional: false
-    category: main
-  - name: clang_osx-arm64
-    version: 14.0.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      cctools_osx-arm64: "*"
-      clang: 14.0.6.*
-      compiler-rt: 14.0.6.*
-      ld64_osx-arm64: "*"
-      llvm-tools: 14.0.6.*
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-14.0.6-h15773ab_4.conda"
-    hash:
-      md5: d0db37e26bfd89ca03a40a5b8ce15635
-      sha256: 4d23a3b87660ee13516d9d04da665587d488b791eb8300da1a0e6c93f6d8aaf8
-    optional: false
-    category: main
-  - name: matplotlib-base
-    version: 3.6.3
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      certifi: ">=2020.6.20"
-      contourpy: ">=1.0.1"
-      cycler: ">=0.10"
-      fonttools: ">=4.22.0"
-      freetype: ">=2.12.1,<3.0a0"
-      kiwisolver: ">=1.0.1"
-      libcxx: ">=14.0.6"
-      numpy: ">=1.20.3,<2.0a0"
-      packaging: ">=20.0"
-      pillow: ">=6.2.0"
-      pyparsing: ">=2.3.1"
-      python: ">=3.9,<3.10.0a0 *_cpython"
-      python-dateutil: ">=2.7"
-      python_abi: 3.9.* *_cp39
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.6.3-py39h35e9e80_0.conda"
-    hash:
-      md5: 6699bbc7c73575331a5dc91f83fffc47
-      sha256: 3df1794307e98ed49b8c3f8ca14c87b220b79ed56e4fcb7c74b0604ef35b36e0
-    optional: false
-    category: main
-  - name: requests
-    version: 2.28.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      certifi: ">=2017.4.17"
-      charset-normalizer: ">=2,<3"
-      idna: ">=2.5,<4"
-      python: ">=3.7,<4.0"
-      urllib3: ">=1.21.1,<1.27"
-    url: "https://conda.anaconda.org/conda-forge/noarch/requests-2.28.2-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 11d178fc55199482ee48d6812ea83983
-      sha256: 22c081b4cdd023a514400413f50efdf2c378f56f2a5ea9d65666aacf4696490a
-    optional: false
-    category: main
-  - name: c-compiler
-    version: 1.5.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      cctools: ">=949.0.1"
-      clang_osx-arm64: 14.*
-      ld64: ">=530"
-      llvm-openmp: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.5.2-h5008568_0.conda"
-    hash:
-      md5: 56a88306583601d05b6eeded173d73d9
-      sha256: 54fabbef178e857a639a9c7a302cdab072ca5c2b94052ac939a7ebcf9dad32e4
-    optional: false
-    category: main
-  - name: clangxx_osx-arm64
-    version: 14.0.6
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      clang_osx-arm64: "==14.0.6 h15773ab_4"
-      clangxx: 14.0.6.*
-      libcxx: ">=14.0.6"
-      libllvm14: ">=14.0.6,<14.1.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-14.0.6-he29aa18_4.conda"
-    hash:
-      md5: 85157d29e430829c4cc5b1f152306f9b
-      sha256: 87d60f5785f2ab4fe119eb43d7c9ae6a7f6a064ebf95409b0165e0fc6c3a2258
-    optional: false
-    category: main
-  - name: gfortran_osx-arm64
-    version: 11.3.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      cctools_osx-arm64: "*"
-      clang: "*"
-      clang_osx-arm64: "*"
-      gfortran_impl_osx-arm64: "==11.3.0"
-      ld64_osx-arm64: "*"
-      libgfortran: 5.*
-      libgfortran-devel_osx-arm64: "==11.3.0"
-      libgfortran5: ">=11.3.0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/gfortran_osx-arm64-11.3.0-h57527a5_0.tar.bz2"
-    hash:
-      md5: ebf560369c33d9a4f568a2c5b5922b52
-      sha256: f8372955a71bef3ae6f06df20d164a9aeb233a4553c7eb92cb8c0d8bae445d6f
-    optional: false
-    category: main
-  - name: matplotlib
-    version: 3.6.3
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      matplotlib-base: ">=3.6.3,<3.6.4.0a0"
-      python: ">=3.9,<3.10.0a0"
-      python_abi: 3.9.* *_cp39
-      tornado: ">=5"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.6.3-py39hdf13c20_0.conda"
-    hash:
-      md5: dc01380d1f0fd2946d0b2b822acf18d6
-      sha256: d78938af23d11a6535ffa5bd75be4c43f81079b9d659869781a0d454ca19ff1c
-    optional: false
-    category: main
-  - name: pooch
-    version: 1.6.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      appdirs: ">=1.3.0"
-      packaging: ">=20.0"
-      python: ">=3.6"
-      requests: ">=2.19.0"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pooch-1.6.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: 6429e1d1091c51f626b5dcfdd38bf429
-      sha256: 1f0548105de86fb2eb6fbb8d3d6cc2004079b8442d232258108687d6cc91eb73
-    optional: false
-    category: main
-  - name: sphinx
-    version: 5.3.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      alabaster: ">=0.7,<0.8"
-      babel: ">=2.9"
-      colorama: ">=0.4.5"
-      docutils: ">=0.14,<0.20"
-      imagesize: ">=1.3"
-      importlib-metadata: ">=4.8"
-      jinja2: ">=3.0"
-      packaging: ">=21.0"
-      pygments: ">=2.12"
-      python: ">=3.7"
-      requests: ">=2.5.0"
-      snowballstemmer: ">=2.0"
-      sphinxcontrib-applehelp: "*"
-      sphinxcontrib-devhelp: "*"
-      sphinxcontrib-htmlhelp: ">=2.0.0"
-      sphinxcontrib-jsmath: "*"
-      sphinxcontrib-qthelp: "*"
-      sphinxcontrib-serializinghtml: ">=1.1.5"
-    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-5.3.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: f9e1fcfe235d655900bfeb6aee426472
-      sha256: f11fd5fb4ae2c65f41ae86e7408e3ab44844898d928264aa9e89929fffc685c8
-    optional: false
-    category: main
-  - name: breathe
-    version: 4.34.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      docutils: ">=0.12"
-      jinja2: ">=2.7.3"
-      markupsafe: ">=0.23"
-      pygments: ">=1.6"
-      python: ">=3.6"
-      sphinx: ">=4.0,<6.0.0a"
-    url: "https://conda.anaconda.org/conda-forge/noarch/breathe-4.34.0-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: a2a04f8e8c2d91adb08ff929b4d73654
-      sha256: 40f86cd741a443363e8928d5d36ba3a49071aaffc26c5a7b24a8167c5bcbba81
-    optional: false
-    category: main
-  - name: cxx-compiler
-    version: 1.5.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      c-compiler: "==1.5.2 h5008568_0"
-      clangxx_osx-arm64: 14.*
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.5.2-hffc8910_0.conda"
-    hash:
-      md5: 3dd2dd956573a59e32711e2e08bb5d8b
-      sha256: 84f23671f8b18aeabcfd4b5315383442c3bdff3c9194b85c30ec5690d14e721a
-    optional: false
-    category: main
-  - name: gfortran
-    version: 11.3.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      cctools: "*"
-      gfortran_osx-arm64: "*"
-      ld64: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/gfortran-11.3.0-h1ca8e4b_0.tar.bz2"
-    hash:
-      md5: 75b415dac7f64e2af572a24469b581d4
-      sha256: 8422479e2ef6937956635ad70303b9dc1aa82d7fde70a49fac4759e73a022464
-    optional: false
-    category: main
-  - name: numpydoc
-    version: 1.4.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      jinja2: ">=2.10"
-      python: ">=3.7"
-      sphinx: ">=1.8"
-    url: "https://conda.anaconda.org/conda-forge/noarch/numpydoc-1.4.0-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: 0aac89c61a466b0f9c4fd0ec44d81f1d
-      sha256: 11a892cc1678a23d169909e553447fb7e312d6baaa314fdcd719f6abff1c7da6
-    optional: false
-    category: main
-  - name: pydata-sphinx-theme
-    version: 0.9.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      beautifulsoup4: "*"
-      docutils: "!=0.17.0"
-      packaging: "*"
-      python: ">=3.7"
-      sphinx: ">=4.0.2"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.9.0-pyhd8ed1ab_1.tar.bz2"
-    hash:
-      md5: ed5f1236283219a21207813d387b44bd
-      sha256: 11d56e0953a8f880d265d18eb3b3adc2f0ba182a33409088141dc84e22dba50c
     optional: false
     category: main
   - name: scipy
@@ -13207,6 +10848,610 @@ package:
       sha256: 165e1537c6a7b43e0f112df5e81691aa192d6614f4ff5229721bf9f493ff90ee
     optional: false
     category: main
+  - name: setuptools
+    version: 59.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/setuptools-59.2.0-py39hf3d152e_0.tar.bz2"
+    hash:
+      md5: 37ef3543fa46bf5d587f23d72b88fbf7
+      sha256: 7e74640590ebe3379bb33c0aed17efa8c305c016b85e987d1e864a40a29743aa
+    optional: false
+    category: main
+  - name: setuptools
+    version: 59.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/setuptools-59.2.0-py39ha65689a_0.tar.bz2"
+    hash:
+      md5: d16c2492792df4ceab4c32d426e49f00
+      sha256: 4cc2357f91ebe448287026240be37e717fd5a82cbc1d49fd5ef3ae721672e5e7
+    optional: false
+    category: main
+  - name: setuptools
+    version: 59.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/setuptools-59.2.0-py39hc1b9086_0.tar.bz2"
+    hash:
+      md5: 4617e1d24d2f1dff048a836d588fde54
+      sha256: ad9e51800a00e3252728011f818d0f227acac77388b1b73a0b8999c1a05944fd
+    optional: false
+    category: main
+  - name: setuptools
+    version: 59.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/setuptools-59.2.0-py39h6e9494a_0.tar.bz2"
+    hash:
+      md5: a0954b685217e8b45fd677da613d4e95
+      sha256: 5f0850fae9a651bc448bc50af4550d93f8d966f168ef85a918e51eca6490d8ab
+    optional: false
+    category: main
+  - name: setuptools
+    version: 59.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/setuptools-59.2.0-py39h2804cbe_0.tar.bz2"
+    hash:
+      md5: 71789b9ebc713ccc0ebae4ce8e07bf71
+      sha256: 83002349c6ae229f4ffa03ad2e3101121f1d47f1f04654c317d31e14528a4bfc
+    optional: false
+    category: main
+  - name: sigtool
+    version: 0.1.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      openssl: ">=3.0.0,<4.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2"
+    hash:
+      md5: fbfb84b9de9a6939cb165c02c69b1865
+      sha256: 46fdeadf8f8d725819c4306838cdfd1099cd8fe3e17bd78862a5dfdcd6de61cf
+    optional: false
+    category: main
+  - name: sigtool
+    version: 0.1.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      openssl: ">=3.0.0,<4.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2"
+    hash:
+      md5: 4a2cac04f86a4540b8c9b8d8f597848f
+      sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
+    optional: false
+    category: main
+  - name: sip
+    version: 6.7.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      packaging: "*"
+      ply: "*"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+      toml: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.7-py39h227be39_0.conda"
+    hash:
+      md5: 7d9a35091552af3655151f164ddd64a3
+      sha256: cbd7ddbe101dfe7d7241c5334e08c56fd9000400a099a2144ba95f63f90b9b45
+    optional: false
+    category: main
+  - name: six
+    version: 1.16.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2"
+    hash:
+      md5: e5f25f8dbc060e9a8d912e432202afc2
+      sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+    optional: false
+    category: main
+  - name: six
+    version: 1.16.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2"
+    hash:
+      md5: e5f25f8dbc060e9a8d912e432202afc2
+      sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+    optional: false
+    category: main
+  - name: six
+    version: 1.16.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2"
+    hash:
+      md5: e5f25f8dbc060e9a8d912e432202afc2
+      sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+    optional: false
+    category: main
+  - name: six
+    version: 1.16.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2"
+    hash:
+      md5: e5f25f8dbc060e9a8d912e432202afc2
+      sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+    optional: false
+    category: main
+  - name: six
+    version: 1.16.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2"
+    hash:
+      md5: e5f25f8dbc060e9a8d912e432202afc2
+      sha256: a85c38227b446f42c5b90d9b642f2c0567880c15d72492d8da074a59c8f91dd6
+    optional: false
+    category: main
+  - name: smmap
+    version: 3.0.5
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/smmap-3.0.5-pyh44b312d_0.tar.bz2"
+    hash:
+      md5: 3a8dc70789709aa315325d5df06fb7e4
+      sha256: 091de70ee6bfe063e0c0f77336975d124fd1e3f49b9c58d97c0c7b3d287c0002
+    optional: false
+    category: main
+  - name: smmap
+    version: 3.0.5
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/smmap-3.0.5-pyh44b312d_0.tar.bz2"
+    hash:
+      md5: 3a8dc70789709aa315325d5df06fb7e4
+      sha256: 091de70ee6bfe063e0c0f77336975d124fd1e3f49b9c58d97c0c7b3d287c0002
+    optional: false
+    category: main
+  - name: smmap
+    version: 3.0.5
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/smmap-3.0.5-pyh44b312d_0.tar.bz2"
+    hash:
+      md5: 3a8dc70789709aa315325d5df06fb7e4
+      sha256: 091de70ee6bfe063e0c0f77336975d124fd1e3f49b9c58d97c0c7b3d287c0002
+    optional: false
+    category: main
+  - name: smmap
+    version: 3.0.5
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/smmap-3.0.5-pyh44b312d_0.tar.bz2"
+    hash:
+      md5: 3a8dc70789709aa315325d5df06fb7e4
+      sha256: 091de70ee6bfe063e0c0f77336975d124fd1e3f49b9c58d97c0c7b3d287c0002
+    optional: false
+    category: main
+  - name: smmap
+    version: 3.0.5
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/smmap-3.0.5-pyh44b312d_0.tar.bz2"
+    hash:
+      md5: 3a8dc70789709aa315325d5df06fb7e4
+      sha256: 091de70ee6bfe063e0c0f77336975d124fd1e3f49b9c58d97c0c7b3d287c0002
+    optional: false
+    category: main
+  - name: snowballstemmer
+    version: 2.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 4d22a9315e78c6827f806065957d566e
+      sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
+    optional: false
+    category: main
+  - name: snowballstemmer
+    version: 2.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 4d22a9315e78c6827f806065957d566e
+      sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
+    optional: false
+    category: main
+  - name: snowballstemmer
+    version: 2.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 4d22a9315e78c6827f806065957d566e
+      sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
+    optional: false
+    category: main
+  - name: snowballstemmer
+    version: 2.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 4d22a9315e78c6827f806065957d566e
+      sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
+    optional: false
+    category: main
+  - name: snowballstemmer
+    version: 2.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=2"
+    url: "https://conda.anaconda.org/conda-forge/noarch/snowballstemmer-2.2.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 4d22a9315e78c6827f806065957d566e
+      sha256: a0fd916633252d99efb6223b1050202841fa8d2d53dacca564b0ed77249d3228
+    optional: false
+    category: main
+  - name: sortedcontainers
+    version: 2.4.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6d6552722448103793743dabfbda532d
+      sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+    optional: false
+    category: main
+  - name: sortedcontainers
+    version: 2.4.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6d6552722448103793743dabfbda532d
+      sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+    optional: false
+    category: main
+  - name: sortedcontainers
+    version: 2.4.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6d6552722448103793743dabfbda532d
+      sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+    optional: false
+    category: main
+  - name: sortedcontainers
+    version: 2.4.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6d6552722448103793743dabfbda532d
+      sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+    optional: false
+    category: main
+  - name: sortedcontainers
+    version: 2.4.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 6d6552722448103793743dabfbda532d
+      sha256: 0cea408397d50c2afb2d25e987ebac4546ae11e549d65b1403d80dc368dfaaa6
+    optional: false
+    category: main
+  - name: soupsieve
+    version: 2.3.2.post1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 146f4541d643d48fc8a75cacf69f03ae
+      sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
+    optional: false
+    category: main
+  - name: soupsieve
+    version: 2.3.2.post1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 146f4541d643d48fc8a75cacf69f03ae
+      sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
+    optional: false
+    category: main
+  - name: soupsieve
+    version: 2.3.2.post1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 146f4541d643d48fc8a75cacf69f03ae
+      sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
+    optional: false
+    category: main
+  - name: soupsieve
+    version: 2.3.2.post1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 146f4541d643d48fc8a75cacf69f03ae
+      sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
+    optional: false
+    category: main
+  - name: soupsieve
+    version: 2.3.2.post1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.3.2.post1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 146f4541d643d48fc8a75cacf69f03ae
+      sha256: 72d80dda41c3902c2619e8ab49d4f5b2a894d13375e1f9ed16fc00074ddd2307
+    optional: false
+    category: main
+  - name: sphinx
+    version: 5.3.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      alabaster: ">=0.7,<0.8"
+      babel: ">=2.9"
+      colorama: ">=0.4.5"
+      docutils: ">=0.14,<0.20"
+      imagesize: ">=1.3"
+      importlib-metadata: ">=4.8"
+      jinja2: ">=3.0"
+      packaging: ">=21.0"
+      pygments: ">=2.12"
+      python: ">=3.7"
+      requests: ">=2.5.0"
+      snowballstemmer: ">=2.0"
+      sphinxcontrib-applehelp: "*"
+      sphinxcontrib-devhelp: "*"
+      sphinxcontrib-htmlhelp: ">=2.0.0"
+      sphinxcontrib-jsmath: "*"
+      sphinxcontrib-qthelp: "*"
+      sphinxcontrib-serializinghtml: ">=1.1.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-5.3.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: f9e1fcfe235d655900bfeb6aee426472
+      sha256: f11fd5fb4ae2c65f41ae86e7408e3ab44844898d928264aa9e89929fffc685c8
+    optional: false
+    category: main
+  - name: sphinx
+    version: 5.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      alabaster: ">=0.7,<0.8"
+      babel: ">=2.9"
+      colorama: ">=0.4.5"
+      docutils: ">=0.14,<0.20"
+      imagesize: ">=1.3"
+      importlib-metadata: ">=4.8"
+      jinja2: ">=3.0"
+      packaging: ">=21.0"
+      pygments: ">=2.12"
+      python: ">=3.7"
+      requests: ">=2.5.0"
+      snowballstemmer: ">=2.0"
+      sphinxcontrib-applehelp: "*"
+      sphinxcontrib-devhelp: "*"
+      sphinxcontrib-htmlhelp: ">=2.0.0"
+      sphinxcontrib-jsmath: "*"
+      sphinxcontrib-qthelp: "*"
+      sphinxcontrib-serializinghtml: ">=1.1.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-5.3.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: f9e1fcfe235d655900bfeb6aee426472
+      sha256: f11fd5fb4ae2c65f41ae86e7408e3ab44844898d928264aa9e89929fffc685c8
+    optional: false
+    category: main
+  - name: sphinx
+    version: 5.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      alabaster: ">=0.7,<0.8"
+      babel: ">=2.9"
+      colorama: ">=0.4.5"
+      docutils: ">=0.14,<0.20"
+      imagesize: ">=1.3"
+      importlib-metadata: ">=4.8"
+      jinja2: ">=3.0"
+      packaging: ">=21.0"
+      pygments: ">=2.12"
+      python: ">=3.7"
+      requests: ">=2.5.0"
+      snowballstemmer: ">=2.0"
+      sphinxcontrib-applehelp: "*"
+      sphinxcontrib-devhelp: "*"
+      sphinxcontrib-htmlhelp: ">=2.0.0"
+      sphinxcontrib-jsmath: "*"
+      sphinxcontrib-qthelp: "*"
+      sphinxcontrib-serializinghtml: ">=1.1.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-5.3.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: f9e1fcfe235d655900bfeb6aee426472
+      sha256: f11fd5fb4ae2c65f41ae86e7408e3ab44844898d928264aa9e89929fffc685c8
+    optional: false
+    category: main
+  - name: sphinx
+    version: 5.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      alabaster: ">=0.7,<0.8"
+      babel: ">=2.9"
+      colorama: ">=0.4.5"
+      docutils: ">=0.14,<0.20"
+      imagesize: ">=1.3"
+      importlib-metadata: ">=4.8"
+      jinja2: ">=3.0"
+      packaging: ">=21.0"
+      pygments: ">=2.12"
+      python: ">=3.7"
+      requests: ">=2.5.0"
+      snowballstemmer: ">=2.0"
+      sphinxcontrib-applehelp: "*"
+      sphinxcontrib-devhelp: "*"
+      sphinxcontrib-htmlhelp: ">=2.0.0"
+      sphinxcontrib-jsmath: "*"
+      sphinxcontrib-qthelp: "*"
+      sphinxcontrib-serializinghtml: ">=1.1.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-5.3.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: f9e1fcfe235d655900bfeb6aee426472
+      sha256: f11fd5fb4ae2c65f41ae86e7408e3ab44844898d928264aa9e89929fffc685c8
+    optional: false
+    category: main
+  - name: sphinx
+    version: 5.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      alabaster: ">=0.7,<0.8"
+      babel: ">=2.9"
+      colorama: ">=0.4.5"
+      docutils: ">=0.14,<0.20"
+      imagesize: ">=1.3"
+      importlib-metadata: ">=4.8"
+      jinja2: ">=3.0"
+      packaging: ">=21.0"
+      pygments: ">=2.12"
+      python: ">=3.7"
+      requests: ">=2.5.0"
+      snowballstemmer: ">=2.0"
+      sphinxcontrib-applehelp: "*"
+      sphinxcontrib-devhelp: "*"
+      sphinxcontrib-htmlhelp: ">=2.0.0"
+      sphinxcontrib-jsmath: "*"
+      sphinxcontrib-qthelp: "*"
+      sphinxcontrib-serializinghtml: ">=1.1.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-5.3.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: f9e1fcfe235d655900bfeb6aee426472
+      sha256: f11fd5fb4ae2c65f41ae86e7408e3ab44844898d928264aa9e89929fffc685c8
+    optional: false
+    category: main
+  - name: sphinx-design
+    version: 0.3.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.6"
+      sphinx: ">=4,<6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-design-0.3.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 83d1a712e6d2bab6b298b1d2f42ad355
+      sha256: 6b193a483a02bbc7a785dcd28614b4c082d1795fec0a1c48690d8d7a0a876e20
+    optional: false
+    category: main
+  - name: sphinx-design
+    version: 0.3.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.6"
+      sphinx: ">=4,<6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-design-0.3.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 83d1a712e6d2bab6b298b1d2f42ad355
+      sha256: 6b193a483a02bbc7a785dcd28614b4c082d1795fec0a1c48690d8d7a0a876e20
+    optional: false
+    category: main
+  - name: sphinx-design
+    version: 0.3.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.6"
+      sphinx: ">=4,<6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-design-0.3.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 83d1a712e6d2bab6b298b1d2f42ad355
+      sha256: 6b193a483a02bbc7a785dcd28614b4c082d1795fec0a1c48690d8d7a0a876e20
+    optional: false
+    category: main
+  - name: sphinx-design
+    version: 0.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.6"
+      sphinx: ">=4,<6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinx-design-0.3.0-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 83d1a712e6d2bab6b298b1d2f42ad355
+      sha256: 6b193a483a02bbc7a785dcd28614b4c082d1795fec0a1c48690d8d7a0a876e20
+    optional: false
+    category: main
   - name: sphinx-design
     version: 0.3.0
     manager: conda
@@ -13220,34 +11465,1790 @@ package:
       sha256: 6b193a483a02bbc7a785dcd28614b4c082d1795fec0a1c48690d8d7a0a876e20
     optional: false
     category: main
-  - name: fortran-compiler
-    version: 1.5.2
+  - name: sphinxcontrib-applehelp
+    version: 1.0.4
     manager: conda
-    platform: osx-arm64
+    platform: linux-64
     dependencies:
-      cctools: ">=949.0.1"
-      gfortran: "*"
-      gfortran_osx-arm64: 11.*
-      ld64: ">=530"
-      llvm-openmp: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/fortran-compiler-1.5.2-h2ccabda_0.conda"
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.4-pyhd8ed1ab_0.conda"
     hash:
-      md5: 21d7e4d79b87bf28d865241f7dff5629
-      sha256: d5b7b998c28252a1a7ee07d4558c89ba0fa43fa12b27f336ab02115e18add806
+      md5: 5a31a7d564f551d0e6dff52fd8cb5b16
+      sha256: 802810d8321d55e5666806d565e72949eabf77ad510fe2758ce1da2441675ef1
     optional: false
     category: main
-  - name: compilers
+  - name: sphinxcontrib-applehelp
+    version: 1.0.4
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.4-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 5a31a7d564f551d0e6dff52fd8cb5b16
+      sha256: 802810d8321d55e5666806d565e72949eabf77ad510fe2758ce1da2441675ef1
+    optional: false
+    category: main
+  - name: sphinxcontrib-applehelp
+    version: 1.0.4
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.4-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 5a31a7d564f551d0e6dff52fd8cb5b16
+      sha256: 802810d8321d55e5666806d565e72949eabf77ad510fe2758ce1da2441675ef1
+    optional: false
+    category: main
+  - name: sphinxcontrib-applehelp
+    version: 1.0.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.4-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 5a31a7d564f551d0e6dff52fd8cb5b16
+      sha256: 802810d8321d55e5666806d565e72949eabf77ad510fe2758ce1da2441675ef1
+    optional: false
+    category: main
+  - name: sphinxcontrib-applehelp
+    version: 1.0.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-applehelp-1.0.4-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 5a31a7d564f551d0e6dff52fd8cb5b16
+      sha256: 802810d8321d55e5666806d565e72949eabf77ad510fe2758ce1da2441675ef1
+    optional: false
+    category: main
+  - name: sphinxcontrib-devhelp
+    version: 1.0.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.2-py_0.tar.bz2"
+    hash:
+      md5: 68e01cac9d38d0e717cd5c87bc3d2cc9
+      sha256: 66cca7eccb7f92eee53f9f5a552e3e1d643daa3a1ebd03c185e2819e5c491576
+    optional: false
+    category: main
+  - name: sphinxcontrib-devhelp
+    version: 1.0.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.2-py_0.tar.bz2"
+    hash:
+      md5: 68e01cac9d38d0e717cd5c87bc3d2cc9
+      sha256: 66cca7eccb7f92eee53f9f5a552e3e1d643daa3a1ebd03c185e2819e5c491576
+    optional: false
+    category: main
+  - name: sphinxcontrib-devhelp
+    version: 1.0.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.2-py_0.tar.bz2"
+    hash:
+      md5: 68e01cac9d38d0e717cd5c87bc3d2cc9
+      sha256: 66cca7eccb7f92eee53f9f5a552e3e1d643daa3a1ebd03c185e2819e5c491576
+    optional: false
+    category: main
+  - name: sphinxcontrib-devhelp
+    version: 1.0.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.2-py_0.tar.bz2"
+    hash:
+      md5: 68e01cac9d38d0e717cd5c87bc3d2cc9
+      sha256: 66cca7eccb7f92eee53f9f5a552e3e1d643daa3a1ebd03c185e2819e5c491576
+    optional: false
+    category: main
+  - name: sphinxcontrib-devhelp
+    version: 1.0.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-devhelp-1.0.2-py_0.tar.bz2"
+    hash:
+      md5: 68e01cac9d38d0e717cd5c87bc3d2cc9
+      sha256: 66cca7eccb7f92eee53f9f5a552e3e1d643daa3a1ebd03c185e2819e5c491576
+    optional: false
+    category: main
+  - name: sphinxcontrib-htmlhelp
+    version: 2.0.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 6c8c4d6eb2325e59290ac6dbbeacd5f0
+      sha256: aeff20be994e6f9520a91fc177a33cb3e4d0911cdf8d27e575d001f00afa33fd
+    optional: false
+    category: main
+  - name: sphinxcontrib-htmlhelp
+    version: 2.0.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 6c8c4d6eb2325e59290ac6dbbeacd5f0
+      sha256: aeff20be994e6f9520a91fc177a33cb3e4d0911cdf8d27e575d001f00afa33fd
+    optional: false
+    category: main
+  - name: sphinxcontrib-htmlhelp
+    version: 2.0.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 6c8c4d6eb2325e59290ac6dbbeacd5f0
+      sha256: aeff20be994e6f9520a91fc177a33cb3e4d0911cdf8d27e575d001f00afa33fd
+    optional: false
+    category: main
+  - name: sphinxcontrib-htmlhelp
+    version: 2.0.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 6c8c4d6eb2325e59290ac6dbbeacd5f0
+      sha256: aeff20be994e6f9520a91fc177a33cb3e4d0911cdf8d27e575d001f00afa33fd
+    optional: false
+    category: main
+  - name: sphinxcontrib-htmlhelp
+    version: 2.0.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-htmlhelp-2.0.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 6c8c4d6eb2325e59290ac6dbbeacd5f0
+      sha256: aeff20be994e6f9520a91fc177a33cb3e4d0911cdf8d27e575d001f00afa33fd
+    optional: false
+    category: main
+  - name: sphinxcontrib-jsmath
+    version: 1.0.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-py_0.tar.bz2"
+    hash:
+      md5: 67cd9d9c0382d37479b4d306c369a2d4
+      sha256: a42415fc789e9f6ae2e18f07ac143d2e9ce73a35a55ecf1dd1b3d055dd1e6dbe
+    optional: false
+    category: main
+  - name: sphinxcontrib-jsmath
+    version: 1.0.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-py_0.tar.bz2"
+    hash:
+      md5: 67cd9d9c0382d37479b4d306c369a2d4
+      sha256: a42415fc789e9f6ae2e18f07ac143d2e9ce73a35a55ecf1dd1b3d055dd1e6dbe
+    optional: false
+    category: main
+  - name: sphinxcontrib-jsmath
+    version: 1.0.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-py_0.tar.bz2"
+    hash:
+      md5: 67cd9d9c0382d37479b4d306c369a2d4
+      sha256: a42415fc789e9f6ae2e18f07ac143d2e9ce73a35a55ecf1dd1b3d055dd1e6dbe
+    optional: false
+    category: main
+  - name: sphinxcontrib-jsmath
+    version: 1.0.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-py_0.tar.bz2"
+    hash:
+      md5: 67cd9d9c0382d37479b4d306c369a2d4
+      sha256: a42415fc789e9f6ae2e18f07ac143d2e9ce73a35a55ecf1dd1b3d055dd1e6dbe
+    optional: false
+    category: main
+  - name: sphinxcontrib-jsmath
+    version: 1.0.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-jsmath-1.0.1-py_0.tar.bz2"
+    hash:
+      md5: 67cd9d9c0382d37479b4d306c369a2d4
+      sha256: a42415fc789e9f6ae2e18f07ac143d2e9ce73a35a55ecf1dd1b3d055dd1e6dbe
+    optional: false
+    category: main
+  - name: sphinxcontrib-qthelp
+    version: 1.0.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2"
+    hash:
+      md5: d01180388e6d1838c3e1ad029590aa7a
+      sha256: 35d8f01fc798d38b72ae003c040d2dee650d315f904268a1f793d4d59460d1e2
+    optional: false
+    category: main
+  - name: sphinxcontrib-qthelp
+    version: 1.0.3
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2"
+    hash:
+      md5: d01180388e6d1838c3e1ad029590aa7a
+      sha256: 35d8f01fc798d38b72ae003c040d2dee650d315f904268a1f793d4d59460d1e2
+    optional: false
+    category: main
+  - name: sphinxcontrib-qthelp
+    version: 1.0.3
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2"
+    hash:
+      md5: d01180388e6d1838c3e1ad029590aa7a
+      sha256: 35d8f01fc798d38b72ae003c040d2dee650d315f904268a1f793d4d59460d1e2
+    optional: false
+    category: main
+  - name: sphinxcontrib-qthelp
+    version: 1.0.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2"
+    hash:
+      md5: d01180388e6d1838c3e1ad029590aa7a
+      sha256: 35d8f01fc798d38b72ae003c040d2dee650d315f904268a1f793d4d59460d1e2
+    optional: false
+    category: main
+  - name: sphinxcontrib-qthelp
+    version: 1.0.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-qthelp-1.0.3-py_0.tar.bz2"
+    hash:
+      md5: d01180388e6d1838c3e1ad029590aa7a
+      sha256: 35d8f01fc798d38b72ae003c040d2dee650d315f904268a1f793d4d59460d1e2
+    optional: false
+    category: main
+  - name: sphinxcontrib-serializinghtml
+    version: 1.1.5
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2"
+    hash:
+      md5: 9ff55a0901cf952f05c654394de76bf7
+      sha256: 890bbf815cff114ddbb618b9876d492fce07d02956c1d7b3d46cb7f835f563f6
+    optional: false
+    category: main
+  - name: sphinxcontrib-serializinghtml
+    version: 1.1.5
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2"
+    hash:
+      md5: 9ff55a0901cf952f05c654394de76bf7
+      sha256: 890bbf815cff114ddbb618b9876d492fce07d02956c1d7b3d46cb7f835f563f6
+    optional: false
+    category: main
+  - name: sphinxcontrib-serializinghtml
+    version: 1.1.5
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2"
+    hash:
+      md5: 9ff55a0901cf952f05c654394de76bf7
+      sha256: 890bbf815cff114ddbb618b9876d492fce07d02956c1d7b3d46cb7f835f563f6
+    optional: false
+    category: main
+  - name: sphinxcontrib-serializinghtml
+    version: 1.1.5
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2"
+    hash:
+      md5: 9ff55a0901cf952f05c654394de76bf7
+      sha256: 890bbf815cff114ddbb618b9876d492fce07d02956c1d7b3d46cb7f835f563f6
+    optional: false
+    category: main
+  - name: sphinxcontrib-serializinghtml
+    version: 1.1.5
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sphinxcontrib-serializinghtml-1.1.5-pyhd8ed1ab_2.tar.bz2"
+    hash:
+      md5: 9ff55a0901cf952f05c654394de76bf7
+      sha256: 890bbf815cff114ddbb618b9876d492fce07d02956c1d7b3d46cb7f835f563f6
+    optional: false
+    category: main
+  - name: stack_data
+    version: 0.6.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      asttokens: "*"
+      executing: "*"
+      pure_eval: "*"
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda"
+    hash:
+      md5: e7df0fdd404616638df5ece6e69ba7af
+      sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+    optional: false
+    category: main
+  - name: stack_data
+    version: 0.6.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      asttokens: "*"
+      executing: "*"
+      pure_eval: "*"
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda"
+    hash:
+      md5: e7df0fdd404616638df5ece6e69ba7af
+      sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+    optional: false
+    category: main
+  - name: stack_data
+    version: 0.6.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      asttokens: "*"
+      executing: "*"
+      pure_eval: "*"
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda"
+    hash:
+      md5: e7df0fdd404616638df5ece6e69ba7af
+      sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+    optional: false
+    category: main
+  - name: stack_data
+    version: 0.6.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      asttokens: "*"
+      executing: "*"
+      pure_eval: "*"
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda"
+    hash:
+      md5: e7df0fdd404616638df5ece6e69ba7af
+      sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+    optional: false
+    category: main
+  - name: stack_data
+    version: 0.6.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      asttokens: "*"
+      executing: "*"
+      pure_eval: "*"
+      python: ">=3.5"
+    url: "https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda"
+    hash:
+      md5: e7df0fdd404616638df5ece6e69ba7af
+      sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
+    optional: false
+    category: main
+  - name: sysroot_linux-64
+    version: "2.12"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      kernel-headers_linux-64: "==2.6.32 he073ed8_15"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_15.tar.bz2"
+    hash:
+      md5: 66c192522eacf5bb763568b4e415d133
+      sha256: 8498c73b60a7ea6faedf36204ec5a339c78d430fa838860f2b9d5d3a1c354eff
+    optional: false
+    category: main
+  - name: sysroot_linux-aarch64
+    version: "2.17"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      kernel-headers_linux-aarch64: "==4.18.0 h5b4a56d_13"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h43d7e78_13.tar.bz2"
+    hash:
+      md5: 6d8f1fd1e675ba478041892112887949
+      sha256: 932f7f8947c206ad4707a18c3bebbe217efdef67fd2cf9e0e94f5ccf0edeee38
+    optional: false
+    category: main
+  - name: sysroot_linux-ppc64le
+    version: "2.17"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      kernel-headers_linux-ppc64le: "==3.10.0 h23d7e6c_13"
+    url: "https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-ppc64le-2.17-h395ec9b_13.tar.bz2"
+    hash:
+      md5: c8016c77c47a363566a72ff10a0233e0
+      sha256: 50b9204fe2d6b90a6e4092d4e5f60ed24561f7914bf2296f46dbd620631efcaa
+    optional: false
+    category: main
+  - name: tapi
+    version: 1100.0.11
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=10.0.0.a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2"
+    hash:
+      md5: f9ff42ccf809a21ba6f8607f8de36108
+      sha256: 34b18ce8d1518b67e333ca1d3af733c3976ecbdf3a36b727f9b4dedddcc588fa
+    optional: false
+    category: main
+  - name: tapi
+    version: 1100.0.11
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libcxx: ">=11.0.0.a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2"
+    hash:
+      md5: d83362e7d0513f35f454bc50b0ca591d
+      sha256: 1709265fbee693a9e8b4126b0a3e68a6c4718b05821c659279c1af051f2d40f3
+    optional: false
+    category: main
+  - name: tk
+    version: 8.6.12
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+      libzlib: ">=1.2.11,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.12-h27826a3_0.tar.bz2"
+    hash:
+      md5: 5b8c42eb62e9fc961af70bdd6a26e168
+      sha256: 032fd769aad9d4cad40ba261ab222675acb7ec951a8832455fce18ef33fa8df0
+    optional: false
+    category: main
+  - name: tk
+    version: 8.6.12
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+      libzlib: ">=1.2.11,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.12-hd8af866_0.tar.bz2"
+    hash:
+      md5: 7894e82ff743bd96c76585ddebe28e2a
+      sha256: d659316c9e502fb0e1b9a284fb0f0c00e273bff787e9385ab14be9af13dcd0d2
+    optional: false
+    category: main
+  - name: tk
+    version: 8.6.12
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+      libzlib: ">=1.2.11,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/tk-8.6.12-h41c6715_0.tar.bz2"
+    hash:
+      md5: c0490995dc12b45388a01094f9959edd
+      sha256: 61ef67fe390109aa3423d30b96faddb97b054dfbcc0e6c8a3192331b13d14d92
+    optional: false
+    category: main
+  - name: tk
+    version: 8.6.12
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libzlib: ">=1.2.11,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.12-h5dbffcc_0.tar.bz2"
+    hash:
+      md5: 8e9480d9c47061db2ed1b4ecce519a7f
+      sha256: 331aa1137a264fd9cc905f04f09a161c801fe504b93da08b4e6697bd7c9ae6a6
+    optional: false
+    category: main
+  - name: tk
+    version: 8.6.12
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libzlib: ">=1.2.11,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.12-he1e0b03_0.tar.bz2"
+    hash:
+      md5: 2cb3d18eac154109107f093860bd545f
+      sha256: 9e43ec80045892e28233e4ca4d974e09d5837392127702fb952f3935b5e985a4
+    optional: false
+    category: main
+  - name: toml
+    version: 0.10.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: f832c45a477c78bebd107098db465095
+      sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
+    optional: false
+    category: main
+  - name: toml
+    version: 0.10.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: f832c45a477c78bebd107098db465095
+      sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
+    optional: false
+    category: main
+  - name: toml
+    version: 0.10.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: f832c45a477c78bebd107098db465095
+      sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
+    optional: false
+    category: main
+  - name: toml
+    version: 0.10.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: f832c45a477c78bebd107098db465095
+      sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
+    optional: false
+    category: main
+  - name: toml
+    version: 0.10.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=2.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: f832c45a477c78bebd107098db465095
+      sha256: f0f3d697349d6580e4c2f35ba9ce05c65dc34f9f049e85e45da03800b46139c1
+    optional: false
+    category: main
+  - name: tomli
+    version: 2.0.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 5844808ffab9ebdb694585b50ba02a96
+      sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+    optional: false
+    category: main
+  - name: tomli
+    version: 2.0.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 5844808ffab9ebdb694585b50ba02a96
+      sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+    optional: false
+    category: main
+  - name: tomli
+    version: 2.0.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 5844808ffab9ebdb694585b50ba02a96
+      sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+    optional: false
+    category: main
+  - name: tomli
+    version: 2.0.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 5844808ffab9ebdb694585b50ba02a96
+      sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+    optional: false
+    category: main
+  - name: tomli
+    version: 2.0.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: 5844808ffab9ebdb694585b50ba02a96
+      sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
+    optional: false
+    category: main
+  - name: tornado
+    version: "6.2"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/tornado-6.2-py39hb9d737c_1.tar.bz2"
+    hash:
+      md5: 8a7d309b08cff6386fe384aa10dd3748
+      sha256: 67c3eef0531caf75a81945844288f363cd3b7b029829bd91ed0994bf6b231f34
+    optional: false
+    category: main
+  - name: tornado
+    version: "6.2"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/tornado-6.2-py39hb9a1dbb_1.tar.bz2"
+    hash:
+      md5: f5f4671e5e76b582263699cb4ab3172c
+      sha256: 432a7832582bdba4cadda30d82a1115d31de069e236573943f2c429b2b20c46f
+    optional: false
+    category: main
+  - name: tornado
+    version: "6.2"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/tornado-6.2-py39h9ca6cee_1.tar.bz2"
+    hash:
+      md5: de4ea4c74f01f9b64e7c7888f7d5c506
+      sha256: f4a3e920896c10dbe6247d0b0536acac4141ce28b6e8a1076c21b8563dd072c5
+    optional: false
+    category: main
+  - name: tornado
+    version: "6.2"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/tornado-6.2-py39ha30fb19_1.tar.bz2"
+    hash:
+      md5: 07917d8456ca9aa09acf950019bf53b2
+      sha256: 1536759eb5feb9fdf9e7974e9fce18a709f0e110a75caff72dd9d83c7192cd86
+    optional: false
+    category: main
+  - name: tornado
+    version: "6.2"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.2-py39h02fc5c5_1.tar.bz2"
+    hash:
+      md5: 54bb01d39f399f9e846530f824db4b03
+      sha256: a09467527b27668ac2e474750d499d298053e4a0a8e87b8333359494e9d36877
+    optional: false
+    category: main
+  - name: traitlets
+    version: 5.9.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: d0b4f5c87cd35ac3fb3d47b223263a64
+      sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
+    optional: false
+    category: main
+  - name: traitlets
+    version: 5.9.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: d0b4f5c87cd35ac3fb3d47b223263a64
+      sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
+    optional: false
+    category: main
+  - name: traitlets
+    version: 5.9.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: d0b4f5c87cd35ac3fb3d47b223263a64
+      sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
+    optional: false
+    category: main
+  - name: traitlets
+    version: 5.9.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: d0b4f5c87cd35ac3fb3d47b223263a64
+      sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
+    optional: false
+    category: main
+  - name: traitlets
+    version: 5.9.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: d0b4f5c87cd35ac3fb3d47b223263a64
+      sha256: 343610bce6dbe8a5090500dd2e9d1706057960b3f3120ebfe0abb4a8ecbada4d
+    optional: false
+    category: main
+  - name: typing-extensions
+    version: 4.4.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      typing_extensions: "==4.4.0 pyha770c72_0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.4.0-hd8ed1ab_0.tar.bz2"
+    hash:
+      md5: be969210b61b897775a0de63cd9e9026
+      sha256: 6f129b1bc18d111dcf3abaec6fcf6cbee00f1b77bb42d0f0bc8d85f8faa65cf0
+    optional: false
+    category: main
+  - name: typing-extensions
+    version: 4.4.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      typing_extensions: "==4.4.0 pyha770c72_0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.4.0-hd8ed1ab_0.tar.bz2"
+    hash:
+      md5: be969210b61b897775a0de63cd9e9026
+      sha256: 6f129b1bc18d111dcf3abaec6fcf6cbee00f1b77bb42d0f0bc8d85f8faa65cf0
+    optional: false
+    category: main
+  - name: typing-extensions
+    version: 4.4.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      typing_extensions: "==4.4.0 pyha770c72_0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.4.0-hd8ed1ab_0.tar.bz2"
+    hash:
+      md5: be969210b61b897775a0de63cd9e9026
+      sha256: 6f129b1bc18d111dcf3abaec6fcf6cbee00f1b77bb42d0f0bc8d85f8faa65cf0
+    optional: false
+    category: main
+  - name: typing-extensions
+    version: 4.4.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      typing_extensions: "==4.4.0 pyha770c72_0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.4.0-hd8ed1ab_0.tar.bz2"
+    hash:
+      md5: be969210b61b897775a0de63cd9e9026
+      sha256: 6f129b1bc18d111dcf3abaec6fcf6cbee00f1b77bb42d0f0bc8d85f8faa65cf0
+    optional: false
+    category: main
+  - name: typing-extensions
+    version: 4.4.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      typing_extensions: "==4.4.0 pyha770c72_0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.4.0-hd8ed1ab_0.tar.bz2"
+    hash:
+      md5: be969210b61b897775a0de63cd9e9026
+      sha256: 6f129b1bc18d111dcf3abaec6fcf6cbee00f1b77bb42d0f0bc8d85f8faa65cf0
+    optional: false
+    category: main
+  - name: typing_extensions
+    version: 4.4.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.4.0-pyha770c72_0.tar.bz2"
+    hash:
+      md5: 2d93b130d148d7fc77e583677792fc6a
+      sha256: 70c57b5ac94cd32e78f1a2fa2c38572bfac85b901a6a99aa254a9e8e126c132d
+    optional: false
+    category: main
+  - name: typing_extensions
+    version: 4.4.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.4.0-pyha770c72_0.tar.bz2"
+    hash:
+      md5: 2d93b130d148d7fc77e583677792fc6a
+      sha256: 70c57b5ac94cd32e78f1a2fa2c38572bfac85b901a6a99aa254a9e8e126c132d
+    optional: false
+    category: main
+  - name: typing_extensions
+    version: 4.4.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.4.0-pyha770c72_0.tar.bz2"
+    hash:
+      md5: 2d93b130d148d7fc77e583677792fc6a
+      sha256: 70c57b5ac94cd32e78f1a2fa2c38572bfac85b901a6a99aa254a9e8e126c132d
+    optional: false
+    category: main
+  - name: typing_extensions
+    version: 4.4.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.4.0-pyha770c72_0.tar.bz2"
+    hash:
+      md5: 2d93b130d148d7fc77e583677792fc6a
+      sha256: 70c57b5ac94cd32e78f1a2fa2c38572bfac85b901a6a99aa254a9e8e126c132d
+    optional: false
+    category: main
+  - name: typing_extensions
+    version: 4.4.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.4.0-pyha770c72_0.tar.bz2"
+    hash:
+      md5: 2d93b130d148d7fc77e583677792fc6a
+      sha256: 70c57b5ac94cd32e78f1a2fa2c38572bfac85b901a6a99aa254a9e8e126c132d
+    optional: false
+    category: main
+  - name: tzdata
+    version: 2022g
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
+    hash:
+      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
+      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
+    optional: false
+    category: main
+  - name: tzdata
+    version: 2022g
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
+    hash:
+      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
+      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
+    optional: false
+    category: main
+  - name: tzdata
+    version: 2022g
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
+    hash:
+      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
+      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
+    optional: false
+    category: main
+  - name: tzdata
+    version: 2022g
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
+    hash:
+      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
+      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
+    optional: false
+    category: main
+  - name: tzdata
+    version: 2022g
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
+    hash:
+      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
+      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
+    optional: false
+    category: main
+  - name: unicodedata2
+    version: 15.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-15.0.0-py39hb9d737c_0.tar.bz2"
+    hash:
+      md5: 230d65004135bf312504a1bbcb0c7a08
+      sha256: 03c2cf05d1f4f2b01fc1e3ced22d5f331f2f233e335c4a4cd11a31fea1fccc0c
+    optional: false
+    category: main
+  - name: unicodedata2
+    version: 15.0.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-15.0.0-py39h0fd3b05_0.tar.bz2"
+    hash:
+      md5: 835f1a9631e600e0176593e95e85f73f
+      sha256: 06d0dd905a8b4555b729d8c5568a8339a385476890d3b3fc2134ec08d0cfc484
+    optional: false
+    category: main
+  - name: unicodedata2
+    version: 15.0.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/unicodedata2-15.0.0-py39h98ec90c_0.tar.bz2"
+    hash:
+      md5: da1d94fc94f0136d8c23c64e6c66c9fb
+      sha256: 06b11396a68fc4d93105e4335da1b28b7465a53561a20c309dcecf1ad5795bcd
+    optional: false
+    category: main
+  - name: unicodedata2
+    version: 15.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.9,<3.10.0a0"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-64/unicodedata2-15.0.0-py39ha30fb19_0.tar.bz2"
+    hash:
+      md5: 17876b4aebf783fb7bba980a79516892
+      sha256: 06ff21e0a28f5acee3719fd8c788c4dffbed408f463c933f7f892399039962fc
+    optional: false
+    category: main
+  - name: unicodedata2
+    version: 15.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.9,<3.10.0a0 *_cpython"
+      python_abi: 3.9.* *_cp39
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-15.0.0-py39h02fc5c5_0.tar.bz2"
+    hash:
+      md5: 1371c4d91f9c3edf170200a1374cb3e8
+      sha256: 3c0454fd960aca8f465db69beb281bbd8b4174e3df48871b625d43b037aea671
+    optional: false
+    category: main
+  - name: urllib3
+    version: 1.26.14
+    manager: conda
+    platform: linux-64
+    dependencies:
+      brotlipy: ">=0.6.0"
+      certifi: "*"
+      cryptography: ">=1.3.4"
+      idna: ">=2.0.0"
+      pyopenssl: ">=0.14"
+      pysocks: ">=1.5.6,<2.0,!=1.5.7"
+      python: "<4.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.14-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 01f33ad2e0aaf6b5ba4add50dad5ad29
+      sha256: f2f09c44e47946ce631dbc9a8a79bb463ac0f4122aaafdbcc51f200a1e420ca6
+    optional: false
+    category: main
+  - name: urllib3
+    version: 1.26.14
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      brotlipy: ">=0.6.0"
+      certifi: "*"
+      cryptography: ">=1.3.4"
+      idna: ">=2.0.0"
+      pyopenssl: ">=0.14"
+      pysocks: ">=1.5.6,<2.0,!=1.5.7"
+      python: "<4.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.14-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 01f33ad2e0aaf6b5ba4add50dad5ad29
+      sha256: f2f09c44e47946ce631dbc9a8a79bb463ac0f4122aaafdbcc51f200a1e420ca6
+    optional: false
+    category: main
+  - name: urllib3
+    version: 1.26.14
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      brotlipy: ">=0.6.0"
+      certifi: "*"
+      cryptography: ">=1.3.4"
+      idna: ">=2.0.0"
+      pyopenssl: ">=0.14"
+      pysocks: ">=1.5.6,<2.0,!=1.5.7"
+      python: "<4.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.14-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 01f33ad2e0aaf6b5ba4add50dad5ad29
+      sha256: f2f09c44e47946ce631dbc9a8a79bb463ac0f4122aaafdbcc51f200a1e420ca6
+    optional: false
+    category: main
+  - name: urllib3
+    version: 1.26.14
+    manager: conda
+    platform: osx-64
+    dependencies:
+      brotlipy: ">=0.6.0"
+      certifi: "*"
+      cryptography: ">=1.3.4"
+      idna: ">=2.0.0"
+      pyopenssl: ">=0.14"
+      pysocks: ">=1.5.6,<2.0,!=1.5.7"
+      python: "<4.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.14-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 01f33ad2e0aaf6b5ba4add50dad5ad29
+      sha256: f2f09c44e47946ce631dbc9a8a79bb463ac0f4122aaafdbcc51f200a1e420ca6
+    optional: false
+    category: main
+  - name: urllib3
+    version: 1.26.14
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      brotlipy: ">=0.6.0"
+      certifi: "*"
+      cryptography: ">=1.3.4"
+      idna: ">=2.0.0"
+      pyopenssl: ">=0.14"
+      pysocks: ">=1.5.6,<2.0,!=1.5.7"
+      python: "<4.0"
+    url: "https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.14-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 01f33ad2e0aaf6b5ba4add50dad5ad29
+      sha256: f2f09c44e47946ce631dbc9a8a79bb463ac0f4122aaafdbcc51f200a1e420ca6
+    optional: false
+    category: main
+  - name: wcwidth
+    version: 0.2.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      backports.functools_lru_cache: "*"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 078979d33523cb477bd1916ce41aacc9
+      sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
+    optional: false
+    category: main
+  - name: wcwidth
+    version: 0.2.6
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      backports.functools_lru_cache: "*"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 078979d33523cb477bd1916ce41aacc9
+      sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
+    optional: false
+    category: main
+  - name: wcwidth
+    version: 0.2.6
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      backports.functools_lru_cache: "*"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 078979d33523cb477bd1916ce41aacc9
+      sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
+    optional: false
+    category: main
+  - name: wcwidth
+    version: 0.2.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      backports.functools_lru_cache: "*"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 078979d33523cb477bd1916ce41aacc9
+      sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
+    optional: false
+    category: main
+  - name: wcwidth
+    version: 0.2.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      backports.functools_lru_cache: "*"
+      python: ">=3.6"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 078979d33523cb477bd1916ce41aacc9
+      sha256: c1bd0ad7d854cae56977b7915ac2b78b652fa5f7ec1e9fc21e7fdb30cf4519b1
+    optional: false
+    category: main
+  - name: wheel
+    version: 0.38.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c829cfb8cb826acb9de0ac1a2df0a940
+      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+    optional: false
+    category: main
+  - name: wheel
+    version: 0.38.4
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c829cfb8cb826acb9de0ac1a2df0a940
+      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+    optional: false
+    category: main
+  - name: wheel
+    version: 0.38.4
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c829cfb8cb826acb9de0ac1a2df0a940
+      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+    optional: false
+    category: main
+  - name: wheel
+    version: 0.38.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c829cfb8cb826acb9de0ac1a2df0a940
+      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+    optional: false
+    category: main
+  - name: wheel
+    version: 0.38.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c829cfb8cb826acb9de0ac1a2df0a940
+      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+    optional: false
+    category: main
+  - name: xcb-util
+    version: 0.4.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libxcb: ">=1.13,<1.14.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-h166bdaf_0.tar.bz2"
+    hash:
+      md5: 384e7fcb3cd162ba3e4aed4b687df566
+      sha256: 292dee40f8390aea0e6a0abbf2f255f179c777326831ed9e1ad7db53665c8562
+    optional: false
+    category: main
+  - name: xcb-util-image
+    version: 0.4.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libxcb: ">=1.13,<1.14.0a0"
+      xcb-util: ">=0.4.0,<0.5.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h166bdaf_0.tar.bz2"
+    hash:
+      md5: c9b568bd804cb2903c6be6f5f68182e4
+      sha256: 6db358d4afa0eb1225e24871f6c64c1b6c433f203babdd43508b0d61252467d1
+    optional: false
+    category: main
+  - name: xcb-util-keysyms
+    version: 0.4.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libxcb: ">=1.13,<1.14.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h166bdaf_0.tar.bz2"
+    hash:
+      md5: 637054603bb7594302e3bf83f0a99879
+      sha256: 6a2c0f38b360a2fda57b2349d2cbeeb7583576a4914a3e4ce17977601ac87613
+    optional: false
+    category: main
+  - name: xcb-util-renderutil
+    version: 0.3.9
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libxcb: ">=1.13,<1.14.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-h166bdaf_0.tar.bz2"
+    hash:
+      md5: 732e22f1741bccea861f5668cf7342a7
+      sha256: 19d27b7af8fb8047e044de2b87244337343c51fe7caa0fbaa9c53c2215787188
+    optional: false
+    category: main
+  - name: xcb-util-wm
+    version: 0.4.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libxcb: ">=1.13,<1.14.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h166bdaf_0.tar.bz2"
+    hash:
+      md5: 0a8e20a8aef954390b9481a527421a8c
+      sha256: a76af35297f233982b58de1f55f1900d8a8ae44018a55d2a94f3084ab97d6c80
+    optional: false
+    category: main
+  - name: xorg-kbproto
+    version: 1.0.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2"
+    hash:
+      md5: 4b230e8381279d76131116660f5a241a
+      sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
+    optional: false
+    category: main
+  - name: xorg-libice
+    version: 1.0.10
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.0.10-h7f98852_0.tar.bz2"
+    hash:
+      md5: d6b0b50b49eccfe0be0373be628be0f3
+      sha256: f15ce1dff16823888bcc2be1738aadcb36699be1e2dd2afa347794c7ec6c1587
+    optional: false
+    category: main
+  - name: xorg-libsm
+    version: 1.2.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+      libuuid: ">=2.32.1,<3.0a0"
+      xorg-libice: 1.0.*
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.3-hd9c2040_1000.tar.bz2"
+    hash:
+      md5: 9e856f78d5c80d5a78f61e72d1d473a3
+      sha256: bdb350539521ddc1f30cc721b6604eced8ef72a0ec146e378bfe89e2be17ab35
+    optional: false
+    category: main
+  - name: xorg-libx11
+    version: 1.7.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+      libxcb: 1.*
+      xorg-kbproto: "*"
+      xorg-xproto: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.7.2-h7f98852_0.tar.bz2"
+    hash:
+      md5: 12a61e640b8894504326aadafccbb790
+      sha256: ec4641131e3afcb4b34614a5fa298efb34f54c2b2960bf9a73a8d202140d47c4
+    optional: false
+    category: main
+  - name: xorg-libxau
+    version: 1.0.9
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.9-h7f98852_0.tar.bz2"
+    hash:
+      md5: bf6f803a544f26ebbdc3bfff272eb179
+      sha256: 9e9b70c24527289ac7ae31925d1eb3b0c1e9a78cb7b8f58a3110cc8bbfe51c26
+    optional: false
+    category: main
+  - name: xorg-libxau
+    version: 1.0.9
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.9-h3557bc0_0.tar.bz2"
+    hash:
+      md5: e0c187f5ce240897762bbb89a8a407cc
+      sha256: 898553ead60af45e3b8b2a7be1b21b0df8ce3c20d5772490c05188cce5ec8b55
+    optional: false
+    category: main
+  - name: xorg-libxau
+    version: 1.0.9
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/xorg-libxau-1.0.9-h4e0d66e_0.tar.bz2"
+    hash:
+      md5: 772615b637baddf37b1012ee28fbc70c
+      sha256: 6e83c6d5d74b20e759766cf34216a21d34d0efbd250fb8d865fbcbd51835c083
+    optional: false
+    category: main
+  - name: xorg-libxau
+    version: 1.0.9
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.9-h35c211d_0.tar.bz2"
+    hash:
+      md5: c5049997b2e98edfbcdd294582f66281
+      sha256: 6dcdbfcdb87c21cb615cd1a0a7fab7e657a443c771e80c771524f7d9b8443304
+    optional: false
+    category: main
+  - name: xorg-libxau
+    version: 1.0.9
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.9-h27ca646_0.tar.bz2"
+    hash:
+      md5: e2fa1f5a28cf0ce02516baf910be132e
+      sha256: a5810ad0fae16b72ee7cbb22e009c926dd1cd95d82885896e7f20fe911f7195f
+    optional: false
+    category: main
+  - name: xorg-libxdmcp
+    version: 1.1.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2"
+    hash:
+      md5: be93aabceefa2fac576e971aef407908
+      sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
+    optional: false
+    category: main
+  - name: xorg-libxdmcp
+    version: 1.1.3
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h3557bc0_0.tar.bz2"
+    hash:
+      md5: a6c9016ae1ca5c47a3603ed4cd65fedd
+      sha256: 2aad9a0b57796170b8fb40317598fd79cfc7ae27fa7fb68c417d815e44499d59
+    optional: false
+    category: main
+  - name: xorg-libxdmcp
+    version: 1.1.3
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/xorg-libxdmcp-1.1.3-h4e0d66e_0.tar.bz2"
+    hash:
+      md5: 95ac359ec2aea12a08fcbeb86bb48df6
+      sha256: 78d953c40eb0b68fa9db8aa059e1f5c899a1ba9b6ca34142400a0dd471d7088a
+    optional: false
+    category: main
+  - name: xorg-libxdmcp
+    version: 1.1.3
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2"
+    hash:
+      md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
+      sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
+    optional: false
+    category: main
+  - name: xorg-libxdmcp
+    version: 1.1.3
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2"
+    hash:
+      md5: 6738b13f7fadc18725965abdd4129c36
+      sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
+    optional: false
+    category: main
+  - name: xorg-libxext
+    version: 1.3.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+      xorg-libx11: ">=1.7.0,<2.0a0"
+      xorg-xextproto: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h7f98852_1.tar.bz2"
+    hash:
+      md5: 536cc5db4d0a3ba0630541aec064b5e4
+      sha256: cf47ccbf49d46189d7bdadeac1387c826be82deb92ce6badbb03baae4b67ed26
+    optional: false
+    category: main
+  - name: xorg-libxrender
+    version: 0.9.10
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+      xorg-libx11: ">=1.7.0,<2.0a0"
+      xorg-renderproto: "*"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.10-h7f98852_1003.tar.bz2"
+    hash:
+      md5: f59c1242cc1dd93e72c2ee2b360979eb
+      sha256: 7d907ed9e2ec5af5d7498fb3ab744accc298914ae31497ab6dcc6ef8bd134d00
+    optional: false
+    category: main
+  - name: xorg-renderproto
+    version: 0.11.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2"
+    hash:
+      md5: 06feff3d2634e3097ce2fe681474b534
+      sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
+    optional: false
+    category: main
+  - name: xorg-xextproto
+    version: 7.3.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h7f98852_1002.tar.bz2"
+    hash:
+      md5: 1e15f6ad85a7d743a2ac68dae6c82b98
+      sha256: d45c4d1c8372c546711eb3863c76d899d03a67c3edb3b5c2c46c9492814cbe03
+    optional: false
+    category: main
+  - name: xorg-xproto
+    version: 7.0.31
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2"
+    hash:
+      md5: b4a4381d54784606820704f7b5f05a15
+      sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
+    optional: false
+    category: main
+  - name: xz
+    version: 5.2.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2"
+    hash:
+      md5: 2161070d867d1b1204ea749c8eec4ef0
+      sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+    optional: false
+    category: main
+  - name: xz
+    version: 5.2.6
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2"
+    hash:
+      md5: 83baad393a31d59c20b63ba4da6592df
+      sha256: 93f58a7b393adf41fa007ac8c55978765e957e90cd31877ece1e5a343cb98220
+    optional: false
+    category: main
+  - name: xz
+    version: 5.2.6
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/xz-5.2.6-hb283c62_0.tar.bz2"
+    hash:
+      md5: a411645e44054e333573ee5280fdb89b
+      sha256: d03eb2b53dc61ac97c88b3ca023cf19c2b83b97520725b3c2ec0bff2c47f4a98
+    optional: false
+    category: main
+  - name: xz
+    version: 5.2.6
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2"
+    hash:
+      md5: a72f9d4ea13d55d745ff1ed594747f10
+      sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+    optional: false
+    category: main
+  - name: xz
+    version: 5.2.6
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2"
+    hash:
+      md5: 39c6b54e94014701dd157f4f576ed211
+      sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+    optional: false
+    category: main
+  - name: zipp
+    version: 3.13.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/zipp-3.13.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 41b09d997939e83b231c4557a90c3b13
+      sha256: 0a9a545b8dc46c847658ebfa636257ea5993a355419c1d3b2f14810730ee0a82
+    optional: false
+    category: main
+  - name: zipp
+    version: 3.13.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/zipp-3.13.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 41b09d997939e83b231c4557a90c3b13
+      sha256: 0a9a545b8dc46c847658ebfa636257ea5993a355419c1d3b2f14810730ee0a82
+    optional: false
+    category: main
+  - name: zipp
+    version: 3.13.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/zipp-3.13.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 41b09d997939e83b231c4557a90c3b13
+      sha256: 0a9a545b8dc46c847658ebfa636257ea5993a355419c1d3b2f14810730ee0a82
+    optional: false
+    category: main
+  - name: zipp
+    version: 3.13.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/zipp-3.13.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 41b09d997939e83b231c4557a90c3b13
+      sha256: 0a9a545b8dc46c847658ebfa636257ea5993a355419c1d3b2f14810730ee0a82
+    optional: false
+    category: main
+  - name: zipp
+    version: 3.13.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/zipp-3.13.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 41b09d997939e83b231c4557a90c3b13
+      sha256: 0a9a545b8dc46c847658ebfa636257ea5993a355419c1d3b2f14810730ee0a82
+    optional: false
+    category: main
+  - name: zlib
+    version: 1.2.13
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libzlib: "==1.2.13 h166bdaf_4"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-h166bdaf_4.tar.bz2"
+    hash:
+      md5: 4b11e365c0275b808be78b30f904e295
+      sha256: 282ce274ebe6da1fbd52efbb61bd5a93dec0365b14d64566e6819d1691b75300
+    optional: false
+    category: main
+  - name: zlib
+    version: 1.2.13
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libzlib: "==1.2.13 hfd90126_4"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-hfd90126_4.tar.bz2"
+    hash:
+      md5: be90e6223c74ea253080abae19b3bdb1
+      sha256: 9db69bb5fc3e19093b550e25d1158cdf82f4f8eddc1f80f8d7d9de33eb8535a4
+    optional: false
+    category: main
+  - name: zlib
+    version: 1.2.13
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libzlib: "==1.2.13 h03a7124_4"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h03a7124_4.tar.bz2"
+    hash:
+      md5: 34161cff4e29cc45e536abf2f13fd6b4
+      sha256: 48844c5c911e2ef69571d6ef7181dcfae68df296c546662cb54057baed008949
+    optional: false
+    category: main
+  - name: zstd
+    version: 1.5.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.2-h3eb15da_6.conda"
+    hash:
+      md5: 6b63daed8feeca47be78f323e793d555
+      sha256: fbe49a8c8df83c2eccb37c5863ad98baeb29796ec96f2c503783d7b89bf80c98
+    optional: false
+    category: main
+  - name: zstd
+    version: 1.5.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.2-h44f6412_6.conda"
+    hash:
+      md5: 6d0d1cd6d184129eabb96bb220afb5b2
+      sha256: d06afa18c6789d29f1d74990d0b2b68ada43665a419deb617d6440368bd951fc
+    optional: false
+    category: main
+  - name: zstd
+    version: 1.5.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libstdcxx-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/zstd-1.5.2-h7affb48_6.conda"
+    hash:
+      md5: ddc6eeb52a9d5e938f96d5dd246341ca
+      sha256: 7c927e9f2a67f0e546094ebee302acb0b3acde7a511b6a13e44155ef28f5b622
+    optional: false
+    category: main
+  - name: zstd
+    version: 1.5.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libcxx: ">=14.0.6"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.2-hbc0c0cd_6.conda"
+    hash:
+      md5: 40a188783d3c425bdccc9ae9104acbb8
+      sha256: f845dafb0b488703ce81e25b6f27ed909ee9061b730c172e6b084fcf7156231f
+    optional: false
+    category: main
+  - name: zstd
     version: 1.5.2
     manager: conda
     platform: osx-arm64
     dependencies:
-      c-compiler: "==1.5.2 h5008568_0"
-      cxx-compiler: "==1.5.2 hffc8910_0"
-      fortran-compiler: "==1.5.2 h2ccabda_0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/compilers-1.5.2-hce30654_0.conda"
+      libcxx: ">=14.0.6"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.2-hf913c23_6.conda"
     hash:
-      md5: 4bf0aaf590a633d103a70841bb9f2f2e
-      sha256: 9a21d680350cf836160476852d18f2fdfb3c95ea9556d061dc08422907c02c1e
+      md5: 8f346953ef63bf5fb482488a659adcf3
+      sha256: 018989ba028e76abc332c246002e8f5975ff123c68f6116a30da8009b14ea88d
     optional: false
     category: main
 version: 1

--- a/crates/rattler_conda_types/src/conda_lock/snapshots/rattler_conda_types__conda_lock__test__read_conda_lock_python.snap
+++ b/crates/rattler_conda_types/src/conda_lock/snapshots/rattler_conda_types__conda_lock__test__read_conda_lock_python.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/conda_lock/mod.rs
+assertion_line: 539
 expression: conda_lock
 ---
 metadata:
@@ -38,49 +39,15 @@ package:
       sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
     optional: false
     category: main
-  - name: ca-certificates
-    version: 2022.12.7
+  - name: _libgcc_mutex
+    version: "0.1"
     manager: conda
-    platform: linux-64
+    platform: linux-ppc64le
     dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2022.12.7-ha878542_0.conda"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/_libgcc_mutex-0.1-conda_forge.tar.bz2"
     hash:
-      md5: ff9f73d45c4a07d6f424495288a26080
-      sha256: 8f6c81b0637771ae0ea73dc03a6d30bec3326ba3927f2a7b91931aa2d59b1789
-    optional: false
-    category: main
-  - name: ld_impl_linux-64
-    version: "2.40"
-    manager: conda
-    platform: linux-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda"
-    hash:
-      md5: 7aca3059a1729aa76c597603f10b0dd3
-      sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
-    optional: false
-    category: main
-  - name: tzdata
-    version: 2022g
-    manager: conda
-    platform: linux-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
-    hash:
-      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
-      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
-    optional: false
-    category: main
-  - name: libgomp
-    version: 12.2.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      _libgcc_mutex: "==0.1 conda_forge"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libgomp-12.2.0-h65d4601_19.tar.bz2"
-    hash:
-      md5: cedcee7c064c01c403f962c9e8d3c373
-      sha256: 81a76d20cfdee9fe0728b93ef057ba93494fd1450d42bc3717af4e468235661e
+      md5: e96f48755dc7c9f86c4aecf4cac40477
+      sha256: 5dd34b412e6274c0614d01a2f616844376ae873dfb8782c2c67d055779de6df6
     optional: false
     category: main
   - name: _openmp_mutex
@@ -96,17 +63,29 @@ package:
       sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
     optional: false
     category: main
-  - name: libgcc-ng
-    version: 12.2.0
+  - name: _openmp_mutex
+    version: "4.5"
     manager: conda
-    platform: linux-64
+    platform: linux-aarch64
+    dependencies:
+      libgomp: ">=7.5.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2"
+    hash:
+      md5: 6168d71addc746e8f2b8d57dfd2edcea
+      sha256: 3702bef2f0a4d38bd8288bbe54aace623602a1343c2cfbefd3fa188e015bebf0
+    optional: false
+    category: main
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: linux-ppc64le
     dependencies:
       _libgcc_mutex: "==0.1 conda_forge"
-      _openmp_mutex: ">=4.5"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-12.2.0-h65d4601_19.tar.bz2"
+      libgomp: ">=7.5.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/_openmp_mutex-4.5-2_gnu.tar.bz2"
     hash:
-      md5: e4c94f80aef025c17ab0828cd85ef535
-      sha256: f3899c26824cee023f1e360bd0859b0e149e2b3e8b1668bc6dd04bfc70dcd659
+      md5: 3e41cbaba7e4988d15a24c4e85e6171b
+      sha256: 4c89c2067cf5e7b0fbbdc3200c3f7affa5896e14812acf10f51575be87ae0c05
     optional: false
     category: main
   - name: bzip2
@@ -121,6 +100,164 @@ package:
       sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
     optional: false
     category: main
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-hf897c2e_4.tar.bz2"
+    hash:
+      md5: 2d787570a729e273a4e75775ddf3348a
+      sha256: 3aeb6ab92aa0351722497b2d2a735dc20921cf6c60d9196c04b7a2b9ece198d2
+    optional: false
+    category: main
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/bzip2-1.0.8-h4e0d66e_4.tar.bz2"
+    hash:
+      md5: 3cbc4e0eede8b25bc53b6a462815aceb
+      sha256: e0edf3c1804547239de9f678f9b650684d0f215e4c277e1d92c281f4d61559b8
+    optional: false
+    category: main
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2"
+    hash:
+      md5: 37edc4e6304ca87316e160f5ca0bd1b5
+      sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
+    optional: false
+    category: main
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2"
+    hash:
+      md5: fc76ace7b94fb1f694988ab1b14dd248
+      sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
+    optional: false
+    category: main
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: win-64
+    dependencies:
+      vc: ">=14.1,<15.0a0"
+      vs2015_runtime: ">=14.16.27012"
+    url: "https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2"
+    hash:
+      md5: 7c03c66026944073040cb19a4f3ec3c9
+      sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
+    optional: false
+    category: main
+  - name: ca-certificates
+    version: 2022.12.7
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2022.12.7-ha878542_0.conda"
+    hash:
+      md5: ff9f73d45c4a07d6f424495288a26080
+      sha256: 8f6c81b0637771ae0ea73dc03a6d30bec3326ba3927f2a7b91931aa2d59b1789
+    optional: false
+    category: main
+  - name: ca-certificates
+    version: 2022.12.7
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2022.12.7-h4fd8a4c_0.conda"
+    hash:
+      md5: 2450fbcaf65634e0d071e47e2b8487b4
+      sha256: bb4e6340d55775738a5867a16071658c294d46cceff7f652f65d8dc6a495a578
+    optional: false
+    category: main
+  - name: ca-certificates
+    version: 2022.12.7
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ca-certificates-2022.12.7-h1084571_0.conda"
+    hash:
+      md5: e3becd49c6d0e94d1b67c9f9a4d50587
+      sha256: 82b77cb085c961b085fbbb5ea3920c1933bda08c2e1dd53685f6f21b16a336ac
+    optional: false
+    category: main
+  - name: ca-certificates
+    version: 2022.12.7
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2022.12.7-h033912b_0.conda"
+    hash:
+      md5: af2bdcd68f16ce030ca957cdeb83d88a
+      sha256: 898276d86de89fb034ecfae05103045d0a0d6a356ced1b6d1832cdbd07a8fc18
+    optional: false
+    category: main
+  - name: ca-certificates
+    version: 2022.12.7
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2022.12.7-h4653dfc_0.conda"
+    hash:
+      md5: 7dc111916edc905957b7417a247583b6
+      sha256: a9634dc719fc9cd4c91cf8ad3167532e59051cace3e90ef2ba305a41c316784a
+    optional: false
+    category: main
+  - name: ca-certificates
+    version: 2022.12.7
+    manager: conda
+    platform: win-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2022.12.7-h5b45459_0.conda"
+    hash:
+      md5: 31de4d9887dc8eaed9e6230a5dfbb9d6
+      sha256: 405f3634e055e2e6b0502b1999bc9b7e7bb6b549b229a9a371b19d660f0b14f0
+    optional: false
+    category: main
+  - name: ld_impl_linux-64
+    version: "2.40"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda"
+    hash:
+      md5: 7aca3059a1729aa76c597603f10b0dd3
+      sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
+    optional: false
+    category: main
+  - name: ld_impl_linux-aarch64
+    version: "2.40"
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h2d8c526_0.conda"
+    hash:
+      md5: 16246d69e945d0b1969a6099e7c5d457
+      sha256: 1ba06e8645094b340b4aee23603a6abb1b0383788180e65f3de34e655c5f577c
+    optional: false
+    category: main
+  - name: ld_impl_linux-ppc64le
+    version: "2.39"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ld_impl_linux-ppc64le-2.39-hea198f4_1.conda"
+    hash:
+      md5: c7db6cc5b9479df1ed884b6147601613
+      sha256: 20d6db1053ae4af65677fc4b4cf9b2d5884ce26ea6b38f7088a5ebad1de62746
+    optional: false
+    category: main
   - name: libffi
     version: 3.4.2
     manager: conda
@@ -131,6 +268,138 @@ package:
     hash:
       md5: d645c6d2ac96843a2bfaccd2d62b3ac3
       sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
+    optional: false
+    category: main
+  - name: libffi
+    version: 3.4.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2"
+    hash:
+      md5: dddd85f4d52121fab0a8b099c5e06501
+      sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
+    optional: false
+    category: main
+  - name: libffi
+    version: 3.4.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libffi-3.4.2-h4e0d66e_5.tar.bz2"
+    hash:
+      md5: 79c37a0a50ef77fea4ee5f6d257b8b3c
+      sha256: 178ca9f82e2144a8834dd01f9af3b4b9b5d482892675931edccff06aee524953
+    optional: false
+    category: main
+  - name: libffi
+    version: 3.4.2
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2"
+    hash:
+      md5: ccb34fb14960ad8b125962d3d79b31a9
+      sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
+    optional: false
+    category: main
+  - name: libffi
+    version: 3.4.2
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2"
+    hash:
+      md5: 086914b672be056eb70fd4285b6783b6
+      sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+    optional: false
+    category: main
+  - name: libffi
+    version: 3.4.2
+    manager: conda
+    platform: win-64
+    dependencies:
+      vc: ">=14.1,<15.0a0"
+      vs2015_runtime: ">=14.16.27012"
+    url: "https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2"
+    hash:
+      md5: 2c96d1b6915b408893f9472569dee135
+      sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
+    optional: false
+    category: main
+  - name: libgcc-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      _libgcc_mutex: "==0.1 conda_forge"
+      _openmp_mutex: ">=4.5"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-12.2.0-h65d4601_19.tar.bz2"
+    hash:
+      md5: e4c94f80aef025c17ab0828cd85ef535
+      sha256: f3899c26824cee023f1e360bd0859b0e149e2b3e8b1668bc6dd04bfc70dcd659
+    optional: false
+    category: main
+  - name: libgcc-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      _openmp_mutex: ">=4.5"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-12.2.0-h607ecd0_19.tar.bz2"
+    hash:
+      md5: 8456a29b6d9fc3123ccb9a966b6b2c49
+      sha256: 0dd30553f6f38b011c9c81471a50f85e98a79e4dd672fdc1fc97904b54b5419b
+    optional: false
+    category: main
+  - name: libgcc-ng
+    version: 12.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      _libgcc_mutex: "==0.1 conda_forge"
+      _openmp_mutex: ">=4.5"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-ng-12.2.0-hbc1322c_19.tar.bz2"
+    hash:
+      md5: 9ad34f95d6fb05300bbd0f553f3bece4
+      sha256: 335a2b7415cb5fbbf05459f6cfcca4dd8bafd43bcbe5bf6aa56bf66b7ed6bf42
+    optional: false
+    category: main
+  - name: libgomp
+    version: 12.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      _libgcc_mutex: "==0.1 conda_forge"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libgomp-12.2.0-h65d4601_19.tar.bz2"
+    hash:
+      md5: cedcee7c064c01c403f962c9e8d3c373
+      sha256: 81a76d20cfdee9fe0728b93ef057ba93494fd1450d42bc3717af4e468235661e
+    optional: false
+    category: main
+  - name: libgomp
+    version: 12.2.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-12.2.0-h607ecd0_19.tar.bz2"
+    hash:
+      md5: 65b9cb876525dcb2e74a90cf02c6762a
+      sha256: d802eaceaf6f77fb8cb2e990aacf9b3eaa83361b16369a760fc1585841d7885c
+    optional: false
+    category: main
+  - name: libgomp
+    version: 12.2.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      _libgcc_mutex: "==0.1 conda_forge"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgomp-12.2.0-hbc1322c_19.tar.bz2"
+    hash:
+      md5: 25647ac31b4d467fce690c6a561a58aa
+      sha256: 56a43985f648c358c6b3eb949863e393dbdb48d8f017315e03ff703031b8a951
     optional: false
     category: main
   - name: libnsl
@@ -145,65 +414,28 @@ package:
       sha256: 32f4fb94d99946b0dabfbbfd442b25852baf909637f2eed1ffe3baea15d02aad
     optional: false
     category: main
-  - name: libuuid
-    version: 2.32.1
+  - name: libnsl
+    version: 2.0.0
     manager: conda
-    platform: linux-64
+    platform: linux-aarch64
     dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.32.1-h7f98852_1000.tar.bz2"
+      libgcc-ng: ">=9.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.0-hf897c2e_0.tar.bz2"
     hash:
-      md5: 772d69f030955d9646d3d0eaf21d859d
-      sha256: 54f118845498353c936826f8da79b5377d23032bcac8c4a02de2019e26c3f6b3
+      md5: 36fdbc05c9d9145ece86f5a63c3f352e
+      sha256: 182dbc318b7ab3ab10bc5a9d3ca161b143ae8db6df8aa11b65140009e322e642
     optional: false
     category: main
-  - name: libzlib
-    version: 1.2.13
+  - name: libnsl
+    version: 2.0.0
     manager: conda
-    platform: linux-64
+    platform: linux-ppc64le
     dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h166bdaf_4.tar.bz2"
+      libgcc-ng: ">=9.4.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libnsl-2.0.0-h4e0d66e_0.tar.bz2"
     hash:
-      md5: f3f9de449d32ca9b9c66a22863c96f41
-      sha256: 22f3663bcf294d349327e60e464a51cd59664a71b8ed70c28a9f512d10bc77dd
-    optional: false
-    category: main
-  - name: ncurses
-    version: "6.3"
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.3-h27087fc_1.tar.bz2"
-    hash:
-      md5: 4acfc691e64342b9dae57cf2adc63238
-      sha256: b801e8cf4b2c9a30bce5616746c6c2a4e36427f045b46d9fc08a4ed40a9f7065
-    optional: false
-    category: main
-  - name: openssl
-    version: 3.0.8
-    manager: conda
-    platform: linux-64
-    dependencies:
-      ca-certificates: "*"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/openssl-3.0.8-h0b41bf4_0.conda"
-    hash:
-      md5: e043403cd18faf815bf7705ab6c1e092
-      sha256: cd981c5c18463bc7a164fcf45c5cf697d58852b780b4dfa5e83c18c1fda6d7cd
-    optional: false
-    category: main
-  - name: xz
-    version: 5.2.6
-    manager: conda
-    platform: linux-64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2"
-    hash:
-      md5: 2161070d867d1b1204ea749c8eec4ef0
-      sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+      md5: e6c718cb0e01f2af330da0a8dbd55b68
+      sha256: 2aa6cd044633586588c7105a3702788ee65b679801ab5d00b48d64265ae2f13c
     optional: false
     category: main
   - name: libsqlite
@@ -219,30 +451,396 @@ package:
       sha256: 6008a0b914bd1a3510a3dba38eada93aa0349ebca3a21e5fa276833c8205bf49
     optional: false
     category: main
-  - name: readline
-    version: 8.1.2
+  - name: libsqlite
+    version: 3.40.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.40.0-hf9034f9_0.tar.bz2"
+    hash:
+      md5: 9afb0d5dbaa403858a660cd0b4a31d29
+      sha256: 15e4a4bef065f73c2aae630c0408fd6108f5915d4640c7d97578f2e07b3f5d11
+    optional: false
+    category: main
+  - name: libsqlite
+    version: 3.39.4
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      libzlib: ">=1.2.12,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libsqlite-3.39.4-hcc10993_0.tar.bz2"
+    hash:
+      md5: 49799ec532f260e4264705336d01310b
+      sha256: 93cdea9743cf1f86fdf9e9516061d5c68b9b5c43b99b7db1dd81d5b3452c4759
+    optional: false
+    category: main
+  - name: libsqlite
+    version: 3.40.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.40.0-ha978bb4_0.tar.bz2"
+    hash:
+      md5: ceb13b6726534b96e3b4e3dda91e9050
+      sha256: ae19f866188cc0c514fed754468460ae9e8dd763ebbd7b7afc4e818d71844297
+    optional: false
+    category: main
+  - name: libsqlite
+    version: 3.40.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libzlib: ">=1.2.13,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.40.0-h76d750c_0.tar.bz2"
+    hash:
+      md5: d090fcec993f4ef0a90e6df7f231a273
+      sha256: 5e8992b2099bb4767996e1bed70945ba39f61399ab912ba2a2770d12c165acb5
+    optional: false
+    category: main
+  - name: libsqlite
+    version: 3.40.0
+    manager: conda
+    platform: win-64
+    dependencies:
+      ucrt: ">=10.0.20348.0"
+      vc: ">=14.2,<15"
+      vs2015_runtime: ">=14.29.30139"
+    url: "https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.40.0-hcfcfb64_0.tar.bz2"
+    hash:
+      md5: 5e5a97795de72f8cc3baf3d9ea6327a2
+      sha256: 4e50b3d90a351c9d47d239d3f90fce4870df2526e4f7fef35203ab3276a6dfc9
+    optional: false
+    category: main
+  - name: libuuid
+    version: 2.32.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.32.1-h7f98852_1000.tar.bz2"
+    hash:
+      md5: 772d69f030955d9646d3d0eaf21d859d
+      sha256: 54f118845498353c936826f8da79b5377d23032bcac8c4a02de2019e26c3f6b3
+    optional: false
+    category: main
+  - name: libuuid
+    version: 2.32.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.32.1-hf897c2e_1000.tar.bz2"
+    hash:
+      md5: e038da5ef9095b0d79aac14a311394e7
+      sha256: 8f7eead3723c32631b252aea336bb39fbbde433b8d0c5a75745f03eaa980447d
+    optional: false
+    category: main
+  - name: libuuid
+    version: 2.32.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=9.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libuuid-2.32.1-h4e0d66e_1000.tar.bz2"
+    hash:
+      md5: ceb7466afcb5be47530ffe9aae8650ae
+      sha256: 58b4f6e27b921ff9171e64b3e382cc644d7da70d5da4e3815b7ceae4b4b452e0
+    optional: false
+    category: main
+  - name: libzlib
+    version: 1.2.13
     manager: conda
     platform: linux-64
     dependencies:
       libgcc-ng: ">=12"
-      ncurses: ">=6.3,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/readline-8.1.2-h0f457ee_0.tar.bz2"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-h166bdaf_4.tar.bz2"
     hash:
-      md5: db2ebbe2943aae81ed051a6a9af8e0fa
-      sha256: f5f383193bdbe01c41cb0d6f99fec68e820875e842e6e8b392dbe1a9b6c43ed8
+      md5: f3f9de449d32ca9b9c66a22863c96f41
+      sha256: 22f3663bcf294d349327e60e464a51cd59664a71b8ed70c28a9f512d10bc77dd
     optional: false
     category: main
-  - name: tk
-    version: 8.6.12
+  - name: libzlib
+    version: 1.2.13
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h4e544f5_4.tar.bz2"
+    hash:
+      md5: 88596b6277fe6d39f046983aae6044db
+      sha256: 9803ac96dbdbc27df9c149e06d4436b778c468bd0e6e023fbcb49a6fe9c404b4
+    optional: false
+    category: main
+  - name: libzlib
+    version: 1.2.13
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libzlib-1.2.13-hb283c62_4.tar.bz2"
+    hash:
+      md5: af99cdd23d3761a569840663bdf0dc0d
+      sha256: 62073ba865b49db36dc14ffeaa2985711bce65d720b853e3aa4cce0a9e5439d8
+    optional: false
+    category: main
+  - name: libzlib
+    version: 1.2.13
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-hfd90126_4.tar.bz2"
+    hash:
+      md5: 35eb3fce8d51ed3c1fd4122bad48250b
+      sha256: 0d954350222cc12666a1f4852dbc9bcf4904d8e467d29505f2b04ded6518f890
+    optional: false
+    category: main
+  - name: libzlib
+    version: 1.2.13
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h03a7124_4.tar.bz2"
+    hash:
+      md5: 780852dc54c4c07e64b276a97f89c162
+      sha256: a1bf4a1c107838fea4570a7f1750306d65d84fcf2913d4e0d30b4db785e8f223
+    optional: false
+    category: main
+  - name: libzlib
+    version: 1.2.13
+    manager: conda
+    platform: win-64
+    dependencies:
+      ucrt: ">=10.0.20348.0"
+      vc: ">=14.2,<15"
+      vs2015_runtime: ">=14.29.30139"
+    url: "https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_4.tar.bz2"
+    hash:
+      md5: 0cc5c5cc64ee1637f37f8540a175854c
+      sha256: 184da12b4296088a47086f4e69e65eb5f8537a824ee3131d8076775e1d1ea767
+    optional: false
+    category: main
+  - name: ncurses
+    version: "6.3"
     manager: conda
     platform: linux-64
     dependencies:
-      libgcc-ng: ">=9.4.0"
-      libzlib: ">=1.2.11,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.12-h27826a3_0.tar.bz2"
+      libgcc-ng: ">=10.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.3-h27087fc_1.tar.bz2"
     hash:
-      md5: 5b8c42eb62e9fc961af70bdd6a26e168
-      sha256: 032fd769aad9d4cad40ba261ab222675acb7ec951a8832455fce18ef33fa8df0
+      md5: 4acfc691e64342b9dae57cf2adc63238
+      sha256: b801e8cf4b2c9a30bce5616746c6c2a4e36427f045b46d9fc08a4ed40a9f7065
+    optional: false
+    category: main
+  - name: ncurses
+    version: "6.3"
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=10.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.3-headf329_1.tar.bz2"
+    hash:
+      md5: 486b68148e121bc8bbadc3cefae4c04f
+      sha256: d410d840cb39175d7edc388690b93b2e3d7613c2e2f5c64b96582dc8b55b2319
+    optional: false
+    category: main
+  - name: ncurses
+    version: "6.3"
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=10.3.0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ncurses-6.3-hab78ccb_1.tar.bz2"
+    hash:
+      md5: 775403ae6d617d309d874f9bff20e670
+      sha256: 37761927f381de5741d7f176dddc1c3b60876f44db10f7d636ad1133381d1a94
+    optional: false
+    category: main
+  - name: ncurses
+    version: "6.3"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.3-h96cf925_1.tar.bz2"
+    hash:
+      md5: 76217ebfbb163ff2770a261f955a5861
+      sha256: 9794a23d03586c99cac49d4ae3d5337faaa6bfc256b31d2662ff4ad5972be143
+    optional: false
+    category: main
+  - name: ncurses
+    version: "6.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.3-h07bb92c_1.tar.bz2"
+    hash:
+      md5: db86e5a978380a13f5559f97afdfe99d
+      sha256: 50ba7c13dd7d05569e7caa98a13a3684450f8547b4965a1e86b54e2f1240debe
+    optional: false
+    category: main
+  - name: openssl
+    version: 3.0.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      ca-certificates: "*"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/openssl-3.0.8-h0b41bf4_0.conda"
+    hash:
+      md5: e043403cd18faf815bf7705ab6c1e092
+      sha256: cd981c5c18463bc7a164fcf45c5cf697d58852b780b4dfa5e83c18c1fda6d7cd
+    optional: false
+    category: main
+  - name: openssl
+    version: 3.0.8
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      ca-certificates: "*"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.0.8-hb4cce97_0.conda"
+    hash:
+      md5: 268fe30a14a3f40fe54da04fc053fd2d
+      sha256: 19d10fdaee08ab2b5506cdce4399922c5c7d012be7ca7ca93c521748bade3e90
+    optional: false
+    category: main
+  - name: openssl
+    version: 3.0.8
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      ca-certificates: "*"
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/openssl-3.0.8-h4194056_0.conda"
+    hash:
+      md5: e952dfc7249a48558697f61b41859864
+      sha256: 62200f7fa9acb5d9cee24b373695e78ef1d7373bdfd77a50b80e57864b536436
+    optional: false
+    category: main
+  - name: openssl
+    version: 3.0.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      ca-certificates: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/openssl-3.0.8-hfd90126_0.conda"
+    hash:
+      md5: 4239d01834a13512079046ea216b6657
+      sha256: 750ebd464414b7c4ea5aaa704788f7238a356c0a54ce76b018af246cdb65bf08
+    optional: false
+    category: main
+  - name: openssl
+    version: 3.0.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      ca-certificates: "*"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.0.8-h03a7124_0.conda"
+    hash:
+      md5: accdc6784b8ae5dd618a9e76f4c3af36
+      sha256: 6d58b0412c4c27669da02368a303f4c4abc1b0edda5f27b2f8155299ab2b45a5
+    optional: false
+    category: main
+  - name: openssl
+    version: 3.0.8
+    manager: conda
+    platform: win-64
+    dependencies:
+      ca-certificates: "*"
+      ucrt: ">=10.0.20348.0"
+      vc: ">=14.2,<15"
+      vs2015_runtime: ">=14.29.30139"
+    url: "https://conda.anaconda.org/conda-forge/win-64/openssl-3.0.8-hcfcfb64_0.conda"
+    hash:
+      md5: 46cd47b2c18522b98c34e5101e583137
+      sha256: 35bf9375b379ab0818a6c58a60b15a4ad85b00ea7f460dd77860da3f3eccfd5d
+    optional: false
+    category: main
+  - name: pip
+    version: 23.0.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+      setuptools: "*"
+      wheel: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 8025ca83b8ba5430b640b83917c2a6f7
+      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
+    optional: false
+    category: main
+  - name: pip
+    version: 23.0.1
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+      setuptools: "*"
+      wheel: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 8025ca83b8ba5430b640b83917c2a6f7
+      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
+    optional: false
+    category: main
+  - name: pip
+    version: 23.0.1
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+      setuptools: "*"
+      wheel: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 8025ca83b8ba5430b640b83917c2a6f7
+      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
+    optional: false
+    category: main
+  - name: pip
+    version: 23.0.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+      setuptools: "*"
+      wheel: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 8025ca83b8ba5430b640b83917c2a6f7
+      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
+    optional: false
+    category: main
+  - name: pip
+    version: 23.0.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+      setuptools: "*"
+      wheel: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 8025ca83b8ba5430b640b83917c2a6f7
+      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
+    optional: false
+    category: main
+  - name: pip
+    version: 23.0.1
+    manager: conda
+    platform: win-64
+    dependencies:
+      python: ">=3.7"
+      setuptools: "*"
+      wheel: "*"
+    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
+    hash:
+      md5: 8025ca83b8ba5430b640b83917c2a6f7
+      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
     optional: false
     category: main
   - name: python
@@ -271,248 +869,6 @@ package:
       sha256: 464f998e406b645ba34771bb53a0a7c2734e855ee78dd021aa4dedfdb65659b7
     optional: false
     category: main
-  - name: setuptools
-    version: 67.4.0
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/setuptools-67.4.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: c6f4b87020c72e2700e3e94c1fc93b70
-      sha256: 7c58de8c7d98b341bd9be117feec64782e704fec5c30f6e14713ebccaab9b5d8
-    optional: false
-    category: main
-  - name: wheel
-    version: 0.38.4
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c829cfb8cb826acb9de0ac1a2df0a940
-      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-    optional: false
-    category: main
-  - name: pip
-    version: 23.0.1
-    manager: conda
-    platform: linux-64
-    dependencies:
-      python: ">=3.7"
-      setuptools: "*"
-      wheel: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 8025ca83b8ba5430b640b83917c2a6f7
-      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
-    optional: false
-    category: main
-  - name: ca-certificates
-    version: 2022.12.7
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2022.12.7-h4fd8a4c_0.conda"
-    hash:
-      md5: 2450fbcaf65634e0d071e47e2b8487b4
-      sha256: bb4e6340d55775738a5867a16071658c294d46cceff7f652f65d8dc6a495a578
-    optional: false
-    category: main
-  - name: ld_impl_linux-aarch64
-    version: "2.40"
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h2d8c526_0.conda"
-    hash:
-      md5: 16246d69e945d0b1969a6099e7c5d457
-      sha256: 1ba06e8645094b340b4aee23603a6abb1b0383788180e65f3de34e655c5f577c
-    optional: false
-    category: main
-  - name: libgomp
-    version: 12.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-12.2.0-h607ecd0_19.tar.bz2"
-    hash:
-      md5: 65b9cb876525dcb2e74a90cf02c6762a
-      sha256: d802eaceaf6f77fb8cb2e990aacf9b3eaa83361b16369a760fc1585841d7885c
-    optional: false
-    category: main
-  - name: tzdata
-    version: 2022g
-    manager: conda
-    platform: linux-aarch64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
-    hash:
-      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
-      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
-    optional: false
-    category: main
-  - name: _openmp_mutex
-    version: "4.5"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgomp: ">=7.5.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2"
-    hash:
-      md5: 6168d71addc746e8f2b8d57dfd2edcea
-      sha256: 3702bef2f0a4d38bd8288bbe54aace623602a1343c2cfbefd3fa188e015bebf0
-    optional: false
-    category: main
-  - name: libgcc-ng
-    version: 12.2.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      _openmp_mutex: ">=4.5"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-12.2.0-h607ecd0_19.tar.bz2"
-    hash:
-      md5: 8456a29b6d9fc3123ccb9a966b6b2c49
-      sha256: 0dd30553f6f38b011c9c81471a50f85e98a79e4dd672fdc1fc97904b54b5419b
-    optional: false
-    category: main
-  - name: bzip2
-    version: 1.0.8
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-hf897c2e_4.tar.bz2"
-    hash:
-      md5: 2d787570a729e273a4e75775ddf3348a
-      sha256: 3aeb6ab92aa0351722497b2d2a735dc20921cf6c60d9196c04b7a2b9ece198d2
-    optional: false
-    category: main
-  - name: libffi
-    version: 3.4.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2"
-    hash:
-      md5: dddd85f4d52121fab0a8b099c5e06501
-      sha256: 7e9258a102480757fe3faeb225a3ca04dffd10fecd2a958c65cdb4cdf75f2c3c
-    optional: false
-    category: main
-  - name: libnsl
-    version: 2.0.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.0-hf897c2e_0.tar.bz2"
-    hash:
-      md5: 36fdbc05c9d9145ece86f5a63c3f352e
-      sha256: 182dbc318b7ab3ab10bc5a9d3ca161b143ae8db6df8aa11b65140009e322e642
-    optional: false
-    category: main
-  - name: libuuid
-    version: 2.32.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.32.1-hf897c2e_1000.tar.bz2"
-    hash:
-      md5: e038da5ef9095b0d79aac14a311394e7
-      sha256: 8f7eead3723c32631b252aea336bb39fbbde433b8d0c5a75745f03eaa980447d
-    optional: false
-    category: main
-  - name: libzlib
-    version: 1.2.13
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h4e544f5_4.tar.bz2"
-    hash:
-      md5: 88596b6277fe6d39f046983aae6044db
-      sha256: 9803ac96dbdbc27df9c149e06d4436b778c468bd0e6e023fbcb49a6fe9c404b4
-    optional: false
-    category: main
-  - name: ncurses
-    version: "6.3"
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.3-headf329_1.tar.bz2"
-    hash:
-      md5: 486b68148e121bc8bbadc3cefae4c04f
-      sha256: d410d840cb39175d7edc388690b93b2e3d7613c2e2f5c64b96582dc8b55b2319
-    optional: false
-    category: main
-  - name: openssl
-    version: 3.0.8
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      ca-certificates: "*"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.0.8-hb4cce97_0.conda"
-    hash:
-      md5: 268fe30a14a3f40fe54da04fc053fd2d
-      sha256: 19d10fdaee08ab2b5506cdce4399922c5c7d012be7ca7ca93c521748bade3e90
-    optional: false
-    category: main
-  - name: xz
-    version: 5.2.6
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2"
-    hash:
-      md5: 83baad393a31d59c20b63ba4da6592df
-      sha256: 93f58a7b393adf41fa007ac8c55978765e957e90cd31877ece1e5a343cb98220
-    optional: false
-    category: main
-  - name: libsqlite
-    version: 3.40.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.40.0-hf9034f9_0.tar.bz2"
-    hash:
-      md5: 9afb0d5dbaa403858a660cd0b4a31d29
-      sha256: 15e4a4bef065f73c2aae630c0408fd6108f5915d4640c7d97578f2e07b3f5d11
-    optional: false
-    category: main
-  - name: readline
-    version: 8.1.2
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=12"
-      ncurses: ">=6.3,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.1.2-h38e3740_0.tar.bz2"
-    hash:
-      md5: 3cdbfb7d7b63ae2c2d35bb167d257ecd
-      sha256: a33bb6e4c93599fb97eb19db0dcca602a90475f2da3c01c14add19b908178fcd
-    optional: false
-    category: main
-  - name: tk
-    version: 8.6.12
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-      libzlib: ">=1.2.11,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.12-hd8af866_0.tar.bz2"
-    hash:
-      md5: 7894e82ff743bd96c76585ddebe28e2a
-      sha256: d659316c9e502fb0e1b9a284fb0f0c00e273bff787e9385ab14be9af13dcd0d2
-    optional: false
-    category: main
   - name: python
     version: 3.11.0
     manager: conda
@@ -537,262 +893,6 @@ package:
     hash:
       md5: e537239a305ab94925b6cd226cd523da
       sha256: 88a786ac9fbf6d5b1e35036f0cb1e7dad694b3be9fa79dd6a71afa954bf02ae3
-    optional: false
-    category: main
-  - name: setuptools
-    version: 67.4.0
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/setuptools-67.4.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: c6f4b87020c72e2700e3e94c1fc93b70
-      sha256: 7c58de8c7d98b341bd9be117feec64782e704fec5c30f6e14713ebccaab9b5d8
-    optional: false
-    category: main
-  - name: wheel
-    version: 0.38.4
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c829cfb8cb826acb9de0ac1a2df0a940
-      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-    optional: false
-    category: main
-  - name: pip
-    version: 23.0.1
-    manager: conda
-    platform: linux-aarch64
-    dependencies:
-      python: ">=3.7"
-      setuptools: "*"
-      wheel: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 8025ca83b8ba5430b640b83917c2a6f7
-      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
-    optional: false
-    category: main
-  - name: _libgcc_mutex
-    version: "0.1"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/_libgcc_mutex-0.1-conda_forge.tar.bz2"
-    hash:
-      md5: e96f48755dc7c9f86c4aecf4cac40477
-      sha256: 5dd34b412e6274c0614d01a2f616844376ae873dfb8782c2c67d055779de6df6
-    optional: false
-    category: main
-  - name: ca-certificates
-    version: 2022.12.7
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ca-certificates-2022.12.7-h1084571_0.conda"
-    hash:
-      md5: e3becd49c6d0e94d1b67c9f9a4d50587
-      sha256: 82b77cb085c961b085fbbb5ea3920c1933bda08c2e1dd53685f6f21b16a336ac
-    optional: false
-    category: main
-  - name: ld_impl_linux-ppc64le
-    version: "2.39"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ld_impl_linux-ppc64le-2.39-hea198f4_1.conda"
-    hash:
-      md5: c7db6cc5b9479df1ed884b6147601613
-      sha256: 20d6db1053ae4af65677fc4b4cf9b2d5884ce26ea6b38f7088a5ebad1de62746
-    optional: false
-    category: main
-  - name: tzdata
-    version: 2022g
-    manager: conda
-    platform: linux-ppc64le
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
-    hash:
-      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
-      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
-    optional: false
-    category: main
-  - name: libgomp
-    version: 12.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      _libgcc_mutex: "==0.1 conda_forge"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgomp-12.2.0-hbc1322c_19.tar.bz2"
-    hash:
-      md5: 25647ac31b4d467fce690c6a561a58aa
-      sha256: 56a43985f648c358c6b3eb949863e393dbdb48d8f017315e03ff703031b8a951
-    optional: false
-    category: main
-  - name: _openmp_mutex
-    version: "4.5"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      _libgcc_mutex: "==0.1 conda_forge"
-      libgomp: ">=7.5.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/_openmp_mutex-4.5-2_gnu.tar.bz2"
-    hash:
-      md5: 3e41cbaba7e4988d15a24c4e85e6171b
-      sha256: 4c89c2067cf5e7b0fbbdc3200c3f7affa5896e14812acf10f51575be87ae0c05
-    optional: false
-    category: main
-  - name: libgcc-ng
-    version: 12.2.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      _libgcc_mutex: "==0.1 conda_forge"
-      _openmp_mutex: ">=4.5"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libgcc-ng-12.2.0-hbc1322c_19.tar.bz2"
-    hash:
-      md5: 9ad34f95d6fb05300bbd0f553f3bece4
-      sha256: 335a2b7415cb5fbbf05459f6cfcca4dd8bafd43bcbe5bf6aa56bf66b7ed6bf42
-    optional: false
-    category: main
-  - name: bzip2
-    version: 1.0.8
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/bzip2-1.0.8-h4e0d66e_4.tar.bz2"
-    hash:
-      md5: 3cbc4e0eede8b25bc53b6a462815aceb
-      sha256: e0edf3c1804547239de9f678f9b650684d0f215e4c277e1d92c281f4d61559b8
-    optional: false
-    category: main
-  - name: libffi
-    version: 3.4.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libffi-3.4.2-h4e0d66e_5.tar.bz2"
-    hash:
-      md5: 79c37a0a50ef77fea4ee5f6d257b8b3c
-      sha256: 178ca9f82e2144a8834dd01f9af3b4b9b5d482892675931edccff06aee524953
-    optional: false
-    category: main
-  - name: libnsl
-    version: 2.0.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libnsl-2.0.0-h4e0d66e_0.tar.bz2"
-    hash:
-      md5: e6c718cb0e01f2af330da0a8dbd55b68
-      sha256: 2aa6cd044633586588c7105a3702788ee65b679801ab5d00b48d64265ae2f13c
-    optional: false
-    category: main
-  - name: libuuid
-    version: 2.32.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libuuid-2.32.1-h4e0d66e_1000.tar.bz2"
-    hash:
-      md5: ceb7466afcb5be47530ffe9aae8650ae
-      sha256: 58b4f6e27b921ff9171e64b3e382cc644d7da70d5da4e3815b7ceae4b4b452e0
-    optional: false
-    category: main
-  - name: libzlib
-    version: 1.2.13
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libzlib-1.2.13-hb283c62_4.tar.bz2"
-    hash:
-      md5: af99cdd23d3761a569840663bdf0dc0d
-      sha256: 62073ba865b49db36dc14ffeaa2985711bce65d720b853e3aa4cce0a9e5439d8
-    optional: false
-    category: main
-  - name: ncurses
-    version: "6.3"
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=10.3.0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/ncurses-6.3-hab78ccb_1.tar.bz2"
-    hash:
-      md5: 775403ae6d617d309d874f9bff20e670
-      sha256: 37761927f381de5741d7f176dddc1c3b60876f44db10f7d636ad1133381d1a94
-    optional: false
-    category: main
-  - name: openssl
-    version: 3.0.8
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      ca-certificates: "*"
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/openssl-3.0.8-h4194056_0.conda"
-    hash:
-      md5: e952dfc7249a48558697f61b41859864
-      sha256: 62200f7fa9acb5d9cee24b373695e78ef1d7373bdfd77a50b80e57864b536436
-    optional: false
-    category: main
-  - name: xz
-    version: 5.2.6
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/xz-5.2.6-hb283c62_0.tar.bz2"
-    hash:
-      md5: a411645e44054e333573ee5280fdb89b
-      sha256: d03eb2b53dc61ac97c88b3ca023cf19c2b83b97520725b3c2ec0bff2c47f4a98
-    optional: false
-    category: main
-  - name: libsqlite
-    version: 3.39.4
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      libzlib: ">=1.2.12,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/libsqlite-3.39.4-hcc10993_0.tar.bz2"
-    hash:
-      md5: 49799ec532f260e4264705336d01310b
-      sha256: 93cdea9743cf1f86fdf9e9516061d5c68b9b5c43b99b7db1dd81d5b3452c4759
-    optional: false
-    category: main
-  - name: readline
-    version: 8.1.2
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=12"
-      ncurses: ">=6.3,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/readline-8.1.2-h6828edc_0.tar.bz2"
-    hash:
-      md5: a8b0d567fd553734fc0fd0ab2447526a
-      sha256: 37e57caeeb181929648aa898487909b8badad20aa9fb49ab603446cccdb743db
-    optional: false
-    category: main
-  - name: tk
-    version: 8.6.12
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      libgcc-ng: ">=9.4.0"
-      libzlib: ">=1.2.11,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/tk-8.6.12-h41c6715_0.tar.bz2"
-    hash:
-      md5: c0490995dc12b45388a01094f9959edd
-      sha256: 61ef67fe390109aa3423d30b96faddb97b054dfbcc0e6c8a3192331b13d14d92
     optional: false
     category: main
   - name: python
@@ -821,169 +921,6 @@ package:
       sha256: de4f1f739b1c2f32fa5fe760fa224faeaa576d9fca166d24412b7332b7c0f62a
     optional: false
     category: main
-  - name: setuptools
-    version: 67.4.0
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/setuptools-67.4.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: c6f4b87020c72e2700e3e94c1fc93b70
-      sha256: 7c58de8c7d98b341bd9be117feec64782e704fec5c30f6e14713ebccaab9b5d8
-    optional: false
-    category: main
-  - name: wheel
-    version: 0.38.4
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c829cfb8cb826acb9de0ac1a2df0a940
-      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-    optional: false
-    category: main
-  - name: pip
-    version: 23.0.1
-    manager: conda
-    platform: linux-ppc64le
-    dependencies:
-      python: ">=3.7"
-      setuptools: "*"
-      wheel: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 8025ca83b8ba5430b640b83917c2a6f7
-      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
-    optional: false
-    category: main
-  - name: bzip2
-    version: 1.0.8
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2"
-    hash:
-      md5: 37edc4e6304ca87316e160f5ca0bd1b5
-      sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
-    optional: false
-    category: main
-  - name: ca-certificates
-    version: 2022.12.7
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2022.12.7-h033912b_0.conda"
-    hash:
-      md5: af2bdcd68f16ce030ca957cdeb83d88a
-      sha256: 898276d86de89fb034ecfae05103045d0a0d6a356ced1b6d1832cdbd07a8fc18
-    optional: false
-    category: main
-  - name: libffi
-    version: 3.4.2
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2"
-    hash:
-      md5: ccb34fb14960ad8b125962d3d79b31a9
-      sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
-    optional: false
-    category: main
-  - name: libzlib
-    version: 1.2.13
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-hfd90126_4.tar.bz2"
-    hash:
-      md5: 35eb3fce8d51ed3c1fd4122bad48250b
-      sha256: 0d954350222cc12666a1f4852dbc9bcf4904d8e467d29505f2b04ded6518f890
-    optional: false
-    category: main
-  - name: ncurses
-    version: "6.3"
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.3-h96cf925_1.tar.bz2"
-    hash:
-      md5: 76217ebfbb163ff2770a261f955a5861
-      sha256: 9794a23d03586c99cac49d4ae3d5337faaa6bfc256b31d2662ff4ad5972be143
-    optional: false
-    category: main
-  - name: tzdata
-    version: 2022g
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
-    hash:
-      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
-      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
-    optional: false
-    category: main
-  - name: xz
-    version: 5.2.6
-    manager: conda
-    platform: osx-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2"
-    hash:
-      md5: a72f9d4ea13d55d745ff1ed594747f10
-      sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
-    optional: false
-    category: main
-  - name: libsqlite
-    version: 3.40.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.40.0-ha978bb4_0.tar.bz2"
-    hash:
-      md5: ceb13b6726534b96e3b4e3dda91e9050
-      sha256: ae19f866188cc0c514fed754468460ae9e8dd763ebbd7b7afc4e818d71844297
-    optional: false
-    category: main
-  - name: openssl
-    version: 3.0.8
-    manager: conda
-    platform: osx-64
-    dependencies:
-      ca-certificates: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/openssl-3.0.8-hfd90126_0.conda"
-    hash:
-      md5: 4239d01834a13512079046ea216b6657
-      sha256: 750ebd464414b7c4ea5aaa704788f7238a356c0a54ce76b018af246cdb65bf08
-    optional: false
-    category: main
-  - name: readline
-    version: 8.1.2
-    manager: conda
-    platform: osx-64
-    dependencies:
-      ncurses: ">=6.3,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/readline-8.1.2-h3899abd_0.tar.bz2"
-    hash:
-      md5: 89fa404901fa8fb7d4f4e07083b8d635
-      sha256: c65dc1200a252832db49bdd6836c512a0eaafe97aa914b9f8358b15eebb1d94b
-    optional: false
-    category: main
-  - name: tk
-    version: 8.6.12
-    manager: conda
-    platform: osx-64
-    dependencies:
-      libzlib: ">=1.2.11,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.12-h5dbffcc_0.tar.bz2"
-    hash:
-      md5: 8e9480d9c47061db2ed1b4ecce519a7f
-      sha256: 331aa1137a264fd9cc905f04f09a161c801fe504b93da08b4e6697bd7c9ae6a6
-    optional: false
-    category: main
   - name: python
     version: 3.11.0
     manager: conda
@@ -1004,169 +941,6 @@ package:
     hash:
       md5: 9ecfa530b33aefd0d22e0272336f638a
       sha256: 5c069c9908e48a4490a56d3752c0bc93c2fc93ab8d8328efc869fdc707618e9f
-    optional: false
-    category: main
-  - name: setuptools
-    version: 67.4.0
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/setuptools-67.4.0-pyhd8ed1ab_0.conda"
-    hash:
-      md5: c6f4b87020c72e2700e3e94c1fc93b70
-      sha256: 7c58de8c7d98b341bd9be117feec64782e704fec5c30f6e14713ebccaab9b5d8
-    optional: false
-    category: main
-  - name: wheel
-    version: 0.38.4
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c829cfb8cb826acb9de0ac1a2df0a940
-      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-    optional: false
-    category: main
-  - name: pip
-    version: 23.0.1
-    manager: conda
-    platform: osx-64
-    dependencies:
-      python: ">=3.7"
-      setuptools: "*"
-      wheel: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 8025ca83b8ba5430b640b83917c2a6f7
-      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
-    optional: false
-    category: main
-  - name: bzip2
-    version: 1.0.8
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2"
-    hash:
-      md5: fc76ace7b94fb1f694988ab1b14dd248
-      sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
-    optional: false
-    category: main
-  - name: ca-certificates
-    version: 2022.12.7
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2022.12.7-h4653dfc_0.conda"
-    hash:
-      md5: 7dc111916edc905957b7417a247583b6
-      sha256: a9634dc719fc9cd4c91cf8ad3167532e59051cace3e90ef2ba305a41c316784a
-    optional: false
-    category: main
-  - name: libffi
-    version: 3.4.2
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2"
-    hash:
-      md5: 086914b672be056eb70fd4285b6783b6
-      sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
-    optional: false
-    category: main
-  - name: libzlib
-    version: 1.2.13
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h03a7124_4.tar.bz2"
-    hash:
-      md5: 780852dc54c4c07e64b276a97f89c162
-      sha256: a1bf4a1c107838fea4570a7f1750306d65d84fcf2913d4e0d30b4db785e8f223
-    optional: false
-    category: main
-  - name: ncurses
-    version: "6.3"
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.3-h07bb92c_1.tar.bz2"
-    hash:
-      md5: db86e5a978380a13f5559f97afdfe99d
-      sha256: 50ba7c13dd7d05569e7caa98a13a3684450f8547b4965a1e86b54e2f1240debe
-    optional: false
-    category: main
-  - name: tzdata
-    version: 2022g
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
-    hash:
-      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
-      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
-    optional: false
-    category: main
-  - name: xz
-    version: 5.2.6
-    manager: conda
-    platform: osx-arm64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2"
-    hash:
-      md5: 39c6b54e94014701dd157f4f576ed211
-      sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
-    optional: false
-    category: main
-  - name: libsqlite
-    version: 3.40.0
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libzlib: ">=1.2.13,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.40.0-h76d750c_0.tar.bz2"
-    hash:
-      md5: d090fcec993f4ef0a90e6df7f231a273
-      sha256: 5e8992b2099bb4767996e1bed70945ba39f61399ab912ba2a2770d12c165acb5
-    optional: false
-    category: main
-  - name: openssl
-    version: 3.0.8
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      ca-certificates: "*"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.0.8-h03a7124_0.conda"
-    hash:
-      md5: accdc6784b8ae5dd618a9e76f4c3af36
-      sha256: 6d58b0412c4c27669da02368a303f4c4abc1b0edda5f27b2f8155299ab2b45a5
-    optional: false
-    category: main
-  - name: readline
-    version: 8.1.2
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      ncurses: ">=6.3,<7.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.1.2-h46ed386_0.tar.bz2"
-    hash:
-      md5: dc790f296d94409efb3f22af84ee968d
-      sha256: 2d2a65fcdd91361ea7e40c03eeec18ff7a453c32f6589a1fce64717f6cd7c7b6
-    optional: false
-    category: main
-  - name: tk
-    version: 8.6.12
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      libzlib: ">=1.2.11,<1.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.12-he1e0b03_0.tar.bz2"
-    hash:
-      md5: 2cb3d18eac154109107f093860bd545f
-      sha256: 9e43ec80045892e28233e4ca4d974e09d5837392127702fb952f3935b5e985a4
     optional: false
     category: main
   - name: python
@@ -1191,6 +965,139 @@ package:
       sha256: 28a54d78cd2624a12bd2ceb0f1816b0cba9b4fd97df846b5843b3c1d51642ab2
     optional: false
     category: main
+  - name: python
+    version: 3.11.0
+    manager: conda
+    platform: win-64
+    dependencies:
+      bzip2: ">=1.0.8,<2.0a0"
+      libffi: ">=3.4.2,<3.5.0a0"
+      libsqlite: ">=3.39.4,<4.0a0"
+      libzlib: ">=1.2.13,<1.3.0a0"
+      openssl: ">=3.0.5,<4.0a0"
+      pip: "*"
+      tk: ">=8.6.12,<8.7.0a0"
+      tzdata: "*"
+      vc: ">=14.1,<15"
+      vs2015_runtime: ">=14.16.27033"
+      xz: ">=5.2.6,<5.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.tar.bz2"
+    hash:
+      md5: 13ee3577afc291dabd2d9edc59736688
+      sha256: 20d1f1b5dc620b745c325844545fd5c0cdbfdb2385a0e27ef1507399844c8c6d
+    optional: false
+    category: main
+  - name: readline
+    version: 8.1.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+      ncurses: ">=6.3,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/readline-8.1.2-h0f457ee_0.tar.bz2"
+    hash:
+      md5: db2ebbe2943aae81ed051a6a9af8e0fa
+      sha256: f5f383193bdbe01c41cb0d6f99fec68e820875e842e6e8b392dbe1a9b6c43ed8
+    optional: false
+    category: main
+  - name: readline
+    version: 8.1.2
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+      ncurses: ">=6.3,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.1.2-h38e3740_0.tar.bz2"
+    hash:
+      md5: 3cdbfb7d7b63ae2c2d35bb167d257ecd
+      sha256: a33bb6e4c93599fb97eb19db0dcca602a90475f2da3c01c14add19b908178fcd
+    optional: false
+    category: main
+  - name: readline
+    version: 8.1.2
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+      ncurses: ">=6.3,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/readline-8.1.2-h6828edc_0.tar.bz2"
+    hash:
+      md5: a8b0d567fd553734fc0fd0ab2447526a
+      sha256: 37e57caeeb181929648aa898487909b8badad20aa9fb49ab603446cccdb743db
+    optional: false
+    category: main
+  - name: readline
+    version: 8.1.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      ncurses: ">=6.3,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/readline-8.1.2-h3899abd_0.tar.bz2"
+    hash:
+      md5: 89fa404901fa8fb7d4f4e07083b8d635
+      sha256: c65dc1200a252832db49bdd6836c512a0eaafe97aa914b9f8358b15eebb1d94b
+    optional: false
+    category: main
+  - name: readline
+    version: 8.1.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      ncurses: ">=6.3,<7.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.1.2-h46ed386_0.tar.bz2"
+    hash:
+      md5: dc790f296d94409efb3f22af84ee968d
+      sha256: 2d2a65fcdd91361ea7e40c03eeec18ff7a453c32f6589a1fce64717f6cd7c7b6
+    optional: false
+    category: main
+  - name: setuptools
+    version: 67.4.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/setuptools-67.4.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: c6f4b87020c72e2700e3e94c1fc93b70
+      sha256: 7c58de8c7d98b341bd9be117feec64782e704fec5c30f6e14713ebccaab9b5d8
+    optional: false
+    category: main
+  - name: setuptools
+    version: 67.4.0
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/setuptools-67.4.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: c6f4b87020c72e2700e3e94c1fc93b70
+      sha256: 7c58de8c7d98b341bd9be117feec64782e704fec5c30f6e14713ebccaab9b5d8
+    optional: false
+    category: main
+  - name: setuptools
+    version: 67.4.0
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/setuptools-67.4.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: c6f4b87020c72e2700e3e94c1fc93b70
+      sha256: 7c58de8c7d98b341bd9be117feec64782e704fec5c30f6e14713ebccaab9b5d8
+    optional: false
+    category: main
+  - name: setuptools
+    version: 67.4.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/setuptools-67.4.0-pyhd8ed1ab_0.conda"
+    hash:
+      md5: c6f4b87020c72e2700e3e94c1fc93b70
+      sha256: 7c58de8c7d98b341bd9be117feec64782e704fec5c30f6e14713ebccaab9b5d8
+    optional: false
+    category: main
   - name: setuptools
     version: 67.4.0
     manager: conda
@@ -1203,41 +1110,147 @@ package:
       sha256: 7c58de8c7d98b341bd9be117feec64782e704fec5c30f6e14713ebccaab9b5d8
     optional: false
     category: main
-  - name: wheel
-    version: 0.38.4
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
-    hash:
-      md5: c829cfb8cb826acb9de0ac1a2df0a940
-      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
-    optional: false
-    category: main
-  - name: pip
-    version: 23.0.1
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      python: ">=3.7"
-      setuptools: "*"
-      wheel: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
-    hash:
-      md5: 8025ca83b8ba5430b640b83917c2a6f7
-      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
-    optional: false
-    category: main
-  - name: ca-certificates
-    version: 2022.12.7
+  - name: setuptools
+    version: 67.4.0
     manager: conda
     platform: win-64
-    dependencies: {}
-    url: "https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2022.12.7-h5b45459_0.conda"
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/setuptools-67.4.0-pyhd8ed1ab_0.conda"
     hash:
-      md5: 31de4d9887dc8eaed9e6230a5dfbb9d6
-      sha256: 405f3634e055e2e6b0502b1999bc9b7e7bb6b549b229a9a371b19d660f0b14f0
+      md5: c6f4b87020c72e2700e3e94c1fc93b70
+      sha256: 7c58de8c7d98b341bd9be117feec64782e704fec5c30f6e14713ebccaab9b5d8
+    optional: false
+    category: main
+  - name: tk
+    version: 8.6.12
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+      libzlib: ">=1.2.11,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.12-h27826a3_0.tar.bz2"
+    hash:
+      md5: 5b8c42eb62e9fc961af70bdd6a26e168
+      sha256: 032fd769aad9d4cad40ba261ab222675acb7ec951a8832455fce18ef33fa8df0
+    optional: false
+    category: main
+  - name: tk
+    version: 8.6.12
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+      libzlib: ">=1.2.11,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.12-hd8af866_0.tar.bz2"
+    hash:
+      md5: 7894e82ff743bd96c76585ddebe28e2a
+      sha256: d659316c9e502fb0e1b9a284fb0f0c00e273bff787e9385ab14be9af13dcd0d2
+    optional: false
+    category: main
+  - name: tk
+    version: 8.6.12
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=9.4.0"
+      libzlib: ">=1.2.11,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/tk-8.6.12-h41c6715_0.tar.bz2"
+    hash:
+      md5: c0490995dc12b45388a01094f9959edd
+      sha256: 61ef67fe390109aa3423d30b96faddb97b054dfbcc0e6c8a3192331b13d14d92
+    optional: false
+    category: main
+  - name: tk
+    version: 8.6.12
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libzlib: ">=1.2.11,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.12-h5dbffcc_0.tar.bz2"
+    hash:
+      md5: 8e9480d9c47061db2ed1b4ecce519a7f
+      sha256: 331aa1137a264fd9cc905f04f09a161c801fe504b93da08b4e6697bd7c9ae6a6
+    optional: false
+    category: main
+  - name: tk
+    version: 8.6.12
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libzlib: ">=1.2.11,<1.3.0a0"
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.12-he1e0b03_0.tar.bz2"
+    hash:
+      md5: 2cb3d18eac154109107f093860bd545f
+      sha256: 9e43ec80045892e28233e4ca4d974e09d5837392127702fb952f3935b5e985a4
+    optional: false
+    category: main
+  - name: tk
+    version: 8.6.12
+    manager: conda
+    platform: win-64
+    dependencies:
+      vc: ">=14.1,<15"
+      vs2015_runtime: ">=14.16.27033"
+    url: "https://conda.anaconda.org/conda-forge/win-64/tk-8.6.12-h8ffe710_0.tar.bz2"
+    hash:
+      md5: c69a5047cc9291ae40afd4a1ad6f0c0f
+      sha256: 087795090a99a1d397ef1ed80b4a01fabfb0122efb141562c168e3c0a76edba6
+    optional: false
+    category: main
+  - name: tzdata
+    version: 2022g
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
+    hash:
+      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
+      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
+    optional: false
+    category: main
+  - name: tzdata
+    version: 2022g
+    manager: conda
+    platform: linux-aarch64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
+    hash:
+      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
+      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
+    optional: false
+    category: main
+  - name: tzdata
+    version: 2022g
+    manager: conda
+    platform: linux-ppc64le
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
+    hash:
+      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
+      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
+    optional: false
+    category: main
+  - name: tzdata
+    version: 2022g
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
+    hash:
+      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
+      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
+    optional: false
+    category: main
+  - name: tzdata
+    version: 2022g
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2022g-h191b570_0.conda"
+    hash:
+      md5: 51fc4fcfb19f5d95ffc8c339db5068e8
+      sha256: 0bfae0b9962bc0dbf79048f9175b913ed4f53c4310d06708dc7acbb290ad82f6
     optional: false
     category: main
   - name: tzdata
@@ -1262,18 +1275,6 @@ package:
       sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
     optional: false
     category: main
-  - name: vs2015_runtime
-    version: 14.34.31931
-    manager: conda
-    platform: win-64
-    dependencies:
-      ucrt: ">=10.0.20348.0"
-    url: "https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.34.31931-h4c5c07a_10.conda"
-    hash:
-      md5: 25640086ba777e79e5d233d079d7c5fc
-      sha256: 3a23d4c98bdb87b06bd8af9e42eea34c39a9da52c3dd96ace706234c55422f2d
-    optional: false
-    category: main
   - name: vc
     version: "14.3"
     manager: conda
@@ -1286,133 +1287,76 @@ package:
       sha256: 05d5ae5859e8d097559f5445ffbaeac638c9875e4d2a0c5fd8c4bb1c010d35c1
     optional: false
     category: main
-  - name: bzip2
-    version: 1.0.8
-    manager: conda
-    platform: win-64
-    dependencies:
-      vc: ">=14.1,<15.0a0"
-      vs2015_runtime: ">=14.16.27012"
-    url: "https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2"
-    hash:
-      md5: 7c03c66026944073040cb19a4f3ec3c9
-      sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
-    optional: false
-    category: main
-  - name: libffi
-    version: 3.4.2
-    manager: conda
-    platform: win-64
-    dependencies:
-      vc: ">=14.1,<15.0a0"
-      vs2015_runtime: ">=14.16.27012"
-    url: "https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2"
-    hash:
-      md5: 2c96d1b6915b408893f9472569dee135
-      sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
-    optional: false
-    category: main
-  - name: libsqlite
-    version: 3.40.0
+  - name: vs2015_runtime
+    version: 14.34.31931
     manager: conda
     platform: win-64
     dependencies:
       ucrt: ">=10.0.20348.0"
-      vc: ">=14.2,<15"
-      vs2015_runtime: ">=14.29.30139"
-    url: "https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.40.0-hcfcfb64_0.tar.bz2"
+    url: "https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.34.31931-h4c5c07a_10.conda"
     hash:
-      md5: 5e5a97795de72f8cc3baf3d9ea6327a2
-      sha256: 4e50b3d90a351c9d47d239d3f90fce4870df2526e4f7fef35203ab3276a6dfc9
+      md5: 25640086ba777e79e5d233d079d7c5fc
+      sha256: 3a23d4c98bdb87b06bd8af9e42eea34c39a9da52c3dd96ace706234c55422f2d
     optional: false
     category: main
-  - name: libzlib
-    version: 1.2.13
+  - name: wheel
+    version: 0.38.4
     manager: conda
-    platform: win-64
-    dependencies:
-      ucrt: ">=10.0.20348.0"
-      vc: ">=14.2,<15"
-      vs2015_runtime: ">=14.29.30139"
-    url: "https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_4.tar.bz2"
-    hash:
-      md5: 0cc5c5cc64ee1637f37f8540a175854c
-      sha256: 184da12b4296088a47086f4e69e65eb5f8537a824ee3131d8076775e1d1ea767
-    optional: false
-    category: main
-  - name: openssl
-    version: 3.0.8
-    manager: conda
-    platform: win-64
-    dependencies:
-      ca-certificates: "*"
-      ucrt: ">=10.0.20348.0"
-      vc: ">=14.2,<15"
-      vs2015_runtime: ">=14.29.30139"
-    url: "https://conda.anaconda.org/conda-forge/win-64/openssl-3.0.8-hcfcfb64_0.conda"
-    hash:
-      md5: 46cd47b2c18522b98c34e5101e583137
-      sha256: 35bf9375b379ab0818a6c58a60b15a4ad85b00ea7f460dd77860da3f3eccfd5d
-    optional: false
-    category: main
-  - name: tk
-    version: 8.6.12
-    manager: conda
-    platform: win-64
-    dependencies:
-      vc: ">=14.1,<15"
-      vs2015_runtime: ">=14.16.27033"
-    url: "https://conda.anaconda.org/conda-forge/win-64/tk-8.6.12-h8ffe710_0.tar.bz2"
-    hash:
-      md5: c69a5047cc9291ae40afd4a1ad6f0c0f
-      sha256: 087795090a99a1d397ef1ed80b4a01fabfb0122efb141562c168e3c0a76edba6
-    optional: false
-    category: main
-  - name: xz
-    version: 5.2.6
-    manager: conda
-    platform: win-64
-    dependencies:
-      vc: ">=14.1,<15"
-      vs2015_runtime: ">=14.16.27033"
-    url: "https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2"
-    hash:
-      md5: 515d77642eaa3639413c6b1bc3f94219
-      sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
-    optional: false
-    category: main
-  - name: python
-    version: 3.11.0
-    manager: conda
-    platform: win-64
-    dependencies:
-      bzip2: ">=1.0.8,<2.0a0"
-      libffi: ">=3.4.2,<3.5.0a0"
-      libsqlite: ">=3.39.4,<4.0a0"
-      libzlib: ">=1.2.13,<1.3.0a0"
-      openssl: ">=3.0.5,<4.0a0"
-      pip: "*"
-      tk: ">=8.6.12,<8.7.0a0"
-      tzdata: "*"
-      vc: ">=14.1,<15"
-      vs2015_runtime: ">=14.16.27033"
-      xz: ">=5.2.6,<5.3.0a0"
-    url: "https://conda.anaconda.org/conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.tar.bz2"
-    hash:
-      md5: 13ee3577afc291dabd2d9edc59736688
-      sha256: 20d1f1b5dc620b745c325844545fd5c0cdbfdb2385a0e27ef1507399844c8c6d
-    optional: false
-    category: main
-  - name: setuptools
-    version: 67.4.0
-    manager: conda
-    platform: win-64
+    platform: linux-64
     dependencies:
       python: ">=3.7"
-    url: "https://conda.anaconda.org/conda-forge/noarch/setuptools-67.4.0-pyhd8ed1ab_0.conda"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
     hash:
-      md5: c6f4b87020c72e2700e3e94c1fc93b70
-      sha256: 7c58de8c7d98b341bd9be117feec64782e704fec5c30f6e14713ebccaab9b5d8
+      md5: c829cfb8cb826acb9de0ac1a2df0a940
+      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+    optional: false
+    category: main
+  - name: wheel
+    version: 0.38.4
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c829cfb8cb826acb9de0ac1a2df0a940
+      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+    optional: false
+    category: main
+  - name: wheel
+    version: 0.38.4
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c829cfb8cb826acb9de0ac1a2df0a940
+      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+    optional: false
+    category: main
+  - name: wheel
+    version: 0.38.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c829cfb8cb826acb9de0ac1a2df0a940
+      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
+    optional: false
+    category: main
+  - name: wheel
+    version: 0.38.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      python: ">=3.7"
+    url: "https://conda.anaconda.org/conda-forge/noarch/wheel-0.38.4-pyhd8ed1ab_0.tar.bz2"
+    hash:
+      md5: c829cfb8cb826acb9de0ac1a2df0a940
+      sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
     optional: false
     category: main
   - name: wheel
@@ -1427,18 +1371,75 @@ package:
       sha256: bd4f11ff075ff251ade9f57686f31473e25be46ab282d9603f551401250f9f44
     optional: false
     category: main
-  - name: pip
-    version: 23.0.1
+  - name: xz
+    version: 5.2.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2"
+    hash:
+      md5: 2161070d867d1b1204ea749c8eec4ef0
+      sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
+    optional: false
+    category: main
+  - name: xz
+    version: 5.2.6
+    manager: conda
+    platform: linux-aarch64
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2"
+    hash:
+      md5: 83baad393a31d59c20b63ba4da6592df
+      sha256: 93f58a7b393adf41fa007ac8c55978765e957e90cd31877ece1e5a343cb98220
+    optional: false
+    category: main
+  - name: xz
+    version: 5.2.6
+    manager: conda
+    platform: linux-ppc64le
+    dependencies:
+      libgcc-ng: ">=12"
+    url: "https://conda.anaconda.org/conda-forge/linux-ppc64le/xz-5.2.6-hb283c62_0.tar.bz2"
+    hash:
+      md5: a411645e44054e333573ee5280fdb89b
+      sha256: d03eb2b53dc61ac97c88b3ca023cf19c2b83b97520725b3c2ec0bff2c47f4a98
+    optional: false
+    category: main
+  - name: xz
+    version: 5.2.6
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2"
+    hash:
+      md5: a72f9d4ea13d55d745ff1ed594747f10
+      sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
+    optional: false
+    category: main
+  - name: xz
+    version: 5.2.6
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2"
+    hash:
+      md5: 39c6b54e94014701dd157f4f576ed211
+      sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+    optional: false
+    category: main
+  - name: xz
+    version: 5.2.6
     manager: conda
     platform: win-64
     dependencies:
-      python: ">=3.7"
-      setuptools: "*"
-      wheel: "*"
-    url: "https://conda.anaconda.org/conda-forge/noarch/pip-23.0.1-pyhd8ed1ab_0.conda"
+      vc: ">=14.1,<15"
+      vs2015_runtime: ">=14.16.27033"
+    url: "https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2"
     hash:
-      md5: 8025ca83b8ba5430b640b83917c2a6f7
-      sha256: e1698cbf4964cd60a2885c0edbc654133cd0db5ac4cb568412250e577dbc42ad
+      md5: 515d77642eaa3639413c6b1bc3f94219
+      sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
     optional: false
     category: main
 version: 1

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.171", features = ["derive"], optional = true }
 sha2 = "0.10.7"
 md-5 = "0.10.5"
 blake2 = "0.10.6"
-serde_with = "3.0.0"
+serde_with = "3.3.0"
 
 [features]
 tokio = ["dep:tokio"]

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -35,7 +35,7 @@ rattler_conda_types = { version = "0.8.0", path = "../rattler_conda_types", opti
 fxhash = { version = "0.2.1", optional = true }
 memmap2 = { version = "0.7.1", optional = true }
 ouroboros = { version = "0.17.0", optional = true }
-serde_with = "3.0.0"
+serde_with = "3.3.0"
 superslice = { version = "1.0.0", optional = true }
 itertools = { version = "0.11.0", optional = true }
 json-patch = "1.0.0"
@@ -62,4 +62,4 @@ rstest = "0.18.1"
 default = ['native-tls']
 native-tls = ['reqwest/native-tls']
 rustls-tls = ['reqwest/rustls-tls']
-sparse = ["rattler_conda_types", "memmap2", "ouroboros",  "superslice", "itertools", "serde_json/raw_value"]
+sparse = ["rattler_conda_types", "memmap2", "ouroboros", "superslice", "itertools", "serde_json/raw_value"]

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -589,6 +589,7 @@ dependencies = [
  "fxhash",
  "glob",
  "hex",
+ "indexmap 2.0.0",
  "itertools",
  "lazy-regex",
  "nom",
@@ -738,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1402f54f9a3b9e2efe71c1cea24e648acce55887983553eeb858cf3115acfd49"
+checksum = "1ca3b16a3d82c4088f343b7480a93550b3eabe1a358569c2dfe38bbcead07237"
 dependencies = [
  "base64",
  "chrono",
@@ -755,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9197f1ad0e3c173a0222d3c4404fb04c3afe87e962bcb327af73e8301fa203c7"
+checksum = "2e6be15c453eb305019bfa438b1593c731f36a289a7853f7707ee29e870b3b3c"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
This PR replaces some of the HashMaps in the conda-lock data structures with `IndexMap` (keeps order of insertion) and `BTreeMap` (sorts by key). This ensures that we get a consistent output in pixi.

I used `IndexMap` in the places where I thought the order of the source elements was important. For instance, the dependencies specified in the repodata.

I used `BTreeMap` where I think the order doesn't matter but it should be consistent.