### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -28,12 +28,12 @@ console = { workspace = true, features = ["windows-console-colors"] }
 futures = { workspace = true }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.22.0", default-features = false }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler = { path="../rattler", version = "0.23.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.2", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.7", default-features = false, features = ["sparse"] }
-rattler_solve = { path="../rattler_solve", version = "0.20.6", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.7", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.8", default-features = false, features = ["sparse"] }
+rattler_solve = { path="../rattler_solve", version = "0.20.7", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.8", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0](https://github.com/mamba-org/rattler/compare/rattler-v0.22.0...rattler-v0.23.0) - 2024-04-25
+
+### Added
+- Expose paths_data as PathEntry in py-rattler ([#620](https://github.com/mamba-org/rattler/pull/620))
+- add support for extracting prefix placeholder data to PathsEntry ([#614](https://github.com/mamba-org/rattler/pull/614))
+
+### Fixed
+- compare `UrlOrPath` ([#618](https://github.com/mamba-org/rattler/pull/618))
+
 ## [0.22.0](https://github.com/mamba-org/rattler/compare/rattler-v0.21.0...rattler-v0.22.0) - 2024-04-19
 
 ### Added

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -31,11 +31,11 @@ itertools = { workspace = true }
 memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.2", default-features = false }
-rattler_shell = { path="../rattler_shell", version = "0.20.0", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.4", default-features = false, features = ["reqwest"] }
+rattler_shell = { path="../rattler_shell", version = "0.20.1", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.5", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.21.0...rattler_conda_types-v0.22.0) - 2024-04-25
+
+### Added
+- add support for extracting prefix placeholder data to PathsEntry ([#614](https://github.com/mamba-org/rattler/pull/614))
+
 ## [0.21.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.20.5...rattler_conda_types-v0.21.0) - 2024-04-19
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.8](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.7...rattler_index-v0.19.8) - 2024-04-25
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.7](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.6...rattler_index-v0.19.7) - 2024-04-19
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.7"
+version = "0.19.8"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.4", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.5", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.3](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.2...rattler_lock-v0.22.3) - 2024-04-25
+
+### Fixed
+- compare `UrlOrPath` ([#618](https://github.com/mamba-org/rattler/pull/618))
+- parse absolute paths on Windows correctly in lockfiles ([#616](https://github.com/mamba-org/rattler/pull/616))
+
 ## [0.22.2](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.1...rattler_lock-v0.22.2) - 2024-04-19
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.2"
+version = "0.22.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.5](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.4...rattler_package_streaming-v0.20.5) - 2024-04-25
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.20.4](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.3...rattler_package_streaming-v0.20.4) - 2024-04-19
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.20.4"
+version = "0.20.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -15,7 +15,7 @@ bzip2 = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.2", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.8](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.7...rattler_repodata_gateway-v0.19.8) - 2024-04-25
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.7](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.6...rattler_repodata_gateway-v0.19.7) - 2024-04-19
 
 ### Added

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.19.7"
+version = "0.19.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -31,7 +31,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 pin-project-lite = { workspace = true }
 rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false, features = ["tokio", "serde"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false, optional = true }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false, optional = true }
 memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 serde_with = { workspace = true }

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.0...rattler_shell-v0.20.1) - 2024-04-25
+
+### Fixed
+- compare `UrlOrPath` ([#618](https://github.com/mamba-org/rattler/pull/618))
+
 ## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.19.6...rattler_shell-v0.20.0) - 2024-04-19
 
 ### Fixed

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.7](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.6...rattler_solve-v0.20.7) - 2024-04-25
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.20.6](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.5...rattler_solve-v0.20.6) - 2024-04-19
 
 ### Added

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.20.6"
+version = "0.20.7"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.8](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.7...rattler_virtual_packages-v0.19.8) - 2024-04-25
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.7](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.6...rattler_virtual_packages-v0.19.7) - 2024-04-19
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "0.19.7"
+version = "0.19.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.21.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler`: 0.22.0 -> 0.23.0 (⚠️ API breaking changes)
* `rattler_conda_types`: 0.21.0 -> 0.22.0 (⚠️ API breaking changes)
* `rattler_shell`: 0.20.0 -> 0.20.1 (✓ API compatible changes)
* `rattler_lock`: 0.22.2 -> 0.22.3 (✓ API compatible changes)
* `rattler_package_streaming`: 0.20.4 -> 0.20.5
* `rattler_repodata_gateway`: 0.19.7 -> 0.19.8
* `rattler_solve`: 0.20.6 -> 0.20.7
* `rattler_virtual_packages`: 0.19.7 -> 0.19.8
* `rattler_index`: 0.19.7 -> 0.19.8

### ⚠️ `rattler` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field LinkedFile.prefix_placeholder in /tmp/.tmpgNa2Hh/rattler/crates/rattler/src/install/link.rs:126
```

### ⚠️ `rattler_conda_types` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PathsEntry.file_mode in /tmp/.tmpgNa2Hh/rattler/crates/rattler_conda_types/src/prefix_record.rs:92
  field PathsEntry.prefix_placeholder in /tmp/.tmpgNa2Hh/rattler/crates/rattler_conda_types/src/prefix_record.rs:96
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`
<blockquote>

## [0.23.0](https://github.com/mamba-org/rattler/compare/rattler-v0.22.0...rattler-v0.23.0) - 2024-04-25

### Added
- Expose paths_data as PathEntry in py-rattler ([#620](https://github.com/mamba-org/rattler/pull/620))
- add support for extracting prefix placeholder data to PathsEntry ([#614](https://github.com/mamba-org/rattler/pull/614))

### Fixed
- compare `UrlOrPath` ([#618](https://github.com/mamba-org/rattler/pull/618))
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.22.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.21.0...rattler_conda_types-v0.22.0) - 2024-04-25

### Added
- add support for extracting prefix placeholder data to PathsEntry ([#614](https://github.com/mamba-org/rattler/pull/614))
</blockquote>

## `rattler_shell`
<blockquote>

## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.0...rattler_shell-v0.20.1) - 2024-04-25

### Fixed
- compare `UrlOrPath` ([#618](https://github.com/mamba-org/rattler/pull/618))
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.3](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.2...rattler_lock-v0.22.3) - 2024-04-25

### Fixed
- compare `UrlOrPath` ([#618](https://github.com/mamba-org/rattler/pull/618))
- parse absolute paths on Windows correctly in lockfiles ([#616](https://github.com/mamba-org/rattler/pull/616))
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.20.5](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.4...rattler_package_streaming-v0.20.5) - 2024-04-25

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.19.8](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.7...rattler_repodata_gateway-v0.19.8) - 2024-04-25

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_solve`
<blockquote>

## [0.20.7](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.6...rattler_solve-v0.20.7) - 2024-04-25

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [0.19.8](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.7...rattler_virtual_packages-v0.19.8) - 2024-04-25

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.8](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.7...rattler_index-v0.19.8) - 2024-04-25

### Other
- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).