### PR TITLE
`Matchable` trait, mentioned in #340

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/matcher.rs
+++ b/crates/rattler_conda_types/src/match_spec/matcher.rs
@@ -5,6 +5,10 @@ use std::{
     str::FromStr,
 };
 
+pub trait Matcher<Element: ?Sized> {
+    fn matches(&self, other: &Element) -> bool;
+}
+
 /// Match a given string either by exact match, glob or regex
 #[derive(Debug, Clone)]
 pub enum StringMatcher {
@@ -41,9 +45,9 @@ impl PartialEq for StringMatcher {
     }
 }
 
-impl StringMatcher {
+impl Matcher<str> for StringMatcher {
     /// Match string against [`StringMatcher`].
-    pub fn matches(&self, other: &str) -> bool {
+    fn matches(&self, other: &str) -> bool {
         match self {
             StringMatcher::Exact(s) => s == other,
             StringMatcher::Glob(glob) => glob.matches(other),

--- a/crates/rattler_conda_types/src/match_spec/matcher.rs
+++ b/crates/rattler_conda_types/src/match_spec/matcher.rs
@@ -5,7 +5,7 @@ use std::{
     str::FromStr,
 };
 
-pub trait Matcher<Element: ?Sized> {
+pub trait Matchable<Element: ?Sized> {
     fn matches(&self, other: &Element) -> bool;
 }
 
@@ -45,7 +45,7 @@ impl PartialEq for StringMatcher {
     }
 }
 
-impl Matcher<str> for StringMatcher {
+impl Matchable<str> for StringMatcher {
     /// Match string against [`StringMatcher`].
     fn matches(&self, other: &str) -> bool {
         match self {

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -8,7 +8,8 @@ use std::hash::Hash;
 pub mod matcher;
 pub mod parse;
 
-use matcher::{Matcher, StringMatcher};
+pub use matcher::Matchable;
+use matcher::StringMatcher;
 
 /// A [`MatchSpec`] is, fundamentally, a query language for conda packages. Any of the fields that
 /// comprise a [`crate::PackageRecord`] can be used to compose a [`MatchSpec`].
@@ -186,9 +187,9 @@ impl Display for MatchSpec {
     }
 }
 
-impl MatchSpec {
+impl Matchable<PackageRecord> for MatchSpec {
     /// Match a MatchSpec against a PackageRecord
-    pub fn matches(&self, record: &PackageRecord) -> bool {
+    fn matches(&self, record: &PackageRecord) -> bool {
         if let Some(name) = self.name.as_ref() {
             if name != &record.name {
                 return false;
@@ -221,7 +222,9 @@ impl MatchSpec {
 
         true
     }
+}
 
+impl MatchSpec {
     /// Decomposes this instance into a [`NamelessMatchSpec`] and a name.
     pub fn into_nameless(self) -> (Option<PackageName>, NamelessMatchSpec) {
         (
@@ -271,9 +274,9 @@ pub struct NamelessMatchSpec {
     pub sha256: Option<Sha256Hash>,
 }
 
-impl NamelessMatchSpec {
+impl Matchable<PackageRecord> for NamelessMatchSpec {
     /// Match a MatchSpec against a PackageRecord
-    pub fn matches(&self, record: &PackageRecord) -> bool {
+    fn matches(&self, record: &PackageRecord) -> bool {
         if let Some(spec) = self.version.as_ref() {
             if !spec.matches(&record.version) {
                 return false;
@@ -371,6 +374,7 @@ mod tests {
 
     use rattler_digest::{parse_digest_from_hex, Md5, Sha256};
 
+    use super::matcher::Matchable;
     use crate::{MatchSpec, NamelessMatchSpec, PackageName, PackageRecord, Version};
     use std::hash::{Hash, Hasher};
 

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -8,7 +8,7 @@ use std::hash::Hash;
 pub mod matcher;
 pub mod parse;
 
-use matcher::StringMatcher;
+use matcher::{Matcher, StringMatcher};
 
 /// A [`MatchSpec`] is, fundamentally, a query language for conda packages. Any of the fields that
 /// comprise a [`crate::PackageRecord`] can be used to compose a [`MatchSpec`].


### PR DESCRIPTION
Adds trait for implementing `matches` method to compare types that are some kind of `Spec` to the type which represents a single instance of the matchable Spec can describe, this was mentioned in #340 

## Question:
- Should this be associated type (as implemented) or a generic? I think the difference has to do if the trait will be implemented for generic types or only needed for concrete types.
- How should this be exported? I don't think all uses of the crate should need to import `Matchable` to call `MatchSpec::matches`.

---
remaining TODOs before moving from draft
impl for VersionSpec