### PR TITLE
Updates to `NamelessMatchSpec` to allow deserializing

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -1,7 +1,7 @@
 use crate::{PackageName, PackageRecord, VersionSpec};
 use rattler_digest::{serde::SerializableHash, Md5Hash, Sha256Hash};
-use serde::Serialize;
-use serde_with::{serde_as, skip_serializing_none};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 
@@ -227,11 +227,13 @@ impl MatchSpec {
 /// where the package name is already known (e.g. `foo = "3.4.1 *cuda"`)
 #[serde_as]
 #[skip_serializing_none]
-#[derive(Debug, Default, Clone, Serialize, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct NamelessMatchSpec {
     /// The version spec of the package (e.g. `1.2.3`, `>=1.2.3`, `1.2.*`)
+    #[serde_as(as = "Option<DisplayFromStr>")]
     pub version: Option<VersionSpec>,
     /// The build string of the package (e.g. `py37_0`, `py37h6de7cb9_0`, `py*`)
+    #[serde_as(as = "Option<DisplayFromStr>")]
     pub build: Option<StringMatcher>,
     /// The build number of the package
     pub build_number: Option<u64>,

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -953,7 +953,7 @@ impl<'v> SegmentIter<'v> {
 /// this is not equal. Useful in ranges where we are talking
 /// about equality over version ranges instead of specific
 /// version instances
-#[derive(Clone, PartialOrd, Ord, Eq, Debug)]
+#[derive(Clone, PartialOrd, Ord, Eq, Debug, Deserialize)]
 pub struct StrictVersion(pub Version);
 
 impl PartialEq for StrictVersion {

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod version_tree;
 use crate::version_spec::version_tree::ParseVersionTreeError;
 use crate::{ParseVersionError, Version};
 pub(crate) use constraint::Constraint;
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Serialize, Serializer};
 use std::convert::TryFrom;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
@@ -21,7 +21,7 @@ pub(crate) use parse::ParseConstraintError;
 
 /// An operator to compare two versions.
 #[allow(missing_docs)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub enum RangeOperator {
     Greater,
     GreaterEquals,
@@ -42,7 +42,7 @@ impl RangeOperator {
 }
 
 #[allow(missing_docs)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub enum StrictRangeOperator {
     StartsWith,
     NotStartsWith,
@@ -64,7 +64,7 @@ impl StrictRangeOperator {
 
 /// An operator set a version equal to another
 #[allow(missing_docs)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub enum EqualityOperator {
     Equals,
     NotEquals,
@@ -93,7 +93,7 @@ pub enum VersionOperators {
 
 /// Logical operator used two compare groups of version comparisions. E.g. `>=3.4,<4.0` or
 /// `>=3.4|<4.0`,
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
 pub enum LogicalOperator {
     /// All comparators must evaluate to true for the group to evaluate to true.
     And,
@@ -114,7 +114,7 @@ impl LogicalOperator {
 
 /// A version specification.
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Deserialize)]
 pub enum VersionSpec {
     /// No version specified
     None,


### PR DESCRIPTION
While working on this issue:

- https://github.com/prefix-dev/pixi/issues/76

I realized that I was going to need to be able to deserialize the `NamelessMatchSpec` struct from a mapping. I believe the easiest way to allow this is by adding `Deserialize` to `derive` in the correct places.

On `NamelessMatchSpec` I also chose to use `DisplayFromStr` for `version` and `build` because I believe that's the easiest way to do it. I would be happy to change it if that's not right though.

Below is my simplified use case:

```rust
use std::fs;
use std::path::PathBuf;

use indexmap::IndexMap;
use clap::{Parser};
use serde::Deserialize;
use serde_with::{serde_as, DisplayFromStr, PickFirst};
use rattler_conda_types::NamelessMatchSpec;

#[derive(Parser)]
#[command(name = "tt - TOML test")]
#[command(author = "Travis Hathaway")]
#[command(version = "0.1.0")]
#[command(about = "Tests with TOML parsing")]
struct Cli {
    /// TOML File
    toml_file: PathBuf,
}

/// Describes the contents of a test project manifest.
#[serde_as]
#[derive(Debug, Clone, Deserialize)]
pub struct MyManifest {
    #[serde_as(as = "IndexMap<_, PickFirst<(_, DisplayFromStr)>>")]
    dependencies: IndexMap<String, NamelessMatchSpec>
}


fn main() -> Result<(), Box<dyn std::error::Error>>{
    let cli = Cli::parse();

    println!("{:?}\n", cli.toml_file);

    if cli.toml_file.exists() {
        let contents = fs::read_to_string(cli.toml_file)?;
        let manifest = toml_edit::de::from_str::<MyManifest>(&contents)?;

        println!("Dependencies:");
        println!("{:?}", manifest.dependencies);

    } else {
        println!("File does not exist");
    }

    Ok(())
}
```