### PR TITLE
fix: correct condition to downweigh track-feature packages

### DIFF
--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -458,7 +458,7 @@ mod test {
             .map(std::vec::Vec::len)
             .sum::<usize>();
 
-        assert_eq!(total_records, 21731);
+        assert_eq!(total_records, 21732);
     }
 
     #[tokio::test]
@@ -494,7 +494,7 @@ mod test {
             .map(std::vec::Vec::len)
             .sum::<usize>();
 
-        assert_eq!(total_records, 16064);
+        assert_eq!(total_records, 16065);
     }
 
     #[test]
@@ -514,7 +514,7 @@ mod test {
             .map(|repo| repo.conda_packages.len() + repo.packages.len())
             .sum::<usize>();
 
-        assert_eq!(total_records, 367595);
+        assert_eq!(total_records, 367596);
     }
 
     #[rstest]

--- a/crates/rattler_solve/src/resolvo/conda_util.rs
+++ b/crates/rattler_solve/src/resolvo/conda_util.rs
@@ -183,7 +183,7 @@ pub(super) fn find_highest_version<'a>(
                         |(version, has_tracked_features)| {
                             (
                                 version.max(record.version().clone()),
-                                has_tracked_features && record.track_features().is_empty(),
+                                has_tracked_features && !record.track_features().is_empty(),
                             )
                         },
                     ))

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -230,6 +230,15 @@ macro_rules! solver_backend_tests {
         }
 
         #[test]
+        fn test_solve_python_numpy() {
+            insta::assert_yaml_snapshot!(solve_real_world::<$T>(vec![
+                "numpy==1.23.2",
+                "scipy==1.8.1",
+                "python=3.9.*"
+            ]));
+        }
+
+        #[test]
         fn test_solve_favored() {
             let result = solve::<$T>(
                 dummy_channel_json_path(),

--- a/crates/rattler_solve/tests/snapshots/backends__libsolv_c__solve_python_numpy.snap
+++ b/crates/rattler_solve/tests/snapshots/backends__libsolv_c__solve_python_numpy.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rattler_solve/tests/backends.rs
+expression: "solve_real_world::<rattler_solve::libsolv_c::Solver>(vec![\"numpy==1.23.2\",\n        \"scipy==1.8.1\", \"python=3.9.*\"])"
+---
+- _libgcc_mutex 0.1 conda_forge
+- _openmp_mutex 4.5 2_gnu
+- bzip2 1.0.8 h7f98852_4
+- ca-certificates 2022.6.15 ha878542_0
+- ld_impl_linux-64 2.36.1 hea4e1c9_2
+- libblas 3.9.0 16_linux64_openblas
+- libcblas 3.9.0 16_linux64_openblas
+- libffi 3.4.2 h7f98852_5
+- libgcc-ng 12.1.0 h8d9b700_16
+- libgfortran-ng 12.1.0 h69a702a_16
+- libgfortran5 12.1.0 hdcd56e2_16
+- libgomp 12.1.0 h8d9b700_16
+- liblapack 3.9.0 16_linux64_openblas
+- libnsl 2.0.0 h7f98852_0
+- libopenblas 0.3.21 pthreads_h78a6416_1
+- libsqlite 3.39.2 h753d276_1
+- libstdcxx-ng 12.1.0 ha89aaad_16
+- libuuid 2.32.1 h7f98852_1000
+- libzlib 1.2.12 h166bdaf_2
+- ncurses 6.3 h27087fc_1
+- numpy 1.23.2 py39hba7629e_0
+- openssl 3.0.5 h166bdaf_1
+- python 3.9.13 h2660328_0_cpython
+- python_abi 3.9 2_cp39
+- readline 8.1.2 h0f457ee_0
+- scipy 1.8.1 py39h8ba3f38_2
+- sqlite 3.39.2 h4ff8645_1
+- tk 8.6.12 h27826a3_0
+- tzdata 2021e he74cb21_0
+- xz 5.2.6 h166bdaf_0
+

--- a/crates/rattler_solve/tests/snapshots/backends__resolvo__solve_python_numpy.snap
+++ b/crates/rattler_solve/tests/snapshots/backends__resolvo__solve_python_numpy.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rattler_solve/tests/backends.rs
+expression: "solve_real_world::<rattler_solve::resolvo::Solver>(vec![\"numpy==1.23.2\",\n        \"scipy==1.8.1\", \"python=3.9.*\"])"
+---
+- _libgcc_mutex 0.1 conda_forge
+- _openmp_mutex 4.5 2_gnu
+- bzip2 1.0.8 h7f98852_4
+- ca-certificates 2022.6.15 ha878542_0
+- ld_impl_linux-64 2.36.1 hea4e1c9_2
+- libblas 3.9.0 16_linux64_openblas
+- libcblas 3.9.0 16_linux64_openblas
+- libffi 3.4.2 h7f98852_5
+- libgcc-ng 12.1.0 h8d9b700_16
+- libgfortran-ng 12.1.0 h69a702a_16
+- libgfortran5 12.1.0 hdcd56e2_16
+- libgomp 12.1.0 h8d9b700_16
+- liblapack 3.9.0 16_linux64_openblas
+- libnsl 2.0.0 h7f98852_0
+- libopenblas 0.3.21 pthreads_h78a6416_1
+- libsqlite 3.39.2 h753d276_1
+- libstdcxx-ng 12.1.0 ha89aaad_16
+- libuuid 2.32.1 h7f98852_1000
+- libzlib 1.2.12 h166bdaf_2
+- ncurses 6.3 h27087fc_1
+- numpy 1.23.2 py39hba7629e_0
+- openssl 3.0.5 h166bdaf_1
+- python 3.9.13 h2660328_0_cpython
+- python_abi 3.9 2_cp39
+- readline 8.1.2 h0f457ee_0
+- scipy 1.8.1 py39h8ba3f38_2
+- sqlite 3.39.2 h4ff8645_1
+- tk 8.6.12 h27826a3_0
+- tzdata 2021e he74cb21_0
+- xz 5.2.6 h166bdaf_0
+

--- a/test-data/channels/conda-forge/linux-64/repodata.json
+++ b/test-data/channels/conda-forge/linux-64/repodata.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:20021d1dff9941ccf189f27404e296c54bc37fc4600c7027b366c03fc0bfa89e
-size 205364233
+oid sha256:7cc0553f5f68b30bbb831a03cb0a76cb5d40cd129e073e551e27c8373ee83f94
+size 205364821


### PR DESCRIPTION
We use track features to de-prioritize packages.
Sometimes, the solver is forced to select a given package, e.g. when selecting `numpy-XY-<hash>` it might have a dependency on `pypy`. Numpy variants themselves are not down-prioritized, though.

If we detect that a package forces only dependencies that have track features (such as the case for the numpy variant that only works together with `pypy`) we also "inherit" the down-weighing to `numpy` (otherwise the solver would be forced to use pypy later on).

We already had the code for this but it was missing a `!` – this PR corrects that. 