### PR TITLE
Default value for conda_packages in repodata.json

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -38,7 +38,11 @@ pub struct RepoData {
 
     /// The conda packages contained in the repodata.json file (under a different key for
     /// backwards compatibility with previous conda versions)
-    #[serde(default, rename = "packages.conda", serialize_with = "sort_map_alphabetically")]
+    #[serde(
+        default,
+        rename = "packages.conda",
+        serialize_with = "sort_map_alphabetically"
+    )]
     pub conda_packages: FxHashMap<String, PackageRecord>,
 
     /// removed packages (files are still accessible, but they are not installable like regular packages)
@@ -465,7 +469,9 @@ mod test {
 
     #[test]
     fn test_deserialize_no_packages_conda() {
-        let repodata = deserialize_json_from_test_data("channels/dummy-no-conda-packages/linux-64/repodata.json");
+        let repodata = deserialize_json_from_test_data(
+            "channels/dummy-no-conda-packages/linux-64/repodata.json",
+        );
         insta::assert_yaml_snapshot!(repodata);
     }
 

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__deserialize_no_packages_conda.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__deserialize_no_packages_conda.snap
@@ -1,0 +1,184 @@
+---
+source: crates/rattler_conda_types/src/repo_data/mod.rs
+assertion_line: 477
+expression: repodata
+---
+info:
+  subdir: linux-64
+  base_url: "../linux-64"
+packages:
+  bar-1.0-unix_py36h1af98f8_2.tar.bz2:
+    build: unix_py36h1af98f8_2
+    build_number: 1
+    depends:
+      - __unix
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: bar
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: 1.2.3
+  "baz-1.0-unix_py36h1af98f8_2\u0000.tar.bz2":
+    build: "unix_py36h1af98f8_2\u0000"
+    build_number: 1
+    depends:
+      - __unix
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: baz
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: 1.2.3
+  "baz-2.0-unix_py36h1af98f8_2\u0000.tar.bz2":
+    build: "unix_py36h1af98f8_2\u0000"
+    build_number: 1
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: baz
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: "2.0"
+  bors-1.0-bla_1.tar.bz2:
+    build: bla_1
+    build_number: 1
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: bors
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: "1.0"
+  bors-1.1-bla_1.tar.bz2:
+    build: bla_1
+    build_number: 1
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: bors
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: "1.1"
+  bors-1.2.1-bla_1.tar.bz2:
+    build: bla_1
+    build_number: 1
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: bors
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: 1.2.1
+  bors-2.0-bla_1.tar.bz2:
+    build: bla_1
+    build_number: 1
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: bors
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: "2.0"
+  bors-2.1-bla_1.tar.bz2:
+    build: bla_1
+    build_number: 1
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: bors
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: "2.1"
+  foo-3.0.2-py36h1af98f8_1.conda:
+    build: py36h1af98f8_1
+    build_number: 1
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: fb731d9290f0bcbf3a054665f33ec94f
+    name: foo
+    sha256: 67a63bec3fd3205170eaad532d487595b8aaceb9814d13c6858d7bac3ef24cd4
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: 3.0.2
+  foo-3.0.2-py36h1af98f8_1.tar.bz2:
+    build: py36h1af98f8_1
+    build_number: 1
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: d65ab674acf3b7294ebacaec05fc5b54
+    name: foo
+    sha256: 1154fceeb5c4ee9bb97d245713ac21eb1910237c724d2b7103747215663273c2
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: 3.0.2
+  foo-4.0.2-py36h1af98f8_2.tar.bz2:
+    build: py36h1af98f8_2
+    build_number: 1
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: foo
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: 4.0.2
+  foobar-2.0-bla_1.tar.bz2:
+    build: bla_1
+    build_number: 1
+    depends:
+      - bors <2.0
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: foobar
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: "2.0"
+  foobar-2.1-bla_1.tar.bz2:
+    build: bla_1
+    build_number: 1
+    depends:
+      - bors <2.0
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: foobar
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1605110689658
+    version: "2.1"
+packages.conda: {}
+repodata_version: 2

--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -196,14 +196,17 @@ struct LazyRepoData<'i> {
     info: Option<ChannelInfo>,
 
     /// The tar.bz2 packages contained in the repodata.json file
-    #[serde(borrow)]
-    #[serde(deserialize_with = "deserialize_filename_and_raw_record")]
+    #[serde(borrow, deserialize_with = "deserialize_filename_and_raw_record")]
     packages: Vec<(PackageFilename<'i>, &'i RawValue)>,
 
     /// The conda packages contained in the repodata.json file (under a different key for
     /// backwards compatibility with previous conda versions)
-    #[serde(borrow, rename = "packages.conda")]
-    #[serde(deserialize_with = "deserialize_filename_and_raw_record")]
+    #[serde(
+        borrow,
+        default,
+        deserialize_with = "deserialize_filename_and_raw_record",
+        rename = "packages.conda"
+    )]
     conda_packages: Vec<(PackageFilename<'i>, &'i RawValue)>,
 }
 

--- a/test-data/channels/dummy-no-conda-packages/linux-64/repodata.json
+++ b/test-data/channels/dummy-no-conda-packages/linux-64/repodata.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:389c8f1f09d29d003be0c486a575b7d97dc9dce84bae3e1a44efa2faae0d5d2e
+size 5979


### PR DESCRIPTION
I am using rattler in a context that has to deal with _really_ old repodata.json files that don't have the "packages.conda" field and thus they fail with this error message:

```
called `Result::unwrap()` on an `Err` value: Custom { kind: InvalidData, error: Error("missing field `packages.conda`", line: 205, column: 1) }
```

I recognize that packages.conda has been created by conda build/index for years now, but this means rattler isn't backwards compatible with the (very) old state of repodatas and it is not trivial to upgrade the repodatas that I am dealing with. Without this, I will be potentially blocked from using rattler in important contexts. Rattler would still produce this field as an empty map by default, and it would default to an empty map when it's missing from a repodata.json that it deserializes. 

Thoughts? Also let me know if I'm missing other changes necessary in order to do this.