### PR TITLE
match conda with `.state.json` -> `.info.json`

### DIFF
--- a/crates/rattler_repodata_gateway/src/fetch/cache/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/cache/mod.rs
@@ -7,7 +7,7 @@ use serde_with::serde_as;
 use std::{fs::File, io::Read, path::Path, str::FromStr, time::SystemTime};
 use url::Url;
 
-/// Representation of the `.state.json` file alongside a `repodata.json` file.
+/// Representation of the `.info.json` file alongside a `repodata.json` file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RepoDataState {
     /// The URL from where the repodata was downloaded. This is the URL of the `repodata.json`,

--- a/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
@@ -70,7 +70,7 @@
 //!         &current_repo_data
 //!     ).await.unwrap();
 //!
-//!     // Now we can use the `updated_jlap_state` object to update our `.state.json` file
+//!     // Now we can use the `updated_jlap_state` object to update our `.info.json` file
 //! }
 //! ```
 //!

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -296,7 +296,7 @@ pub async fn fetch_repo_data(
             .expect("file name is valid"),
     );
     let repo_data_json_path = cache_path.join(format!("{}.json", cache_key));
-    let cache_state_path = cache_path.join(format!("{}.state.json", cache_key));
+    let cache_state_path = cache_path.join(format!("{}.info.json", cache_key));
 
     // Lock all files that have to do with that cache key
     let lock_file_path = cache_path.join(format!("{}.lock", &cache_key));
@@ -867,7 +867,7 @@ fn validate_cached_state(
     cache_key: &str,
 ) -> ValidatedCacheState {
     let repo_data_json_path = cache_path.join(format!("{}.json", cache_key));
-    let cache_state_path = cache_path.join(format!("{}.state.json", cache_key));
+    let cache_state_path = cache_path.join(format!("{}.info.json", cache_key));
 
     // Check if we have cached repodata.json file
     let json_metadata = match std::fs::metadata(&repo_data_json_path) {


### PR DESCRIPTION
Conda has been using `.info.json` for a few releases now.

My edits to the draft CEP are expressed in https://github.com/conda-incubator/ceps/pull/48/files

I noticed rattler is back to using `.lock` files copied from what cargo does, instead of the (has plenty of its own problems) record locking found in mamba.