### PR TITLE
refactor: remove repo from pool

### DIFF
--- a/crates/rattler_libsolv_rs/src/id.rs
+++ b/crates/rattler_libsolv_rs/src/id.rs
@@ -1,16 +1,5 @@
 use crate::arena::ArenaId;
 
-/// The id associated to a libsolv repo
-#[repr(transparent)]
-#[derive(Clone, Copy, Eq, PartialEq, Hash)]
-pub struct RepoId(u32);
-
-impl RepoId {
-    pub(crate) fn new(id: u32) -> Self {
-        Self(id)
-    }
-}
-
 /// The id associated to a package name
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/crates/rattler_libsolv_rs/src/lib.rs
+++ b/crates/rattler_libsolv_rs/src/lib.rs
@@ -20,7 +20,7 @@ mod solve_jobs;
 mod solver;
 mod transaction;
 
-pub use id::{NameId, RepoId, SolvableId, VersionSetId};
+pub use id::{NameId, SolvableId, VersionSetId};
 pub use pool::Pool;
 pub use solvable::PackageSolvable;
 pub use solve_jobs::SolveJobs;

--- a/crates/rattler_libsolv_rs/src/solvable.rs
+++ b/crates/rattler_libsolv_rs/src/solvable.rs
@@ -1,5 +1,5 @@
+use crate::id::NameId;
 use crate::id::VersionSetId;
-use crate::id::{NameId, RepoId};
 
 use std::fmt::{Display, Formatter};
 
@@ -8,7 +8,6 @@ use std::fmt::{Display, Formatter};
 /// Contains a reference to the `PackageRecord` that corresponds to the solvable (the `'a` lifetime
 /// comes from the original `PackageRecord`)
 pub struct PackageSolvable<V> {
-    pub(crate) repo_id: RepoId,
     pub(crate) dependencies: Vec<VersionSetId>,
     pub(crate) constrains: Vec<VersionSetId>,
     pub(crate) inner: V,
@@ -16,11 +15,6 @@ pub struct PackageSolvable<V> {
 }
 
 impl<V> PackageSolvable<V> {
-    /// Returns the [`RepoId`] associated to this solvable
-    pub fn repo_id(&self) -> RepoId {
-        self.repo_id
-    }
-
     /// Gets the record associated to this solvable
     pub fn inner(&self) -> &V {
         &self.inner
@@ -60,10 +54,9 @@ impl<V> Solvable<V> {
         }
     }
 
-    pub(crate) fn new_package(repo_id: RepoId, name: NameId, record: V) -> Self {
+    pub(crate) fn new_package(name: NameId, record: V) -> Self {
         Self {
             inner: SolvableInner::Package(PackageSolvable {
-                repo_id,
                 inner: record,
                 name,
                 dependencies: Vec::new(),

--- a/crates/rattler_libsolv_rs/src/solver/mod.rs
+++ b/crates/rattler_libsolv_rs/src/solver/mod.rs
@@ -924,7 +924,7 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>> Sol
 mod test {
     use super::*;
     use crate::solvable::Solvable;
-    use crate::{id::RepoId, VersionTrait};
+    use crate::VersionTrait;
     use std::fmt::{Debug, Display, Formatter};
     use std::ops::Range;
     use std::str::FromStr;
@@ -1102,7 +1102,7 @@ mod test {
         // Add the package
         let version = package_version;
         let name_id = pool.intern_package_name(package_name);
-        let package_id = pool.add_package(RepoId::new(0), name_id, version);
+        let package_id = pool.add_package(name_id, version);
 
         // And its the dependencies
         for dep in dependencies {

--- a/crates/rattler_solve/src/libsolv_rs/input.rs
+++ b/crates/rattler_solve/src/libsolv_rs/input.rs
@@ -5,7 +5,7 @@ use crate::libsolv_rs::{SolverMatchSpec, SolverPackageRecord};
 use rattler_conda_types::package::ArchiveType;
 use rattler_conda_types::{GenericVirtualPackage, RepoDataRecord};
 use rattler_conda_types::{MatchSpec, NamelessMatchSpec, ParseMatchSpecError};
-use rattler_libsolv_rs::{Pool, RepoId, SolvableId, VersionSetId};
+use rattler_libsolv_rs::{Pool, SolvableId, VersionSetId};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -18,7 +18,6 @@ use std::str::FromStr;
 /// Panics if the repo does not belong to the pool
 pub(super) fn add_repodata_records<'a>(
     pool: &mut Pool<SolverMatchSpec<'a>>,
-    repo_id: RepoId,
     repo_datas: impl IntoIterator<Item = &'a RepoDataRecord>,
     parse_match_spec_cache: &mut HashMap<String, VersionSetId>,
 ) -> Result<Vec<SolvableId>, ParseMatchSpecError> {
@@ -62,8 +61,7 @@ pub(super) fn add_repodata_records<'a>(
 
         // Add the package to the pool
         let name_id = pool.intern_package_name(record.name.as_normalized());
-        let solvable_id =
-            pool.add_package(repo_id, name_id, SolverPackageRecord::Record(repo_data));
+        let solvable_id = pool.add_package(name_id, SolverPackageRecord::Record(repo_data));
 
         // Dependencies
         for match_spec_str in record.depends.iter() {
@@ -83,13 +81,11 @@ pub(super) fn add_repodata_records<'a>(
 
 pub(super) fn add_virtual_packages<'a>(
     pool: &mut Pool<SolverMatchSpec<'a>>,
-    repo_id: RepoId,
     packages: &'a [GenericVirtualPackage],
 ) {
     for package in packages {
         let package_name_id = pool.intern_package_name(package.name.as_normalized());
         pool.add_package(
-            repo_id,
             package_name_id,
             SolverPackageRecord::VirtualPackage(package),
         );

--- a/crates/rattler_solve/src/libsolv_rs/mod.rs
+++ b/crates/rattler_solve/src/libsolv_rs/mod.rs
@@ -213,8 +213,7 @@ impl super::SolverImpl for Solver {
         let mut parse_match_spec_cache = HashMap::new();
 
         // Add virtual packages
-        let repo_id = pool.new_repo();
-        add_virtual_packages(&mut pool, repo_id, &task.virtual_packages);
+        add_virtual_packages(&mut pool, &task.virtual_packages);
 
         // Create repos for all channel + platform combinations
         for repodata in task.available_packages.into_iter().map(IntoRepoData::into) {
@@ -222,29 +221,23 @@ impl super::SolverImpl for Solver {
                 continue;
             }
 
-            let repo_id = pool.new_repo();
             add_repodata_records(
                 &mut pool,
-                repo_id,
                 repodata.records.iter().copied(),
                 &mut parse_match_spec_cache,
             )?;
         }
 
         // Create a special pool for records that are already installed or locked.
-        let repo_id = pool.new_repo();
         let installed_solvables = add_repodata_records(
             &mut pool,
-            repo_id,
             &task.locked_packages,
             &mut parse_match_spec_cache,
         )?;
 
         // Create a special pool for records that are pinned and cannot be changed.
-        let repo_id = pool.new_repo();
         let pinned_solvables = add_repodata_records(
             &mut pool,
-            repo_id,
             &task.pinned_packages,
             &mut parse_match_spec_cache,
         )?;


### PR DESCRIPTION
This removes the notion of "repo" from the solver. This information was not used at all and can now be stored inside the generic parameters if you need it.