### PR TITLE
fix: no shebang on windows to make spaces in prefix work

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -68,7 +68,10 @@ pub struct Opt {
 pub async fn create(opt: Opt) -> anyhow::Result<()> {
     let channel_config = ChannelConfig::default();
     let current_dir = env::current_dir()?;
-    let target_prefix = opt.target_prefix.unwrap_or_else(|| current_dir.join(".prefix"));
+    let target_prefix = opt
+        .target_prefix
+        .unwrap_or_else(|| current_dir.join(".prefix"));
+    println!("target prefix: {target_prefix:?}");
 
     // Determine the platform we're going to install for
     let install_platform = if let Some(platform) = opt.platform {

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -60,11 +60,15 @@ pub struct Opt {
 
     #[clap(long)]
     timeout: Option<u64>,
+
+    #[clap(long)]
+    target_prefix: Option<PathBuf>,
 }
 
 pub async fn create(opt: Opt) -> anyhow::Result<()> {
     let channel_config = ChannelConfig::default();
-    let target_prefix = env::current_dir()?.join(".prefix");
+    let current_dir = env::current_dir()?;
+    let target_prefix = opt.target_prefix.unwrap_or_else(|| current_dir.join(".prefix"));
 
     // Determine the platform we're going to install for
     let install_platform = if let Some(platform) = opt.platform {

--- a/crates/rattler/src/install/entry_point.rs
+++ b/crates/rattler/src/install/entry_point.rs
@@ -197,11 +197,20 @@ mod test {
     fn test_entry_point_script() {
         let script = super::python_entry_point_template(
             "/prefix",
-            true,
+            false,
             &EntryPoint::from_str("jupyter-lab = jupyterlab.labapp:main").unwrap(),
             &PythonInfo::from_version(&Version::from_str("3.11.0").unwrap(), Platform::Linux64)
                 .unwrap(),
         );
         insta::assert_snapshot!(script);
+
+        let script = super::python_entry_point_template(
+            "/prefix",
+            true,
+            &EntryPoint::from_str("jupyter-lab = jupyterlab.labapp:main").unwrap(),
+            &PythonInfo::from_version(&Version::from_str("3.11.0").unwrap(), Platform::Linux64)
+                .unwrap(),
+        );
+        insta::assert_snapshot!("windows", script);
     }
 }

--- a/crates/rattler/src/install/snapshots/rattler__install__entry_point__test__windows.snap
+++ b/crates/rattler/src/install/snapshots/rattler__install__entry_point__test__windows.snap
@@ -1,0 +1,13 @@
+---
+source: crates/rattler/src/install/entry_point.rs
+expression: script
+---
+# -*- coding: utf-8 -*-
+import re
+import sys
+
+from jupyterlab.labapp import main
+
+if __name__ == '__main__':
+	sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+	sys.exit(main())


### PR DESCRIPTION
This is a different fix from using the `uv` trampolines but fixes the immediate issue of spaces in prefix paths not working on Windows entrypoints.