### PR TITLE
refactor: make the channel in the matchspec struct an actual channel

### DIFF
--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -19,7 +19,7 @@ itertools = "0.11.0"
 lazy-regex = "3.0.2"
 nom = "7.1.3"
 regex = "1.9.6"
-serde = { version = "1.0.188", features = ["derive"] }
+serde = { version = "1.0.188", features = ["derive", "rc"] }
 serde_json = "1.0.107"
 serde_yaml = "0.9.25"
 serde_with = { version = "3.3.0", features = ["indexmap_2"] }

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -208,7 +208,7 @@ impl Channel {
                 let config = ChannelConfig::default();
 
                 Channel::from_str(str_val, &config)
-                    .map(|channel|Some(Arc::new(channel)))
+                    .map(|channel| Some(Arc::new(channel)))
                     .map_err(serde::de::Error::custom)
             }
             None => Ok(None),

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Arc;
 
 use serde::{Deserialize, Deserializer, Serialize};
 use smallvec::SmallVec;
@@ -196,7 +197,7 @@ impl Channel {
     }
 
     ///  Deserialize channel from string
-    pub fn deserialize_optional<'de, D>(deserializer: D) -> Result<Option<Self>, D::Error>
+    pub fn deserialize_optional<'de, D>(deserializer: D) -> Result<Option<Arc<Self>>, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -207,7 +208,7 @@ impl Channel {
                 let config = ChannelConfig::default();
 
                 Channel::from_str(str_val, &config)
-                    .map(Some)
+                    .map(|channel|Some(Arc::new(channel)))
                     .map_err(serde::de::Error::custom)
             }
             None => Ok(None),

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -206,7 +206,7 @@ impl Channel {
             Some(str_val) => {
                 let config = ChannelConfig::default();
 
-                Channel::from_str(&str_val, &config)
+                Channel::from_str(str_val, &config)
                     .map(Some)
                     .map_err(serde::de::Error::custom)
             }

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -195,25 +195,6 @@ impl Channel {
     pub fn canonical_name(&self) -> String {
         self.base_url.to_string()
     }
-
-    ///  Deserialize channel from string
-    pub fn deserialize_optional<'de, D>(deserializer: D) -> Result<Option<Arc<Self>>, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s: Option<String> = Option::deserialize(deserializer)?;
-
-        match s {
-            Some(str_val) => {
-                let config = ChannelConfig::default();
-
-                Channel::from_str(str_val, &config)
-                    .map(|channel| Some(Arc::new(channel)))
-                    .map_err(serde::de::Error::custom)
-            }
-            None => Ok(None),
-        }
-    }
 }
 
 #[derive(Debug, Error, Clone, Eq, PartialEq)]

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
 
