### PR TITLE
hide implementation detail, version_spec::Constraint

### DIFF
--- a/crates/rattler_conda_types/src/version_spec/constraint.rs
+++ b/crates/rattler_conda_types/src/version_spec/constraint.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 /// A single version constraint (e.g. `>3.4.5` or `1.2.*`)
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-pub(crate) enum Constraint {
+pub enum Constraint {
     /// Matches anything (`*`)
     Any,
 

--- a/crates/rattler_conda_types/src/version_spec/parse.rs
+++ b/crates/rattler_conda_types/src/version_spec/parse.rs
@@ -189,7 +189,7 @@ fn logical_constraint_parser(input: &str) -> IResult<&str, Constraint, ParseCons
 }
 
 /// Parses a version constraint.
-pub(crate) fn constraint_parser(input: &str) -> IResult<&str, Constraint, ParseConstraintError> {
+pub fn constraint_parser(input: &str) -> IResult<&str, Constraint, ParseConstraintError> {
     alt((
         regex_constraint_parser,
         any_constraint_parser,


### PR DESCRIPTION
removed pub and pub(crate) on Constraint, it's
parsing and implemented From<Constraint> for
VersionSpec

Revert "expose other cargo commands"

This reverts commit 9a22ec9966b3ad679e1d54af773f23e179725eef.