### PR TITLE
feat: improve zstd compression

### DIFF
--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -25,8 +25,9 @@ tokio-util = { version = "0.7", optional = true }
 reqwest = { version = "0.11.22", optional = true, default-features = false }
 url = "2.4.1"
 zip = { version = "0.6.6", default-features = false, features = ["deflate", "time"] }
-zstd = { version = "0.12.4", default-features = false }
+zstd = { version = "0.12.4", default-features = false, features = ["zstdmt"] }
 rattler_networking = { version = "0.15.0", path = "../rattler_networking", default-features = false }
+num_cpus = "1.16.0"
 
 [features]
 default = ["native-tls", "blocking"]

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -28,6 +28,7 @@ zip = { version = "0.6.6", default-features = false, features = ["deflate", "tim
 zstd = { version = "0.12.4", default-features = false, features = ["zstdmt"] }
 rattler_networking = { version = "0.15.0", path = "../rattler_networking", default-features = false }
 num_cpus = "1.16.0"
+tempfile = "3.8.0"
 
 [features]
 default = ["native-tls", "blocking"]
@@ -38,7 +39,6 @@ blocking = ["rattler_networking/blocking"]
 wasm = ["zstd/wasm"]
 
 [dev-dependencies]
-tempfile = "3.8.0"
 tokio = { version = "1", features = ["rt", "macros"] }
 walkdir = "2.4.0"
 rstest = "0.18.2"

--- a/crates/rattler_package_streaming/src/write.rs
+++ b/crates/rattler_package_streaming/src/write.rs
@@ -1,5 +1,4 @@
 //! Functionality for writing conda packages
-use std::env;
 use std::fs::{self, File};
 use std::io::{self, Seek, Write};
 use std::path::{Path, PathBuf};
@@ -136,13 +135,12 @@ pub fn write_tar_bz2_package<W: Write>(
 }
 
 /// Write the contents of a list of paths to a tar zst archive
-///
-/// The number of threads can be configured via `ZSTD_NUMTHREADS` environment variable.
 fn write_zst_archive<W: Write>(
     writer: W,
     base_path: &Path,
     paths: impl Iterator<Item = PathBuf>,
     compression_level: CompressionLevel,
+    num_threads: Option<u32>,
     timestamp: Option<&chrono::DateTime<chrono::Utc>>,
 ) -> Result<(), std::io::Error> {
     // Create a temporary tar file
@@ -158,12 +156,7 @@ fn write_zst_archive<W: Write>(
     let mut tar_file = File::open(&tar_path)?;
     let compression_level = compression_level.to_zstd_level()?;
     let mut zst_encoder = zstd::Encoder::new(writer, compression_level)?;
-    zst_encoder.multithread(
-        env::var("ZSTD_NUMTHREADS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or_else(|| num_cpus::get() as u32),
-    )?;
+    zst_encoder.multithread(num_threads.unwrap_or_else(|| num_cpus::get() as u32))?;
     zst_encoder.set_pledged_src_size(tar_file.metadata().map(|v| v.len()).ok())?;
     zst_encoder.include_contentsize(true)?;
 
@@ -186,6 +179,8 @@ fn write_zst_archive<W: Write>(
 /// * `base_path` - the base path of the package. All paths in `paths` are relative to this path
 /// * `paths` - a list of paths to include in the package
 /// * `compression_level` - the compression level to use for the inner zstd encoded files
+/// * `compression_num_threads` - the number of threads to use for zstd compression (defaults to
+/// the number of CPU cores if `None`)
 /// * `timestamp` - optional a timestamp to use for all archive files (useful for reproducible builds)
 ///
 /// # Errors
@@ -197,6 +192,7 @@ pub fn write_conda_package<W: Write + Seek>(
     base_path: &Path,
     paths: &[PathBuf],
     compression_level: CompressionLevel,
+    compression_num_threads: Option<u32>,
     out_name: &str,
     timestamp: Option<&chrono::DateTime<chrono::Utc>>,
 ) -> Result<(), std::io::Error> {
@@ -220,6 +216,7 @@ pub fn write_conda_package<W: Write + Seek>(
         base_path,
         other_paths,
         compression_level,
+        compression_num_threads,
         timestamp,
     )?;
 
@@ -231,6 +228,7 @@ pub fn write_conda_package<W: Write + Seek>(
         base_path,
         info_paths,
         compression_level,
+        compression_num_threads,
         timestamp,
     )?;
 

--- a/crates/rattler_package_streaming/tests/write.rs
+++ b/crates/rattler_package_streaming/tests/write.rs
@@ -217,6 +217,7 @@ fn test_rewrite_conda() {
             &target_dir,
             &paths,
             CompressionLevel::Default,
+            None,
             &name,
             None,
         )


### PR DESCRIPTION
This PR improves the zstd compression by:

- enabling multithreading for compression (closes #133)
- sets the size of the archive which affects compression effectiveness
  - see [`set_pledged_src_size`](https://docs.rs/zstd/latest/zstd/stream/write/struct.Encoder.html#method.set_pledged_src_size)
  - see <https://github.com/conda/conda-package-streaming/issues/57>
