### PR TITLE
bump: json-patch 1.1.0

### DIFF
--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -38,7 +38,7 @@ ouroboros = { version = "0.17.2", optional = true }
 serde_with = "3.3.0"
 superslice = { version = "1.0.0", optional = true }
 itertools = { version = "0.11.0", optional = true }
-json-patch = "1.0.0"
+json-patch = "1.1.0"
 hex = { version = "0.4.3", features = ["serde"] }
 rattler_networking = { version = "0.8.0", path = "../rattler_networking", default-features = false }
 

--- a/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
@@ -531,7 +531,7 @@ async fn apply_jlap_patches(
         );
         // Apply the patches we current have to it
         for patch in patches[start_index..].iter() {
-            if let Err(error) = json_patch::patch(&mut doc, &patch.patch) {
+            if let Err(error) = json_patch::patch_unsafe(&mut doc, &patch.patch) {
                 return Err(JLAPError::JSONPatch(error));
             }
         }


### PR DESCRIPTION
Bump json-patch to include https://github.com/idubrov/json-patch/pull/28. This fixes an issue where an unrecoverable stack overflow could occur when applying jlap patches.