### PR TITLE
chore: fix warning for deref on a double reference

### DIFF
--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -445,8 +445,8 @@ impl super::SolverImpl for Solver {
         // Get the resulting packages from the solver.
         let required_records = solvables
             .into_iter()
-            .filter_map(|id| match solver.pool().resolve_solvable(id).inner() {
-                SolverPackageRecord::Record(rec) => Some(rec.deref().clone()),
+            .filter_map(|id| match *solver.pool().resolve_solvable(id).inner() {
+                SolverPackageRecord::Record(rec) => Some(rec.clone()),
                 SolverPackageRecord::VirtualPackage(_) => None,
             })
             .collect();


### PR DESCRIPTION
When building pixi, I got the warning:

```
warning: using `.deref()` on a double reference, which returns `&RepoDataRecord` instead of dereferencing the inner type
   --> /Users/wolfv/Programs/rattler/crates/rattler_solve/src/resolvo/mod.rs:449:61
    |
449 |                 SolverPackageRecord::Record(rec) => Some(rec.deref().clone()),
    |                                                             ^^^^^^^^
    |
    = note: `#[warn(suspicious_double_ref_op)]` on by default

warning: `rattler_solve` (lib) generated 1 warning
```

I think this fixes it.