### PR TITLE
fix: use correct platform to decide the windows launcher

### DIFF
--- a/crates/rattler/src/install/entry_point.rs
+++ b/crates/rattler/src/install/entry_point.rs
@@ -38,6 +38,7 @@ pub fn create_windows_python_entry_point(
     target_prefix: &str,
     entry_point: &EntryPoint,
     python_info: &PythonInfo,
+    target_platform: &Platform,
 ) -> Result<[PathsEntry; 2], std::io::Error> {
     // Construct the path to where we will be creating the python entry point script.
     let relative_path_script_py = python_info
@@ -60,7 +61,7 @@ pub fn create_windows_python_entry_point(
         .join(format!("{}.exe", &entry_point.command));
 
     // Include the bytes of the launcher directly in the binary so we can write it to disk.
-    let launcher_bytes = get_windows_launcher(&Platform::current());
+    let launcher_bytes = get_windows_launcher(target_platform);
     std::fs::write(target_dir.join(&relative_path_script_exe), launcher_bytes)?;
 
     let fixed_launcher_digest = rattler_digest::parse_digest_from_hex::<rattler_digest::Sha256>(

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -384,6 +384,7 @@ pub async fn link_package(
                         &target_prefix,
                         &entry_point,
                         &python_info,
+                        &platform,
                     ) {
                         Ok([a, b]) => {
                             let _ = tx.blocking_send(Ok((number_of_paths_entries, a)));


### PR DESCRIPTION
We should also fix the win-arm64 launcher and maybe use the `uv` trampoline?