### PR TITLE
fix: dont use workspace dependencies for local crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,17 +91,6 @@ plist = "1"
 purl = { version = "0.1.2", features = ["serde"] }
 quote = "1.0.35"
 rand = "0.8.5"
-rattler = { version = "0.19.0", path = "crates/rattler", default-features = false }
-rattler_conda_types = { version = "0.19.0", path = "crates/rattler_conda_types", default-features = false }
-rattler_digest = { version = "0.19.0", path = "crates/rattler_digest", default-features = false }
-rattler_libsolv_c = { version = "0.19.0", path = "crates/rattler_libsolv_c", default-features = false }
-rattler_lock = { version = "0.19.0", path = "crates/rattler_lock" }
-rattler_macros = { version = "0.19.0", path = "crates/rattler_macros", default-features = false }
-rattler_networking = { version = "0.19.0", path = "crates/rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.19.0", path = "crates/rattler_package_streaming", default-features = false }
-rattler_repodata_gateway = { version = "0.19.0", path = "crates/rattler_repodata_gateway", default-features = false }
-rattler_solve = { version = "0.19.0", path = "crates/rattler_solve", default-features = false }
-rattler_virtual_packages = { version = "0.19.0", path = "crates/rattler_virtual_packages", default-features = false }
 reflink-copy = "0.1.14"
 regex = "1.10.3"
 reqwest = { version = "0.11.24", default-features = false }

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -30,12 +30,12 @@ futures = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
 once_cell = { workspace = true }
