### PR TITLE
ci: fix python release

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -150,12 +150,6 @@ jobs:
             arch: aarch64
           - target: armv7-unknown-linux-gnueabihf
             arch: armv7
-          - target: s390x-unknown-linux-gnu
-            arch: s390x
-          - target: powerpc64le-unknown-linux-gnu
-            arch: ppc64le
-          - target: powerpc64-unknown-linux-gnu
-            arch: ppc64
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -282,7 +282,7 @@ jobs:
           options: -v ${{ github.workspace }}:/io -w /io
           run: |
             apk add py3-pip
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/py-rattler/dist/ --force-reinstall
+            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links /io/py-rattler/dist/ --force-reinstall --break-system-packages
             python3 -c "import rattler; print(rattler.__version__)"
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4
@@ -326,7 +326,7 @@ jobs:
           install: |
             apk add py3-pip
           run: |
-            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links py-rattler/dist/ --force-reinstall
+            pip3 install ${{ env.PACKAGE_NAME }} --no-index --find-links py-rattler/dist/ --force-reinstall --break-system-packages
             python3 -c "import rattler; print(rattler.__version__)"
       - name: "Upload wheels"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -437,7 +437,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          merge-multiple: true
           path: wheels
       - name: Publish to PyPi
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Fixes:
- pip error on some targets while testing wheel

Removes:
- removes rustls wheel compilation targets:
  - s390x-unknown-linux-gnu
  - powerpc64le-unknown-linux-gnu
  - powerpc64-unknown-linux-gnu