### PR TITLE
chore(ci): add workflow to lint pr title

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,20 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -3,10 +3,18 @@ name: Python bindings CI
 on:
   push:
     branches: [ main ]
-    paths:
-      - 'py-rattler/**/*'
-      - '.github/workflows/python-bindings.yml'
   pull_request:
+    paths:
+      # When we change pyproject.toml, we want to ensure that the maturin builds still work
+      - test-data/**
+      - crates/**
+      - Cargo.*
+
+      # When something in the bindings themselves changes
+      - 'py-rattler/**/*'
+
+      # Or when this workflow changes
+      - '.github/workflows/python-bindings.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -17,6 +17,10 @@ on:
       - '.github/workflows/python-bindings.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Adds a workflow to lint PR titles to ensure that they follow conventional commit.