### PR TITLE
fix: better handle utf8 paths in CmdExe and Powershell

### DIFF
--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -417,6 +417,8 @@ impl<T: Shell + Clone> Activator<T> {
         // activation script followed by again emitting all environment variables. Any changes
         // should then become visible.
         let mut activation_detection_script = String::new();
+        self.shell_type
+            .force_utf8(&mut activation_detection_script)?;
         self.shell_type.env(&mut activation_detection_script)?;
         self.shell_type
             .echo(&mut activation_detection_script, ENV_START_SEPERATOR)?;


### PR DESCRIPTION
Adds a function to force a shell to handle utf8 encoding. An implementation is provided for cmdexe through the use of the `chcp 65001` command and something similar for Powershell.

This should fix the issue encountered here https://github.com/prefix-dev/pixi/issues/930