### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -30,12 +30,12 @@ futures = { workspace = true }
 indicatif = { workspace = true }
 itertools = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.19.4", default-features = false }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.19.2", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.3", default-features = false, features = ["sparse"] }
-rattler_solve = { path="../rattler_solve", version = "0.20.2", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.3", default-features = false }
+rattler = { path="../rattler", version = "0.19.5", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.3", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.0", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.4", default-features = false, features = ["sparse"] }
+rattler_solve = { path="../rattler_solve", version = "0.20.3", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.4", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.5](https://github.com/mamba-org/rattler/compare/rattler-v0.19.4...rattler-v0.19.5) - 2024-03-21
+
+### Fixed
+- typo ([#576](https://github.com/mamba-org/rattler/pull/576))
+
 ## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler-v0.19.3...rattler-v0.19.4) - 2024-03-19
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.19.4"
+version = "0.19.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -36,10 +36,10 @@ memmap2 = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.3", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.19.2", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.0", default-features = false, features = ["reqwest"] }
+rattler_networking = { path="../rattler_networking", version = "0.20.0", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.1", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.20.2...rattler_conda_types-v0.20.3) - 2024-03-21
+
+### Fixed
+- allow not starts with in strict mode ([#577](https://github.com/mamba-org/rattler/pull/577))
+
 ## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.20.1...rattler_conda_types-v0.20.2) - 2024-03-14
 
 ### Other

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.20.2"
+version = "0.20.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.3...rattler_index-v0.19.4) - 2024-03-21
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.2...rattler_index-v0.19.3) - 2024-03-14
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.3"
+version = "0.19.4"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.3", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.0", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.1", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.20.2...rattler_lock-v0.21.0) - 2024-03-21
+
+### Added
+- allow passing pypi paths ([#572](https://github.com/mamba-org/rattler/pull/572))
+
 ## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.20.1...rattler_lock-v0.20.2) - 2024-03-14
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.20.2"
+version = "0.21.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.3", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.19.2...rattler_networking-v0.20.0) - 2024-03-21
+
+### Fixed
+- implement cache for authentication filestorage backend ([#573](https://github.com/mamba-org/rattler/pull/573))
+
 ## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.19.1...rattler_networking-v0.19.2) - 2024-03-14
 
 ### Added

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.19.2"
+version = "0.20.0"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.0...rattler_package_streaming-v0.20.1) - 2024-03-21
+
+### Other
+- updated the following local packages: rattler_conda_types, rattler_networking
+
 ## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.19.2...rattler_package_streaming-v0.20.0) - 2024-03-14
 
 ### Added

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,9 +16,9 @@ chrono = { workspace = true }
 futures-util = { workspace = true }
 itertools = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.3", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.19.2", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.0", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.3...rattler_repodata_gateway-v0.19.4) - 2024-03-21
+
+### Other
+- updated the following local packages: rattler_conda_types, rattler_networking
+
 ## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.2...rattler_repodata_gateway-v0.19.3) - 2024-03-14
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.19.3"
+version = "0.19.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -32,7 +32,7 @@ serde_json = { workspace = true }
 pin-project-lite = { workspace = true }
 md-5 = { workspace = true }
 rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false, features = ["tokio", "serde"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false, optional = true }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.3", default-features = false, optional = true }
 fxhash = { workspace = true, optional = true }
 memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
@@ -41,7 +41,7 @@ superslice = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 json-patch = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
-rattler_networking = { path="../rattler_networking", version = "0.19.2", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.0", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.3...rattler_shell-v0.19.4) - 2024-03-21
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.2...rattler_shell-v0.19.3) - 2024-03-14
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.19.3"
+version = "0.19.4"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.3", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.2...rattler_solve-v0.20.3) - 2024-03-21
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.1...rattler_solve-v0.20.2) - 2024-03-14
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.20.2"
+version = "0.20.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.3", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
 libc = { workspace = true, optional = true }
 anyhow = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.3...rattler_virtual_packages-v0.19.4) - 2024-03-21
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.2...rattler_virtual_packages-v0.19.3) - 2024-03-14
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "0.19.3"
+version = "0.19.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -15,7 +15,7 @@ cfg-if = { workspace = true }
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.20.3", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler`: 0.19.4 -> 0.19.5 (✓ API compatible changes)
* `rattler_conda_types`: 0.20.2 -> 0.20.3 (✓ API compatible changes)
* `rattler_networking`: 0.19.2 -> 0.20.0 (⚠️ API breaking changes)
* `rattler_lock`: 0.20.2 -> 0.21.0 (⚠️ API breaking changes)
* `rattler_package_streaming`: 0.20.0 -> 0.20.1
* `rattler_repodata_gateway`: 0.19.3 -> 0.19.4
* `rattler_solve`: 0.20.2 -> 0.20.3
* `rattler_virtual_packages`: 0.19.3 -> 0.19.4
* `rattler_index`: 0.19.3 -> 0.19.4
* `rattler_shell`: 0.19.3 -> 0.19.4

### ⚠️ `rattler_networking` breaking changes

```
--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field FileStorage.cache in /tmp/.tmpQ4WEef/rattler/crates/rattler_networking/src/authentication_storage/backends/file.rs:28
```

### ⚠️ `rattler_lock` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PypiPackageData.url_or_path in /tmp/.tmpQ4WEef/rattler/crates/rattler_lock/src/pypi.rs:22

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/inherent_method_missing.ron

Failed in:
  Package::url, previously in file /tmp/.tmpSe8F94/rattler_lock/src/lib.rs:448

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.29.1/src/lints/struct_pub_field_missing.ron

Failed in:
  field url of struct PypiPackageData, previously in file /tmp/.tmpSe8F94/rattler_lock/src/pypi.rs:22
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`
<blockquote>

## [0.19.5](https://github.com/mamba-org/rattler/compare/rattler-v0.19.4...rattler-v0.19.5) - 2024-03-21

### Fixed
- typo ([#576](https://github.com/mamba-org/rattler/pull/576))
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.20.3](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.20.2...rattler_conda_types-v0.20.3) - 2024-03-21

### Fixed
- allow not starts with in strict mode ([#577](https://github.com/mamba-org/rattler/pull/577))
</blockquote>

## `rattler_networking`
<blockquote>

## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.19.2...rattler_networking-v0.20.0) - 2024-03-21

### Fixed
- implement cache for authentication filestorage backend ([#573](https://github.com/mamba-org/rattler/pull/573))
</blockquote>

## `rattler_lock`
<blockquote>

## [0.21.0](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.20.2...rattler_lock-v0.21.0) - 2024-03-21

### Added
- allow passing pypi paths ([#572](https://github.com/mamba-org/rattler/pull/572))
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.0...rattler_package_streaming-v0.20.1) - 2024-03-21

### Other
- updated the following local packages: rattler_conda_types, rattler_networking
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.3...rattler_repodata_gateway-v0.19.4) - 2024-03-21

### Other
- updated the following local packages: rattler_conda_types, rattler_networking
</blockquote>

## `rattler_solve`
<blockquote>

## [0.20.3](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.2...rattler_solve-v0.20.3) - 2024-03-21

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.3...rattler_virtual_packages-v0.19.4) - 2024-03-21

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.3...rattler_index-v0.19.4) - 2024-03-21

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_shell`
<blockquote>

## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.3...rattler_shell-v0.19.4) - 2024-03-21

### Other
- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).