### PR TITLE
feat: proper archspec detection using archspec-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ lto = true
 
 [workspace.dependencies]
 anyhow = "1.0.80"
+archspec = "0.1.2"
 assert_matches = "1.5.0"
 async-compression = { version = "0.4.6", features = [
     "gzip",

--- a/crates/rattler-bin/src/commands/mod.rs
+++ b/crates/rattler-bin/src/commands/mod.rs
@@ -1,1 +1,2 @@
 pub mod create;
+pub mod virtual_packages;

--- a/crates/rattler-bin/src/commands/virtual_packages.rs
+++ b/crates/rattler-bin/src/commands/virtual_packages.rs
@@ -1,0 +1,12 @@
+use rattler_conda_types::GenericVirtualPackage;
+
+#[derive(Debug, clap::Parser)]
+pub struct Opt {}
+
+pub fn virtual_packages(_opt: Opt) -> anyhow::Result<()> {
+    let virtual_packages = rattler_virtual_packages::VirtualPackage::current()?;
+    for package in virtual_packages {
+        println!("{}", GenericVirtualPackage::from(package.clone()));
+    }
+    Ok(())
+}

--- a/crates/rattler-bin/src/main.rs
+++ b/crates/rattler-bin/src/main.rs
@@ -38,6 +38,7 @@ struct Opt {
 #[derive(Debug, clap::Subcommand)]
 enum Command {
     Create(commands::create::Opt),
+    VirtualPackages(commands::virtual_packages::Opt),
 }
 
 /// Entry point of the `rattler` cli.
@@ -70,5 +71,6 @@ async fn main() -> anyhow::Result<()> {
     // Dispatch the selected comment
     match opt.command {
         Command::Create(opts) => commands::create::create(opts).await,
+        Command::VirtualPackages(opts) => commands::virtual_packages::virtual_packages(opts),
     }
 }

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -20,6 +20,7 @@ regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+archspec = { workspace = true }
 
 [target.'cfg(target_os="macos")'.dependencies]
 plist = { workspace = true }


### PR DESCRIPTION
Implements proper archspec detection using https://github.com/prefix-dev/archspec-rs which is a port of https://github.com/archspec/archspec used by `conda`. This opens the doors to build and use architecture specific packages.

We loose the `__archspec` virtual package for wasm targets because the archspec standard does not describe these targets.

I set the default archspec for `osx-arm64` to `m1` because I think thats greatest common denominator for arm based chips on mac.

I also added a subcommand to rattler-bin to print the detected virtual packages.

On my windows machine:

```
> cargo run -- virtual-packages
__win=0=0
__cuda=12.3=0
__archspec=1=skylake
```

Under WSL:

```
> cargo run -- virtual-packages
__unix=0=0
__linux=5.15.146.1=0
__glibc=2.35=0
__cuda=12.3=0
__archspec=1=skylake
```

@wolfv Would you be able to run this on you mac and report the output?
@ruben-arts Can you try on your machines as well?

You can verify that this is the same as conda by creating an environment with `conda` and `archspec` and running `conda info`.