### PR TITLE
fix: do not do cstring replacement on windows

### DIFF
--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -481,6 +481,8 @@ pub fn copy_and_replace_placeholders(
             )?;
         }
         FileMode::Binary => {
+            // conda does not replace the prefix in the binary files on windows
+            // DLLs are loaded quite differently anyways (there is no rpath, for example).
             if !target_platform.is_windows() {
                 copy_and_replace_cstring_placeholder(
                     source_bytes,

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -196,6 +196,7 @@ pub fn link_file(
             &mut destination_writer,
             placeholder,
             &target_prefix,
+            &target_platform,
             *file_mode,
         )
         .map_err(|err| LinkFileError::IoError(String::from("replacing placeholders"), err))?;
@@ -467,6 +468,7 @@ pub fn copy_and_replace_placeholders(
     destination: impl Write,
     prefix_placeholder: &str,
     target_prefix: &str,
+    target_platform: &Platform,
     file_mode: FileMode,
 ) -> Result<(), std::io::Error> {
     match file_mode {
@@ -479,12 +481,14 @@ pub fn copy_and_replace_placeholders(
             )?;
         }
         FileMode::Binary => {
-            copy_and_replace_cstring_placeholder(
-                source_bytes,
-                destination,
-                prefix_placeholder,
-                target_prefix,
-            )?;
+            if !target_platform.is_windows() {
+                copy_and_replace_cstring_placeholder(
+                    source_bytes,
+                    destination,
+                    prefix_placeholder,
+                    target_prefix,
+                )?;
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
There is only one form of binary replacement on Windows, and that's for "pyzzer" entrypoints. I don't think they are widely used though.

I think this might fix the issue described in https://github.com/prefix-dev/pixi/issues/1096