### PR TITLE
emscripten is a unix variant

### DIFF
--- a/crates/rattler_conda_types/src/platform.rs
+++ b/crates/rattler_conda_types/src/platform.rs
@@ -179,7 +179,7 @@ impl Platform {
 
     /// Returns true if the platform is a unix based platform.
     pub const fn is_unix(self) -> bool {
-        self.is_linux() || self.is_osx()
+        self.is_linux() || self.is_osx() || matches!(self, Platform::EmscriptenWasm32)
     }
 
     /// Returns true if the platform is a linux based platform.


### PR DESCRIPTION
Rust is also thinking like this: https://github.com/rust-lang/rust/blob/e437e57954ee1d1cd4630d222e42ad0277cd4bf2/library/std/src/sys/unix/env.rs#L177-L186

(and not for WASI).