### PR TITLE
expose `StringMatcherParseError`

### DIFF
--- a/crates/rattler_conda_types/src/lib.rs
+++ b/crates/rattler_conda_types/src/lib.rs
@@ -29,7 +29,7 @@ pub use explicit_environment_spec::{
     ParseExplicitEnvironmentSpecError, ParsePackageArchiveHashError,
 };
 pub use generic_virtual_package::GenericVirtualPackage;
-pub use match_spec::matcher::StringMatcher;
+pub use match_spec::matcher::{StringMatcher, StringMatcherParseError};
 pub use match_spec::parse::ParseMatchSpecError;
 pub use match_spec::{MatchSpec, NamelessMatchSpec};
 pub use no_arch_type::{NoArchKind, NoArchType};

--- a/crates/rattler_conda_types/src/match_spec/matcher.rs
+++ b/crates/rattler_conda_types/src/match_spec/matcher.rs
@@ -52,13 +52,22 @@ impl StringMatcher {
     }
 }
 
+/// Error when parsing [`StringMatcher`]
 #[derive(Debug, Clone, Eq, PartialEq, thiserror::Error)]
 pub enum StringMatcherParseError {
+    /// Could not parse the string as a glob
     #[error("invalid glob: {glob}")]
-    InvalidGlob { glob: String },
+    InvalidGlob {
+        /// The invalid glob
+        glob: String,
+    },
 
+    /// Could not parse the string as a regex
     #[error("invalid regex: {regex}")]
-    InvalidRegex { regex: String },
+    InvalidRegex {
+        /// The invalid regex
+        regex: String,
+    },
 }
 
 impl FromStr for StringMatcher {


### PR DESCRIPTION
I could've used this error in `rattler-build`.