### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -28,12 +28,12 @@ console = { workspace = true, features = ["windows-console-colors"] }
 futures = { workspace = true }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.21.0", default-features = false }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.5", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.1", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.6", default-features = false, features = ["sparse"] }
-rattler_solve = { path="../rattler_solve", version = "0.20.5", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.6", default-features = false }
+rattler = { path="../rattler", version = "0.22.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.2", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.7", default-features = false, features = ["sparse"] }
+rattler_solve = { path="../rattler_solve", version = "0.20.6", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.7", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/mamba-org/rattler/compare/rattler-v0.21.0...rattler-v0.22.0) - 2024-04-19
+
+### Added
+- make root dir configurable in channel config ([#602](https://github.com/mamba-org/rattler/pull/602))
+
+### Fixed
+- unicode activation issues on windows ([#604](https://github.com/mamba-org/rattler/pull/604))
+- no shebang on windows to make spaces in prefix work ([#611](https://github.com/mamba-org/rattler/pull/611))
+- use correct platform to decide the windows launcher ([#608](https://github.com/mamba-org/rattler/pull/608))
+
+### Other
+- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
+
 ## [0.21.0](https://github.com/baszalmstra/rattler/compare/rattler-v0.20.1...rattler-v0.21.0) - 2024-04-05
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -31,11 +31,11 @@ itertools = { workspace = true }
 memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.5", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.1", default-features = false }
-rattler_shell = { path="../rattler_shell", version = "0.19.6", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.3", default-features = false, features = ["reqwest"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.2", default-features = false }
+rattler_shell = { path="../rattler_shell", version = "0.20.0", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.4", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.20.5...rattler_conda_types-v0.21.0) - 2024-04-19
+
+### Added
+- make root dir configurable in channel config ([#602](https://github.com/mamba-org/rattler/pull/602))
+
+### Fixed
+- better value for `link` field ([#610](https://github.com/mamba-org/rattler/pull/610))
+
+### Other
+- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
+
 ## [0.20.5](https://github.com/baszalmstra/rattler/compare/rattler_conda_types-v0.20.4...rattler_conda_types-v0.20.5) - 2024-04-05
 
 ### Fixed

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.20.5"
+version = "0.21.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -19,8 +19,8 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false, features = ["serde"] }
-rattler_macros = { path="../rattler_macros", version = "0.19.2", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false, features = ["serde"] }
+rattler_macros = { path="../rattler_macros", version = "0.19.3", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_digest-v0.19.2...rattler_digest-v0.19.3) - 2024-04-19
+
+### Other
+- update Cargo.toml dependencies
+
 ## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_digest-v0.19.1...rattler_digest-v0.19.2) - 2024-03-14
 
 ### Other

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "0.19.2"
+version = "0.19.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.7](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.6...rattler_index-v0.19.7) - 2024-04-19
+
+### Other
+- update Cargo.toml dependencies
+
 ## [0.19.6](https://github.com/baszalmstra/rattler/compare/rattler_index-v0.19.5...rattler_index-v0.19.6) - 2024-04-05
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.6"
+version = "0.19.7"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.5", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.4", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_libsolv_c/CHANGELOG.md
+++ b/crates/rattler_libsolv_c/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_libsolv_c-v0.19.2...rattler_libsolv_c-v0.19.3) - 2024-04-19
+
+### Other
+- update Cargo.toml dependencies
+
 ## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_libsolv_c-v0.19.1...rattler_libsolv_c-v0.19.2) - 2024-03-14
 
 ### Other

--- a/crates/rattler_libsolv_c/Cargo.toml
+++ b/crates/rattler_libsolv_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_libsolv_c"
-version = "0.19.2"
+version = "0.19.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Bindings for libsolv"

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.1...rattler_lock-v0.22.2) - 2024-04-19
+
+### Other
+- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
+
 ## [0.22.1](https://github.com/baszalmstra/rattler/compare/rattler_lock-v0.22.0...rattler_lock-v0.22.1) - 2024-04-05
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.1"
+version = "0.22.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,8 +15,8 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.5", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_macros/CHANGELOG.md
+++ b/crates/rattler_macros/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_macros-v0.19.2...rattler_macros-v0.19.3) - 2024-04-19
+
+### Other
+- update Cargo.toml dependencies
+
 ## [0.19.2](https://github.com/mamba-org/rattler/compare/rattler_macros-v0.19.1...rattler_macros-v0.19.2) - 2024-03-14
 
 ### Other

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_macros"
-version = "0.19.2"
+version = "0.19.3"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate that provideds some procedural macros for the rattler project"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.20.1...rattler_networking-v0.20.2) - 2024-04-19
+
+### Added
+- enable zst support for OCI registry ([#601](https://github.com/mamba-org/rattler/pull/601))
+
+### Other
+- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
+
 ## [0.20.1](https://github.com/baszalmstra/rattler/compare/rattler_networking-v0.20.0...rattler_networking-v0.20.1) - 2024-04-05
 
 ### Fixed

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.4](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.3...rattler_package_streaming-v0.20.4) - 2024-04-19
+
+### Other
+- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
+
 ## [0.20.3](https://github.com/baszalmstra/rattler/compare/rattler_package_streaming-v0.20.2...rattler_package_streaming-v0.20.3) - 2024-04-05
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.20.3"
+version = "0.20.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -15,9 +15,9 @@ bzip2 = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.5", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.2", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.7](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.6...rattler_repodata_gateway-v0.19.7) - 2024-04-19
+
+### Added
+- make root dir configurable in channel config ([#602](https://github.com/mamba-org/rattler/pull/602))
+
+### Other
+- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
+
 ## [0.19.6](https://github.com/baszalmstra/rattler/compare/rattler_repodata_gateway-v0.19.5...rattler_repodata_gateway-v0.19.6) - 2024-04-05
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.19.6"
+version = "0.19.7"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -30,8 +30,8 @@ anyhow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 pin-project-lite = { workspace = true }
-rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false, features = ["tokio", "serde"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.5", default-features = false, optional = true }
+rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false, features = ["tokio", "serde"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false, optional = true }
 memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 serde_with = { workspace = true }
@@ -39,7 +39,7 @@ superslice = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 json-patch = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
-rattler_networking = { path="../rattler_networking", version = "0.20.1", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.2", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.6...rattler_shell-v0.20.0) - 2024-04-19
+
+### Fixed
+- unicode activation issues on windows ([#604](https://github.com/mamba-org/rattler/pull/604))
+
 ## [0.19.6](https://github.com/baszalmstra/rattler/compare/rattler_shell-v0.19.5...rattler_shell-v0.19.6) - 2024-04-05
 
 ### Fixed

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.19.6"
+version = "0.20.0"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.5", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.6](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.5...rattler_solve-v0.20.6) - 2024-04-19
+
+### Added
+- make root dir configurable in channel config ([#602](https://github.com/mamba-org/rattler/pull/602))
+
+### Other
+- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
+
 ## [0.20.5](https://github.com/baszalmstra/rattler/compare/rattler_solve-v0.20.4...rattler_solve-v0.20.5) - 2024-04-05
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.20.5"
+version = "0.20.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,8 +11,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.5", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 url = { workspace = true }
 tempfile = { workspace = true }
-rattler_libsolv_c = { path="../rattler_libsolv_c", version = "0.19.2", default-features = false, optional = true }
+rattler_libsolv_c = { path="../rattler_libsolv_c", version = "0.19.3", default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.7](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.6...rattler_virtual_packages-v0.19.7) - 2024-04-19
+
+### Other
+- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
+
 ## [0.19.6](https://github.com/baszalmstra/rattler/compare/rattler_virtual_packages-v0.19.5...rattler_virtual_packages-v0.19.6) - 2024-04-05
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "0.19.6"
+version = "0.19.7"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.20.5", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler`: 0.21.0 -> 0.22.0 (⚠️ API breaking changes)
* `rattler_conda_types`: 0.20.5 -> 0.21.0 (⚠️ API breaking changes)
* `rattler_digest`: 0.19.2 -> 0.19.3 (✓ API compatible changes)
* `rattler_macros`: 0.19.2 -> 0.19.3
* `rattler_package_streaming`: 0.20.3 -> 0.20.4 (✓ API compatible changes)
* `rattler_networking`: 0.20.1 -> 0.20.2 (✓ API compatible changes)
* `rattler_shell`: 0.19.6 -> 0.20.0 (⚠️ API breaking changes)
* `rattler_lock`: 0.22.1 -> 0.22.2 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.19.6 -> 0.19.7 (✓ API compatible changes)
* `rattler_solve`: 0.20.5 -> 0.20.6 (✓ API compatible changes)
* `rattler_libsolv_c`: 0.19.2 -> 0.19.3 (✓ API compatible changes)
* `rattler_virtual_packages`: 0.19.6 -> 0.19.7 (✓ API compatible changes)
* `rattler_index`: 0.19.6 -> 0.19.7 (✓ API compatible changes)

### ⚠️ `rattler` breaking changes

```
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rattler::install::python_entry_point_template now takes 4 parameters instead of 3, in /tmp/.tmpxM1WaQ/rattler/crates/rattler/src/install/entry_point.rs:144
```

### ⚠️ `rattler_conda_types` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ChannelConfig.root_dir in /tmp/.tmpxM1WaQ/rattler/crates/rattler_conda_types/src/channel/mod.rs:36
```

### ⚠️ `rattler_shell` breaking changes

```
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field contents of struct ShellScript, previously in file /tmp/.tmpOwIeSJ/rattler_shell/src/shell/mod.rs:695

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field ShellScript.contents in file /tmp/.tmpxM1WaQ/rattler/crates/rattler_shell/src/shell/mod.rs:721

--- failure trait_method_missing: pub trait method removed or renamed ---

Description:
A trait method is no longer callable, and may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#major-any-change-to-trait-item-signatures
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/trait_method_missing.ron

Failed in:
  method env of trait Shell, previously in file /tmp/.tmpOwIeSJ/rattler_shell/src/shell/mod.rs:121
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`
<blockquote>

## [0.22.0](https://github.com/mamba-org/rattler/compare/rattler-v0.21.0...rattler-v0.22.0) - 2024-04-19

### Added
- make root dir configurable in channel config ([#602](https://github.com/mamba-org/rattler/pull/602))

### Fixed
- unicode activation issues on windows ([#604](https://github.com/mamba-org/rattler/pull/604))
- no shebang on windows to make spaces in prefix work ([#611](https://github.com/mamba-org/rattler/pull/611))
- use correct platform to decide the windows launcher ([#608](https://github.com/mamba-org/rattler/pull/608))

### Other
- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.21.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.20.5...rattler_conda_types-v0.21.0) - 2024-04-19

### Added
- make root dir configurable in channel config ([#602](https://github.com/mamba-org/rattler/pull/602))

### Fixed
- better value for `link` field ([#610](https://github.com/mamba-org/rattler/pull/610))

### Other
- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
</blockquote>

## `rattler_digest`
<blockquote>

## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_digest-v0.19.2...rattler_digest-v0.19.3) - 2024-04-19

### Other
- update Cargo.toml dependencies
</blockquote>

## `rattler_macros`
<blockquote>

## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_macros-v0.19.2...rattler_macros-v0.19.3) - 2024-04-19

### Other
- update Cargo.toml dependencies
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.20.4](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.3...rattler_package_streaming-v0.20.4) - 2024-04-19

### Other
- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
</blockquote>

## `rattler_networking`
<blockquote>

## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.20.1...rattler_networking-v0.20.2) - 2024-04-19

### Added
- enable zst support for OCI registry ([#601](https://github.com/mamba-org/rattler/pull/601))

### Other
- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
</blockquote>

## `rattler_shell`
<blockquote>

## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.6...rattler_shell-v0.20.0) - 2024-04-19

### Fixed
- unicode activation issues on windows ([#604](https://github.com/mamba-org/rattler/pull/604))
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.2](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.1...rattler_lock-v0.22.2) - 2024-04-19

### Other
- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.19.7](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.6...rattler_repodata_gateway-v0.19.7) - 2024-04-19

### Added
- make root dir configurable in channel config ([#602](https://github.com/mamba-org/rattler/pull/602))

### Other
- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
</blockquote>

## `rattler_solve`
<blockquote>

## [0.20.6](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.5...rattler_solve-v0.20.6) - 2024-04-19

### Added
- make root dir configurable in channel config ([#602](https://github.com/mamba-org/rattler/pull/602))

### Other
- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
</blockquote>

## `rattler_libsolv_c`
<blockquote>

## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_libsolv_c-v0.19.2...rattler_libsolv_c-v0.19.3) - 2024-04-19

### Other
- update Cargo.toml dependencies
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [0.19.7](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.6...rattler_virtual_packages-v0.19.7) - 2024-04-19

### Other
- update dependencies incl. reqwest ([#606](https://github.com/mamba-org/rattler/pull/606))
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.7](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.6...rattler_index-v0.19.7) - 2024-04-19

### Other
- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).