### PR TITLE
Added ParseMatchSpecError tests

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/matcher.rs
+++ b/crates/rattler_conda_types/src/match_spec/matcher.rs
@@ -151,4 +151,12 @@ mod tests {
             .unwrap()
             .matches("foobar"));
     }
+
+    #[test]
+    fn test_special_characters_matches() {
+        let special_characters = "~!@#$%^&*()_-+={}[]|;:'<>,.?/";
+        for special_character in special_characters.chars()  {
+            assert!(StringMatcher::from_str(&special_character.to_string()).unwrap().matches(&special_character.to_string()));
+        }  
+    } 
 }

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -474,7 +474,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::{
-        split_version_and_build, strip_brackets, BracketVec, MatchSpec, ParseMatchSpecError,
+        split_version_and_build, strip_brackets, BracketVec, MatchSpec, ParseMatchSpecError, strip_package_name,
     };
     use crate::match_spec::parse::parse_bracket_list;
     use crate::{BuildNumberSpec, Channel, NamelessMatchSpec, VersionSpec};
@@ -739,5 +739,17 @@ mod tests {
         let _unknown_key = String::from("unknown");
         let spec = MatchSpec::from_str("conda-forge::foo[unknown=1.0.*]");
         assert_matches!(spec,  Err(ParseMatchSpecError::InvalidBracketKey(_unknown_key)));
+    }
+
+    #[test]
+    fn test_invalid_number_of_colons() {
+        let spec = MatchSpec::from_str("conda-forge::::foo[version=\"1.0.*\"]");
+        assert_matches!(spec,  Err(ParseMatchSpecError::InvalidNumberOfColons));
+    }
+
+    #[test]
+    fn test_missing_package_name() {
+        let package_name = strip_package_name("");
+        assert_matches!(package_name,  Err(ParseMatchSpecError::MissingPackageName));
     }
 }

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -733,4 +733,11 @@ mod tests {
             Err(ParseMatchSpecError::InvalidBracket)
         );
     }
+
+    #[test]
+    fn test_invalid_bracket_key() {
+        let _unknown_key = String::from("unknown");
+        let spec = MatchSpec::from_str("conda-forge::foo[unknown=1.0.*]");
+        assert_matches!(spec,  Err(ParseMatchSpecError::InvalidBracketKey(_unknown_key)));
+    }
 }

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -506,15 +506,6 @@ mod tests {
         assert_eq!(result.0, "bla ");
         let expected: BracketVec = smallvec![("version", "1.2.3"), ("build_number", "1")];
         assert_eq!(result.1, expected);
-
-        assert_matches!(
-            strip_brackets(r#"bla [version="1.2.3", build_number=]"#),
-            Err(ParseMatchSpecError::InvalidBracket)
-        );
-        assert_matches!(
-            strip_brackets(r#"bla [version="1.2.3, build_number=1]"#),
-            Err(ParseMatchSpecError::InvalidBracket)
-        );
     }
 
     #[test]
@@ -729,5 +720,17 @@ mod tests {
             })
             .collect();
         insta::assert_yaml_snapshot!("parsed matchspecs", evaluated);
+    }
+
+    #[test]
+    fn test_invalid_bracket() {
+        assert_matches!(
+            strip_brackets(r#"bla [version="1.2.3", build_number=]"#),
+            Err(ParseMatchSpecError::InvalidBracket)
+        );
+        assert_matches!(
+            strip_brackets(r#"bla [version="1.2.3, build_number=1]"#),
+            Err(ParseMatchSpecError::InvalidBracket)
+        );
     }
 }


### PR DESCRIPTION
Attempt to add some tests for ParseMatchSpecError and extra test case for matcher and special characters: [Test: Check invalidation of matchspecs that are formatted incorrect](https://github.com/mamba-org/rattler/issues/205)