### PR TITLE
feat: make root dir configurable in channel config

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -67,7 +67,7 @@ pub struct Opt {
 }
 
 pub async fn create(opt: Opt) -> anyhow::Result<()> {
-    let channel_config = ChannelConfig::default();
+    let channel_config = ChannelConfig::default_with_root_dir(env::current_dir()?);
     let current_dir = env::current_dir()?;
     let target_prefix = opt
         .target_prefix

--- a/crates/rattler/src/lib.rs
+++ b/crates/rattler/src/lib.rs
@@ -26,7 +26,9 @@ pub fn empty_channel() -> rattler_conda_types::Channel {
     let channel_path = manifest_dir.join("../../test-data/channels/empty");
     rattler_conda_types::Channel::from_str(
         format!("file://{}[noarch]", channel_path.display()),
-        &rattler_conda_types::ChannelConfig::default(),
+        &rattler_conda_types::ChannelConfig::default_with_root_dir(
+            std::env::current_dir().unwrap(),
+        ),
     )
     .unwrap()
 }

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -39,11 +39,11 @@ pub struct ChannelConfig {
 impl ChannelConfig {
     /// Create a new `ChannelConfig` with the default values.
     pub fn default_with_root_dir(root_dir: PathBuf) -> Self {
-        return Self {
+        Self {
             root_dir,
             channel_alias: Url::from_str(DEFAULT_CHANNEL_ALIAS)
                 .expect("could not parse default channel alias"),
-        };
+        }
     }
 
     /// Returns the canonical name of a channel with the given base url.

--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -489,19 +489,24 @@ mod tests {
     #[test]
     fn test_absolute_path() {
         let current_dir = std::env::current_dir().expect("no current dir?");
-        assert_eq!(absolute_path(Path::new(".")).as_ref(), &current_dir);
-        assert_eq!(absolute_path(Path::new(".")).as_ref(), &current_dir);
         assert_eq!(
-            absolute_path(Path::new("foo")).as_ref(),
+            absolute_path(Path::new("."), &current_dir).as_ref(),
+            &current_dir
+        );
+        assert_eq!(
+            absolute_path(Path::new("foo"), &current_dir).as_ref(),
             &current_dir.join("foo")
         );
 
-        let mut parent_dir = current_dir;
+        let mut parent_dir = current_dir.clone();
         assert!(parent_dir.pop());
 
-        assert_eq!(absolute_path(Path::new("..")).as_ref(), &parent_dir);
         assert_eq!(
-            absolute_path(Path::new("../foo")).as_ref(),
+            absolute_path(Path::new(".."), &current_dir).as_ref(),
+            &parent_dir
+        );
+        assert_eq!(
+            absolute_path(Path::new("../foo"), &current_dir).as_ref(),
             &parent_dir.join("foo")
         );
     }
@@ -577,9 +582,12 @@ mod tests {
         assert_eq!(channel.name.as_deref(), Some("./dir/does/not_exist"));
         assert_eq!(
             channel.name(),
-            Url::from_directory_path(absolute_path(Path::new("./dir/does/not_exist")))
-                .unwrap()
-                .as_str()
+            Url::from_directory_path(absolute_path(
+                Path::new("./dir/does/not_exist"),
+                &current_dir
+            ))
+            .unwrap()
+            .as_str()
         );
         assert_eq!(channel.platforms, None);
         assert_eq!(
@@ -663,6 +671,7 @@ mod tests {
     fn config_canonical_name() {
         let channel_config = ChannelConfig {
             channel_alias: Url::from_str("https://conda.anaconda.org").unwrap(),
+            root_dir: std::env::current_dir().expect("No current dir set"),
         };
         assert_eq!(
             channel_config

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -388,7 +388,9 @@ where
 
     match s {
         Some(str_val) => {
-            let config = ChannelConfig::default();
+            let config = ChannelConfig::default_with_root_dir(
+                std::env::current_dir().expect("Could not determine current directory"),
+            );
 
             Channel::from_str(str_val, &config)
                 .map(|channel| Some(Arc::new(channel)))

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -68,10 +68,11 @@ use matcher::StringMatcher;
 /// # Examples:
 ///
 /// ```rust
-/// use rattler_conda_types::{MatchSpec, VersionSpec, StringMatcher, PackageName, Channel, ParseStrictness::*};
+/// use rattler_conda_types::{MatchSpec, VersionSpec, StringMatcher, PackageName, Channel, ChannelConfig, ParseStrictness::*};
 /// use std::str::FromStr;
 /// use std::sync::Arc;
 ///
+/// let channel_config = ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
 /// let spec = MatchSpec::from_str("foo 1.0 py27_0", Strict).unwrap();
 /// assert_eq!(spec.name, Some(PackageName::new_unchecked("foo")));
 /// assert_eq!(spec.version, Some(VersionSpec::from_str("1.0", Strict).unwrap()));
@@ -85,18 +86,18 @@ use matcher::StringMatcher;
 /// let spec = MatchSpec::from_str(r#"conda-forge::foo[version="1.0.*"]"#, Strict).unwrap();
 /// assert_eq!(spec.name, Some(PackageName::new_unchecked("foo")));
 /// assert_eq!(spec.version, Some(VersionSpec::from_str("1.0.*", Strict).unwrap()));
-/// assert_eq!(spec.channel, Some(Channel::from_str("conda-forge", &Default::default()).map(|channel| Arc::new(channel)).unwrap()));
+/// assert_eq!(spec.channel, Some(Channel::from_str("conda-forge", &channel_config).map(|channel| Arc::new(channel)).unwrap()));
 ///
 /// let spec = MatchSpec::from_str("conda-forge/linux-64::foo>=1.0", Strict).unwrap();
 /// assert_eq!(spec.name, Some(PackageName::new_unchecked("foo")));
 /// assert_eq!(spec.version, Some(VersionSpec::from_str(">=1.0", Strict).unwrap()));
-/// assert_eq!(spec.channel, Some(Channel::from_str("conda-forge", &Default::default()).map(|channel| Arc::new(channel)).unwrap()));
+/// assert_eq!(spec.channel, Some(Channel::from_str("conda-forge", &channel_config).map(|channel| Arc::new(channel)).unwrap()));
 /// assert_eq!(spec.subdir, Some("linux-64".to_string()));
 ///
 /// let spec = MatchSpec::from_str("*/linux-64::foo>=1.0", Strict).unwrap();
 /// assert_eq!(spec.name, Some(PackageName::new_unchecked("foo")));
 /// assert_eq!(spec.version, Some(VersionSpec::from_str(">=1.0", Strict).unwrap()));
-/// assert_eq!(spec.channel, Some(Channel::from_str("*", &Default::default()).map(|channel| Arc::new(channel)).unwrap()));
+/// assert_eq!(spec.channel, Some(Channel::from_str("*", &channel_config).map(|channel| Arc::new(channel)).unwrap()));
 /// assert_eq!(spec.subdir, Some("linux-64".to_string()));
 ///
 /// let spec = MatchSpec::from_str(r#"foo[build="py2*"]"#, Strict).unwrap();

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -421,13 +421,15 @@ fn matchspec_parser(
         .or(nameless_match_spec.namespace);
 
     if let Some(channel_str) = channel_str {
+        let channel_config = ChannelConfig::default_with_root_dir(
+            std::env::current_dir().expect("Could not get current directory"),
+        );
         if let Some((channel, subdir)) = channel_str.rsplit_once('/') {
-            nameless_match_spec.channel =
-                Some(Channel::from_str(channel, &ChannelConfig::default())?.into());
+            nameless_match_spec.channel = Some(Channel::from_str(channel, &channel_config)?.into());
             nameless_match_spec.subdir = Some(subdir.to_string());
         } else {
             nameless_match_spec.channel =
-                Some(Channel::from_str(channel_str, &ChannelConfig::default())?.into());
+                Some(Channel::from_str(channel_str, &channel_config)?.into());
         }
     }
 
@@ -505,6 +507,12 @@ mod tests {
     use crate::match_spec::parse::parse_bracket_list;
     use crate::{BuildNumberSpec, Channel, ChannelConfig, NamelessMatchSpec, VersionSpec};
     use smallvec::smallvec;
+
+    fn channel_config() -> ChannelConfig {
+        ChannelConfig::default_with_root_dir(
+            std::env::current_dir().expect("Could not get current directory"),
+        )
+    }
 
     #[test]
     fn test_strip_brackets() {
@@ -600,7 +608,7 @@ mod tests {
         assert_eq!(
             spec.channel,
             Some(
-                Channel::from_str("conda-forge", &ChannelConfig::default())
+                Channel::from_str("conda-forge", &channel_config())
                     .map(Arc::new)
                     .unwrap()
             )
@@ -615,7 +623,7 @@ mod tests {
         assert_eq!(
             spec.channel,
             Some(
-                Channel::from_str("conda-forge", &ChannelConfig::default())
+                Channel::from_str("conda-forge", &channel_config())
                     .map(Arc::new)
                     .unwrap()
             )
@@ -634,7 +642,7 @@ mod tests {
         assert_eq!(
             spec.channel,
             Some(
-                Channel::from_str("conda-forge", &ChannelConfig::default())
+                Channel::from_str("conda-forge", &channel_config())
                     .map(Arc::new)
                     .unwrap()
             )

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -491,7 +491,7 @@ mod test {
             url::Url::from_directory_path(data_path.parent().unwrap().parent().unwrap())
                 .unwrap()
                 .as_str(),
-            &ChannelConfig::default(),
+            &ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap()),
         )
         .unwrap();
 
@@ -512,7 +512,11 @@ mod test {
 
     #[test]
     fn test_base_url() {
-        let channel = Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap();
+        let channel = Channel::from_str(
+            "conda-forge",
+            &ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap()),
+        )
+        .unwrap();
         let base_url = channel.base_url().join("linux-64/").unwrap();
         assert_eq!(
             compute_package_url(&base_url, None, "bla.conda").to_string(),

--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -398,15 +398,16 @@ mod test {
     async fn load_sparse(
         package_names: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> Vec<Vec<RepoDataRecord>> {
+        let channel_config = ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
         load_repo_data_recursively(
             [
                 (
-                    Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap(),
+                    Channel::from_str("conda-forge", &channel_config).unwrap(),
                     "noarch",
                     test_dir().join("channels/conda-forge/noarch/repodata.json"),
                 ),
                 (
-                    Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap(),
+                    Channel::from_str("conda-forge", &channel_config).unwrap(),
                     "linux-64",
                     test_dir().join("channels/conda-forge/linux-64/repodata.json"),
                 ),

--- a/crates/rattler_solve/benches/bench.rs
+++ b/crates/rattler_solve/benches/bench.rs
@@ -22,7 +22,11 @@ fn conda_json_path_noarch() -> String {
 
 fn read_sparse_repodata(path: &str) -> SparseRepoData {
     SparseRepoData::new(
-        Channel::from_str("dummy", &ChannelConfig::default()).unwrap(),
+        Channel::from_str(
+            "dummy",
+            &ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap()),
+        )
+        .unwrap(),
         "dummy".to_string(),
         path,
         None,

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -9,6 +9,10 @@ use std::str::FromStr;
 use std::time::Instant;
 use url::Url;
 
+fn channel_config() -> ChannelConfig {
+    ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap())
+}
+
 fn conda_json_path() -> String {
     format!(
         "{}/{}",
@@ -56,14 +60,12 @@ fn dummy_sha256_hash() -> rattler_digest::Sha256Hash {
 fn read_repodata(path: &str) -> Vec<RepoDataRecord> {
     let repo_data: RepoData =
         serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
-    repo_data.into_repo_data_records(
-        &Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap(),
-    )
+    repo_data.into_repo_data_records(&Channel::from_str("conda-forge", &channel_config()).unwrap())
 }
 
 fn read_sparse_repodata(path: &str) -> SparseRepoData {
     SparseRepoData::new(
-        Channel::from_str("dummy", &ChannelConfig::default()).unwrap(),
+        Channel::from_str("dummy", &channel_config()).unwrap(),
         "dummy".to_string(),
         path,
         None,
@@ -175,7 +177,7 @@ fn read_pytorch_sparse_repo_data() -> &'static SparseRepoData {
     static REPO_DATA: Lazy<SparseRepoData> = Lazy::new(|| {
         let pytorch = pytorch_json_path();
         SparseRepoData::new(
-            Channel::from_str("pytorch", &ChannelConfig::default()).unwrap(),
+            Channel::from_str("pytorch", &channel_config()).unwrap(),
             "pytorch".to_string(),
             pytorch,
             None,
@@ -190,7 +192,7 @@ fn read_conda_forge_sparse_repo_data() -> &'static SparseRepoData {
     static REPO_DATA: Lazy<SparseRepoData> = Lazy::new(|| {
         let conda_forge = conda_json_path();
         SparseRepoData::new(
-            Channel::from_str("conda-forge", &ChannelConfig::default()).unwrap(),
+            Channel::from_str("conda-forge", &channel_config()).unwrap(),
             "conda-forge".to_string(),
             conda_forge,
             None,
@@ -516,10 +518,13 @@ mod libsolv_c {
         let repo_data = read_repodata(&dummy_channel_json_path());
 
         let cached_repo_data = rattler_solve::libsolv_c::cache_repodata(
-            Channel::from_str("conda-forge", &ChannelConfig::default())
-                .unwrap()
-                .platform_url(rattler_conda_types::Platform::Linux64)
-                .to_string(),
+            Channel::from_str(
+                "conda-forge",
+                &ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap()),
+            )
+            .unwrap()
+            .platform_url(rattler_conda_types::Platform::Linux64)
+            .to_string(),
             &repo_data,
         );
 

--- a/py-rattler/rattler/channel/channel_config.py
+++ b/py-rattler/rattler/channel/channel_config.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
-
+import os
 from rattler.rattler import PyChannelConfig
 
 
 class ChannelConfig:
-    def __init__(self, channel_alias: str = "https://conda.anaconda.org/") -> None:
+    def __init__(self, channel_alias: str = "https://conda.anaconda.org/", root_dir: str = os.getcwd()) -> None:
         """
         Create a new channel configuration.
 
@@ -12,15 +12,18 @@ class ChannelConfig:
         --------
         ```python
         >>> channel_config = ChannelConfig()
+        >>> channel_config # doctest: +ELLIPSIS
+        ChannelConfig(channel_alias="https://conda.anaconda.org/", ...
+        >>> channel_config = ChannelConfig("https://repo.prefix.dev/", "/path/to/root/dir")
         >>> channel_config
-        ChannelConfig(channel_alias="https://conda.anaconda.org/")
-        >>> channel_config = ChannelConfig("https://repo.prefix.dev/")
-        >>> channel_config
-        ChannelConfig(channel_alias="https://repo.prefix.dev/")
+        ChannelConfig(channel_alias="https://repo.prefix.dev/", root_dir="/path/to/root/dir")
         >>>
         ```
         """
-        self._channel_configuration = PyChannelConfig(channel_alias)
+        if root_dir is None:
+            # Use the current working directory as the root directory.
+            root_dir = os.getcwd()
+        self._channel_configuration = PyChannelConfig(channel_alias, root_dir)
 
     def __repr__(self) -> str:
         """
@@ -30,10 +33,11 @@ class ChannelConfig:
         --------
         ```python
         >>> channel_config = ChannelConfig()
-        >>> channel_config
-        ChannelConfig(channel_alias="https://conda.anaconda.org/")
+        >>> channel_config # doctest: +ELLIPSIS
+        ChannelConfig(channel_alias="https://conda.anaconda.org/", root_dir="...
         >>>
         ```
         """
         alias = self._channel_configuration.channel_alias
-        return f'ChannelConfig(channel_alias="{alias}")'
+        root_dir = self._channel_configuration.root_dir
+        return f'ChannelConfig(channel_alias="{alias}", root_dir="{root_dir}")'

--- a/py-rattler/src/channel/mod.rs
+++ b/py-rattler/src/channel/mod.rs
@@ -14,10 +14,11 @@ pub struct PyChannelConfig {
 #[pymethods]
 impl PyChannelConfig {
     #[new]
-    pub fn __init__(channel_alias: &str) -> pyo3::PyResult<Self> {
+    pub fn __init__(channel_alias: &str, root_dir: &str) -> pyo3::PyResult<Self> {
         Ok(Self {
             inner: ChannelConfig {
                 channel_alias: Url::parse(channel_alias).map_err(PyRattlerError::from)?,
+                root_dir: root_dir.into(),
             },
         })
     }
@@ -26,6 +27,12 @@ impl PyChannelConfig {
     #[getter]
     fn channel_alias(&self) -> String {
         self.inner.channel_alias.to_string()
+    }
+
+    /// Returns the root directory for local channels
+    #[getter]
+    fn root_dir(&self) -> String {
+        self.inner.root_dir.to_string_lossy().into()
     }
 }
 


### PR DESCRIPTION
This would be useful for making sure that channels are resolved relative to the `pixi.toml` file (and not the current working directory). It also makes the call to current work dir the responsibility of the user and they can catch errors (e.g. the current wrok dir is not available in wasm32 and maybe some other embedded systems or so).

I am not sure about the name though. Happy about suggestions :)