### PR TITLE
feat: implement base_url cep

### DIFF
--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -43,6 +43,8 @@ rstest = "0.18.2"
 assert_matches = "1.5.0"
 hex-literal = "0.4.1"
 criterion = { version = "0.5", features = ["html_reports"] }
+pathdiff = "0.2.1"
+dunce = "1.0.4"
 
 [[bench]]
 name = "parse"

--- a/crates/rattler_conda_types/src/lib.rs
+++ b/crates/rattler_conda_types/src/lib.rs
@@ -36,7 +36,9 @@ pub use package_name::{InvalidPackageNameError, PackageName};
 pub use platform::{Arch, ParseArchError, ParsePlatformError, Platform};
 pub use prefix_record::PrefixRecord;
 pub use repo_data::patches::{PackageRecordPatch, PatchInstructions, RepoDataPatch};
-pub use repo_data::{ChannelInfo, ConvertSubdirError, PackageRecord, RepoData};
+pub use repo_data::{
+    compute_package_url, ChannelInfo, ConvertSubdirError, PackageRecord, RepoData,
+};
 pub use repo_data_record::RepoDataRecord;
 pub use run_export::RunExportKind;
 pub use version::{

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -485,7 +485,7 @@ mod test {
                 pathdiff::diff_paths(r.url.to_file_path().unwrap(), &test_data_path)
                     .unwrap()
                     .to_string_lossy()
-                    .replace('\\',"/")
+                    .replace('\\', "/")
             })
             .collect::<Vec<_>>();
 

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
@@ -1,0 +1,11 @@
+---
+source: crates/rattler_conda_types/src/repo_data/mod.rs
+assertion_line: 488
+expression: file_urls
+---
+- "file:///E:/Developer/prefix/rattler/test-data/channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_1.tar.bz2"
+- "file:///E:/Developer/prefix/rattler/test-data/channels/dummy/linux-64/baz-1.0-unix_py36h1af98f8_2%00.tar.bz2"
+- "file:///E:/Developer/prefix/rattler/test-data/channels/dummy/linux-64/foo-4.0.2-py36h1af98f8_2.tar.bz2"
+- "file:///E:/Developer/prefix/rattler/test-data/channels/dummy/linux-64/bar-1.0-unix_py36h1af98f8_2.tar.bz2"
+- "file:///E:/Developer/prefix/rattler/test-data/channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_1.conda"
+

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
@@ -1,11 +1,11 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
-assertion_line: 488
+assertion_line: 493
 expression: file_urls
 ---
-- "file:///E:/Developer/prefix/rattler/test-data/channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_1.tar.bz2"
-- "file:///E:/Developer/prefix/rattler/test-data/channels/dummy/linux-64/baz-1.0-unix_py36h1af98f8_2%00.tar.bz2"
-- "file:///E:/Developer/prefix/rattler/test-data/channels/dummy/linux-64/foo-4.0.2-py36h1af98f8_2.tar.bz2"
-- "file:///E:/Developer/prefix/rattler/test-data/channels/dummy/linux-64/bar-1.0-unix_py36h1af98f8_2.tar.bz2"
-- "file:///E:/Developer/prefix/rattler/test-data/channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_1.conda"
+- channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_1.tar.bz2
+- "channels/dummy/linux-64/baz-1.0-unix_py36h1af98f8_2\u0000.tar.bz2"
+- channels/dummy/linux-64/foo-4.0.2-py36h1af98f8_2.tar.bz2
+- channels/dummy/linux-64/bar-1.0-unix_py36h1af98f8_2.tar.bz2
+- channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_1.conda
 

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
+assertion_line: 438
 expression: repodata
 ---
 info: ~
@@ -13,5 +14,5 @@ removed:
   - quux
   - qux
   - xyz
-repodata_version: 1
+repodata_version: 2
 

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
@@ -1,10 +1,12 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
+assertion_line: 460
 expression: json
 ---
 {
   "info": {
-    "subdir": "linux-64"
+    "subdir": "linux-64",
+    "base_url": "../linux-64"
   },
   "packages": {
     "bar-1.0-unix_py36h1af98f8_2.tar.bz2": {
@@ -83,5 +85,5 @@ expression: json
     }
   },
   "packages.conda": {},
-  "repodata_version": 1
+  "repodata_version": 2
 }

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
@@ -1,9 +1,11 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
+assertion_line: 448
 expression: repodata
 ---
 info:
   subdir: linux-64
+  base_url: "../linux-64"
 packages:
   bar-1.0-unix_py36h1af98f8_2.tar.bz2:
     build: unix_py36h1af98f8_2
@@ -73,5 +75,5 @@ packages:
     timestamp: 1605110689658
     version: 4.0.2
 packages.conda: {}
