### PR TITLE
add options to disable zstd and bz2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+#### Added
+
+* Options to disable `bz2` and `zstd` in `fetch_repo_data`
+
 ## [0.13.0] - 2023-11-27
 
 ### 📃 Details
@@ -14,8 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 
 * Experimental support for purls in PackageRecord and derived datastructures ([#414](https://github.com/mamba-org/rattler/pull/414))
-
-* Options to disable `bz2` and `zstd` in `fetch_repo_data`
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Experimental support for purls in PackageRecord and derived datastructures ([#414](https://github.com/mamba-org/rattler/pull/414))
 
+* Options to disable `bz2` and `zstd` in `fetch_repo_data`
+
 #### Changed
 
 * Rename `pip` to `pypi` in lockfile ([#415](https://github.com/mamba-org/rattler/pull/415))

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -164,7 +164,7 @@ pub struct FetchRepoDataOptions {
     pub jlap_enabled: bool,
 
     /// When enabled, the zstd variant will be used if available
-    pub zstd_enabled: bool, 
+    pub zstd_enabled: bool,
 
     /// When enabled, the bz2 variant will be used if available
     pub bz2_enabled: bool,


### PR DESCRIPTION
We want to try `rattler` and `rattler-build` within the client infrastructure. This client uses JFrog Artifactory to proxy conda repositories. The deployed version has a bug where the `repodata.json.zst` is cached indefinitely. An option to disable support for bz2 and zstd would allow us to use rattler with this version.