### PR TITLE
Add repodata config to channel

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -571,13 +571,24 @@ async fn fetch_repo_data_records_with_progress(
     );
     progress_bar.enable_steady_tick(Duration::from_millis(100));
 
+    // TODO: Should this be in some utils place?
+    let options = match channel.repodata_options {
+        Some(ref options) => FetchRepoDataOptions {
+            bz2_enabled: options.bz2_enabled,
+            jlap_enabled: options.jlap_enabled,
+            zstd_enabled: options.zstd_enabled,
+            ..Default::default()
+        },
+        None => FetchRepoDataOptions::default(),
+    };
+
     // Download the repodata.json
     let download_progress_progress_bar = progress_bar.clone();
     let result = rattler_repodata_gateway::fetch::fetch_repo_data(
         channel.platform_url(platform),
         client,
         repodata_cache.to_path_buf(),
-        FetchRepoDataOptions::default(),
+        options,
         Some(Box::new(move |DownloadProgress { total, bytes }| {
             download_progress_progress_bar.set_length(total.unwrap_or(bytes));
             download_progress_progress_bar.set_position(bytes);

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-use std::convert::identity;
 use thiserror::Error;
 use url::Url;
 

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -5,9 +5,9 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
+use std::convert::identity;
 use thiserror::Error;
 use url::Url;
-use std::convert::identity;
 
 use super::{ParsePlatformError, Platform};
 


### PR DESCRIPTION
This builds on some of the idea of #420 

When fetching from certain channels it would be handy to disable some of the repodata methods that are known to be expensive / non-functional.

This is particularly true for artifactory where the HEAD request for the .bz2 repodata will eager compress the contents and not cache it. :(

Idea is that in downstream tools like pixi a user can define their channel and add some of these options in 

```
channels = [
   { base_url = "https://somehost/channel", repodata_options = { bz2_enabled = False }}
]
```

