### PR TITLE
fix: better value for `link` field

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -11,8 +11,7 @@ use rattler::{
     package_cache::PackageCache,
 };
 use rattler_conda_types::{
-    Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, PackageRecord, ParseStrictness,
-    Platform, PrefixRecord, RepoDataRecord, Version,
+    prefix_record::{Link, LinkType}, Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, PackageRecord, ParseStrictness, Platform, PrefixRecord, RepoDataRecord, Version
 };
 use rattler_networking::{
     retry_policies::default_retry_policy, AuthenticationMiddleware, AuthenticationStorage,
@@ -498,8 +497,12 @@ async fn install_package_to_environment(
         paths_data: paths.into(),
         // TODO: Retrieve the requested spec for this package from the request
         requested_spec: None,
-        // TODO: What to do with this?
-        link: None,
+
+        link: Some(Link {
+            source: package_dir,
+            // TODO: compute the right value here based on the options and `can_hard_link` ...
+            link_type: Some(LinkType::HardLink)
+        }),
     };
 
     // Create the conda-meta directory if it doesnt exist yet.

--- a/crates/rattler_conda_types/src/prefix_record.rs
+++ b/crates/rattler_conda_types/src/prefix_record.rs
@@ -152,11 +152,13 @@ pub struct PrefixRecord {
     #[serde(default)]
     pub paths_data: PrefixPaths,
 
-    /// TODO: I dont understand this field
+    /// This field contains a reference to the package cache from where the package was linked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub link: Option<Link>,
 
     /// The spec that was used when this package was installed. Note that this field is not updated if the
-    /// currently another spec was used.
+    /// currently another spec was used. Note: conda seems to serialize a "None" string value instead of `null`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requested_spec: Option<String>,
 }
 
@@ -266,7 +268,7 @@ impl FromStr for PrefixRecord {
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
 pub struct Link {
     /// The path to the file source that was installed
-    pub source: String,
+    pub source: PathBuf,
 
     /// The link type that was used to install the file
     #[serde(rename = "type")]


### PR DESCRIPTION
We should also make this change in `pixi`. 

Basically, `link` should record where the source for the linked files is on the fs.

For the LinkType option we should ideally do some computation based on wether the package _can_ be hard-/soft-linked and the available options. The conda code looks like this:

```py
def determine_link_type(extracted_package_dir, target_prefix):
    source_test_file = join(extracted_package_dir, "info", "index.json")
    if context.always_copy:
        return LinkType.copy
    if context.always_softlink:
        return LinkType.softlink
    if hardlink_supported(source_test_file, target_prefix):
        return LinkType.hardlink
    if context.allow_softlinks and softlink_supported(source_test_file, target_prefix):
        return LinkType.softlink
    return LinkType.copy
```

However, our options are a little reversed ... Also I don't think that it matters much anyways ... 