### PR TITLE
Change solver implementation doc comment

### DIFF
--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -326,7 +326,7 @@ impl SolvableDisplay<SolverMatchSpec<'_>> for CondaSolvableDisplay {
     }
 }
 
-/// A [`Solver`] implemented using the `libsolv` library
+/// A [`Solver`] implemented using the `resolvo` library
 #[derive(Default)]
 pub struct Solver;
 


### PR DESCRIPTION
I've found a typo in `rattler_solve/src/resolvo/mod.rs` which stated that `this` solver is implemented using the `libsolv` library. 
I think the correct word should be `resolvo` because we implement it for `resolvo` and we do it under `src/resolvo`.