### PR TITLE
make archive type `serialize` and `deserialize`

### DIFF
--- a/crates/rattler_conda_types/src/package/archive_type.rs
+++ b/crates/rattler_conda_types/src/package/archive_type.rs
@@ -1,7 +1,8 @@
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 
 /// Describes the type of package archive. This can be derived from the file extension of a package.
-#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum ArchiveType {
     /// A file with the `.tar.bz2` extension.
     TarBz2,

--- a/crates/rattler_conda_types/src/package/archive_type.rs
+++ b/crates/rattler_conda_types/src/package/archive_type.rs
@@ -5,9 +5,11 @@ use std::path::Path;
 #[derive(Copy, Clone, Debug, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub enum ArchiveType {
     /// A file with the `.tar.bz2` extension.
+    #[serde(rename = "tar.bz2")]
     TarBz2,
 
     /// A file with the `.conda` extension.
+    #[serde(rename = "conda")]
     Conda,
 }
 
@@ -48,10 +50,10 @@ mod test {
     fn test_archive_type_serialization() {
         let archive_type = ArchiveType::TarBz2;
         let serialized = serde_json::to_string(&archive_type).unwrap();
-        assert_eq!(serialized, "\"TarBz2\"");
+        assert_eq!(serialized, "\"tar.bz2\"");
 
         let archive_type = ArchiveType::Conda;
         let serialized = serde_json::to_string(&archive_type).unwrap();
-        assert_eq!(serialized, "\"Conda\"");
+        assert_eq!(serialized, "\"conda\"");
     }
 }

--- a/crates/rattler_conda_types/src/package/archive_type.rs
+++ b/crates/rattler_conda_types/src/package/archive_type.rs
@@ -38,3 +38,20 @@ impl ArchiveType {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::ArchiveType;
+
+    /// test snapshot for archive type serialization
+    #[test]
+    fn test_archive_type_serialization() {
+        let archive_type = ArchiveType::TarBz2;
+        let serialized = serde_json::to_string(&archive_type).unwrap();
+        assert_eq!(serialized, "\"TarBz2\"");
+
+        let archive_type = ArchiveType::Conda;
+        let serialized = serde_json::to_string(&archive_type).unwrap();
+        assert_eq!(serialized, "\"Conda\"");
+    }
+}


### PR DESCRIPTION
This would be useful to serialize the rattler-build outputs.