### PR TITLE
fix: matchspec empty namespace and channel cannonical name

### DIFF
--- a/crates/rattler_conda_types/src/lib.rs
+++ b/crates/rattler_conda_types/src/lib.rs
@@ -23,7 +23,7 @@ mod package_name;
 pub mod prefix_record;
 
 pub use build_spec::{BuildNumber, BuildNumberSpec, ParseBuildNumberSpecError};
-pub use channel::{Channel, ChannelConfig, ParseChannelError};
+pub use channel::{Channel, ChannelConfig, NamedChannelOrUrl, ParseChannelError};
 pub use channel_data::{ChannelData, ChannelDataPackage};
 pub use explicit_environment_spec::{
     ExplicitEnvironmentEntry, ExplicitEnvironmentSpec, PackageArchiveHash,

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -415,6 +415,8 @@ fn matchspec_parser(
     };
 
     nameless_match_spec.namespace = namespace
+        .map(str::trim)
+        .filter(|namespace| !namespace.is_empty())
         .map(ToOwned::to_owned)
         .or(nameless_match_spec.namespace);
 
@@ -794,5 +796,11 @@ mod tests {
     fn test_missing_package_name() {
         let package_name = strip_package_name("");
         assert_matches!(package_name, Err(ParseMatchSpecError::MissingPackageName));
+    }
+
+    #[test]
+    fn test_empty_namespace() {
+        let spec = MatchSpec::from_str("conda-forge::foo", Strict).unwrap();
+        assert!(spec.namespace.is_none());
     }
 }


### PR DESCRIPTION
* Adds a simple way to go from a Channel to a name and back using a `ChannelConfig`.
* Parses `conda-forge::foo` as not having a namespace.