### PR TITLE
make builds deterministic

### DIFF
--- a/crates/rattler_package_streaming/src/write.rs
+++ b/crates/rattler_package_streaming/src/write.rs
@@ -239,6 +239,8 @@ fn prepare_header(
 
     if let Some(timestamp) = timestamp {
         header.set_mtime(timestamp.timestamp().unsigned_abs());
+    } else {
+        header.set_mtime(1153704088);
     }
 
     // let file_size = stat.len();
@@ -259,6 +261,10 @@ fn append_path_to_archive(
     path: &Path,
     timestamp: &Option<&chrono::DateTime<chrono::Utc>>,
 ) -> Result<(), std::io::Error> {
+
+    // set header mode to deterministic for _now_
+    archive.mode(tar::HeaderMode::Deterministic);
+
     // create a tar header
     let mut header = prepare_header(&base_path.join(path), timestamp)
         .map_err(|err| trace_file_error(&base_path.join(path), err))?;


### PR DESCRIPTION
This was just for testing. 
I think we might want some more control.

The `append_file` function wasn't actually using the prepared header so the `mtime` was still set from the file system. Changing that to the `tar::HeaderMode::Deterministic` works. I think we might still want more control. The Deterministic header from the tar library does something to the `chmod` bits and also sets the mtime to the same constant that I copied out because that is the birthdate of Rust and some programs don't handle a mtime of `0` not well apparently.