### PR TITLE
bump: resolvo 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ tag-prefix = ""
 lto = true
 
 [patch.crates-io]
-resolvo = { git = "https://github.com/mamba-org/resolvo.git", branch = "main" }
+#resolvo = { git = "https://github.com/mamba-org/resolvo.git", branch = "main" }

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -24,7 +24,7 @@ url = "2.4.1"
 hex = "0.4.3"
 tempfile = "3.8.0"
 rattler_libsolv_c = { version = "0.16.2", path = "../rattler_libsolv_c", optional = true }
-resolvo = { version = "0.2.0", optional = true }
+resolvo = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 rattler_repodata_gateway = { version = "0.16.2", path = "../rattler_repodata_gateway", default-features = false, features = ["sparse"] }


### PR DESCRIPTION
Bumps resolvo to 0.3.0 and removes source dependency in preperation of a new release.