### PR TITLE
chore: remove resolve git dependency

### DIFF
--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -59,7 +59,6 @@ pyo3-build-config = "0.20"
 
 
 [patch.crates-io]
-resolvo = { git = "https://github.com/mamba-org/resolvo.git", branch = "main" }
 
 # Prevent package from thinking it's in the workspace
 [workspace]


### PR DESCRIPTION
Remove patch to use resolvo git dependency from the py-rattler crate.