### PR TITLE
fix: remove drop-bomb, move empty folder removal to `post_process`

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -353,7 +353,8 @@ async fn execute_transaction(
     link_pb.enable_steady_tick(Duration::from_millis(100));
 
     // Perform all transactions operations in parallel.
-    stream::iter(transaction.operations)
+    let operations = transaction.operations.clone();
+    stream::iter(operations)
         .map(Ok)
         .try_for_each_concurrent(50, |op| {
             let target_prefix = target_prefix.clone();
@@ -380,11 +381,8 @@ async fn execute_transaction(
         .await?;
 
     // Perform any post processing that is required.
-    let prefix_records = find_installed_packages(&target_prefix, 100)
-        .await
-        .context("failed to determine currently installed packages")?;
     install_driver
-        .post_process(&prefix_records, &target_prefix)
+        .post_process(&transaction, &target_prefix)
         .expect("bla");
 
     Ok(())

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -722,12 +722,6 @@ mod test {
             })
             .await;
 
-        // test doesn't write conda-meta, so we ignore the post processing
-        let prefix_records = vec![];
-        install_driver
-            .post_process(&prefix_records, target_dir.path())
-            .unwrap();
-
         // Run the python command and validate the version it outputs
         let python_path = if Platform::current().is_windows() {
             "python.exe"
@@ -770,10 +764,6 @@ mod test {
         )
         .await
         .unwrap();
-
-        install_driver
-            .post_process(&vec![], environment_dir.path())
-            .unwrap();
 
         insta::assert_yaml_snapshot!(paths);
     }

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -13,7 +13,7 @@ pub enum TransactionError {
 }
 
 /// Describes an operation to perform
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TransactionOperation<Old, New> {
     /// The given package record should be installed
     Install(New),
@@ -75,6 +75,24 @@ pub struct Transaction<Old, New> {
 
     /// The target platform of the transaction
     pub platform: Platform,
+}
+
+impl<Old, New> Transaction<Old, New> {
+    /// Return an iterator over the prefix records of all packages that are going to be removed.
+    pub fn removed_packages(&self) -> impl Iterator<Item = &Old> + '_ {
+        self.operations
+            .iter()
+            .filter_map(TransactionOperation::record_to_remove)
+    }
+}
+
+impl<Old: AsRef<New>, New> Transaction<Old, New> {
+    /// Return an iterator over the prefix records of all packages that are going to be installed.
+    pub fn installed_packages(&self) -> impl Iterator<Item = &New> + '_ {
+        self.operations
+            .iter()
+            .filter_map(TransactionOperation::record_to_install)
+    }
 }
 
 impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New> {

--- a/crates/rattler/src/install/unlink.rs
+++ b/crates/rattler/src/install/unlink.rs
@@ -6,8 +6,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use indexmap::IndexSet;
-use itertools::Itertools;
 use rattler_conda_types::PrefixRecord;
 
 /// Error that can occur while unlinking a package.
@@ -26,13 +24,17 @@ pub enum UnlinkError {
     FailedToReadDirectory(String, std::io::Error),
 }
 
-fn recursively_remove_empty_directories(
+pub(crate) fn recursively_remove_empty_directories(
     directory_path: &Path,
     target_prefix: &Path,
     is_python_noarch: bool,
+    keep_directories: &HashSet<PathBuf>,
 ) -> Result<PathBuf, UnlinkError> {
     // Never delete the target prefix
-    if directory_path == target_prefix || !directory_path.exists() {
+    if directory_path == target_prefix
+        || keep_directories.contains(directory_path)
+        || !directory_path.exists()
+    {
         return Ok(directory_path.to_path_buf());
     }
 
@@ -55,7 +57,12 @@ fn recursively_remove_empty_directories(
 
             // Recursively remove the parent directory
             if let Some(parent) = directory_path.parent() {
-                recursively_remove_empty_directories(parent, target_prefix, is_python_noarch)
+                recursively_remove_empty_directories(
+                    parent,
+                    target_prefix,
+                    is_python_noarch,
+                    keep_directories,
+                )
             } else {
                 Ok(directory_path.into())
             }
@@ -77,7 +84,12 @@ fn recursively_remove_empty_directories(
 
             // Recursively remove the parent directory
             if let Some(parent) = directory_path.parent() {
-                recursively_remove_empty_directories(parent, target_prefix, is_python_noarch)
+                recursively_remove_empty_directories(
+                    parent,
+                    target_prefix,
+                    is_python_noarch,
+                    keep_directories,
+                )
             } else {
                 Ok(directory_path.into())
             }
@@ -91,15 +103,6 @@ pub async fn unlink_package(
     target_prefix: &Path,
     prefix_record: &PrefixRecord,
 ) -> Result<(), UnlinkError> {
-    // Check if package is python noarch
-    let is_python_noarch = prefix_record
-        .repodata_record
-        .package_record
-        .noarch
-        .is_python();
-
-    let mut directories = HashSet::new();
-
     // Remove all entries
     for paths in prefix_record.paths_data.paths.iter() {
         match tokio::fs::remove_file(target_prefix.join(&paths.relative_path)).await {
@@ -112,26 +115,6 @@ pub async fn unlink_package(
                     paths.relative_path.to_string_lossy().to_string(),
                     e,
                 ))
-            }
-        }
-
-        if let Some(parent) = paths.relative_path.parent() {
-            directories.insert(parent.to_path_buf());
-        }
-    }
-
-    // Sort the directories by length, so that we delete the deepest directories first.
-    let mut directories: IndexSet<_> = directories.into_iter().sorted().collect();
-    while let Some(directory) = directories.pop() {
-        let directory_path = target_prefix.join(&directory);
-        let removed_until =
-            recursively_remove_empty_directories(&directory_path, target_prefix, is_python_noarch)?;
-
-        // The directory is not empty which means our parent directory is also not empty,
-        // recursively remove the parent directory from the set as well.
-        while let Some(parent) = removed_until.parent() {
-            if !directories.shift_remove(parent) {
-                break;
             }
         }
     }
@@ -159,11 +142,13 @@ mod tests {
         str::FromStr,
     };
 
-    use rattler_conda_types::{Platform, PrefixRecord, Version};
+    use rattler_conda_types::{Platform, PrefixRecord, RepoDataRecord, Version};
 
     use crate::{
         get_repodata_record, get_test_data_dir,
-        install::{link_package, unlink_package, InstallDriver, InstallOptions, PythonInfo},
+        install::{
+            link_package, unlink_package, InstallDriver, InstallOptions, PythonInfo, Transaction,
+        },
     };
 
     async fn link_ruff(target_prefix: &Path, package: &str) -> PrefixRecord {
@@ -200,10 +185,6 @@ mod tests {
         let prefix_record =
             PrefixRecord::from_repodata_record(repodata_record, None, None, paths, None, None);
 
-        install_driver
-            .post_process(&vec![prefix_record.clone()], target_prefix)
-            .unwrap();
-
         return prefix_record;
     }
 
@@ -226,6 +207,20 @@ mod tests {
 
         // Check if the conda-meta file is gone
         assert!(!pkg_meta_path.exists());
+
+        // Set up install driver to run post-processing steps ...
+        let install_driver = InstallDriver::default();
+
+        let transaction = Transaction::from_current_and_desired(
+            vec![prefix_record.clone()],
+            Vec::<RepoDataRecord>::new().into_iter(),
+            Platform::current(),
+        )
+        .unwrap();
+
+        install_driver
+            .remove_empty_directories(&transaction, &[], environment_dir.path())
+            .unwrap();
 
         // check that the environment is completely empty except for the conda-meta folder
         let entries = std::fs::read_dir(environment_dir.path())
@@ -272,6 +267,18 @@ mod tests {
 
         // Check if the conda-meta file is gone
         assert!(!pkg_meta_path.exists());
+        let install_driver = InstallDriver::default();
+
+        let transaction = Transaction::from_current_and_desired(
+            vec![prefix_record.clone()],
+            Vec::<RepoDataRecord>::new().into_iter(),
+            Platform::current(),
+        )
+        .unwrap();
+
+        install_driver
+            .remove_empty_directories(&transaction, &[], target_prefix.path())
+            .unwrap();
 
         // check that the environment is completely empty except for the conda-meta folder
         let entries = std::fs::read_dir(target_prefix.path())

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -100,8 +100,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "zstd 0.13.0",
- "zstd-safe 7.0.0",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -428,10 +428,8 @@ checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-targets 0.52.0",
 ]
 
@@ -979,7 +977,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.1",
+ "indexmap 2.2.2",
  "slab",
  "tokio",
  "tokio-util",
@@ -1189,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1241,6 +1239,15 @@ name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
@@ -1422,9 +1429,9 @@ checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
-version = "0.7.1"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
 dependencies = [
  "libc",
 ]
@@ -1714,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "ouroboros"
-version = "0.17.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ba07320d39dfea882faa70554b4bd342a5f273ed59ba7c1c6b4c840492c954"
+checksum = "97b7be5a8a3462b752f4be3ff2b2bf2f7f1d00834902e46be2a4d68b87b0573c"
 dependencies = [
  "aliasable",
  "ouroboros_macro",
@@ -1725,13 +1732,14 @@ dependencies = [
 
 [[package]]
 name = "ouroboros_macro"
-version = "0.17.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4c6225c69b4ca778c0aea097321a64c421cf4577b331c61b229267edabb6f8"
+checksum = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33"
 dependencies = [
  "heck",
- "proc-macro-error",
+ "itertools 0.12.1",
  "proc-macro2",
+ "proc-macro2-diagnostics",
  "quote",
  "syn 2.0.48",
 ]
@@ -1778,7 +1786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.1",
+ "indexmap 2.2.2",
 ]
 
 [[package]]
@@ -1861,7 +1869,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef"
 dependencies = [
  "base64",
- "indexmap 2.2.1",
+ "indexmap 2.2.2",
  "line-wrap",
  "quick-xml",
  "serde",
@@ -1921,36 +1929,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2134,7 +2131,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2146,8 +2143,8 @@ dependencies = [
  "futures",
  "fxhash",
  "hex",
- "indexmap 2.2.1",
- "itertools",
+ "indexmap 2.2.2",
+ "itertools 0.12.1",
  "memchr",
  "memmap2",
  "nom",
@@ -2177,14 +2174,14 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "chrono",
  "fxhash",
  "glob",
  "hex",
- "indexmap 2.2.1",
- "itertools",
+ "indexmap 2.2.2",
+ "itertools 0.12.1",
  "lazy-regex",
  "nom",
  "purl",
@@ -2205,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "blake2",
  "digest",
@@ -2219,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "fs-err",
  "rattler_conda_types",
@@ -2232,7 +2229,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -2240,7 +2237,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2248,7 +2245,7 @@ dependencies = [
  "dirs",
  "fslock",
  "getrandom",
- "itertools",
+ "itertools 0.12.1",
  "keyring",
  "lazy_static",
  "libc",
@@ -2267,12 +2264,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "bzip2",
  "chrono",
  "futures-util",
- "itertools",
+ "itertools 0.12.1",
  "num_cpus",
  "rattler_conda_types",
  "rattler_digest",
@@ -2287,12 +2284,12 @@ dependencies = [
  "tokio-util",
  "url",
  "zip",
- "zstd 0.12.4",
+ "zstd",
 ]
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2303,7 +2300,7 @@ dependencies = [
  "hex",
  "humansize",
  "humantime",
- "itertools",
+ "itertools 0.12.1",
  "json-patch",
  "libc",
  "md-5",
@@ -2325,16 +2322,16 @@ dependencies = [
  "tokio-util",
  "tracing",
  "url",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rattler_shell"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "enum_dispatch",
- "indexmap 2.2.1",
- "itertools",
+ "indexmap 2.2.2",
+ "itertools 0.12.1",
  "rattler_conda_types",
  "serde_json",
  "shlex",
@@ -2345,12 +2342,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "chrono",
  "hex",
- "itertools",
+ "itertools 0.12.1",
  "rattler_conda_types",
  "rattler_digest",
  "resolvo",
@@ -2363,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "cfg-if",
  "libloading",
@@ -2439,9 +2436,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
  "async-compression",
  "base64",
@@ -2469,6 +2466,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2501,12 +2499,13 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.2.0"
-source = "git+https://github.com/mamba-org/resolvo.git?branch=main#d39c732d8221eae6400669425aead8afbaa9e774"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd163bc7df01195423c83a7a391fecf319ff41d3de899694a9ccb698e790b29"
 dependencies = [
  "bitvec",
  "elsa",
- "itertools",
+ "itertools 0.11.0",
  "petgraph",
  "tracing",
 ]
@@ -2720,7 +2719,7 @@ version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
- "indexmap 2.2.1",
+ "indexmap 2.2.2",
  "itoa",
  "ryu",
  "serde",
@@ -2751,16 +2750,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.5.1"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
+checksum = "15d167997bd841ec232f5b2b8e0e26606df2e7caa4c31b95ea9ca52b200bd270"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.1",
+ "indexmap 2.2.2",
  "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
  "time",
@@ -2768,9 +2768,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.5.1"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
+checksum = "865f9743393e638991566a8b7a479043c2c8da94a33e0a31f18214c9cae0a64d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2784,7 +2784,7 @@ version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adf8a49373e98a4c5f0ceb5d05aa7c648d75f63774981ed95b7c7443bbd50c6e"
 dependencies = [
- "indexmap 2.2.1",
+ "indexmap 2.2.2",
  "itoa",
  "ryu",
  "serde",
@@ -2909,18 +2909,18 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2962,6 +2962,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "system-configuration"
@@ -3150,6 +3156,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3178,7 +3185,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.1",
+ "indexmap 2.2.2",
  "toml_datetime",
  "winnow",
 ]
@@ -3433,9 +3440,9 @@ checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-streams"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4609d447824375f43e1ffbc051b50ad8f4b3ae8219680c94452ea05eb240ac7"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3692,6 +3699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "1.0.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1367295b8f788d371ce2dbc842c7b709c73ee1364d30351dd300ec2203b12377"
+
+[[package]]
 name = "zbus"
 version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3772,30 +3785,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe 6.0.6",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
- "zstd-safe 7.0.0",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]


### PR DESCRIPTION
We observed a race condition when removing empty folders - during the execution of a transaction it can happen that one package gets unlinked and cleans up empty folders after itself, while another one is already installing new files into the folders. This is a race condition due to the way we parellely link all the files. 

In order to fix this issue this PR moves the cleaning out of empty folders until after we're done unlinking and linking new files into the prefix and then does a (synchronous) cleaning of all empty folders in the prefix (that are not explicitly mentioned as empty directories).