### PR TITLE
chore: try to upgrade most dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,8 @@ tag-prefix = ""
 lto = true
 
 [workspace.dependencies]
-anyhow = "1.0.75"
-async-compression = { version = "0.4.3", features = ["gzip", "tokio", "bzip2", "zstd"] }
+anyhow = "1.0.79"
+async-compression = { version = "0.4.6", features = ["gzip", "tokio", "bzip2", "zstd"] }
 async-trait = "0.1.77"
 base64 = "0.21.7"
 bindgen = "0.66.1"
@@ -37,9 +37,9 @@ bytes = "1.5.0"
 bzip2 = "0.4.4"
 cache_control = "0.2.0"
 cfg-if = "1.0"
-chrono = { version = "0.4.31", default-features = false, features = ["std", "serde", "alloc"] }
-clap = { version = "4.4.6", features = ["derive"] }
-console = { version = "0.15.7", features = ["windows-console-colors"] }
+chrono = { version = "0.4.33", default-features = false, features = ["std", "serde", "alloc"] }
+clap = { version = "4.4.18", features = ["derive"] }
+console = { version = "0.15.8", features = ["windows-console-colors"] }
 difference = "2.0.0"
 digest = "0.10.7"
 dirs = "5.0.1"
@@ -47,39 +47,39 @@ drop_bomb = "0.1.5"
 enum_dispatch = "0.3.12"
 fs-err = "2.11.0"
 fslock = "0.2.1"
-futures = "0.3.28"
-futures-util = "0.3.28"
+futures = "0.3.30"
+futures-util = "0.3.30"
 fxhash = "0.2.1"
-getrandom = { version = "0.2.10", default-features = false }
+getrandom = { version = "0.2.12", default-features = false }
 glob = "0.3.1"
 hex = "0.4.3"
 http-content-range = "0.1.2"
 humansize = "2.1.3"
 humantime = "2.1.0"
-indexmap = "2.1.0"
+indexmap = "2.2.2"
 indicatif = "0.17.7"
-itertools = "0.12.0"
-json-patch = "1.1.0"
-keyring = "2.0.5"
-lazy-regex = "3.0.2"
+itertools = "0.12.1"
+json-patch = "1.2.0"
+keyring = "2.3.2"
+lazy-regex = "3.1.0"
 lazy_static = "1.4.0"
 libc = { version = "0.2" }
 libloading = "0.8.1"
-libz-sys = { version = "1.1.12", default-features = false }
+libz-sys = { version = "1.1.15", default-features = false }
 md-5 = "0.10.6"
-memchr = "2.6.4"
-memmap2 = "0.9.0"
+memchr = "2.7.1"
+memmap2 = "0.9.4"
 netrc-rs = "0.1.2"
 nom = "7.1.3"
 num_cpus = "1.16.0"
-once_cell = "1.18.0"
-ouroboros = "0.17.2"
+once_cell = "1.19.0"
+ouroboros = "0.18.3"
 pep440_rs = { version = "0.3.12" }
 pep508_rs = { version = "0.2.3" }
 pin-project-lite = "0.2.13"
 plist = "1"
 purl = { version = "0.1.2", features = ["serde"] }
-quote = "1.0.33"
+quote = "1.0.35"
 rattler = { version = "0.16.2", path = "crates/rattler", default-features = false }
 rattler_conda_types = { version = "0.16.2", path = "crates/rattler_conda_types", default-features = false }
 rattler_digest = { version = "0.16.2", path = "crates/rattler_digest", default-features = false }