-rattler = { workspace = true }
-rattler_conda_types = { workspace = true }
-rattler_networking = { workspace = true }
-rattler_repodata_gateway = { workspace = true, features = ["sparse"] }
-rattler_solve = { workspace = true, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { workspace = true }
+rattler = { version = "0.19.0", default-features = false }
+rattler_conda_types = { version = "0.19.0", default-features = false }
+rattler_networking = { version = "0.19.0", default-features = false }
+rattler_repodata_gateway = { version = "0.19.0", default-features = false, features = ["sparse"] }
+rattler_solve = { version = "0.19.0", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { version = "0.19.0", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -30,12 +30,12 @@ futures = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
 once_cell = { workspace = true }
-rattler = { version = "0.19.0", default-features = false }
-rattler_conda_types = { version = "0.19.0", default-features = false }
-rattler_networking = { version = "0.19.0", default-features = false }
-rattler_repodata_gateway = { version = "0.19.0", default-features = false, features = ["sparse"] }
-rattler_solve = { version = "0.19.0", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { version = "0.19.0", default-features = false }
+rattler = { path="../rattler", version = "0.19.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.19.0", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.19.0", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.0", default-features = false, features = ["sparse"] }
+rattler_solve = { path="../rattler_solve", version = "0.19.0", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.0", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -34,10 +34,10 @@ memmap2 = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { workspace = true }
-rattler_digest = { workspace = true }
-rattler_networking = { workspace = true }
-rattler_package_streaming = { workspace = true, features = ["reqwest"] }
+rattler_conda_types = { version = "0.19.0", default-features = false }
+rattler_digest = { version = "0.19.0", default-features = false }
+rattler_networking = { version = "0.19.0", default-features = false }
+rattler_package_streaming = { version = "0.19.0", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -34,10 +34,10 @@ memmap2 = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { version = "0.19.0", default-features = false }
-rattler_digest = { version = "0.19.0", default-features = false }
-rattler_networking = { version = "0.19.0", default-features = false }
-rattler_package_streaming = { version = "0.19.0", default-features = false, features = ["reqwest"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.19.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.0", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.19.0", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.19.0", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -20,8 +20,8 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { workspace = true, features = ["serde"] }
-rattler_macros = { workspace = true }
+rattler_digest = { version = "0.19.0", default-features = false, features = ["serde"] }
+rattler_macros = { version = "0.19.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -20,8 +20,8 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { version = "0.19.0", default-features = false, features = ["serde"] }
-rattler_macros = { version = "0.19.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.0", default-features = false, features = ["serde"] }
+rattler_macros = { path="../rattler_macros", version = "0.19.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { workspace = true }
-rattler_digest = { workspace = true }
-rattler_package_streaming = { workspace = true }
+rattler_conda_types = { version = "0.19.0", default-features = false }
+rattler_digest = { version = "0.19.0", default-features = false }
+rattler_package_streaming = { version = "0.19.0", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { version = "0.19.0", default-features = false }
-rattler_digest = { version = "0.19.0", default-features = false }
-rattler_package_streaming = { version = "0.19.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.19.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.0", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.19.0", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -15,8 +15,8 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { version = "0.19.0", default-features = false }
-rattler_digest = { version = "0.19.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.19.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.0", default-features = false }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -15,8 +15,8 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { workspace = true }
-rattler_digest = { workspace = true }
+rattler_conda_types = { version = "0.19.0", default-features = false }
+rattler_digest = { version = "0.19.0", default-features = false }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -16,9 +16,9 @@ chrono = { workspace = true }
 futures-util = { workspace = true }
 itertools = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { workspace = true }
-rattler_digest = { workspace = true }
-rattler_networking = { workspace = true }
+rattler_conda_types = { version = "0.19.0", default-features = false }
+rattler_digest = { version = "0.19.0", default-features = false }
+rattler_networking = { version = "0.19.0", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -16,9 +16,9 @@ chrono = { workspace = true }
 futures-util = { workspace = true }
 itertools = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { version = "0.19.0", default-features = false }
-rattler_digest = { version = "0.19.0", default-features = false }
-rattler_networking = { version = "0.19.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.19.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.0", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.19.0", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -31,8 +31,8 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 pin-project-lite = { workspace = true }
 md-5 = { workspace = true }
-rattler_digest = { workspace = true, features = ["tokio", "serde"] }
-rattler_conda_types = { workspace = true, optional = true }
+rattler_digest = { version = "0.19.0", default-features = false, features = ["tokio", "serde"] }
+rattler_conda_types = { version = "0.19.0", default-features = false, optional = true }
 fxhash = { workspace = true, optional = true }
 memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
@@ -41,7 +41,7 @@ superslice = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 json-patch = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
-rattler_networking = { workspace = true }
+rattler_networking = { version = "0.19.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -31,8 +31,8 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 pin-project-lite = { workspace = true }
 md-5 = { workspace = true }
-rattler_digest = { version = "0.19.0", default-features = false, features = ["tokio", "serde"] }
-rattler_conda_types = { version = "0.19.0", default-features = false, optional = true }
+rattler_digest = { path="../rattler_digest", version = "0.19.0", default-features = false, features = ["tokio", "serde"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.19.0", default-features = false, optional = true }
 fxhash = { workspace = true, optional = true }
 memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
@@ -41,7 +41,7 @@ superslice = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 json-patch = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
-rattler_networking = { version = "0.19.0", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.19.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { workspace = true }
+rattler_conda_types = { version = "0.19.0", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { version = "0.19.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.19.0", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -11,8 +11,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { version = "0.19.0", default-features = false }
-rattler_digest = { version = "0.19.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.19.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.0", default-features = false }
 libc = { workspace = true, optional = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
@@ -23,7 +23,7 @@ serde = { workspace = true, features = ["derive"] }
 url = { workspace = true }
 hex = { workspace = true }
 tempfile = { workspace = true }
-rattler_libsolv_c = { version = "0.19.0", default-features = false, optional = true }
+rattler_libsolv_c = { path="../rattler_libsolv_c", version = "0.19.0", default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -11,8 +11,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { workspace = true }
-rattler_digest = { workspace = true }
+rattler_conda_types = { version = "0.19.0", default-features = false }
+rattler_digest = { version = "0.19.0", default-features = false }
 libc = { workspace = true, optional = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
@@ -23,7 +23,7 @@ serde = { workspace = true, features = ["derive"] }
 url = { workspace = true }
 hex = { workspace = true }
 tempfile = { workspace = true }
-rattler_libsolv_c = { workspace = true, optional = true }
+rattler_libsolv_c = { version = "0.19.0", default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -15,7 +15,7 @@ cfg-if = { workspace = true }
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { version = "0.19.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.19.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -15,7 +15,7 @@ cfg-if = { workspace = true }
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { workspace = true }
+rattler_conda_types = { version = "0.19.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/py-rattler/.gitignore
+++ b/py-rattler/.gitignore
@@ -1,5 +1,6 @@
 /target
 !Cargo.lock
+!pixi.lock
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
Releaze-pls seems to bump all packages if their dependencies are defined in the workspace. This PR reverts that change and instead makes every crate depend on other crates in the same workspace via local references.