### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -30,12 +30,12 @@ futures = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.19.2", default-features = false }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.19.1", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.2", default-features = false, features = ["sparse"] }
-rattler_solve = { path="../rattler_solve", version = "0.20.1", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.2", default-features = false }
+rattler = { path="../rattler", version = "0.19.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.19.2", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.3", default-features = false, features = ["sparse"] }
+rattler_solve = { path="../rattler_solve", version = "0.20.2", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.3", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler-v0.19.2...rattler-v0.19.3) - 2024-03-14
+
+### Added
+- add mirror handling and OCI mirror type ([#553](https://github.com/mamba-org/rattler/pull/553))
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler-v0.19.1...rattler-v0.19.2) - 2024-03-08
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.19.2"
+version = "0.19.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -36,10 +36,10 @@ memmap2 = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.19.1", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.19.2", default-features = false, features = ["reqwest"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.19.2", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.0", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.20.1...rattler_conda_types-v0.20.2) - 2024-03-14
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.20.0...rattler_conda_types-v0.20.1) - 2024-03-08
 
 ### Fixed

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -20,8 +20,8 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false, features = ["serde"] }
-rattler_macros = { path="../rattler_macros", version = "0.19.1", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false, features = ["serde"] }
+rattler_macros = { path="../rattler_macros", version = "0.19.2", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_digest-v0.19.1...rattler_digest-v0.19.2) - 2024-03-14
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.19.1](https://github.com/mamba-org/rattler/compare/rattler_digest-v0.19.0...rattler_digest-v0.19.1) - 2024-03-06
 
 ### Other

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.2...rattler_index-v0.19.3) - 2024-03-14
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.1...rattler_index-v0.19.2) - 2024-03-08
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.2"
+version = "0.19.3"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.19.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.0", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_libsolv_c/CHANGELOG.md
+++ b/crates/rattler_libsolv_c/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_libsolv_c-v0.19.1...rattler_libsolv_c-v0.19.2) - 2024-03-14
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.19.1](https://github.com/mamba-org/rattler/compare/rattler_libsolv_c-v0.19.0...rattler_libsolv_c-v0.19.1) - 2024-03-06
 
 ### Other

--- a/crates/rattler_libsolv_c/Cargo.toml
+++ b/crates/rattler_libsolv_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_libsolv_c"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Bindings for libsolv"

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.20.1...rattler_lock-v0.20.2) - 2024-03-14
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.20.0...rattler_lock-v0.20.1) - 2024-03-08
 
 ### Fixed

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,8 +15,8 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_macros/CHANGELOG.md
+++ b/crates/rattler_macros/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_macros-v0.19.1...rattler_macros-v0.19.2) - 2024-03-14
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.19.1](https://github.com/mamba-org/rattler/compare/rattler_macros-v0.19.0...rattler_macros-v0.19.1) - 2024-03-06
 
 ### Other

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_macros"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate that provideds some procedural macros for the rattler project"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.19.1...rattler_networking-v0.19.2) - 2024-03-14
+
+### Added
+- add mirror handling and OCI mirror type ([#553](https://github.com/mamba-org/rattler/pull/553))
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.19.1](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.19.0...rattler_networking-v0.19.1) - 2024-03-06
 
 ### Fixed

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.19.2...rattler_package_streaming-v0.20.0) - 2024-03-14
+
+### Added
+- add mirror handling and OCI mirror type ([#553](https://github.com/mamba-org/rattler/pull/553))
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.19.1...rattler_package_streaming-v0.19.2) - 2024-03-08
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.19.2"
+version = "0.20.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,9 +16,9 @@ chrono = { workspace = true }
 futures-util = { workspace = true }
 itertools = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.19.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.19.2", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.2...rattler_repodata_gateway-v0.19.3) - 2024-03-14
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.1...rattler_repodata_gateway-v0.19.2) - 2024-03-08
 
 ### Fixed

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.19.2"
+version = "0.19.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -31,8 +31,8 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 pin-project-lite = { workspace = true }
 md-5 = { workspace = true }
-rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false, features = ["tokio", "serde"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false, optional = true }
+rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false, features = ["tokio", "serde"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false, optional = true }
 fxhash = { workspace = true, optional = true }
 memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
@@ -41,7 +41,7 @@ superslice = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 json-patch = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
-rattler_networking = { path="../rattler_networking", version = "0.19.1", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.19.2", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.2...rattler_shell-v0.19.3) - 2024-03-14
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.1...rattler_shell-v0.19.2) - 2024-03-08
 
 ### Fixed

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.19.2"
+version = "0.19.3"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.1...rattler_solve-v0.20.2) - 2024-03-14
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.0...rattler_solve-v0.20.1) - 2024-03-08
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,8 +11,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
 libc = { workspace = true, optional = true }
 anyhow = { workspace = true }
 chrono = { workspace = true }