-use serde::{Deserialize, Serialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use smallvec::SmallVec;
 use thiserror::Error;
 use url::Url;
@@ -197,8 +197,8 @@ impl Channel {
 
     ///  Deserialize channel from string
     pub fn deserialize_optional<'de, D>(deserializer: D) -> Result<Option<Self>, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         let s: Option<String> = Option::deserialize(deserializer)?;
 

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -1,9 +1,8 @@
 use std::borrow::Cow;
 use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
 
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use thiserror::Error;
 use url::Url;

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -38,7 +38,7 @@ impl Default for ChannelConfig {
 }
 
 /// `Channel`s are the primary source of package information.
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Serialize, Eq, PartialEq, Hash)]
 pub struct Channel {
     /// The platforms supported by this channel, or None if no explicit platforms have been
     /// specified.

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -383,8 +383,8 @@ impl MatchSpec {
 /// TODO: This should be refactored so that the front ends are the one setting the channel config,
 /// and rattler only takes care of the url.
 fn deserialize_channel<'de, D>(deserializer: D) -> Result<Option<Arc<Channel>>, D::Error>
-    where
-        D: Deserializer<'de>,
+where
+    D: Deserializer<'de>,
 {
     let s: Option<String> = Option::deserialize(deserializer)?;
 

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -4,7 +4,10 @@ use crate::build_spec::{BuildNumberSpec, ParseBuildNumberSpecError};
 use crate::package::ArchiveType;
 use crate::version_spec::version_tree::{recognize_constraint, recognize_version};
 use crate::version_spec::{is_start_of_version_constraint, ParseVersionSpecError};
-use crate::{Channel, InvalidPackageNameError, NamelessMatchSpec, PackageName, ParseChannelError, VersionSpec};
+use crate::{
+    Channel, InvalidPackageNameError, NamelessMatchSpec, PackageName, ParseChannelError,
+    VersionSpec,
+};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till1, take_until, take_while, take_while1};
 use nom::character::complete::{char, multispace0, one_of};
@@ -398,7 +401,8 @@ fn parse(input: &str) -> Result<MatchSpec, ParseMatchSpecError> {
             nameless_match_spec.channel = Some(Channel::from_str(channel, &Default::default())?);
             nameless_match_spec.subdir = Some(subdir.to_string());
         } else {
-            nameless_match_spec.channel = Some(Channel::from_str(channel_str, &Default::default())?);
+            nameless_match_spec.channel =
+                Some(Channel::from_str(channel_str, &Default::default())?);
         }
     }
 
@@ -571,18 +575,27 @@ mod tests {
         let spec = MatchSpec::from_str("conda-forge::foo[version=\"1.0.*\"]").unwrap();
         assert_eq!(spec.name, Some("foo".parse().unwrap()));
         assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
-        assert_eq!(spec.channel, Some(Channel::from_str("conda-forge", &Default::default()).unwrap()));
+        assert_eq!(
+            spec.channel,
+            Some(Channel::from_str("conda-forge", &Default::default()).unwrap())
+        );
 
         let spec = MatchSpec::from_str("conda-forge::foo[version=1.0.*]").unwrap();
         assert_eq!(spec.name, Some("foo".parse().unwrap()));
         assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
-        assert_eq!(spec.channel, Some(Channel::from_str("conda-forge", &Default::default()).unwrap()));
+        assert_eq!(
+            spec.channel,
+            Some(Channel::from_str("conda-forge", &Default::default()).unwrap())
+        );
 
         let spec =
             MatchSpec::from_str(r#"conda-forge::foo[version=1.0.*, build_number=">6"]"#).unwrap();
         assert_eq!(spec.name, Some("foo".parse().unwrap()));
         assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
-        assert_eq!(spec.channel, Some(Channel::from_str("conda-forge", &Default::default()).unwrap()));
+        assert_eq!(
+            spec.channel,
+            Some(Channel::from_str("conda-forge", &Default::default()).unwrap())
+        );
         assert_eq!(
             spec.build_number,
             Some(BuildNumberSpec::from_str(">6").unwrap())

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -398,11 +398,11 @@ fn parse(input: &str) -> Result<MatchSpec, ParseMatchSpecError> {
 
     if let Some(channel_str) = channel_str {
         if let Some((channel, subdir)) = channel_str.rsplit_once('/') {
-            nameless_match_spec.channel = Some(Channel::from_str(channel, &Default::default())?);
+            nameless_match_spec.channel = Some(Channel::from_str(channel, &Default::default())?.into());
             nameless_match_spec.subdir = Some(subdir.to_string());
         } else {
             nameless_match_spec.channel =
-                Some(Channel::from_str(channel_str, &Default::default())?);
+                Some(Channel::from_str(channel_str, &Default::default())?.into());
         }
     }
 
@@ -470,6 +470,7 @@ mod tests {
     use serde::Serialize;
     use std::collections::BTreeMap;
     use std::str::FromStr;
+    use std::sync::Arc;
 
     use super::{
         split_version_and_build, strip_brackets, BracketVec, MatchSpec, ParseMatchSpecError,
@@ -577,7 +578,7 @@ mod tests {
         assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
         assert_eq!(
             spec.channel,
-            Some(Channel::from_str("conda-forge", &Default::default()).unwrap())
+            Some(Channel::from_str("conda-forge", &Default::default()).map(|channel| Arc::new(channel)).unwrap())
         );
 
         let spec = MatchSpec::from_str("conda-forge::foo[version=1.0.*]").unwrap();
@@ -585,7 +586,7 @@ mod tests {
         assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
         assert_eq!(
             spec.channel,
-            Some(Channel::from_str("conda-forge", &Default::default()).unwrap())
+            Some(Channel::from_str("conda-forge", &Default::default()).map(|channel| Arc::new(channel)).unwrap())
         );
 
         let spec =
@@ -594,7 +595,7 @@ mod tests {
         assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
         assert_eq!(
             spec.channel,
-            Some(Channel::from_str("conda-forge", &Default::default()).unwrap())
+            Some(Channel::from_str("conda-forge", &Default::default()).map(|channel| Arc::new(channel)).unwrap())
         );
         assert_eq!(
             spec.build_number,

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -398,7 +398,8 @@ fn parse(input: &str) -> Result<MatchSpec, ParseMatchSpecError> {
 
     if let Some(channel_str) = channel_str {
         if let Some((channel, subdir)) = channel_str.rsplit_once('/') {
-            nameless_match_spec.channel = Some(Channel::from_str(channel, &Default::default())?.into());
+            nameless_match_spec.channel =
+                Some(Channel::from_str(channel, &Default::default())?.into());
             nameless_match_spec.subdir = Some(subdir.to_string());
         } else {
             nameless_match_spec.channel =
@@ -578,7 +579,11 @@ mod tests {
         assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
         assert_eq!(
             spec.channel,
-            Some(Channel::from_str("conda-forge", &Default::default()).map(|channel| Arc::new(channel)).unwrap())
+            Some(
+                Channel::from_str("conda-forge", &Default::default())
+                    .map(|channel| Arc::new(channel))
+                    .unwrap()
+            )
         );
 
         let spec = MatchSpec::from_str("conda-forge::foo[version=1.0.*]").unwrap();
@@ -586,7 +591,11 @@ mod tests {
         assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
         assert_eq!(
             spec.channel,
-            Some(Channel::from_str("conda-forge", &Default::default()).map(|channel| Arc::new(channel)).unwrap())
+            Some(
+                Channel::from_str("conda-forge", &Default::default())
+                    .map(|channel| Arc::new(channel))
+                    .unwrap()
+            )
         );
 
         let spec =
@@ -595,7 +604,11 @@ mod tests {
         assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*").unwrap()));
         assert_eq!(
             spec.channel,
-            Some(Channel::from_str("conda-forge", &Default::default()).map(|channel| Arc::new(channel)).unwrap())
+            Some(
+                Channel::from_str("conda-forge", &Default::default())
+                    .map(|channel| Arc::new(channel))
+                    .unwrap()
+            )
         );
         assert_eq!(
             spec.build_number,

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -3,8 +3,8 @@
 use crate::{IntoRepoData, SolveError, SolverRepoData, SolverTask};
 use rattler_conda_types::package::ArchiveType;
 use rattler_conda_types::{
-    GenericVirtualPackage, MatchSpec, NamelessMatchSpec, PackageRecord,
-    ParseMatchSpecError, RepoDataRecord,
+    GenericVirtualPackage, MatchSpec, NamelessMatchSpec, PackageRecord, ParseMatchSpecError,
+    RepoDataRecord,
 };
 use resolvo::{
     Candidates, Dependencies, DependencyProvider, NameId, Pool, SolvableDisplay, SolvableId,
@@ -264,12 +264,14 @@ impl<'a> CondaDependencyProvider<'a> {
                                 // Add record to the excluded with reason of being in the non requested channel.
                                 let message = format!(
                                     "candidate not in requested channel: '{}'",
-                                    spec_channel.name.clone().map(|s| s.to_string()).unwrap_or(spec_channel.base_url.to_string())
+                                    spec_channel
+                                        .name
+                                        .clone()
+                                        .unwrap_or(spec_channel.base_url.to_string())
                                 );
-                                candidates.excluded.push((
-                                    solvable_id,
-                                    pool.intern_string(message),
-                                ));
+                                candidates
+                                    .excluded
+                                    .push((solvable_id, pool.intern_string(message)));
                                 continue;
                             }
                         }

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -3,8 +3,8 @@
 use crate::{IntoRepoData, SolveError, SolverRepoData, SolverTask};
 use rattler_conda_types::package::ArchiveType;
 use rattler_conda_types::{
-    GenericVirtualPackage, MatchSpec, NamelessMatchSpec, PackageRecord, ParseMatchSpecError,
-    RepoDataRecord,
+    GenericVirtualPackage, MatchSpec, NamelessMatchSpec, PackageRecord,
+    ParseMatchSpecError, RepoDataRecord,
 };
 use resolvo::{
     Candidates, Dependencies, DependencyProvider, NameId, Pool, SolvableDisplay, SolvableId,
@@ -259,14 +259,16 @@ impl<'a> CondaDependencyProvider<'a> {
                     }) {
                         // Check if the spec has a channel, and compare it to the repodata channel
                         if let Some(spec_channel) = &spec.channel {
-                            if !&record.channel.contains(spec_channel) {
+                            if record.channel != spec_channel.base_url.to_string() {
                                 tracing::debug!("Ignoring {} from {} because it was not requested from that channel.", &record.package_record.name.as_normalized(), &record.channel);
                                 // Add record to the excluded with reason of being in the non requested channel.
+                                let message = format!(
+                                    "candidate not in requested channel: '{}'",
+                                    spec_channel.name.clone().map(|s| s.to_string()).unwrap_or(spec_channel.base_url.to_string())
+                                );
                                 candidates.excluded.push((
                                     solvable_id,
-                                    pool.intern_string(format!(
-                                        "candidate not in requested channel: '{spec_channel}'"
-                                    )),
+                                    pool.intern_string(message),
                                 ));
                                 continue;
                             }


### PR DESCRIPTION
This should really help make installation more correct. 

I got the issue that `conda-forge::python` and `conda::python` got the same result after installation. 
So I changed the type of the channel to be a channel from the start. 

WDYT?