### PR TITLE
fix: replace long shebangs with `/usr/bin/env`

### DIFF
--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -529,13 +529,11 @@ fn replace_long_shebang(shebang: &str, platform: &Platform) -> String {
     } else {
         assert!(shebang.starts_with("#!"));
         if let Some(captures) = SHEBANG_REGEX.captures(shebang) {
-            let shebang_path = Path::new(&captures[2]);
-            tracing::debug!("New shebang path {}", shebang_path.display());
-            format!(
-                "#!/usr/bin/env {}{}",
-                shebang_path.file_name().unwrap().to_str().unwrap(),
-                &captures[3]
-            )
+            let shebang_path = &captures[2];
+            let filename = shebang_path
+                .rsplit_once('/')
+                .map_or(shebang_path, |(_, f)| f);
+            format!("#!/usr/bin/env {}{}", filename, &captures[3])
         } else {
             tracing::warn!("Could not replace shebang ({})", shebang);
             shebang.to_string()

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -366,18 +366,10 @@ fn reflink_to_destination(
             Err(e) if e.kind() == ErrorKind::Unsupported && !allow_hard_links => {
                 return copy_to_destination(source_path, destination_path)
             }
-            Err(e) => {
+            Err(_) => {
                 return if allow_hard_links {
-                    tracing::debug!(
-                        "failed to reflink {}: {e}, falling back to hard linking.",
-                        destination_path.display()
-                    );
                     hardlink_to_destination(source_path, destination_path)
                 } else {
-                    tracing::debug!(
-                        "failed to reflink {}: {e}, falling back to copying.",
-                        destination_path.display()
-                    );
                     copy_to_destination(source_path, destination_path)
                 }
             }
@@ -486,15 +478,15 @@ pub fn copy_and_replace_placeholders(
         FileMode::Binary => {
             // conda does not replace the prefix in the binary files on windows
             // DLLs are loaded quite differently anyways (there is no rpath, for example).
-            if !target_platform.is_windows() {
+            if target_platform.is_windows() {
+                destination.write_all(source_bytes)?;
+            } else {
                 copy_and_replace_cstring_placeholder(
                     source_bytes,
                     destination,
                     prefix_placeholder,
                     target_prefix,
                 )?;
-            } else {
-                destination.write_all(source_bytes)?;
             }
         }
     }

--- a/crates/rattler/src/install/snapshots/rattler__install__link__test__replace_long_prefix_in_text_file.snap
+++ b/crates/rattler/src/install/snapshots/rattler__install__link__test__replace_long_prefix_in_text_file.snap
@@ -1,0 +1,12 @@
+---
+source: crates/rattler/src/install/link.rs
+expression: replaced
+---
+#!/usr/bin/env python -m 123123
+
+# just a comment
+
+import sys
+import re
+
+main(...)

--- a/test-data/shebang_test.txt
+++ b/test-data/shebang_test.txt
@@ -1,0 +1,8 @@
+#!/this/is/placeholder/python -m 123123
+
+# just a comment
+
+import sys
+import re
+
+main(...)


### PR DESCRIPTION
Note: I should test the whole replace function as well