### PR TITLE
chore: add pixi badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ![License][license-badge]
 [![Build Status][build-badge]][build]
 [![Project Chat][chat-badge]][chat-url]
+[![Pixi Badge][pixi-badge]][pixi-url]
 [![docs main][docs-main-badge]][docs-main]
 [![python docs main][py-docs-main-badge]][py-docs-main]
 
@@ -23,6 +24,8 @@
 [docs-main]: https://mamba-org.github.io/rattler
 [py-docs-main-badge]: https://img.shields.io/badge/python_docs-main-yellow.svg?style=flat-square
 [py-docs-main]: https://mamba-org.github.io/rattler/py-rattler
+[pixi-badge]:https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json
+[pixi-url]: https://pixi.sh
 
 Rattler is a library that provides common functionality used within the conda ecosystem ([what is conda & conda-forge?](#what-is-conda--conda-forge)).
 The goal of the library is to enable programs and other libraries to easily interact with the conda ecosystem without being dependent on Python.


### PR DESCRIPTION
Adds this badge: [![Pixi Badge](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/prefix-dev/pixi/main/assets/badge/v0.json)](https://pixi.sh)