### PR TITLE
fix: jlap wrong hash

### DIFF
--- a/crates/rattler_digest/src/lib.rs
+++ b/crates/rattler_digest/src/lib.rs
@@ -64,8 +64,14 @@ pub type Md5Hash = md5::digest::Output<Md5>;
 /// A type for a 32 bit length blake2b digest.
 pub type Blake2b256 = Blake2b<U32>;
 
+/// A type alias for the output of a [`Blake2b256`] hash.
+pub type Blake2b256Hash = blake2::digest::Output<Blake2b256>;
+
 /// A type alias for the output of a blake2b256 hash.
 pub type Blake2bMac256 = Blake2bMac<U32>;
+
+/// A type alias for the output of a [`Blake2bMac256`] hash.
+pub type Blake2bMac256Hash = blake2::digest::Output<Blake2bMac256>;
 
 /// Compute a hash of the file at the specified location.
 pub fn compute_file_digest<D: Digest + Default + Write>(

--- a/crates/rattler_repodata_gateway/src/fetch/cache/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/cache/mod.rs
@@ -40,6 +40,16 @@ pub struct RepoDataState {
     )]
     pub blake2_hash: Option<blake2::digest::Output<Blake2b256>>,
 
+    /// Upstream hash represented by the on-disk file. Used for jlap which reformats the cached json
+    /// but knows equivalent remote repodata.json hashes.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_blake2_hash",
+        serialize_with = "serialize_blake2_hash"
+    )]
+    pub blake2_hash_nominal: Option<blake2::digest::Output<Blake2b256>>,
+
     /// Whether or not zst is available for the subdirectory
     pub has_zst: Option<Expiring<bool>>,
 

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -237,6 +237,7 @@ async fn repodata_from_file(
         },
         cache_last_modified: SystemTime::now(),
         blake2_hash: None,
+        blake2_hash_nominal: None,
         has_zst: None,
         has_bz2: None,
         has_jlap: None,
@@ -403,10 +404,11 @@ pub async fn fetch_repo_data(
         )
         .await
         {
-            Ok(state) => {
+            Ok((state, disk_hash)) => {
                 tracing::info!("fetched JLAP patches successfully");
                 let cache_state = RepoDataState {
-                    blake2_hash: Some(state.footer.latest),
+                    blake2_hash: Some(disk_hash),
+                    blake2_hash_nominal: Some(state.footer.latest),
                     has_zst: variant_availability.has_zst,
                     has_bz2: variant_availability.has_bz2,
                     has_jlap: variant_availability.has_jlap,
@@ -559,6 +561,7 @@ pub async fn fetch_repo_data(
             .map_err(FetchRepoDataError::FailedToGetMetadata)?,
         cache_size: repo_data_json_metadata.len(),
         blake2_hash: Some(blake2_hash),
+        blake2_hash_nominal: None,
         has_zst: variant_availability.has_zst,
         has_bz2: variant_availability.has_bz2,
         has_jlap: variant_availability.has_jlap,


### PR DESCRIPTION
Fixes an issue where the client-side hash was used to determine the required server-side patches. This will fail in a lot of cases because the data is not actually bit-for-bit the same. JLAP actually stores the server-side hash seperately, which is not what this code does as well. I also refactored the code a bit to remove whitespaces in the repodata file which saves a significant amount of space.