### PR TITLE
refactor: rename pip to pypi in lock

### DIFF
--- a/crates/rattler_lock/src/builder.rs
+++ b/crates/rattler_lock/src/builder.rs
@@ -4,7 +4,7 @@ use crate::conda::ConversionError;
 use crate::{
     content_hash, content_hash::CalculateContentHashError, Channel, CondaLock,
     CondaLockedDependency, GitMeta, LockMeta, LockedDependency, MatchSpec, NoArchType,
-    PackageHashes, PackageName, PipLockedDependency, Platform, RepoDataRecord, TimeMeta,
+    PackageHashes, PackageName, PypiLockedDependency, Platform, RepoDataRecord, TimeMeta,
 };
 use fxhash::{FxHashMap, FxHashSet};
 use rattler_conda_types::{NamelessMatchSpec, PackageUrl};
@@ -109,7 +109,7 @@ pub struct LockedPackagesBuilder {
 
 pub enum LockedDependencyBuilder {
     Conda(CondaLockedDependencyBuilder),
-    Pip(PipLockedDependencyBuilder),
+    Pypi(PypiLockedDependencyBuilder),
 }
 
 impl From<CondaLockedDependencyBuilder> for LockedDependencyBuilder {
@@ -118,9 +118,9 @@ impl From<CondaLockedDependencyBuilder> for LockedDependencyBuilder {
     }
 }
 
-impl From<PipLockedDependencyBuilder> for LockedDependencyBuilder {
-    fn from(value: PipLockedDependencyBuilder) -> Self {
-        LockedDependencyBuilder::Pip(value)
+impl From<PypiLockedDependencyBuilder> for LockedDependencyBuilder {
+    fn from(value: PypiLockedDependencyBuilder) -> Self {
+        LockedDependencyBuilder::Pypi(value)
     }
 }
 
@@ -178,12 +178,12 @@ impl LockedPackagesBuilder {
                     }
                     .into(),
                 },
-                LockedDependencyBuilder::Pip(locked_package) => LockedDependency {
+                LockedDependencyBuilder::Pypi(locked_package) => LockedDependency {
                     platform: self.platform,
                     version: locked_package.version,
                     name: locked_package.name.to_string(),
                     category: super::default_category(),
-                    kind: PipLockedDependency {
+                    kind: PypiLockedDependency {
                         requires_dist: locked_package.requires_dist,
                         requires_python: locked_package.requires_python,
                         extras: locked_package.extras,
@@ -414,7 +414,7 @@ impl CondaLockedDependencyBuilder {
     }
 }
 
-pub struct PipLockedDependencyBuilder {
+pub struct PypiLockedDependencyBuilder {
     /// Name of the locked package
     pub name: String,
     /// Package version

--- a/crates/rattler_lock/src/builder.rs
+++ b/crates/rattler_lock/src/builder.rs
@@ -4,7 +4,7 @@ use crate::conda::ConversionError;
 use crate::{
     content_hash, content_hash::CalculateContentHashError, Channel, CondaLock,
     CondaLockedDependency, GitMeta, LockMeta, LockedDependency, MatchSpec, NoArchType,
-    PackageHashes, PackageName, PypiLockedDependency, Platform, RepoDataRecord, TimeMeta,
+    PackageHashes, PackageName, Platform, PypiLockedDependency, RepoDataRecord, TimeMeta,
 };
 use fxhash::{FxHashMap, FxHashSet};
 use rattler_conda_types::{NamelessMatchSpec, PackageUrl};

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -165,11 +165,11 @@ impl LockedDependency {
     }
 
     /// Returns a reference to the internal [`PypiLockedDependency`] if this instance represents
-    /// a pip package.
-    pub fn as_pip(&self) -> Option<&PypiLockedDependency> {
+    /// a pypi package.
+    pub fn as_pypi(&self) -> Option<&PypiLockedDependency> {
         match &self.kind {
             LockedDependencyKind::Conda(_) => None,
-            LockedDependencyKind::Pypi(pip) => Some(pip),
+            LockedDependencyKind::Pypi(pypi) => Some(pypi),
         }
     }
 
@@ -178,8 +178,8 @@ impl LockedDependency {
         matches!(self.kind, LockedDependencyKind::Conda(_))
     }
 
-    /// Returns true if this instance represents a pip package.
-    pub fn is_pip(&self) -> bool {
+    /// Returns true if this instance represents a Pypi package.
+    pub fn is_pypi(&self) -> bool {
         matches!(self.kind, LockedDependencyKind::Pypi(_))
     }
 }
@@ -204,7 +204,7 @@ impl From<PypiLockedDependency> for LockedDependencyKind {
     }
 }
 
-/// The URL for the dependency (currently only used for pip packages)
+/// The URL for the dependency (currently only used for pypi packages)
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone, Debug, Hash)]
 pub struct DependencySource {
     // According to:

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -14,14 +14,14 @@ pub mod builder;
 mod conda;
 mod content_hash;
 mod hash;
-mod pip;
+mod pypi;
 mod serde;
 mod utils;
 
 use crate::conda::ConversionError;
 pub use conda::CondaLockedDependency;
 pub use hash::PackageHashes;
-pub use pip::PipLockedDependency;
+pub use pypi::PypiLockedDependency;
 
 /// Represents the conda-lock file
 /// Contains the metadata regarding the lock files
@@ -160,16 +160,16 @@ impl LockedDependency {
     pub fn as_conda(&self) -> Option<&CondaLockedDependency> {
         match &self.kind {
             LockedDependencyKind::Conda(conda) => Some(conda),
-            LockedDependencyKind::Pip(_) => None,
+            LockedDependencyKind::Pypi(_) => None,
         }
     }
 
-    /// Returns a reference to the internal [`PipLockedDependency`] if this instance represents
+    /// Returns a reference to the internal [`PypiLockedDependency`] if this instance represents
     /// a pip package.
-    pub fn as_pip(&self) -> Option<&PipLockedDependency> {
+    pub fn as_pip(&self) -> Option<&PypiLockedDependency> {
         match &self.kind {
             LockedDependencyKind::Conda(_) => None,
-            LockedDependencyKind::Pip(pip) => Some(pip),
+            LockedDependencyKind::Pypi(pip) => Some(pip),
         }
     }
 
@@ -180,7 +180,7 @@ impl LockedDependency {
 
     /// Returns true if this instance represents a pip package.
     pub fn is_pip(&self) -> bool {
-        matches!(self.kind, LockedDependencyKind::Pip(_))
+        matches!(self.kind, LockedDependencyKind::Pypi(_))
     }
 }
 
@@ -188,7 +188,8 @@ impl LockedDependency {
 #[serde(tag = "manager", rename_all = "snake_case")]
 pub enum LockedDependencyKind {
     Conda(CondaLockedDependency),
-    Pip(PipLockedDependency),
+    #[serde(alias = "pip")]
+    Pypi(PypiLockedDependency),
 }
 
 impl From<CondaLockedDependency> for LockedDependencyKind {
@@ -197,9 +198,9 @@ impl From<CondaLockedDependency> for LockedDependencyKind {
     }
 }
 
-impl From<PipLockedDependency> for LockedDependencyKind {
-    fn from(value: PipLockedDependency) -> Self {
-        LockedDependencyKind::Pip(value)
+impl From<PypiLockedDependency> for LockedDependencyKind {
+    fn from(value: PypiLockedDependency) -> Self {
+        LockedDependencyKind::Pypi(value)
     }
 }
 

--- a/crates/rattler_lock/src/pypi.rs
+++ b/crates/rattler_lock/src/pypi.rs
@@ -4,13 +4,13 @@ use serde_with::{serde_as, skip_serializing_none};
 use std::collections::HashSet;
 use url::Url;
 
-/// A pinned Pip package
+/// A pinned PyPi package
 #[serde_as]
 #[skip_serializing_none]
 #[derive(Serialize, Deserialize, Eq, PartialEq, Clone, Debug)]
-pub struct PipLockedDependency {
+pub struct PypiLockedDependency {
     /// A list of dependencies on other packages that the wheel listed.
-    #[serde(default, alias = "dependencies")]
+    #[serde(default, alias = "dependencies", skip_serializing_if = "Vec::is_empty")]
     #[serde_as(deserialize_as = "crate::utils::serde::Pep440MapOrVec")]
     pub requires_dist: Vec<String>,
 
@@ -18,7 +18,7 @@ pub struct PipLockedDependency {
     pub requires_python: Option<String>,
 
     /// A list of extras that are selected
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub extras: HashSet<String>,
 
     /// The URL that points to where the artifact can be downloaded from.

--- a/crates/rattler_lock/src/serde.rs
+++ b/crates/rattler_lock/src/serde.rs
@@ -82,9 +82,9 @@ impl Serialize for CondaLock {
                     (LockedDependencyKind::Conda(a), LockedDependencyKind::Conda(b)) => {
                         a.build.cmp(&b.build)
                     }
-                    (LockedDependencyKind::Pip(_), LockedDependencyKind::Pip(_)) => Ordering::Equal,
-                    (LockedDependencyKind::Pip(_), _) => Ordering::Less,
-                    (_, LockedDependencyKind::Pip(_)) => Ordering::Greater,
+                    (LockedDependencyKind::Pypi(_), LockedDependencyKind::Pypi(_)) => Ordering::Equal,
+                    (LockedDependencyKind::Pypi(_), _) => Ordering::Less,
+                    (_, LockedDependencyKind::Pypi(_)) => Ordering::Greater,
                 })
         });
 

--- a/crates/rattler_lock/src/serde.rs
+++ b/crates/rattler_lock/src/serde.rs
@@ -115,6 +115,6 @@ mod test {
         )
         .unwrap_err();
 
-        insta::assert_snapshot!(format!("{}", err), @"found newer file format version 1000, but only up to including version 2 is supported");
+        insta::assert_snapshot!(format!("{}", err), @"found newer file format version 1000, but only up to including version 3 is supported");
     }
 }

--- a/crates/rattler_lock/src/serde.rs
+++ b/crates/rattler_lock/src/serde.rs
@@ -3,7 +3,9 @@ use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::cmp::Ordering;
 
-const FILE_VERSION: u32 = 2;
+// Version 2: dependencies are now arrays instead of maps
+// Version 3: pip has been renamed to pypi
+const FILE_VERSION: u32 = 3;
 
 /// A helper struct to deserialize the version field of the lock file and provide potential errors
 /// in-line.
@@ -82,7 +84,9 @@ impl Serialize for CondaLock {
                     (LockedDependencyKind::Conda(a), LockedDependencyKind::Conda(b)) => {
                         a.build.cmp(&b.build)
                     }
-                    (LockedDependencyKind::Pypi(_), LockedDependencyKind::Pypi(_)) => Ordering::Equal,
+                    (LockedDependencyKind::Pypi(_), LockedDependencyKind::Pypi(_)) => {
+                        Ordering::Equal
+                    }
                     (LockedDependencyKind::Pypi(_), _) => Ordering::Less,
                     (_, LockedDependencyKind::Pypi(_)) => Ordering::Greater,
                 })

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__read_conda_lock.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__read_conda_lock.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
-assertion_line: 300
+assertion_line: 301
 expression: conda_lock
 ---
-version: 2
+version: 3
 metadata:
   content_hash:
     linux-64: db07b15e6c03c3be1c2b06b6b6c916d625f68bba2d5911b013b31970eaa2e5c3

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__read_conda_lock_python.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__read_conda_lock_python.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
-assertion_line: 310
+assertion_line: 311
 expression: conda_lock
 ---
-version: 2
+version: 3
 metadata:
   content_hash:
     linux-64: 63fe6f5b3868946659fb21a6f0a5871c672c00ce5846fe67e044d5d3fa7c2b3b


### PR DESCRIPTION
This renames `pip` to `pypi` in lock files. `pip` is actually the installer and we don't really use that. When we talk about pip packages we usually mean pypi packages.

Since this is a forward-incompatible change I bumped the lock-file version to 3.