### PR TITLE
feat: add support for extracting prefix placeholder data to PathsEntry

### DIFF
--- a/crates/rattler/src/install/entry_point.rs
+++ b/crates/rattler/src/install/entry_point.rs
@@ -80,6 +80,8 @@ pub fn create_windows_python_entry_point(
             sha256: Some(hash),
             sha256_in_prefix: None,
             size_in_bytes: Some(size as _),
+            prefix_placeholder: None,
+            file_mode: None,
         },
         PathsEntry {
             relative_path: relative_path_script_exe,
@@ -89,6 +91,8 @@ pub fn create_windows_python_entry_point(
             sha256: Some(fixed_launcher_digest),
             sha256_in_prefix: None,
             size_in_bytes: Some(launcher_bytes.len() as u64),
+            prefix_placeholder: None,
+            file_mode: None
         },
     ])
 }
@@ -136,6 +140,8 @@ pub fn create_unix_python_entry_point(
         sha256: Some(hash),
         sha256_in_prefix: None,
         size_in_bytes: Some(size as _),
+        prefix_placeholder: None,
+        file_mode: None,
     })
 }
 

--- a/crates/rattler/src/install/entry_point.rs
+++ b/crates/rattler/src/install/entry_point.rs
@@ -92,7 +92,7 @@ pub fn create_windows_python_entry_point(
             sha256_in_prefix: None,
             size_in_bytes: Some(launcher_bytes.len() as u64),
             prefix_placeholder: None,
-            file_mode: None
+            file_mode: None,
         },
     ])
 }

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -121,6 +121,9 @@ pub struct LinkedFile {
 
     /// The way the file was linked
     pub method: LinkMethod,
+
+    /// The original prefix placeholder that was replaced
+    pub prefix_placeholder: Option<String>,
 }
 
 /// Installs a single file from a `package_dir` to the the `target_dir`. Replaces any
@@ -279,6 +282,7 @@ pub fn link_file(
             .map_err(LinkFileError::FailedToOpenDestinationFile)?;
         metadata.len()
     };
+    let prefix_placeholder: Option<String> = path_json_entry.prefix_placeholder.as_ref().map(|p| p.placeholder.clone());
 
     Ok(LinkedFile {
         clobbered: false,
@@ -286,6 +290,7 @@ pub fn link_file(
         file_size,
         relative_path: destination_relative_path,
         method: link_method,
+        prefix_placeholder
     })
 }
 

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -282,7 +282,10 @@ pub fn link_file(
             .map_err(LinkFileError::FailedToOpenDestinationFile)?;
         metadata.len()
     };
-    let prefix_placeholder: Option<String> = path_json_entry.prefix_placeholder.as_ref().map(|p| p.placeholder.clone());
+    let prefix_placeholder: Option<String> = path_json_entry
+        .prefix_placeholder
+        .as_ref()
+        .map(|p| p.placeholder.clone());
 
     Ok(LinkedFile {
         clobbered: false,
@@ -290,7 +293,7 @@ pub fn link_file(
         file_size,
         relative_path: destination_relative_path,
         method: link_method,
-        prefix_placeholder
+        prefix_placeholder,
     })
 }
 

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -28,7 +28,7 @@ mod test_utils;
 
 pub use crate::install::entry_point::{get_windows_launcher, python_entry_point_template};
 pub use driver::InstallDriver;
-pub use link::{link_file, LinkMethod, LinkFileError};
+pub use link::{link_file, LinkFileError, LinkMethod};
 use rattler_conda_types::prefix_record::PathsEntry;
 pub use transaction::{Transaction, TransactionError, TransactionOperation};
 pub use unlink::unlink_package;
@@ -337,7 +337,10 @@ pub async fn link_package(
                             LinkMethod::Patched(file_mode) => Some(file_mode),
                             _ => None,
                         },
-                        prefix_placeholder: entry.prefix_placeholder.as_ref().map(|p| p.placeholder.clone()),
+                        prefix_placeholder: entry
+                            .prefix_placeholder
+                            .as_ref()
+                            .map(|p| p.placeholder.clone()),
                     },
                 )),
                 Err(e) => Err(InstallError::FailedToLink(entry.relative_path.clone(), e)),

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -28,7 +28,7 @@ mod test_utils;
 
 pub use crate::install::entry_point::{get_windows_launcher, python_entry_point_template};
 pub use driver::InstallDriver;
-pub use link::{link_file, LinkFileError};
+pub use link::{link_file, LinkMethod, LinkFileError};
 use rattler_conda_types::prefix_record::PathsEntry;
 pub use transaction::{Transaction, TransactionError, TransactionOperation};
 pub use unlink::unlink_package;
@@ -333,6 +333,11 @@ pub async fn link_package(
                         sha256: entry.sha256,
                         sha256_in_prefix: Some(result.sha256),
                         size_in_bytes: Some(result.file_size),
+                        file_mode: match result.method {
+                            LinkMethod::Patched(file_mode) => Some(file_mode),
+                            _ => None,
+                        },
+                        prefix_placeholder: entry.prefix_placeholder.as_ref().map(|p| p.placeholder.clone()),
                     },
                 )),
                 Err(e) => Err(InstallError::FailedToLink(entry.relative_path.clone(), e)),

