### PR TITLE
feat: add forward compatibility error

### DIFF
--- a/crates/rattler_lock/src/serde.rs
+++ b/crates/rattler_lock/src/serde.rs
@@ -1,0 +1,116 @@
+use super::{CondaLock, LockMeta, LockedDependency, LockedDependencyKind};
+use serde::de::Error;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cmp::Ordering;
+
+const FILE_VERSION: u32 = 2;
+
+/// A helper struct to deserialize the version field of the lock file and provide potential errors
+/// in-line.
+#[derive(Serialize)]
+#[serde(transparent)]
+struct Version(u32);
+
+impl Default for Version {
+    fn default() -> Self {
+        Self(FILE_VERSION)
+    }
+}
+
+impl<'de> Deserialize<'de> for Version {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let version = u32::deserialize(deserializer)?;
+
+        if version > FILE_VERSION {
+            return Err(D::Error::custom(format!(
+                "found newer file format version {}, but only up to including version {} is supported",
+                version, FILE_VERSION
+            )));
+        }
+
+        Ok(Self(version))
+    }
+}
+
+impl<'de> Deserialize<'de> for CondaLock {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[allow(dead_code)]
+        #[derive(Deserialize)]
+        struct Raw {
+            version: Version,
+            metadata: LockMeta,
+            package: Vec<LockedDependency>,
+        }
+
+        let raw = Raw::deserialize(deserializer)?;
+        Ok(Self {
+            metadata: raw.metadata,
+            package: raw.package,
+        })
+    }
+}
+
+impl Serialize for CondaLock {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct Raw<'a> {
+            version: Version,
+            metadata: &'a LockMeta,
+            package: Vec<&'a LockedDependency>,
+        }
+
+        // Sort all packages in alphabetical order. We choose to use alphabetic order instead of
+        // topological because the alphabetic order will create smaller diffs when packages change
+        // or are added.
+        // See: https://github.com/conda/conda-lock/issues/491
+        let mut sorted_deps = self.package.iter().collect::<Vec<_>>();
+        sorted_deps.sort_by(|&a, &b| {
+            a.name
+                .cmp(&b.name)
+                .then_with(|| a.platform.cmp(&b.platform))
+                .then_with(|| a.version.cmp(&b.version))
+                .then_with(|| match (&a.kind, &b.kind) {
+                    (LockedDependencyKind::Conda(a), LockedDependencyKind::Conda(b)) => {
+                        a.build.cmp(&b.build)
+                    }
+                    (LockedDependencyKind::Pip(_), LockedDependencyKind::Pip(_)) => Ordering::Equal,
+                    (LockedDependencyKind::Pip(_), _) => Ordering::Less,
+                    (_, LockedDependencyKind::Pip(_)) => Ordering::Greater,
+                })
+        });
+
+        let raw = Raw {
+            version: Default::default(),
+            metadata: &self.metadata,
+            package: sorted_deps,
+        };
+
+        raw.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn read_conda_lock() {
+        let err = CondaLock::from_path(
+            &Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../test-data/conda-lock/forward-compatible-lock.yml"),
+        )
+        .unwrap_err();
+
+        insta::assert_snapshot!(format!("{}", err), @"found newer file format version 1000, but only up to including version 2 is supported");
+    }
+}

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__read_conda_lock.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__read_conda_lock.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
-assertion_line: 606
+assertion_line: 300
 expression: conda_lock
 ---
+version: 2
 metadata:
   content_hash:
     linux-64: db07b15e6c03c3be1c2b06b6b6c916d625f68bba2d5911b013b31970eaa2e5c3
@@ -12281,5 +12282,4 @@ package:
     platform: osx-arm64
     url: "https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.2-hf913c23_6.conda"
     version: 1.5.2
-version: 1
 

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__read_conda_lock_python.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__read_conda_lock_python.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
-assertion_line: 616
+assertion_line: 310
 expression: conda_lock
 ---
+version: 2
 metadata:
   content_hash:
     linux-64: 63fe6f5b3868946659fb21a6f0a5871c672c00ce5846fe67e044d5d3fa7c2b3b
@@ -1331,5 +1332,4 @@ package:
     platform: win-64
     url: "https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2"
     version: 5.2.6
-version: 1
 

--- a/test-data/conda-lock/forward-compatible-lock.yml
+++ b/test-data/conda-lock/forward-compatible-lock.yml
@@ -1,0 +1,11 @@
+metadata:
+  content_hash:
+    win-64: e90c2ee71ad70fc0a1c8302029533a7d1498f2bffcd0eaa8d2934700e775dc1d
+  channels:
+  - url: https://conda.anaconda.org/conda-forge/
+    used_env_vars: []
+  platforms:
+  - win-64
+  sources: []
+package:
+version: 1000


### PR DESCRIPTION
Adds an error when parsing a lockfile with a version higher than the currently supported version. 

Should make https://github.com/prefix-dev/pixi/issues/424 more clear.