-repodata_version: 1
+repodata_version: 2
 

--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -3,7 +3,9 @@
 
 use futures::{stream, StreamExt, TryFutureExt, TryStreamExt};
 use itertools::Itertools;
-use rattler_conda_types::{Channel, PackageName, PackageRecord, RepoDataRecord};
+use rattler_conda_types::{
+    compute_package_url, Channel, ChannelInfo, PackageName, PackageRecord, RepoDataRecord,
+};
 use serde::{
     de::{Error, MapAccess, Visitor},
     Deserialize, Deserializer,
@@ -90,9 +92,11 @@ impl SparseRepoData {
     /// Returns all the records for the specified package name.
     pub fn load_records(&self, package_name: &PackageName) -> io::Result<Vec<RepoDataRecord>> {
         let repo_data = self.inner.borrow_repo_data();
+        let base_url = repo_data.info.as_ref().and_then(|i| i.base_url.as_deref());
         let mut records = parse_records(
             package_name,
             &repo_data.packages,
+            base_url,
             &self.channel,
             &self.subdir,
             self.patch_record_fn,
@@ -100,6 +104,7 @@ impl SparseRepoData {
         let mut conda_records = parse_records(
             package_name,
             &repo_data.conda_packages,
+            base_url,
             &self.channel,
             &self.subdir,
             self.patch_record_fn,
@@ -133,11 +138,16 @@ impl SparseRepoData {
         while let Some(next_package) = pending.pop_front() {
             for (i, repo_data) in repo_data.iter().enumerate() {
                 let repo_data_packages = repo_data.inner.borrow_repo_data();
+                let base_url = repo_data_packages
+                    .info
+                    .as_ref()
+                    .and_then(|i| i.base_url.as_deref());
 
                 // Get all records from the repodata
                 let mut records = parse_records(
                     &next_package,
                     &repo_data_packages.packages,
+                    base_url,
                     &repo_data.channel,
                     &repo_data.subdir,
                     patch_function,
@@ -145,6 +155,7 @@ impl SparseRepoData {
                 let mut conda_records = parse_records(
                     &next_package,
                     &repo_data_packages.conda_packages,
+                    base_url,
                     &repo_data.channel,
                     &repo_data.subdir,
                     patch_function,
@@ -180,6 +191,9 @@ impl SparseRepoData {
 /// A serde compatible struct that only sparsely parses a repodata.json file.
 #[derive(Deserialize)]
 struct LazyRepoData<'i> {
+    /// The channel information contained in the repodata.json file
+    info: Option<ChannelInfo>,
+
     /// The tar.bz2 packages contained in the repodata.json file
     #[serde(borrow)]
     #[serde(deserialize_with = "deserialize_filename_and_raw_record")]
@@ -196,6 +210,7 @@ struct LazyRepoData<'i> {
 fn parse_records<'i>(
     package_name: &PackageName,
     packages: &[(PackageFilename<'i>, &'i RawValue)],
+    base_url: Option<&str>,
     channel: &Channel,
     subdir: &str,
     patch_function: Option<fn(&mut PackageRecord)>,
@@ -212,10 +227,7 @@ fn parse_records<'i>(
             package_record.subdir = subdir.to_owned();
         }
         result.push(RepoDataRecord {
-            url: channel
-                .base_url()
-                .join(&format!("{}/{}", &package_record.subdir, &key.filename))
-                .expect("failed to build a url from channel and package record"),
+            url: compute_package_url(channel, base_url, key.filename, &package_record.subdir),
             channel: channel_name.clone(),
             package_record,
             file_name: key.filename.to_owned(),

--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -227,7 +227,14 @@ fn parse_records<'i>(
             package_record.subdir = subdir.to_owned();
         }
         result.push(RepoDataRecord {
-            url: compute_package_url(channel, base_url, key.filename, &package_record.subdir),
+            url: compute_package_url(
+                &channel
+                    .base_url
+                    .join(&format!("{}/", &package_record.subdir))
+                    .expect("failed determine repo_base_url"),
+                base_url,
+                key.filename,
+            ),
             channel: channel_name.clone(),
             package_record,
             file_name: key.filename.to_owned(),

--- a/test-data/channels/dummy/linux-64/repodata.json
+++ b/test-data/channels/dummy/linux-64/repodata.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a8b4ace3d680d33498f54cb36d5f4c5234bac3929f72dff6858888bc02b13148
-size 2417
+oid sha256:659258cfd03f77f6af79d51d882dfdbafd68f9fb6fde2475a45f3452f7389345
+size 2449


### PR DESCRIPTION
Implements the changes discussed in https://github.com/conda-incubator/ceps/pull/61 . 

This shouldn't really affect anyone just yet since there are no server implementations of repodata version 2 yet.