### PR TITLE
fix wildcard expansion for stored credentials of domains

### DIFF
--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -119,7 +119,7 @@ impl AuthenticationStorage {
                         Some(domain) => domain,
                         None => return Ok((url, None)),
                     };
-                    
+
                     let mut splits = domain.split('.').collect::<Vec<&str>>();
 
                     while !splits.is_empty() {
@@ -133,7 +133,7 @@ impl AuthenticationStorage {
                             Ok(None) => {
                                 splits.remove(0);
                             }
-                            _ => {},
+                            _ => {}
                         }
                     }
 


### PR DESCRIPTION
While testing the `auth-file` feature for `rattler-build` (https://github.com/prefix-dev/rattler-build/pull/413) I noticed that the wildcard extension for domains does not work correctly:

`https://repo.prefix.dev` was matched with `repo.prefix.dev` and `*.repo.prefix.dev`, but not with `*.prefix.dev`. On closer inspection, it looks like the function never worked properly: See https://github.com/mamba-org/rattler/pull/252

This PR fixes the wildcard handling and adds a unit test for it.