### PR TITLE
Fix/auth fallback

### DIFF
--- a/crates/rattler_networking/src/authentication_storage/fallback_storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/fallback_storage.rs
@@ -69,7 +69,6 @@ impl FallbackStorage {
         let file = std::fs::File::open(&self.path)?;
         let reader = std::io::BufReader::new(file);
         let dict = serde_json::from_reader(reader)?;
-        tracing::info!("read dict {:?}", dict);
         Ok(dict)
     }
 

--- a/crates/rattler_networking/src/authentication_storage/fallback_storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/fallback_storage.rs
@@ -63,7 +63,7 @@ impl FallbackStorage {
     /// does not exist
     fn read_json(&self) -> Result<std::collections::HashMap<String, String>, FallbackStorageError> {
         if !self.path.exists() {
-            tracing::warn!("Cant find path for fall back storage on {}", self.path.to_string_lossy());
+            tracing::warn!("Can't find path for fallback storage on {}", self.path.to_string_lossy());
             return Ok(std::collections::HashMap::new());
         }
         let file = std::fs::File::open(&self.path)?;

--- a/crates/rattler_networking/src/authentication_storage/fallback_storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/fallback_storage.rs
@@ -63,7 +63,10 @@ impl FallbackStorage {
     /// does not exist
     fn read_json(&self) -> Result<std::collections::HashMap<String, String>, FallbackStorageError> {
         if !self.path.exists() {
-            tracing::warn!("Can't find path for fallback storage on {}", self.path.to_string_lossy());
+            tracing::warn!(
+                "Can't find path for fallback storage on {}",
+                self.path.to_string_lossy()
+            );
             return Ok(std::collections::HashMap::new());
         }
         let file = std::fs::File::open(&self.path)?;

--- a/crates/rattler_networking/src/authentication_storage/fallback_storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/fallback_storage.rs
@@ -63,11 +63,13 @@ impl FallbackStorage {
     /// does not exist
     fn read_json(&self) -> Result<std::collections::HashMap<String, String>, FallbackStorageError> {
         if !self.path.exists() {
+            tracing::warn!("Cant find path for fall back storage on {}", self.path.to_string_lossy());
             return Ok(std::collections::HashMap::new());
         }
         let file = std::fs::File::open(&self.path)?;
         let reader = std::io::BufReader::new(file);
         let dict = serde_json::from_reader(reader)?;
+        tracing::info!("read dict {:?}", dict);
         Ok(dict)
     }
 

--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -19,8 +19,8 @@ pub struct AuthenticationStorage {
     /// in a global dictionary in the operating system
     pub store_key: String,
 
-    /// Fallback Storage
-    fallback_storage: fallback_storage::FallbackStorage,
+    /// Fallback Storage that will be used if the is no key store application available.
+    pub fallback_storage: fallback_storage::FallbackStorage,
 
     /// A cache so that we don't have to access the keyring all the time
     cache: Arc<Mutex<HashMap<String, Option<Authentication>>>>,

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -20,11 +20,21 @@ pub struct AuthenticatedClient {
     auth_storage: AuthenticationStorage,
 }
 
+/// Default location for fallback authentication storage.
+pub fn get_default_auth_store_location() -> PathBuf {
+    dirs::home_dir().unwrap().join(".rattler")
+}
+
+/// Setup default authentication storage
+pub fn default_authentication_storage() -> AuthenticationStorage {
+    AuthenticationStorage::new("rattler", &get_default_auth_store_location())
+}
+
 impl Default for AuthenticatedClient {
     fn default() -> Self {
         AuthenticatedClient {
             client: Client::default(),
-            auth_storage: AuthenticationStorage::new("rattler", &PathBuf::from("~/.rattler")),
+            auth_storage: default_authentication_storage(),
         }
     }
 }
@@ -140,7 +150,7 @@ impl Default for AuthenticatedClientBlocking {
     fn default() -> Self {
         AuthenticatedClientBlocking {
             client: Default::default(),
-            auth_storage: AuthenticationStorage::new("rattler", &PathBuf::from("~/.rattler")),
+            auth_storage: default_authentication_storage(),
         }
     }
 }

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -30,7 +30,7 @@ pub fn default_auth_store_fallback_directory() -> &'static Path {
         dirs::home_dir()
             .map(|home| home.join(".rattler/"))
             .unwrap_or_else(|| {
-                tracing::warn!("Home directory could not be found, using '/rattler'");
+                tracing::warn!("using '/rattler' to store fallback authentication credentials because the home directory could not be found");
                 // This can only happen if the dirs lib can't find a home directory this is very unlikely.
                 PathBuf::from("/rattler/")
             })

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -2,7 +2,8 @@
 
 //! Networking utilities for Rattler, specifically authenticating requests
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 
 pub use authentication_storage::{authentication::Authentication, storage::AuthenticationStorage};
 use reqwest::{Client, IntoUrl, Method, Url};
@@ -10,8 +11,9 @@ use reqwest::{Client, IntoUrl, Method, Url};
 pub mod authentication_storage;
 pub mod retry_policies;
 
-/// A client that can be used to make authenticated requests, based on the [`reqwest::Client`]
-#[derive(Clone)]
+/// A client that can be used to make authenticated requests, based on the [`reqwest::Client`].
+/// By default it uses the fallback storage in the default [`default_auth_store_fallback_directory`].
+#[derive(Clone, Default)]
 pub struct AuthenticatedClient {
     /// The underlying client
     client: Client,
@@ -20,22 +22,24 @@ pub struct AuthenticatedClient {
     auth_storage: AuthenticationStorage,
 }
 
-/// Default location for fallback authentication storage.
-pub fn get_default_auth_store_location() -> PathBuf {
-    dirs::home_dir().unwrap().join(".rattler")
+/// Returns the default auth storage directory used by rattler.
+/// Would be placed in $HOME/.rattler, except when there is no home then it will be put in '/rattler/'
+pub fn default_auth_store_fallback_directory() -> &'static Path {
+    static FALLBACK_AUTH_DIR: OnceLock<PathBuf> = OnceLock::new();
+    FALLBACK_AUTH_DIR.get_or_init(|| {
+        dirs::home_dir()
+            .map(|home| home.join(".rattler/"))
+            .unwrap_or_else(|| {
+                tracing::warn!("Home directory could not be found, using '/rattler'");
+                // This can only happen if the dirs lib can't find a home directory this is very unlikely.
+                PathBuf::from("/rattler/")
+            })
+    })
 }
 
-/// Setup default authentication storage
-pub fn default_authentication_storage() -> AuthenticationStorage {
-    AuthenticationStorage::new("rattler", &get_default_auth_store_location())
-}
-
-impl Default for AuthenticatedClient {
+impl Default for AuthenticationStorage {
     fn default() -> Self {
-        AuthenticatedClient {
-            client: Client::default(),
-            auth_storage: default_authentication_storage(),
-        }
+        AuthenticationStorage::new("rattler", default_auth_store_fallback_directory())
     }
 }
 
@@ -123,6 +127,8 @@ impl AuthenticatedClient {
 
 #[cfg(feature = "blocking")]
 /// A blocking client that can be used to make authenticated requests, based on the [`reqwest::blocking::Client`]
+/// By default it uses the fallback storage in the default [`default_auth_store_fallback_directory`].
+#[derive(Default)]
 pub struct AuthenticatedClientBlocking {
     /// The underlying client
     client: reqwest::blocking::Client,
@@ -141,16 +147,6 @@ impl AuthenticatedClientBlocking {
         AuthenticatedClientBlocking {
             client,
             auth_storage,
-        }
-    }
-}
-
-#[cfg(feature = "blocking")]
-impl Default for AuthenticatedClientBlocking {
-    fn default() -> Self {
-        AuthenticatedClientBlocking {
-            client: Default::default(),
-            auth_storage: default_authentication_storage(),
         }
     }
 }


### PR DESCRIPTION
The [authentication](https://github.com/prefix-dev/pixi/issues/334) issue was a result of the `~` not being recognized transformed in an actual home directory. This fixes that. 

This also creates a set of defaults, so `pixi` can use the same function as rattler. 