@@ -91,50 +91,50 @@ rattler_repodata_gateway = { version = "0.16.2", path = "crates/rattler_repodata
 rattler_solve = { version = "0.16.2", path = "crates/rattler_solve", default-features = false }
 rattler_virtual_packages = { version = "0.16.2", path = "crates/rattler_virtual_packages", default-features = false }
 reflink-copy = "0.1.14"
-regex = "1.9.6"
-reqwest = { version = "0.11.22", default-features = false }
+regex = "1.10.3"
+reqwest = { version = "0.11.24", default-features = false }
 reqwest-middleware = "0.2.4"
 resolvo = { version = "0.3.0" }
-retry-policies = { version = "0.2.0", default-features = false }
-serde = { version = "1.0.188" }
+retry-policies = { version = "0.2.1", default-features = false }
+serde = { version = "1.0.196" }
 serde-json-python-formatter = "0.1.0"
-serde_json = { version = "1.0.107" }
+serde_json = { version = "1.0.113" }
 serde_repr = "0.1"
-serde_with = "3.3.0"
-serde_yaml = "0.9.25"
+serde_with = "3.6.0"
+serde_yaml = "0.9.31"
 sha2 = "0.10.8"
 shlex = "1.3.0"
-smallvec = { version = "1.11.1", features = ["serde", "const_new", "const_generics", "union"] }
-strum = { version = "0.25.0", features = ["derive"] }
+smallvec = { version = "1.13.1", features = ["serde", "const_new", "const_generics", "union"] }
+strum = { version = "0.26.1", features = ["derive"] }
 superslice = "1.0.0"
-syn = "2.0.37"
-sysinfo = "0.29.10"
+syn = "2.0.48"
+sysinfo = "0.30.5"
 tar = "0.4.40"
 task-local-extensions = "0.1.4"
 tempdir = "0.3.7"
-tempfile = "3.8.0"
+tempfile = "3.9.0"
 thiserror = "1.0"
-tokio = { version = "1.33.0", default-features = false }
+tokio = { version = "1.35.1", default-features = false }
 tokio-stream = "0.1.14"
-tokio-util = "0.7.9"
+tokio-util = "0.7.10"
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.17", default-features = false }
-url = { version = "2.4.1" }
-uuid = { version = "1.4.1", default-features = false }
+tracing-subscriber = { version = "0.3.18", default-features = false }
+url = { version = "2.5.0" }
+uuid = { version = "1.7.0", default-features = false }
 walkdir = "2.4.0"
-windows-sys = { version = "0.48.0", default-features = false }
+windows-sys = { version = "0.52.0", default-features = false }
 zip = { version = "0.6.6", default-features = false }
-zstd = { version = "0.12.4", default-features = false }
+zstd = { version = "0.13.0", default-features = false }
 
-axum = { version = "0.6.20", default-features = false }
-tower-http = { version = "0.4.4", default-features = false }
-async_zip = { version = "0.0.15", default-features = false }
+axum = { version = "0.7.4", default-features = false, features = ["tokio", "http1"] }
+tower-http = { version = "0.5.1", default-features = false }
+async_zip = { version = "0.0.16", default-features = false }
 assert_matches = "1.5.0"
 rstest = { version = "0.18.2" }
 
 rand = "0.8.5"
 tracing-test = { version = "0.2.4" }
-insta = { version = "1.33.0" }
+insta = { version = "1.34.0" }
 rattler_lock = { version = "0.16.2", path = "crates/rattler_lock" }
 tower = { version = "0.4.13", default-features = false }
 
@@ -147,8 +147,8 @@ cmake = "0.1.50"
 
 similar-asserts = "1.5.0"
 
-trybuild = { version = "1.0.85" }
+trybuild = { version = "1.0.89" }
 
 rstest_reuse = "0.6.0"
 
-test-log = "0.2.12"
+test-log = "0.2.14"

--- a/crates/rattler_package_streaming/tests/write.rs
+++ b/crates/rattler_package_streaming/tests/write.rs
@@ -101,7 +101,8 @@ fn compare_two_tar_archives<T: Read>(
         }
         FilterFiles::None => {}
     }
-
+    println!("Map 1: {:?}", map1);
+    println!("Map 2: {:?}", map2);
     assert_eq!(map1.len(), map2.len());
 
     for (path, header1) in map1 {

--- a/crates/rattler_package_streaming/tests/write.rs
+++ b/crates/rattler_package_streaming/tests/write.rs
@@ -101,8 +101,6 @@ fn compare_two_tar_archives<T: Read>(
         }
         FilterFiles::None => {}
     }