@@ -23,7 +23,7 @@ serde = { workspace = true, features = ["derive"] }
 url = { workspace = true }
 hex = { workspace = true }
 tempfile = { workspace = true }
-rattler_libsolv_c = { path="../rattler_libsolv_c", version = "0.19.1", default-features = false, optional = true }
+rattler_libsolv_c = { path="../rattler_libsolv_c", version = "0.19.2", default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.2...rattler_virtual_packages-v0.19.3) - 2024-03-14
+
+### Other
+- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
+
 ## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.1...rattler_virtual_packages-v0.19.2) - 2024-03-08
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "0.19.2"
+version = "0.19.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -15,7 +15,7 @@ cfg-if = { workspace = true }
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler`: 0.19.2 -> 0.19.3 (✓ API compatible changes)
* `rattler_conda_types`: 0.20.1 -> 0.20.2 (✓ API compatible changes)
* `rattler_digest`: 0.19.1 -> 0.19.2 (✓ API compatible changes)
* `rattler_macros`: 0.19.1 -> 0.19.2
* `rattler_package_streaming`: 0.19.2 -> 0.20.0 (⚠️ API breaking changes)
* `rattler_networking`: 0.19.1 -> 0.19.2 (✓ API compatible changes)
* `rattler_lock`: 0.20.1 -> 0.20.2 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.19.2 -> 0.19.3 (✓ API compatible changes)
* `rattler_solve`: 0.20.1 -> 0.20.2 (✓ API compatible changes)
* `rattler_libsolv_c`: 0.19.1 -> 0.19.2 (✓ API compatible changes)
* `rattler_virtual_packages`: 0.19.2 -> 0.19.3 (✓ API compatible changes)
* `rattler_index`: 0.19.2 -> 0.19.3 (✓ API compatible changes)
* `rattler_shell`: 0.19.2 -> 0.19.3 (✓ API compatible changes)

### ⚠️ `rattler_package_streaming` breaking changes

```
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/function_parameter_count_changed.ron

Failed in:
  rattler_package_streaming::reqwest::tokio::extract_tar_bz2 now takes 4 parameters instead of 3, in /tmp/.tmpd3nURg/rattler/crates/rattler_package_streaming/src/reqwest/tokio.rs:76
  rattler_package_streaming::reqwest::tokio::extract now takes 4 parameters instead of 3, in /tmp/.tmpd3nURg/rattler/crates/rattler_package_streaming/src/reqwest/tokio.rs:137
  rattler_package_streaming::reqwest::tokio::extract_conda now takes 4 parameters instead of 3, in /tmp/.tmpd3nURg/rattler/crates/rattler_package_streaming/src/reqwest/tokio.rs:106
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`
<blockquote>

## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler-v0.19.2...rattler-v0.19.3) - 2024-03-14

### Added
- add mirror handling and OCI mirror type ([#553](https://github.com/mamba-org/rattler/pull/553))

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.20.1...rattler_conda_types-v0.20.2) - 2024-03-14

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_digest`
<blockquote>

## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_digest-v0.19.1...rattler_digest-v0.19.2) - 2024-03-14

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_macros`
<blockquote>

## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_macros-v0.19.1...rattler_macros-v0.19.2) - 2024-03-14

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.19.2...rattler_package_streaming-v0.20.0) - 2024-03-14

### Added
- add mirror handling and OCI mirror type ([#553](https://github.com/mamba-org/rattler/pull/553))

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_networking`
<blockquote>

## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.19.1...rattler_networking-v0.19.2) - 2024-03-14

### Added
- add mirror handling and OCI mirror type ([#553](https://github.com/mamba-org/rattler/pull/553))

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_lock`
<blockquote>

## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.20.1...rattler_lock-v0.20.2) - 2024-03-14

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.2...rattler_repodata_gateway-v0.19.3) - 2024-03-14

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_solve`
<blockquote>

## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.1...rattler_solve-v0.20.2) - 2024-03-14

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_libsolv_c`
<blockquote>

## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_libsolv_c-v0.19.1...rattler_libsolv_c-v0.19.2) - 2024-03-14

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.2...rattler_virtual_packages-v0.19.3) - 2024-03-14

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.2...rattler_index-v0.19.3) - 2024-03-14

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>

## `rattler_shell`
<blockquote>

## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.2...rattler_shell-v0.19.3) - 2024-03-14

### Other
- add pixi badge ([#563](https://github.com/mamba-org/rattler/pull/563))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).