### PR TITLE
refactor: improve formatting

### DIFF
--- a/crates/rattler_libsolv_rs/Cargo.toml
+++ b/crates/rattler_libsolv_rs/Cargo.toml
@@ -19,3 +19,4 @@ elsa = "1.9.0"
 [dev-dependencies]
 insta = "1.31.0"
 indexmap = "2.0.0"
+tracing-test = "0.2.4"

--- a/crates/rattler_libsolv_rs/src/id.rs
+++ b/crates/rattler_libsolv_rs/src/id.rs
@@ -1,4 +1,7 @@
 use crate::arena::ArenaId;
+use crate::solvable::DisplaySolvable;
+use crate::{PackageName, Pool, VersionSet};
+use std::fmt::Display;
 
 /// The id associated to a package name
 #[repr(transparent)]
@@ -50,6 +53,14 @@ impl SolvableId {
 
     pub(crate) fn is_null(self) -> bool {
         self.0 == u32::MAX
+    }
+
+    /// Returns an object that enables formatting the solvable.
+    pub fn display<VS: VersionSet, N: PackageName + Display>(
+        self,
+        pool: &Pool<VS, N>,
+    ) -> DisplaySolvable<VS, N> {
+        pool.resolve_internal_solvable(self).display(pool)
     }
 }
 

--- a/crates/rattler_libsolv_rs/src/problem.rs
+++ b/crates/rattler_libsolv_rs/src/problem.rs
@@ -304,7 +304,7 @@ impl ProblemGraph {
                             }
                         }
 
-                        pool.resolve_internal_solvable(solvable_2).to_string()
+                        solvable_2.display(pool).to_string()
                     }
                     ProblemNode::UnresolvedDependency => "unresolved".to_string(),
                 };
@@ -312,7 +312,8 @@ impl ProblemGraph {
                 write!(
                     f,
                     "\"{}\" -> \"{}\"[color={color}, label=\"{label}\"];",
-                    solvable, target
+                    solvable.display(pool),
+                    target
                 )?;
             }
         }

--- a/crates/rattler_libsolv_rs/src/solvable.rs
+++ b/crates/rattler_libsolv_rs/src/solvable.rs
@@ -1,5 +1,6 @@
 use crate::id::NameId;
 
+use crate::{PackageName, Pool, VersionSet};
 use std::fmt::{Display, Formatter};
 
 /// A solvable represents a single candidate of a package.
@@ -57,13 +58,30 @@ impl<V> InternalSolvable<V> {
     pub fn solvable(&self) -> &Solvable<V> {
         self.get_solvable().expect("unexpected root solvable")
     }
+
+    pub fn display<'pool, VS: VersionSet<V = V>, N: PackageName + Display>(
+        &'pool self,
+        pool: &'pool Pool<VS, N>,
+    ) -> DisplaySolvable<'pool, VS, N> {
+        DisplaySolvable {
+            pool,
+            solvable: self,
+        }
+    }
 }
 
-impl<V: Display> Display for InternalSolvable<V> {
+pub struct DisplaySolvable<'pool, VS: VersionSet, N: PackageName> {
+    pool: &'pool Pool<VS, N>,
+    solvable: &'pool InternalSolvable<VS::V>,
+}
+
+impl<'pool, VS: VersionSet, N: PackageName + Display> Display for DisplaySolvable<'pool, VS, N> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match &self.inner {
+        match &self.solvable.inner {
             SolvableInner::Root => write!(f, "<root>"),
-            SolvableInner::Package(p) => write!(f, "{}", &p.inner),
+            SolvableInner::Package(p) => {
+                write!(f, "{}={}", self.pool.resolve_package_name(p.name), &p.inner)
+            }
         }
     }
 }

