### PR TITLE
Fix: Add indexed packages to the relevant section in the repodata

### DIFF
--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -178,9 +178,12 @@ pub fn index(
                 tracing::info!("Could not read package record from {:?}", p);
                 continue;
             };
-            repodata
-                .conda_packages
-                .insert(file_name.to_string_lossy().to_string(), record);
+            match t {
+                ArchiveType::TarBz2 => repodata.packages.insert(file_name.to_string_lossy().to_string(), record),
+                ArchiveType::Conda => repodata
+                    .conda_packages
+                    .insert(file_name.to_string_lossy().to_string(), record),
+            };
         }
         let out_file = output_folder.join(platform).join("repodata.json");
         File::create(&out_file)?.write_all(serde_json::to_string_pretty(&repodata)?.as_bytes())?;

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -179,7 +179,9 @@ pub fn index(
                 continue;
             };
             match t {
-                ArchiveType::TarBz2 => repodata.packages.insert(file_name.to_string_lossy().to_string(), record),
+                ArchiveType::TarBz2 => repodata
+                    .packages
+                    .insert(file_name.to_string_lossy().to_string(), record),
                 ArchiveType::Conda => repodata
                     .conda_packages
                     .insert(file_name.to_string_lossy().to_string(), record),

--- a/crates/rattler_index/tests/test_index.rs
+++ b/crates/rattler_index/tests/test_index.rs
@@ -21,11 +21,13 @@ fn test_index() {
     fs::copy(
         test_data_dir().join(conda_file_path),
         temp_dir.path().join(subdir_path).join(conda_file_path),
-    ).unwrap();
+    )
+    .unwrap();
     fs::copy(
         test_data_dir().join(tar_bz2_file_path),
         temp_dir.path().join(subdir_path).join(tar_bz2_file_path),
-    ).unwrap();
+    )
+    .unwrap();
 
     let res = index(temp_dir.path(), Some(&Platform::Win64));
     assert!(res.is_ok());
@@ -46,7 +48,11 @@ fn test_index() {
             .as_str(),
         Some("win-64")
     );
-    assert!(repodata_json.get("packages").unwrap().get("conda-22.9.0-py38haa244fe_2.tar.bz2").is_some());
+    assert!(repodata_json
+        .get("packages")
+        .unwrap()
+        .get("conda-22.9.0-py38haa244fe_2.tar.bz2")
+        .is_some());
     assert_eq!(
         repodata_json
             .get("packages.conda")

--- a/crates/rattler_index/tests/test_index.rs
+++ b/crates/rattler_index/tests/test_index.rs
@@ -13,14 +13,19 @@ fn test_data_dir() -> PathBuf {
 fn test_index() {
     let temp_dir = tempfile::tempdir().unwrap();
     let subdir_path = Path::new("win-64");
-    let file_path = Path::new("conda-22.11.1-py38haa244fe_1.conda");
+    let conda_file_path = Path::new("conda-22.11.1-py38haa244fe_1.conda");
     let index_json_path = Path::new("conda-22.11.1-py38haa244fe_1-index.json");
+    let tar_bz2_file_path = Path::new("conda-22.9.0-py38haa244fe_2.tar.bz2");
+
     fs::create_dir(temp_dir.path().join(subdir_path)).unwrap();
     fs::copy(
-        test_data_dir().join(file_path),
-        temp_dir.path().join(subdir_path).join(file_path),
-    )
-    .unwrap();
+        test_data_dir().join(conda_file_path),
+        temp_dir.path().join(subdir_path).join(conda_file_path),
+    ).unwrap();
+    fs::copy(
+        test_data_dir().join(tar_bz2_file_path),
+        temp_dir.path().join(subdir_path).join(tar_bz2_file_path),
+    ).unwrap();
 
     let res = index(temp_dir.path(), Some(&Platform::Win64));
     assert!(res.is_ok());
@@ -41,7 +46,7 @@ fn test_index() {
             .as_str(),
         Some("win-64")
     );
-    assert!(repodata_json.get("packages").is_some());
+    assert!(repodata_json.get("packages").unwrap().get("conda-22.9.0-py38haa244fe_2.tar.bz2").is_some());
     assert_eq!(
         repodata_json
             .get("packages.conda")


### PR DESCRIPTION
## Before this PR

The produced repodata.json from `rattler_index` would put all the packages, regardless of the file format, into the `packages.conda` section of the repodata.json

## After this PR

TarBz2 packages now go to the `packages` section, while Conda packages still go to `packages.conda`. I've added a test case to validate the desired behaviour.