### PR TITLE
feat: download to disk before extracting

### DIFF
--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -17,16 +17,17 @@ futures-util = { version = "0.3.28", optional = true }
 itertools = "0.11.0"
 rattler_conda_types = { version = "0.13.0", path = "../rattler_conda_types" }
 rattler_digest = { version = "0.13.0", path = "../rattler_digest" }
+rattler_networking = { version = "0.13.0", path = "../rattler_networking", default-features = false }
+reqwest = { version = "0.11.22", optional = true, default-features = false }
 serde_json = "1.0.107"
 tar = { version = "0.4.40" }
+tempfile = "3.8.0"
 thiserror = "1.0.49"
 tokio = { version = "1", optional = true }
 tokio-util = { version = "0.7", optional = true }
-reqwest = { version = "0.11.22", optional = true, default-features = false }
 url = "2.4.1"
 zip = { version = "0.6.6", default-features = false, features = ["deflate", "time"] }
 zstd = { version = "0.12.4", default-features = false }
-rattler_networking = { version = "0.13.0", path = "../rattler_networking", default-features = false }
 
 [features]
 default = ["native-tls", "blocking"]
@@ -37,7 +38,6 @@ blocking = ["rattler_networking/blocking"]
 wasm = ["zstd/wasm"]
 
 [dev-dependencies]
-tempfile = "3.8.0"
 tokio = { version = "1", features = ["rt", "macros"] }
 walkdir = "2.4.0"
 rstest = "0.18.2"

--- a/crates/rattler_package_streaming/src/reqwest/tokio.rs
+++ b/crates/rattler_package_streaming/src/reqwest/tokio.rs
@@ -33,9 +33,11 @@ async fn get_reader(
     client: AuthenticatedClient,
 ) -> Result<impl Read + Send + 'static, ExtractError> {
     // If the url is a file path, then just open the file
-    if let Ok(path) = url.to_file_path() {
-        let file = File::open(path).map_err(ExtractError::IoError)?;
-        return Ok(LocalOrTemp::Local(BufReader::new(file)));
+    if url.scheme() == "file" {
+        if let Ok(path) = url.to_file_path() {
+            let file = File::open(path).map_err(ExtractError::IoError)?;
+            return Ok(LocalOrTemp::Local(BufReader::new(file)));
+        }
     }
 
     // Create a request for the file.


### PR DESCRIPTION
This changes the behavior of downloading packages. Decompressing and extracting the stream turns out to often be slower than downloading the file. This causes the download speed to decrease not utilizing the full bandwidth of the system.

This PR changes the behavior to first download the file to memory (or to disk if the file is too large) and only then extract the whole archive. In the future, we could possibly make this even more awesome by using a FIFO file queue so we can buffer the download to disk while still extracting at the same time.

I didn't do formal tests but on my machine, the downloads "feel" much faster.