### PR TITLE
Refactor `Mapping`

### DIFF
--- a/crates/rattler_libsolv_rs/src/mapping.rs
+++ b/crates/rattler_libsolv_rs/src/mapping.rs
@@ -93,6 +93,9 @@ impl<TId: ArenaId, TValue> Mapping<TId, TValue> {
     }
 
     /// Get a specific value in the mapping without bound checks
+    ///
+    /// # Safety
+    /// The caller must uphold most of the safety requirements for `get_unchecked`. i.e. the id having been inserted into the Mapping before.
     pub unsafe fn get_unchecked(&self, id: TId) -> &TValue {
         let (chunk, offset) = Self::chunk_and_offset(id.to_usize());
         self.chunks
@@ -103,6 +106,9 @@ impl<TId: ArenaId, TValue> Mapping<TId, TValue> {
     }
 
     /// Get a specific value in the mapping without bound checks
+    ///
+    /// # Safety
+    /// The caller must uphold most of the safety requirements for `get_unchecked_mut`. i.e. the id having been inserted into the Mapping before.
     pub unsafe fn get_unchecked_mut(&mut self, id: TId) -> &mut TValue {
         let (chunk, offset) = Self::chunk_and_offset(id.to_usize());
         self.chunks
@@ -115,6 +121,11 @@ impl<TId: ArenaId, TValue> Mapping<TId, TValue> {
     /// Returns the number of mapped items
     pub fn len(&self) -> usize {
         self.len
+    }
+
+    /// Returns true if the Mapping is empty
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     /// Defines the number of slots that can be used

--- a/crates/rattler_libsolv_rs/src/mapping.rs
+++ b/crates/rattler_libsolv_rs/src/mapping.rs
@@ -1,57 +1,219 @@
 use crate::arena::ArenaId;
+use std::cmp;
+use std::iter::FusedIterator;
 use std::marker::PhantomData;
-use std::ops::{Index, IndexMut};
+
+const VALUES_PER_CHUNK: usize = 128;
 
 /// A `Mapping<TValue>` holds a collection of `TValue`s that can be addressed by `TId`s. You can
 /// think of it as a HashMap<TId, TValue>, optimized for the case in which we know the `TId`s are
 /// contiguous.
-#[derive(Default)]
-pub struct Mapping<TId: ArenaId, TValue> {
-    data: Vec<TValue>,
-    phantom: PhantomData<TId>,
+pub struct Mapping<TId, TValue> {
+    chunks: Vec<[Option<TValue>; VALUES_PER_CHUNK]>,
+    len: usize,
+    _phantom: PhantomData<TId>,
+}
+
+impl<TId: ArenaId, TValue: Clone> Default for Mapping<TId, TValue> {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[allow(unused)]
 impl<TId: ArenaId, TValue> Mapping<TId, TValue> {
-    pub(crate) fn empty() -> Self {
-        Self::new(Vec::new())
+    pub(crate) fn new() -> Self {
+        Self::with_capacity(1)
     }
 
-    /// TODO: if we get rid of the `init` for the cache this need not be public
-    pub fn new(data: Vec<TValue>) -> Self {
+    /// Constructs a new arena with a capacity for `n` values pre-allocated.
+    pub fn with_capacity(n: usize) -> Self {
+        let n = cmp::max(1, n);
+        let n_chunks = (n - 1) / VALUES_PER_CHUNK + 1;
+        let mut chunks = Vec::new();
+        chunks.resize_with(n_chunks, || std::array::from_fn(|_| None));
         Self {
-            data,
-            phantom: PhantomData::default(),
+            chunks,
+            len: 0,
+            _phantom: Default::default(),
         }
     }
 
-    pub(crate) fn get(&self, id: TId) -> Option<&TValue> {
-        self.data.get(id.to_usize())
+    /// Get chunk and offset for specific id
+    #[inline]
+    pub const fn chunk_and_offset(id: usize) -> (usize, usize) {
+        let chunk = id / VALUES_PER_CHUNK;
+        let offset = id % VALUES_PER_CHUNK;
+        (chunk, offset)
     }
 
-    pub(crate) fn extend(&mut self, value: TValue) {
-        self.data.push(value);
+    /// Insert into the mapping with the specific value
+    pub fn insert(&mut self, id: TId, value: TValue) {
+        let (chunk, offset) = Self::chunk_and_offset(id.to_usize());
+
+        // Resize to fit if needed
+        if chunk >= self.chunks.len() {
+            self.chunks
+                .resize_with(chunk + 1, || {
+                    std::array::from_fn(|_| None)
+                });
+        }
+        self.chunks[chunk][offset] = Some(value);
+        self.len += 1;
     }
 
-    pub(crate) fn values(&self) -> impl Iterator<Item = &TValue> {
-        self.data.iter()
+    /// Get a specific value in the mapping with bound checks
+    pub fn get(&self, id: TId) -> Option<&TValue> {
+        let (chunk, offset) = Self::chunk_and_offset(id.to_usize());
+        if chunk > self.chunks.len() {
+            return None;
+        }
+
+        // Safety: we know that the chunk and offset are valid
+        unsafe {
+            self.chunks
+                .get_unchecked(chunk)
+                .get_unchecked(offset)
+                .as_ref()
+        }
     }
 
-    pub(crate) fn len(&self) -> usize {
-        self.data.len()
+    /// Get a mutable specific value in the mapping with bound checks
+    pub fn get_mut(&mut self, id: TId) -> Option<&mut TValue> {
+        let (chunk, offset) = Self::chunk_and_offset(id.to_usize());
+        if chunk > self.chunks.len() {
+            return None;
+        }
+
+        // Safety: we know that the chunk and offset are valid
+        unsafe {
+            self.chunks
+                .get_unchecked_mut(chunk)
+                .get_unchecked_mut(offset)
+                .as_mut()
+        }
+    }
+
+    /// Get a specific value in the mapping without bound checks
+    pub unsafe fn get_unchecked(&self, id: TId) -> &TValue {
+        let (chunk, offset) = Self::chunk_and_offset(id.to_usize());
+        self.chunks
+            .get_unchecked(chunk)
+            .get_unchecked(offset)
+            .as_ref()
+            .unwrap()
+    }
+
+    /// Get a specific value in the mapping without bound checks
+    pub unsafe fn get_unchecked_mut(&mut self, id: TId) -> &mut TValue {
+        let (chunk, offset) = Self::chunk_and_offset(id.to_usize());
+        self.chunks
+            .get_unchecked_mut(chunk)
+            .get_unchecked_mut(offset)
+            .as_mut()
+            .unwrap()
+    }
+
+    /// Returns the number of mapped items
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Defines the number of slots that can be used
+    /// theses slots are not initialized
+    pub fn slots(&self) -> usize {
+        self.chunks.len() * VALUES_PER_CHUNK
+    }
+
+    /// Returns an iterator over all the existing key value pairs.
+    pub fn iter(&self) -> MappingIter<TId, TValue> {
+        MappingIter {
+            mapping: self,
+            offset: 0,
+        }
     }
 }
 
-impl<TId: ArenaId, TValue> Index<TId> for Mapping<TId, TValue> {
-    type Output = TValue;
+pub struct MappingIter<'a, TId, TValue> {
+    mapping: &'a Mapping<TId, TValue>,
+    offset: usize,
+}
 
-    fn index(&self, index: TId) -> &Self::Output {
-        &self.data[index.to_usize()]
+impl<'a, TId: ArenaId, TValue> Iterator for MappingIter<'a, TId, TValue> {
+    type Item = (TId, &'a TValue);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.offset >= self.mapping.len {
+                return None;
+            }
+
+            let (chunk, offset) = Mapping::<TId, TValue>::chunk_and_offset(self.offset);
+            let id = TId::from_usize(self.offset);
+            self.offset += 1;
+
+            unsafe {
+                if let Some(value) = &self
+                    .mapping
+                    .chunks
+                    .get_unchecked(chunk)
+                    .get_unchecked(offset)
+                {
+                    break Some((id, value));
+                }
+            }
+        }
     }
 }
 
-impl<TId: ArenaId, TValue> IndexMut<TId> for Mapping<TId, TValue> {
-    fn index_mut(&mut self, index: TId) -> &mut Self::Output {
-        &mut self.data[index.to_usize()]
+impl<'a, TId: ArenaId, TValue> FusedIterator for MappingIter<'a, TId, TValue> {}
+
+#[cfg(test)]
+mod tests {
+    use crate::arena::ArenaId;
+
+    struct Id {
+        id: usize,
+    }
+
+    impl ArenaId for Id {
+        fn from_usize(x: usize) -> Self {
+            Id { id: x }
+        }
+
+        fn to_usize(self) -> usize {
+            self.id
+        }
+    }
+
+    #[test]
+    pub fn test_mapping() {
+        // New mapping should have 128 slots per default
+        let mut mapping = super::Mapping::<Id, usize>::new();
+        assert_eq!(mapping.len(), 0);
+        assert_eq!(mapping.slots(), super::VALUES_PER_CHUNK);
+
+        // Inserting a value should increase the length
+        // and the number of slots should stay the same
+        mapping.insert(Id::from_usize(0), 10usize);
+        assert_eq!(mapping.len(), 1);
+
+        // Should be able to get it
+        assert_eq!(*mapping.get(Id::from_usize(0)).unwrap(), 10usize);
+        assert_eq!(mapping.slots(), super::VALUES_PER_CHUNK);
+
+        // Inserting higher than the slot size should trigger a resize
+        mapping.insert(Id::from_usize(super::VALUES_PER_CHUNK), 20usize);
+        assert_eq!(
+            *mapping
+                .get(Id::from_usize(super::VALUES_PER_CHUNK))
+                .unwrap(),
+            20usize
+        );
+
+        // Now contains 2 elements
+        assert_eq!(mapping.len(), 2);
+        // And double number of slots due to resize
+        assert_eq!(mapping.slots(), super::VALUES_PER_CHUNK * 2);
     }
 }

--- a/crates/rattler_libsolv_rs/src/mapping.rs
+++ b/crates/rattler_libsolv_rs/src/mapping.rs
@@ -65,7 +65,7 @@ impl<TId: ArenaId, TValue> Mapping<TId, TValue> {
     /// Get a specific value in the mapping with bound checks
     pub fn get(&self, id: TId) -> Option<&TValue> {
         let (chunk, offset) = Self::chunk_and_offset(id.to_usize());
-        if chunk > self.chunks.len() {
+        if chunk >= self.chunks.len() {
             return None;
         }
 
@@ -81,7 +81,7 @@ impl<TId: ArenaId, TValue> Mapping<TId, TValue> {
     /// Get a mutable specific value in the mapping with bound checks
     pub fn get_mut(&mut self, id: TId) -> Option<&mut TValue> {
         let (chunk, offset) = Self::chunk_and_offset(id.to_usize());
-        if chunk > self.chunks.len() {
+        if chunk >= self.chunks.len() {
             return None;
         }
 

--- a/crates/rattler_libsolv_rs/src/mapping.rs
+++ b/crates/rattler_libsolv_rs/src/mapping.rs
@@ -54,9 +54,7 @@ impl<TId: ArenaId, TValue> Mapping<TId, TValue> {
         // Resize to fit if needed
         if chunk >= self.chunks.len() {
             self.chunks
-                .resize_with(chunk + 1, || {
-                    std::array::from_fn(|_| None)
-                });
+                .resize_with(chunk + 1, || std::array::from_fn(|_| None));
         }
         self.chunks[chunk][offset] = Some(value);
         self.len += 1;

--- a/crates/rattler_libsolv_rs/src/solver/mod.rs
+++ b/crates/rattler_libsolv_rs/src/solver/mod.rs
@@ -999,8 +999,6 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>> Sol
     }
 
     fn make_watches(&mut self) {
-        self.watches.initialize(self.pool().solvables.len());
-
         // Watches are already initialized in the clauses themselves, here we build a linked list for
         // each package (a clause will be linked to other clauses that are watching the same package)
         for (clause_id, clause) in self.clauses.iter_mut() {

--- a/crates/rattler_libsolv_rs/src/solver/mod.rs
+++ b/crates/rattler_libsolv_rs/src/solver/mod.rs
@@ -802,7 +802,10 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>> Sol
                     return;
                 }
 
-                for &cause in learnt_why.get(learnt_clause_id).expect("no cause for learnt clause available") {
+                for &cause in learnt_why
+                    .get(learnt_clause_id)
+                    .expect("no cause for learnt clause available")
+                {
                     Self::analyze_unsolvable_clause(clauses, learnt_why, cause, problem, seen);
                 }
             }
@@ -970,7 +973,7 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>> Sol
 
         // Add the clause
         let learnt_id = self.learnt_clauses.alloc(learnt.clone());
-        self.learnt_why.insert(learnt_id,learnt_why);
+        self.learnt_why.insert(learnt_id, learnt_why);
 
         let clause_id = self.clauses.alloc(ClauseState::learnt(learnt_id, &learnt));
         self.learnt_clause_ids.push(clause_id);

--- a/crates/rattler_libsolv_rs/src/solver/mod.rs
+++ b/crates/rattler_libsolv_rs/src/solver/mod.rs
@@ -76,7 +76,7 @@ impl<VS: VersionSet, N: PackageName, D: DependencyProvider<VS, N>> Solver<VS, N,
             clauses: Arena::new(),
             watches: WatchMap::new(),
             learnt_clauses: Arena::new(),
-            learnt_why: Mapping::empty(),
+            learnt_why: Mapping::new(),
             learnt_clause_ids: Vec::new(),
             decision_tracker: DecisionTracker::new(),
             candidates: Arena::new(),
@@ -237,7 +237,7 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>> Sol
         // Clear state
         self.decision_tracker.clear();
         self.learnt_clauses.clear();
-        self.learnt_why = Mapping::empty();
+        self.learnt_why = Mapping::new();
         self.clauses = Default::default();
         self.root_requirements = root_requirements;
 
@@ -802,7 +802,7 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>> Sol
                     return;
                 }
 
-                for &cause in &learnt_why[learnt_clause_id] {
+                for &cause in learnt_why.get(learnt_clause_id).expect("no cause for learnt clause available") {
                     Self::analyze_unsolvable_clause(clauses, learnt_why, cause, problem, seen);
                 }
             }
@@ -970,7 +970,7 @@ impl<VS: VersionSet, N: PackageName + Display, D: DependencyProvider<VS, N>> Sol
 
         // Add the clause
         let learnt_id = self.learnt_clauses.alloc(learnt.clone());
-        self.learnt_why.extend(learnt_why);
+        self.learnt_why.insert(learnt_id,learnt_why);
 
         let clause_id = self.clauses.alloc(ClauseState::learnt(learnt_id, &learnt));
         self.learnt_clause_ids.push(clause_id);

--- a/crates/rattler_libsolv_rs/src/solver/watch_map.rs
+++ b/crates/rattler_libsolv_rs/src/solver/watch_map.rs
@@ -17,10 +17,6 @@ impl WatchMap {
         }
     }
 
-    pub(crate) fn initialize(&mut self, solvable_count: usize) {
-        self.map = Mapping::with_capacity(solvable_count);
-    }
-
     pub(crate) fn start_watching(&mut self, clause: &mut ClauseState, clause_id: ClauseId) {
         for (watch_index, watched_solvable) in clause.watched_literals.into_iter().enumerate() {
             let already_watching = self.first_clause_watching_solvable(watched_solvable);
@@ -65,7 +61,7 @@ impl WatchMap {
         &mut self,
         watched_solvable: SolvableId,
     ) -> ClauseId {
-        *self.map.get(watched_solvable).expect("unknown solvable")
+        self.map.get(watched_solvable).copied().unwrap_or(ClauseId::null())
     }
 
     pub(crate) fn watch_solvable(&mut self, watched_solvable: SolvableId, id: ClauseId) {

--- a/crates/rattler_libsolv_rs/src/solver/watch_map.rs
+++ b/crates/rattler_libsolv_rs/src/solver/watch_map.rs
@@ -13,12 +13,12 @@ pub(crate) struct WatchMap {
 impl WatchMap {
     pub(crate) fn new() -> Self {
         Self {
-            map: Mapping::empty(),
+            map: Mapping::new(),
         }
     }
 
     pub(crate) fn initialize(&mut self, solvable_count: usize) {
-        self.map = Mapping::new(vec![ClauseId::null(); solvable_count]);
+        self.map = Mapping::with_capacity(solvable_count);
     }
 
     pub(crate) fn start_watching(&mut self, clause: &mut ClauseState, clause_id: ClauseId) {
@@ -45,23 +45,30 @@ impl WatchMap {
             predecessor_clause.unlink_clause(clause, previous_watch, watch_index);
         } else {
             // This was the first clause in the chain
-            self.map[previous_watch] = clause.get_linked_clause(watch_index);
+            self.map
+                .insert(previous_watch, clause.get_linked_clause(watch_index));
         }
 
         // Set the new watch
         clause.watched_literals[watch_index] = new_watch;
-        clause.link_to_clause(watch_index, self.map[new_watch]);
-        self.map[new_watch] = clause_id;
+        clause.link_to_clause(
+            watch_index,
+            *self
+                .map
+                .get(new_watch)
+                .expect("linking to unknown solvable"),
+        );
+        self.map.insert(new_watch, clause_id);
     }
 
     pub(crate) fn first_clause_watching_solvable(
         &mut self,
         watched_solvable: SolvableId,
     ) -> ClauseId {
-        self.map[watched_solvable]
+        *self.map.get(watched_solvable).expect("unknown solvable")
     }
 
     pub(crate) fn watch_solvable(&mut self, watched_solvable: SolvableId, id: ClauseId) {
-        self.map[watched_solvable] = id;
+        self.map.insert(watched_solvable, id);
     }
 }

--- a/crates/rattler_libsolv_rs/src/solver/watch_map.rs
+++ b/crates/rattler_libsolv_rs/src/solver/watch_map.rs
@@ -61,7 +61,10 @@ impl WatchMap {
         &mut self,
         watched_solvable: SolvableId,
     ) -> ClauseId {
-        self.map.get(watched_solvable).copied().unwrap_or(ClauseId::null())
+        self.map
+            .get(watched_solvable)
+            .copied()
+            .unwrap_or(ClauseId::null())
     }
 
     pub(crate) fn watch_solvable(&mut self, watched_solvable: SolvableId, id: ClauseId) {


### PR DESCRIPTION
Refactored the `Mapping` class so that it allows random insertion, and can be used when the number of elements is not yet known.

Should speed up the current `watch_map`.