-    println!("Map 1: {:?}", map1);
-    println!("Map 2: {:?}", map2);
     assert_eq!(map1.len(), map2.len());
 
     for (path, header1) in map1 {

--- a/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
@@ -826,7 +826,7 @@ mod test {
     impl TestEnvironment {
         pub async fn new(repo_data: &str, jlap_data: &str, repo_data_state: &str) -> Self {
             let subdir_path = setup_server_environment(None, Some(jlap_data)).await;
-            let server = SimpleChannelServer::new(subdir_path.path());
+            let server = SimpleChannelServer::new(subdir_path.path()).await;
             let server_url = server.url();
 
             let (cache_dir, cache_repo_data) =

--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -1132,7 +1132,7 @@ mod test {
         // Create a directory with some repodata.
         let subdir_path = TempDir::new().unwrap();
         std::fs::write(subdir_path.path().join("repodata.json"), FAKE_REPO_DATA).unwrap();
-        let server = SimpleChannelServer::new(subdir_path.path());
+        let server = SimpleChannelServer::new(subdir_path.path()).await;
 
         // Download the data from the channel with an empty cache.
         let cache_dir = TempDir::new().unwrap();
@@ -1162,7 +1162,7 @@ mod test {
         // Create a directory with some repodata.
         let subdir_path = TempDir::new().unwrap();
         std::fs::write(subdir_path.path().join("repodata.json"), FAKE_REPO_DATA).unwrap();
-        let server = SimpleChannelServer::new(subdir_path.path());
+        let server = SimpleChannelServer::new(subdir_path.path()).await;
 
         // Download the data from the channel with an empty cache.
         let cache_dir = TempDir::new().unwrap();
@@ -1228,7 +1228,7 @@ mod test {
         .await
         .unwrap();
 
-        let server = SimpleChannelServer::new(subdir_path.path());
+        let server = SimpleChannelServer::new(subdir_path.path()).await;
 
         // Download the data from the channel with an empty cache.
         let cache_dir = TempDir::new().unwrap();
@@ -1270,7 +1270,7 @@ mod test {
         .await
         .unwrap();
 
-        let server = SimpleChannelServer::new(subdir_path.path());
+        let server = SimpleChannelServer::new(subdir_path.path()).await;
 
         // Download the data from the channel with an empty cache.
         let cache_dir = TempDir::new().unwrap();
@@ -1319,7 +1319,7 @@ mod test {
         .await
         .unwrap();
 
-        let server = SimpleChannelServer::new(subdir_path.path());
+        let server = SimpleChannelServer::new(subdir_path.path()).await;
 
         // Download the data from the channel with an empty cache.
         let cache_dir = TempDir::new().unwrap();
@@ -1366,7 +1366,7 @@ mod test {
         // The server is configured in such a way that if file `a` is requested but a file called
         // `a.gz` is available it will stream the `a.gz` file and report that its a `gzip` encoded
         // stream.
-        let server = SimpleChannelServer::new(subdir_path.path());
+        let server = SimpleChannelServer::new(subdir_path.path()).await;
 
         // Download the data from the channel
         let cache_dir = TempDir::new().unwrap();
@@ -1398,7 +1398,7 @@ mod test {
         // Create a directory with some repodata.
         let subdir_path = TempDir::new().unwrap();
         std::fs::write(subdir_path.path().join("repodata.json"), FAKE_REPO_DATA).unwrap();
-        let server = SimpleChannelServer::new(subdir_path.path());
+        let server = SimpleChannelServer::new(subdir_path.path()).await;
 
         let last_download_progress = Arc::new(AtomicU64::new(0));
         let last_download_progress_captured = last_download_progress.clone();
@@ -1450,7 +1450,7 @@ mod test {
         ));
 
         // Start a server to test the http error
-        let server = SimpleChannelServer::new(subdir_path.path());
+        let server = SimpleChannelServer::new(subdir_path.path()).await;
 
         // Download the "data" from the channel.
         let cache_dir = TempDir::new().unwrap();

--- a/crates/rattler_shell/src/shell/mod.rs
+++ b/crates/rattler_shell/src/shell/mod.rs
@@ -572,7 +572,7 @@ impl ShellEnum {
     /// Guesses the current shell by checking the name of the parent process.
     #[cfg(feature = "sysinfo")]
     pub fn from_parent_process() -> Option<Self> {
-        use sysinfo::{get_current_pid, ProcessExt, SystemExt};
+        use sysinfo::get_current_pid;
 
         let mut system_info = sysinfo::System::new();
 


### PR DESCRIPTION
- The Zip Reader now reads 3 ranges instead of two, but I didn't investigate further why that would happen ... kinda weird!
- I didn't manage to update `axum`. They removed the `axum::Server` and point to `hyper` instead. However, if I see correctly, the server in hyper is also more complicated. There is a more simple `axum::serve` that I used e.g. in `rattler-server` but idk how to deal with the graceful shutdown etc. that we are using.