### PR TITLE
drop support for repodata.json.bz2

### DIFF
--- a/crates/rattler_repodata_gateway/src/fetch/cache/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/cache/mod.rs
@@ -43,9 +43,6 @@ pub struct RepoDataState {
     /// Whether or not zst is available for the subdirectory
     pub has_zst: Option<Expiring<bool>>,
 
-    /// Whether a bz2 compressed version is available for the subdirectory
-    pub has_bz2: Option<Expiring<bool>>,
-
     /// Whether or not JLAP is available for the subdirectory
     pub has_jlap: Option<Expiring<bool>>,
 

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -738,10 +738,7 @@ pub async fn check_variant_availability(
     // the cache is still valid.
     let (has_zst, has_jlap) = futures::join!(zst_future, jlap_future);
 
-    VariantAvailability {
-        has_zst,
-        has_jlap,
-    }
+    VariantAvailability { has_zst, has_jlap }
 }
 
 /// Performs a HEAD request on the given URL to see if it is available.

--- a/crates/rattler_repodata_gateway/src/utils/encoding.rs
+++ b/crates/rattler_repodata_gateway/src/utils/encoding.rs
@@ -8,7 +8,6 @@ use tokio::io::{AsyncBufRead, AsyncRead, ReadBuf};
 pub enum Encoding {
     Passthrough,
     GZip,
-    Bz2,
     Zst,
 }
 
@@ -58,9 +57,6 @@ impl<T: AsyncBufRead> AsyncEncoding for T {
             Encoding::Passthrough => Decoder::Passthrough { inner: self },
             Encoding::GZip => Decoder::GZip {
                 inner: async_compression::tokio::bufread::GzipDecoder::new(self),
-            },
-            Encoding::Bz2 => Decoder::Bz2 {
-                inner: async_compression::tokio::bufread::BzDecoder::new(self),
             },
             Encoding::Zst => Decoder::Zst {
                 inner: async_compression::tokio::bufread::ZstdDecoder::new(self),


### PR DESCRIPTION
As explained in #308 `repodata.json.bz2` should be obsolete. Remove from rattler.

Fix #308

Does this make unwanted API changes to rattler?