### PR TITLE
fix: keep in mind python: noarch packages in clobber calculations

### DIFF
--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -23,6 +23,7 @@ chrono = { workspace = true }
 digest = { workspace = true }
 dirs = { workspace = true }
 drop_bomb = { workspace = true }
+fs-err = "2.11.0"
 futures = { workspace = true }
 fxhash = { workspace = true }
 hex = { workspace = true }

--- a/crates/rattler/src/install/clobber_registry.rs
+++ b/crates/rattler/src/install/clobber_registry.rs
@@ -105,33 +105,6 @@ impl ClobberRegistry {
             self.package_names.len() - 1
         };
 
-        // let entry_points = if index_json.noarch.is_python() {
-        //     let mut res = Vec::new();
-        //     if let (Some(link_json), Some(python_info)) = (link_json, python_info) {
-        //         // register entry points
-        //         if let NoArchLinks::Python(entry_points) = &link_json.noarch {
-        //             for entry_point in &entry_points.entry_points {
-        //                 if python_info.platform.is_windows() {
-        //                     let relative_path_script_py = python_info
-        //                         .bin_dir
-        //                         .join(format!("{}-script.py", &entry_point.command));
-        //                     let relative_path_script_exe = python_info
-        //                         .bin_dir
-        //                         .join(format!("{}.exe", &entry_point.command));
-        //                     res.push(relative_path_script_py);
-        //                     res.push(relative_path_script_exe);
-        //                 } else {
-        //                     let file = python_info.bin_dir.join(&entry_point.command);
-        //                     res.push(file);
-        //                 }
-        //             }
-        //         }
-        //     }
-        //     res
-        // } else {
-        //     Vec::new()
-        // };
-
         for (_, path) in computed_paths {
             // if we find an entry, we have a clobbering path!
             if let Some(e) = self.paths_registry.get(path) {
@@ -156,7 +129,6 @@ impl ClobberRegistry {
         clobber_paths
     }
 
-    /// Unclobber the paths after all installation steps have been completed.
     /// Unclobber the paths after all installation steps have been completed.
     pub fn unclobber(
         &mut self,

--- a/crates/rattler/src/install/driver.rs
+++ b/crates/rattler/src/install/driver.rs
@@ -173,7 +173,10 @@ impl InstallDriver {
 
         self.clobber_registry()
             .unclobber(&required_packages, target_prefix)
-            .map_err(InstallError::PostProcessFailed)?;
+            .map_err(|e| {
+                tracing::error!("Error unclobbering packages: {:?}", e);
+                InstallError::PostProcessFailed(e)
+            })?;
 
         Ok(())
     }

--- a/crates/rattler/src/install/python.rs
+++ b/crates/rattler/src/install/python.rs
@@ -6,6 +6,9 @@ use std::path::{Path, PathBuf};
 /// a specific Python version that is installed in an environment.
 #[derive(Debug, Clone)]
 pub struct PythonInfo {
+    /// The platform that the python package is installed for
+    pub platform: Platform,
+
     /// The major and minor version
     pub short_version: (u64, u64),
 
@@ -56,6 +59,7 @@ impl PythonInfo {
         };
 
         Ok(Self {
+            platform,
             short_version: (major, minor),
             path,
             site_packages_path,

--- a/test-data/clobber/clobber-pynoarch-1-0.1.0-pyh4616a5c_0.tar.bz2
+++ b/test-data/clobber/clobber-pynoarch-1-0.1.0-pyh4616a5c_0.tar.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6427935f717e6e833f8c5c1b1c5902fc2288a10744e715450418a770575296f7
+size 1498

--- a/test-data/clobber/clobber-pynoarch-2-0.1.0-pyh4616a5c_0.tar.bz2
+++ b/test-data/clobber/clobber-pynoarch-2-0.1.0-pyh4616a5c_0.tar.bz2
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f8c37455849942b8449041bb4136542346d518e2bf78bd6ad2a376e24fd1c76
+size 1481

--- a/test-data/clobber/recipe/recipe-noarch.yaml
+++ b/test-data/clobber/recipe/recipe-noarch.yaml
@@ -1,0 +1,24 @@
+recipe:
+  name: clobber
+  version: 0.1.0
+
+outputs:
+  - package:
+      name: clobber-pynoarch-1
+      version: 0.1.0
+    
+    build:  
+      noarch: python
+      script:
+        - mkdir -p $PREFIX/site-packages/clobber
+        - echo "print('hello world')" > $PREFIX/site-packages/clobber/clobber.py
+
+  - package:
+      name: clobber-pynoarch-2
+      version: 0.1.0
+    
+    build:  
+      noarch: python
+      script:
+        - mkdir -p $PREFIX/site-packages/clobber
+        - echo "print('hello world')" > $PREFIX/site-packages/clobber/clobber.py


### PR DESCRIPTION
I hit a bug where the `unclobber` function tried to run `fs::rename` on non-existing files (because these files came from `noarch: python` packages where the final path got renamed from `site-packages/bla.py` to `lib/pythonX.X/site-packages/bla.py`).

This fix is relatively ugly (because we compute the "final" name for the file multiple times and entry points are also not properly handled yet.

Maybe we should discuss real quick how we want to handle entry points (entry points don't need to strictly be linked into the env since we can recreate them when we need to).