### PR TITLE
feat: allow using `str` in `HashMap`s with a `PackageName` key

### DIFF
--- a/crates/rattler_conda_types/src/package_name.rs
+++ b/crates/rattler_conda_types/src/package_name.rs
@@ -1,6 +1,7 @@
 use crate::utils::serde::DeserializeFromStrUnchecked;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{DeserializeAs, DeserializeFromStr};
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
@@ -141,6 +142,12 @@ impl<'de> DeserializeAs<'de, PackageName> for DeserializeFromStrUnchecked {
     {
         let source = String::deserialize(deserializer)?;
         Ok(PackageName::new_unchecked(source))
+    }
+}
+
+impl Borrow<str> for PackageName {
+    fn borrow(&self) -> &str {
+        self.as_normalized()
     }
 }
 


### PR DESCRIPTION
Adds a `Borrow<str>` implementation for `PackageName`.

This allows indexing `HashMap`s with a `PackageName` as key with a `str`. e.g.:

```rust
fn get_package_version(map: &HashMap<PackageName, Version>) -> Option<&Version> {
    maps.get("normalized_package_name")
}
```

just works.

Previously you would have to write:

```rust
fn get_package_version(map: &HashMap<PackageName, Version>) -> Option<&Version> {
    maps.get(PackageName::from_str("normalized_package_name").unwrap())
}
```

Similar to https://github.com/prefix-dev/rip/pull/89