### PR TITLE
misc: simplify code and change warning to debug

### DIFF
--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -111,9 +111,9 @@ impl AuthenticationStorage {
                     e,
                     self.fallback_storage.path.display()
                 );
-                match self.fallback_storage.get_password(host)?{
-                    None => { return Ok(None) }
-                    Some(password) => {password}
+                match self.fallback_storage.get_password(host)? {
+                    None => return Ok(None),
+                    Some(password) => password,
                 }
             }
         };

--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -105,17 +105,16 @@ impl AuthenticationStorage {
                 return Ok(None);
             }
             Err(e) => {
-                tracing::warn!(
-                    "Error retrieving credentials for {}: {}, using fallback storage at {}",
+                tracing::debug!(
+                    "Unable to retrieve credentials for {}: {}, using fallback credential storage at {}",
                     host,
                     e,
                     self.fallback_storage.path.display()
                 );
-                let fb_pw = self.fallback_storage.get_password(host)?;
-                if fb_pw.is_none() {
-                    return Ok(None);
+                match self.fallback_storage.get_password(host)?{
+                    None => { return Ok(None) }
+                    Some(password) => {password}
                 }
-                fb_pw.unwrap()
             }
         };
 


### PR DESCRIPTION
closes #363 

This reduces the way the message used to scream at you, while it is totally normal to not have a keyring on your system. 

Still not the best as it might be better to give this warning only once but this should help.
