### PR TITLE
fix: redaction

### DIFF
--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -11,6 +11,4 @@ pub mod retry_policies;
 
 mod redaction;
 
-pub use redaction::{
-    redact_known_secrets_from_error, redact_known_secrets_from_url, DEFAULT_REDACTION_STR,
-};
+pub use redaction::{redact_known_secrets_from_url, Redact, DEFAULT_REDACTION_STR};

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -5,6 +5,7 @@
 use std::path::PathBuf;
 
 use rattler_digest::{Md5Hash, Sha256Hash};
+use rattler_networking::Redact;
 
 pub mod read;
 pub mod seek;
@@ -50,22 +51,9 @@ pub enum ExtractError {
 }
 
 #[cfg(feature = "reqwest")]
-impl From<::reqwest::Error> for ExtractError {
-    fn from(err: ::reqwest::Error) -> Self {
-        Self::ReqwestError(rattler_networking::redact_known_secrets_from_error(err).into())
-    }
-}
-
-#[cfg(feature = "reqwest")]
 impl From<::reqwest_middleware::Error> for ExtractError {
     fn from(err: ::reqwest_middleware::Error) -> Self {
-        let err = if let reqwest_middleware::Error::Reqwest(err) = err {
-            rattler_networking::redact_known_secrets_from_error(err).into()
-        } else {
-            err
-        };
-
-        ExtractError::ReqwestError(err)
+        ExtractError::ReqwestError(err.redact())
     }
 }
 

--- a/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
@@ -83,7 +83,7 @@ use blake2::digest::{FixedOutput, Update};
 use rattler_digest::{
     parse_digest_from_hex, serde::SerializableHash, Blake2b256, Blake2b256Hash, Blake2bMac256,
 };
-use rattler_networking::redact_known_secrets_from_error;
+use rattler_networking::Redact;
 use reqwest::{
     header::{HeaderMap, HeaderValue},
     Response, StatusCode,
@@ -166,17 +166,13 @@ pub enum JLAPError {
 
 impl From<reqwest_middleware::Error> for JLAPError {
     fn from(value: reqwest_middleware::Error) -> Self {
-        Self::HTTP(if let reqwest_middleware::Error::Reqwest(err) = value {
-            reqwest_middleware::Error::Reqwest(redact_known_secrets_from_error(err))
-        } else {
-            value
-        })
+        Self::HTTP(value.redact())
     }
 }
 
 impl From<reqwest::Error> for JLAPError {
     fn from(value: reqwest::Error) -> Self {
-        Self::HTTP(redact_known_secrets_from_error(value).into())
+        Self::HTTP(value.redact().into())
     }
 }
 


### PR DESCRIPTION
I think some of the redaction code got lost when we migrated to `reqwest_middleware`. This PR should fix that.

Fix #524 