--- a/crates/rattler_libsolv_rs/src/solver/clause.rs
+++ b/crates/rattler_libsolv_rs/src/solver/clause.rs
@@ -490,15 +490,15 @@ impl<VS: VersionSet, N: PackageName + Display> Debug for ClauseDebug<'_, VS, N> 
                 write!(
                     f,
                     "{} requires {match_spec}",
-                    self.pool.resolve_internal_solvable(solvable_id)
+                    solvable_id.display(self.pool),
                 )
             }
             Clause::Constrains(s1, s2, vset_id) => {
                 write!(
                     f,
                     "{} excludes {} by {}",
-                    self.pool.resolve_internal_solvable(s1),
-                    self.pool.resolve_internal_solvable(s2),
+                    s1.display(self.pool),
+                    s2.display(self.pool),
                     self.pool.resolve_version_set(vset_id)
                 )
             }
@@ -506,8 +506,8 @@ impl<VS: VersionSet, N: PackageName + Display> Debug for ClauseDebug<'_, VS, N> 
                 write!(
                     f,
                     "{} is locked, so {} is forbidden",
-                    self.pool.resolve_internal_solvable(locked),
-                    self.pool.resolve_internal_solvable(forbidden)
+                    locked.display(self.pool),
+                    forbidden.display(self.pool)
                 )
             }
             Clause::ForbidMultipleInstances(s1, _) => {

--- a/crates/rattler_libsolv_rs/src/solver/snapshots/rattler_libsolv_rs__solver__test__missing_dep.snap
+++ b/crates/rattler_libsolv_rs/src/solver/snapshots/rattler_libsolv_rs__solver__test__missing_dep.snap
@@ -1,8 +1,6 @@
 ---
 source: crates/rattler_libsolv_rs/src/solver/mod.rs
-expression: display_result
+expression: result
 ---
-conflicting=0
-asdf=3
-efgh=7
+a=1
 

--- a/crates/rattler_libsolv_rs/src/solver/snapshots/rattler_libsolv_rs__solver__test__no_backtracking.snap
+++ b/crates/rattler_libsolv_rs/src/solver/snapshots/rattler_libsolv_rs__solver__test__no_backtracking.snap
@@ -1,0 +1,7 @@
+---
+source: crates/rattler_libsolv_rs/src/solver/mod.rs
+expression: "transaction_to_string(solver.pool(), &solved)"
+---
+quetz-server=1
+pydantic=9
+

--- a/crates/rattler_libsolv_rs/src/solver/snapshots/rattler_libsolv_rs__solver__test__unsat_constrains_2.snap
+++ b/crates/rattler_libsolv_rs/src/solver/snapshots/rattler_libsolv_rs__solver__test__unsat_constrains_2.snap
@@ -1,0 +1,27 @@
+---
+source: crates/rattler_libsolv_rs/src/solver/mod.rs
+expression: error
+---
+The following packages are incompatible
+|-- a * cannot be installed because there are no viable options:
+    |-- a 2 would require
+        |-- b *, which cannot be installed because there are no viable options:
+            |-- b 2 would require
+                |-- c 2..3, which cannot be installed because there are no viable options:
+                    |-- c 2 would constrain
+                        |-- a 3..4 , which conflicts with any installable versions previously reported
+            |-- b 1 would require
+                |-- c 1..2, which cannot be installed because there are no viable options:
+                    |-- c 1 would constrain
+                        |-- a 3..4 , which conflicts with any installable versions previously reported
+    |-- a 1 would require
+        |-- b *, which cannot be installed because there are no viable options:
+            |-- b 2 would require
+                |-- c 2..3, which cannot be installed because there are no viable options:
+                    |-- c 2 would constrain
+                        |-- a 3..4 , which conflicts with any installable versions previously reported
+            |-- b 1 would require
+                |-- c 1..2, which cannot be installed because there are no viable options:
+                    |-- c 1 would constrain
+                        |-- a 3..4 , which conflicts with any installable versions previously reported
+


### PR DESCRIPTION
Adds some formatting improvements for solvables and out logging.

Also adds:
- Additional tests
- Reformats some of the insta tests to make them more clear (e.g. `9` becomes `foo=9`).