### PR TITLE
fix: redact tokens from urls in errors

### DIFF
--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -22,12 +22,14 @@ dirs = "5.0.1"
 keyring = "2.0.5"
 lazy_static = "1.4.0"
 libc = "0.2.148"
-reqwest = { version = "0.11.22", default-features = false}
+reqwest = { version = "0.11.22", default-features = false }
 retry-policies = { version = "0.2.0", default-features = false }
 serde = "1.0.188"
 serde_json = "1.0.107"
 thiserror = "1.0.49"
 tracing = "0.1.37"
+url = "2.4.1"
+itertools = "0.11.0"
 
 [target.'cfg( target_arch = "wasm32" )'.dependencies]
 getrandom = { version = "0.2.10", features = ["js"] }

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -11,6 +11,12 @@ use reqwest::{Client, IntoUrl, Method, Url};
 pub mod authentication_storage;
 pub mod retry_policies;
 
+mod redaction;
+
+pub use redaction::{
+    redact_known_secrets_from_error, redact_known_secrets_from_url, DEFAULT_REDACTION_STR,
+};
+
 /// A client that can be used to make authenticated requests, based on the [`reqwest::Client`].
 /// By default it uses the fallback storage in the default [`default_auth_store_fallback_directory`].
 #[derive(Clone, Default)]

--- a/crates/rattler_networking/src/redaction.rs
+++ b/crates/rattler_networking/src/redaction.rs
@@ -1,0 +1,86 @@
+use itertools::Itertools;
+use url::Url;
+
+/// A default string to use for redaction.
+pub const DEFAULT_REDACTION_STR: &str = "xxxxxxxx";
+
+/// Anaconda channels are not always publicly available. This function checks if a URL contains a
+/// secret by identifying whether it contains certain patterns. If it does, the function returns a
+/// modified URL where any secret has been masked.
+///
+/// The `redaction` argument can be used to specify a custom string that should be used to replace
+/// a secret. For consistency between application it is recommended to pass
+/// [`DEFAULT_REDACTION_STR`].
+///
+/// # Example
+///
+/// ```rust
+/// # use rattler_networking::{redact_known_secrets_from_url, DEFAULT_REDACTION_STR};
+/// # use url::Url;
+///
+/// let url = Url::parse("https://conda.anaconda.org/t/12345677/conda-forge/noarch/repodata.json").unwrap();
+/// let redacted_url = redact_known_secrets_from_url(&url, DEFAULT_REDACTION_STR).unwrap_or(url);
+/// ```
+pub fn redact_known_secrets_from_url(url: &Url, redaction: &str) -> Option<Url> {
+    let mut segments = url.path_segments()?;
+    match (segments.next(), segments.next()) {
+        (Some("t"), Some(_)) => {
+            let remainder = segments.collect_vec();
+            let redacted_path = format!(
+                "t/{redaction}{seperator}{remainder}",
+                seperator = if remainder.is_empty() { "" } else { "/" },
+                remainder = remainder.iter().format("/")
+            );
+
+            let mut url = url.clone();
+            url.set_path(&redacted_path);
+            Some(url)
+        }
+        _ => None,
+    }
+}
+
+/// Redacts known secrets from a [`reqwest::Error`].
+pub fn redact_known_secrets_from_error(err: reqwest::Error) -> reqwest::Error {
+    if let Some(url) = err.url() {
+        let redacted_url = redact_known_secrets_from_url(url, DEFAULT_REDACTION_STR)
+            .unwrap_or_else(|| url.clone());
+        err.with_url(redacted_url)
+    } else {
+        err
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_remove_known_secrets_from_url() {
+        assert_eq!(
+            redact_known_secrets_from_url(
+                &Url::from_str(
+                    "https://conda.anaconda.org/t/12345677/conda-forge/noarch/repodata.json"
+                )
+                .unwrap(),
+                DEFAULT_REDACTION_STR
+            ),
+            Some(
+                Url::from_str(
+                    "https://conda.anaconda.org/t/xxxxxxxx/conda-forge/noarch/repodata.json"
+                )
+                .unwrap()
+            )
+        );
+
+        assert_eq!(
+            redact_known_secrets_from_url(
+                &Url::from_str("https://conda.anaconda.org/conda-forge/noarch/repodata.json")
+                    .unwrap(),
+                "helloworld"
+            ),
+            None,
+        );
+    }
+}

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate provides the ability to extract a Conda package archive or specific parts of it.
 
 use rattler_digest::{Md5Hash, Sha256Hash};
+use rattler_networking::redact_known_secrets_from_error;
 
 pub mod read;
 pub mod seek;
@@ -43,6 +44,13 @@ pub enum ExtractError {
 
     #[error("the task was cancelled")]
     Cancelled,
+}
+
+#[cfg(feature = "reqwest")]
+impl From<::reqwest::Error> for ExtractError {
+    fn from(err: ::reqwest::Error) -> Self {
+        Self::ReqwestError(redact_known_secrets_from_error(err))
+    }
 }
 
 /// Result struct returned by extraction functions.


### PR DESCRIPTION
This PR adds redaction of tokens in URLs used by errors. I may have missed a few locations, but I think I got them all..