### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -30,12 +30,12 @@ futures = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.19.1", default-features = false }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.0", default-features = false }
+rattler = { path="../rattler", version = "0.19.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.19.1", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.1", default-features = false, features = ["sparse"] }
-rattler_solve = { path="../rattler_solve", version = "0.20.0", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.1", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.2", default-features = false, features = ["sparse"] }
+rattler_solve = { path="../rattler_solve", version = "0.20.1", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.2", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler-v0.19.1...rattler-v0.19.2) - 2024-03-08
+
+### Other
+- update Cargo.toml dependencies
+
 ## [0.19.1](https://github.com/mamba-org/rattler/compare/rattler-v0.19.0...rattler-v0.19.1) - 2024-03-06
 
 ### Added

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -36,10 +36,10 @@ memmap2 = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.19.1", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.19.1", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.19.2", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.20.0...rattler_conda_types-v0.20.1) - 2024-03-08
+
+### Fixed
+- chrono deprecation warnings ([#558](https://github.com/mamba-org/rattler/pull/558))
+
 ## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.19.0...rattler_conda_types-v0.20.0) - 2024-03-06
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.1...rattler_index-v0.19.2) - 2024-03-08
+
+### Other
+- updated the following local packages: rattler_conda_types, rattler_package_streaming
+
 ## [0.19.1](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.0...rattler_index-v0.19.1) - 2024-03-06
 
 ### Fixed

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.19.1", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.19.2", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.20.0...rattler_lock-v0.20.1) - 2024-03-08
+
+### Fixed
+- chrono deprecation warnings ([#558](https://github.com/mamba-org/rattler/pull/558))
+
 ## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.19.0...rattler_lock-v0.20.0) - 2024-03-06
 
 ### Added

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.19.1...rattler_package_streaming-v0.19.2) - 2024-03-08
+
+### Other
+- update Cargo.toml dependencies
+
 ## [0.19.1](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.19.0...rattler_package_streaming-v0.19.1) - 2024-03-06
 
 ### Fixed

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,7 +16,7 @@ chrono = { workspace = true }
 futures-util = { workspace = true }
 itertools = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.19.1", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.1...rattler_repodata_gateway-v0.19.2) - 2024-03-08
+
+### Fixed
+- chrono deprecation warnings ([#558](https://github.com/mamba-org/rattler/pull/558))
+
 ## [0.19.1](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.0...rattler_repodata_gateway-v0.19.1) - 2024-03-06
 
 ### Fixed

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -32,7 +32,7 @@ serde_json = { workspace = true }
 pin-project-lite = { workspace = true }
 md-5 = { workspace = true }
 rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false, features = ["tokio", "serde"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.0", default-features = false, optional = true }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false, optional = true }
 fxhash = { workspace = true, optional = true }
 memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.1...rattler_shell-v0.19.2) - 2024-03-08
+
+### Fixed
+- better handle utf8 paths in CmdExe and Powershell ([#561](https://github.com/mamba-org/rattler/pull/561))
+
 ## [0.19.1](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.0...rattler_shell-v0.19.1) - 2024-03-06
 
 ### Fixed

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.0...rattler_solve-v0.20.1) - 2024-03-08
+
+### Other
+- update Cargo.toml dependencies
+
 ## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.19.0...rattler_solve-v0.20.0) - 2024-03-06
 
 ### Added

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false }
 libc = { workspace = true, optional = true }
 anyhow = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.1...rattler_virtual_packages-v0.19.2) - 2024-03-08
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.1](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.0...rattler_virtual_packages-v0.19.1) - 2024-03-06
 
 ### Fixed

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -15,7 +15,7 @@ cfg-if = { workspace = true }
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler`: 0.19.1 -> 0.19.2 (✓ API compatible changes)
* `rattler_conda_types`: 0.20.0 -> 0.20.1 (✓ API compatible changes)
* `rattler_package_streaming`: 0.19.1 -> 0.19.2 (✓ API compatible changes)
* `rattler_lock`: 0.20.0 -> 0.20.1 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.19.1 -> 0.19.2 (✓ API compatible changes)
* `rattler_solve`: 0.20.0 -> 0.20.1 (✓ API compatible changes)
* `rattler_shell`: 0.19.1 -> 0.19.2 (✓ API compatible changes)
* `rattler_virtual_packages`: 0.19.1 -> 0.19.2
* `rattler_index`: 0.19.1 -> 0.19.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`
<blockquote>

## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler-v0.19.1...rattler-v0.19.2) - 2024-03-08

### Other
- update Cargo.toml dependencies
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.20.0...rattler_conda_types-v0.20.1) - 2024-03-08

### Fixed
- chrono deprecation warnings ([#558](https://github.com/mamba-org/rattler/pull/558))
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.19.1...rattler_package_streaming-v0.19.2) - 2024-03-08

### Other
- update Cargo.toml dependencies
</blockquote>

## `rattler_lock`
<blockquote>

## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.20.0...rattler_lock-v0.20.1) - 2024-03-08

### Fixed
- chrono deprecation warnings ([#558](https://github.com/mamba-org/rattler/pull/558))
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.1...rattler_repodata_gateway-v0.19.2) - 2024-03-08

### Fixed
- chrono deprecation warnings ([#558](https://github.com/mamba-org/rattler/pull/558))
</blockquote>

## `rattler_solve`
<blockquote>

## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.0...rattler_solve-v0.20.1) - 2024-03-08

### Other
- update Cargo.toml dependencies
</blockquote>

## `rattler_shell`
<blockquote>

## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.1...rattler_shell-v0.19.2) - 2024-03-08

### Fixed
- better handle utf8 paths in CmdExe and Powershell ([#561](https://github.com/mamba-org/rattler/pull/561))
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.1...rattler_virtual_packages-v0.19.2) - 2024-03-08

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.1...rattler_index-v0.19.2) - 2024-03-08

### Other
- updated the following local packages: rattler_conda_types, rattler_package_streaming
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).