--- a/crates/rattler_conda_types/src/prefix_record.rs
+++ b/crates/rattler_conda_types/src/prefix_record.rs
@@ -1,8 +1,8 @@
 //! Defines the `[PrefixRecord]` struct.
 
+use crate::package::FileMode;
 use crate::repo_data_record::RepoDataRecord;
 use crate::PackageRecord;
-use crate::package::FileMode;
 use rattler_digest::serde::SerializableHash;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -44,7 +44,6 @@ impl From<Vec<PathsEntry>> for PrefixPaths {
         }
     }
 }
-
 
 /// Information about a single file installed for a package.
 ///

--- a/crates/rattler_conda_types/src/prefix_record.rs
+++ b/crates/rattler_conda_types/src/prefix_record.rs
@@ -2,6 +2,7 @@
 
 use crate::repo_data_record::RepoDataRecord;
 use crate::PackageRecord;
+use crate::package::FileMode;
 use rattler_digest::serde::SerializableHash;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
@@ -44,6 +45,7 @@ impl From<Vec<PathsEntry>> for PrefixPaths {
     }
 }
 
+
 /// Information about a single file installed for a package.
 ///
 /// This struct is similar to the [`crate::package::PathsEntry`] struct. The difference is that this
@@ -85,6 +87,14 @@ pub struct PathsEntry {
     /// The size of the file in bytes
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub size_in_bytes: Option<u64>,
+
+    /// The file mode of the entry. This is used in conjunction with a prefix_placeholder
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_mode: Option<FileMode>,
+
+    /// The original sentinel value used for prefix-replacement from the package
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefix_placeholder: Option<String>,
 }
 
 /// Information about a single file installed for a package.

--- a/crates/rattler_conda_types/src/snapshots/rattler_conda_types__prefix_record__test__tk-8_6_12-h8ffe710_0_json.snap
+++ b/crates/rattler_conda_types/src/snapshots/rattler_conda_types__prefix_record__test__tk-8_6_12-h8ffe710_0_json.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/prefix_record.rs
+assertion_line: 344
 expression: prefix_record
 ---
 arch: x86_64
@@ -1131,6 +1132,8 @@ paths_data:
       sha256: d9ad2cbf80850fbdacab735ded03e83edc71089ec115307bff3be58bf55cef1e
       sha256_in_prefix: d9ad2cbf80850fbdacab735ded03e83edc71089ec115307bff3be58bf55cef1e
       size_in_bytes: 1711616
+      file_mode: binary
+      prefix_placeholder: "D:\\bld\\tk_1645032569673\\_h_env"
     - _path: Library/bin/tclsh.exe
       path_type: hardlink
       sha256: bbde6d63c5f16fd17476ae144fd6475641d93e1f8ceed20759a16bb3adda26e5
@@ -5586,6 +5589,8 @@ paths_data:
       sha256: 1bba23ef9c21a2a9befbaf11dc751236f66efeb3c84d0bb1b3ed4f1065c8f791
       sha256_in_prefix: af0e03028d2d594f8ff285b9892b5802d18a72e7622953d208e0ad1ca88ed095
       size_in_bytes: 7876
+      file_mode: text
+      prefix_placeholder: "D:\\bld\\tk_1645032569673\\_h_env"
     - _path: Library/lib/tclooConfig.sh
       path_type: hardlink
       sha256: 9a3210c14cba9aead381e376ff4bb454cc3dfd96f9d112fc66d8770e5197c17d
@@ -5621,6 +5626,8 @@ paths_data:
       sha256: 96ee03106a57ecf7cbcb568392b682c7c9e435d0eb03848a2b3aeb5655bf1ce0
       sha256_in_prefix: dcf2d84c37c9f3c63be5a09dad166945464bce9664fe93aee875d9d18c43308f
       size_in_bytes: 3978
+      file_mode: text
+      prefix_placeholder: "D:\\bld\\tk_1645032569673\\_h_env"
     - _path: Library/lib/tdbc1.1.3/tdbc_connection.n
       path_type: hardlink
       sha256: bbda03d846bfe392b8ebbfe3b5cc2c69c2a2d5c49b05730b40ac254429ea322a
@@ -6625,4 +6632,3 @@ link:
   source: "C:\\Users\\bas\\micromamba\\envs\\conda\\pkgs\\tk-8.6.12-h8ffe710_0"
   type: 1
 requested_spec: "conda-forge/win-64::tk==8.6.12=h8ffe710_0[md5=c69a5047cc9291ae40afd4a1ad6f0c0f]"
-


### PR DESCRIPTION
This is a prerequisite for #613. Currently, records in conda-meta contain prefix placeholder metadata. This isn't currently being extracted in `PathsEntry`.

This PR extracts the placeholder information so `PathsEntry` now contains exactly what's in the records in conda-meta.