### PR TITLE
fix: compare `UrlOrPath`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ ouroboros = "0.18.3"
 pathdiff = "0.2.1"
 pep440_rs = { version = "0.5.0" }
 pep508_rs = { version = "0.4.2" }
+percent-encoding = "2.3.1"
 pin-project-lite = "0.2.14"
 plist = "1"
 purl = { version = "0.1.2", features = ["serde"] }

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -779,7 +779,7 @@ mod test {
         for _ in 0..15 {
             target_prefix.push_str("verylongstring/");
         }
-        let input = std::fs::read(&test_file).unwrap();
+        let input = std::fs::read(test_file).unwrap();
         let mut output = Cursor::new(Vec::new());
         super::copy_and_replace_textual_placeholder(
             &input,

--- a/crates/rattler/src/install/unlink.rs
+++ b/crates/rattler/src/install/unlink.rs
@@ -182,10 +182,8 @@ mod tests {
 
         let repodata_record = get_repodata_record(package);
         // Construct a PrefixRecord for the package
-        let prefix_record =
-            PrefixRecord::from_repodata_record(repodata_record, None, None, paths, None, None);
 
-        prefix_record
+        PrefixRecord::from_repodata_record(repodata_record, None, None, paths, None, None)
     }
 
     #[tokio::test]

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -26,6 +26,7 @@ serde_with = { workspace = true, features = ["indexmap_2"] }
 thiserror = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 purl = { workspace = true, features = ["serde"] }
+percent-encoding = {  workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true, features = ["yaml"] }

--- a/crates/rattler_lock/src/url_or_path.rs
+++ b/crates/rattler_lock/src/url_or_path.rs
@@ -236,10 +236,6 @@ mod test {
             (UrlOrPath::Url("https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2".parse().unwrap()),
              UrlOrPath::Url("https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2".parse().unwrap())),
 
-            // Seperator shouldn't matter
-            (UrlOrPath::Path("../foobar".parse().unwrap()),
-             UrlOrPath::Path("..\\foobar".parse().unwrap())),
-
             // Absolute paths as file and direct path
             (UrlOrPath::Url("file:///home/bob/test-file.txt".parse().unwrap()),
              UrlOrPath::Path("/home/bob/test-file.txt".parse().unwrap())),
@@ -256,9 +252,6 @@ mod test {
             // Same urls
             ("https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2",
              "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2"),
-
-            // Seperator shouldn't matter
-            ("../foobar", "..\\foobar"),
 
             // Absolute paths as file and direct path
             ("file:///home/bob/test-file.txt", "/home/bob/test-file.txt"),

--- a/crates/rattler_lock/src/url_or_path.rs
+++ b/crates/rattler_lock/src/url_or_path.rs
@@ -1,13 +1,16 @@
 use itertools::Itertools;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
+use std::hash::Hash;
 use std::path::Path;
 use std::{
     fmt::{Display, Formatter},
     path::PathBuf,
     str::FromStr,
 };
+use std::borrow::Cow;
+use percent_encoding::percent_decode;
 use thiserror::Error;
-use url::Url;
+use url::{Host, Url};
 
 /// Represents either a URL or a path.
 ///
@@ -15,13 +18,99 @@ use url::Url;
 /// [`url`] we can only create urls for absolute file paths for the current os.
 ///
 /// This also looks better when looking at the lockfile.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, SerializeDisplay, DeserializeFromStr)]
+#[derive(Debug, Clone, Eq, SerializeDisplay, DeserializeFromStr)]
 pub enum UrlOrPath {
     /// A URL.
     Url(Url),
 
     /// A local (or networked) path.
     Path(PathBuf),
+}
+
+/// Returns true if the specified segment is considered to be a Windows drive letter segment.
+/// E.g. the segment `C:` or `C%3A` would be considered a drive letter segment.
+fn is_windows_drive_letter_segment(segment: &str) -> Option<String> {
+    // Segment is a simple drive letter: X:
+    if let Some((drive_letter, ':')) = segment.chars().collect_tuple() {
+        if drive_letter.is_ascii_alphabetic() {
+            return Some(format!("{}:\\", drive_letter).into());
+        }
+    }
+
+    // Segment is a simple drive letter but the colon is percent escaped: E.g. X%3A
+    if let Some((drive_letter, '%', '3', 'a' | 'A')) = segment.chars().collect_tuple() {
+        if drive_letter.is_ascii_alphabetic() {
+            return Some(format!("{}:\\", drive_letter).into());
+        }
+    }
+
+    None
+}
+
+/// Tries to convert a `file://` based URL to a path.
+///
+/// We assume that any passed URL that represents a path is an absolute path.
+///
+/// [`Url::to_file_path`] has a different code path for Windows and other operating systems, this
+/// can cause URLs to parse perfectly fine on Windows, but fail to parse on Linux. This function
+/// tries to parse the URL as a path on all operating systems.
+fn url_to_path(url: &Url) -> Option<PathBuf> {
+    if url.scheme() != "file" {
+        return None;
+    }
+
+    let mut segments = url.path_segments()?;
+    let host = match url.host() {
+        None | Some(Host::Domain("localhost")) => None,
+        Some(host) => Some(host),
+    };
+
+    let (mut path, seperator) = if let Some(host) = host {
+        // A host is only present for Windows UNC paths
+        (format!("\\\\{host}\\"), "\\")
+    } else {
+        let first = segments.next()?;
+        if first.starts_with('.') {
+            // Relative file paths are not supported
+            return None;
+        }
+
+        match is_windows_drive_letter_segment(first) {
+            Some(drive_letter) => (drive_letter, "\\"),
+            None => (format!("/{first}/"), "/"),
+        }
+    };
+
+    for (idx, segment) in segments.enumerate() {
+        if idx > 0 {
+            path.push_str(seperator);
+        }
+        match String::from_utf8(percent_decode(segment.as_bytes()).collect()) {
+            Ok(s) => path.push_str(&s),
+            _ => return None,
+        }
+    }
+
+    Some(PathBuf::from(path))
+}
+
+impl PartialEq for UrlOrPath {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.canonicalize().as_ref(), other.canonicalize().as_ref()) {
+            (UrlOrPath::Path(a), UrlOrPath::Path(b)) => a == b,
+            (UrlOrPath::Url(a), UrlOrPath::Url(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Hash for UrlOrPath {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self.canonicalize().as_ref() {
+            UrlOrPath::Url(url) => url.hash(state),
+            UrlOrPath::Path(path) => path.hash(state),
+        }
+    }
 }
 
 impl From<PathBuf> for UrlOrPath {
@@ -38,7 +127,12 @@ impl From<&Path> for UrlOrPath {
 
 impl From<Url> for UrlOrPath {
     fn from(value: Url) -> Self {
-        UrlOrPath::Url(value)
+        // Try to normalize the URL to a path if possible.
+        if let Some(path) = url_to_path(&value) {
+            UrlOrPath::Path(path)
+        } else {
+            UrlOrPath::Url(value)
+        }
     }
 }
 
@@ -67,6 +161,17 @@ impl UrlOrPath {
             UrlOrPath::Url(_) => None,
         }
     }
+
+    /// Canonicalizes the instance to be a path if possible.
+    ///
+    /// If this instance is a URL with a `file://` scheme, this will try to convert it to a path.
+    pub fn canonicalize(&self) -> Cow<'_, Self> {
+        if let Some(path) = self.as_url().and_then(url_to_path) {
+            return Cow::Owned(UrlOrPath::Path(path));
+        }
+
+        Cow::Borrowed(self)
+    }
 }
 
 #[derive(Debug, Error, Eq, PartialEq)]
@@ -75,26 +180,27 @@ pub enum PathOrUrlError {
     InvalidUrl(url::ParseError),
 }
 
-fn scheme_is_drive_letter(scheme: &str) -> bool {
-    let Some((drive_letter,)) = scheme.chars().collect_tuple() else {
-        return false;
-    };
-    drive_letter.is_ascii_alphabetic()
-}
-
 impl FromStr for UrlOrPath {
     type Err = PathOrUrlError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         // First try to parse the string as a path.
-        match Url::from_str(s) {
+        return match Url::from_str(s) {
             Ok(url) => Ok(if scheme_is_drive_letter(url.scheme()) {
                 UrlOrPath::Path(PathBuf::from(s))
             } else {
-                UrlOrPath::Url(url)
+                UrlOrPath::Url(url).canonicalize().into_owned()
             }),
             Err(url::ParseError::RelativeUrlWithoutBase) => Ok(UrlOrPath::Path(PathBuf::from(s))),
             Err(e) => Err(PathOrUrlError::InvalidUrl(e)),
+        };
+
+
+        fn scheme_is_drive_letter(scheme: &str) -> bool {
+            let Some((drive_letter, )) = scheme.chars().collect_tuple() else {
+                return false;
+            };
+            drive_letter.is_ascii_alphabetic()
         }
     }
 }
@@ -103,6 +209,68 @@ impl FromStr for UrlOrPath {
 mod test {
     use super::*;
     use std::str::FromStr;
+
+    #[test]
+    fn test_url_to_path() {
+        let urls = [
+            ("file:///home/bob/test-file.txt", "/home/bob/test-file.txt"),
+            ("file:///C:/Test/Foo.txt", "C:\\Test\\Foo.txt"),
+            ("file:///c:/temp/test-file.txt", "c:\\temp\\test-file.txt"),
+            ("file:///c:\\temp\\test-file.txt", "c:\\temp\\test-file.txt"),
+
+            // Percent encoding
+            ("file:///foo/ba%20r", "/foo/ba r"),
+            ("file:///C%3A/Test/Foo.txt", "C:\\Test\\Foo.txt"),
+        ];
+
+        for (url, path) in urls {
+            assert_eq!(
+                url_to_path(&Url::from_str(url).unwrap()).unwrap(),
+                PathBuf::from(path)
+            );
+        }
+    }
+
+    #[test]
+    fn test_equality() {
+        let tests = [
+            // Same urls
+            (UrlOrPath::Url("https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2".parse().unwrap()),
+             UrlOrPath::Url("https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2".parse().unwrap())),
+
+            // Seperator shouldn't matter
+            (UrlOrPath::Path("../foobar".parse().unwrap()),
+             UrlOrPath::Path("..\\foobar".parse().unwrap())),
+
+            // Absolute paths as file and direct path
+            (UrlOrPath::Url("file:///home/bob/test-file.txt".parse().unwrap()),
+             UrlOrPath::Path("/home/bob/test-file.txt".parse().unwrap())),
+        ];
+
+        for (a, b) in &tests {
+            assert_eq!(a, b);
+        }
+    }
+
+    #[test]
+    fn test_equality_from_str() {
+        let tests = [
+            // Same urls
+            ("https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2",
+             "https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2"),
+
+            // Seperator shouldn't matter
+            ("../foobar", "..\\foobar"),
+
+            // Absolute paths as file and direct path
+            ("file:///home/bob/test-file.txt", "/home/bob/test-file.txt"),
+        ];
+
+        for (a, b) in &tests {
+            assert_eq!(UrlOrPath::from_str(a).unwrap(),
+                       UrlOrPath::from_str(b).unwrap());
+        }
+    }
 
     #[test]
     fn test_from_str() {

--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -749,8 +749,8 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn test_run_activation_cmd() {
-        test_run_activation(crate::shell::CmdExe::default().into(), false);
-        test_run_activation(crate::shell::CmdExe::default().into(), true);
+        test_run_activation(crate::shell::CmdExe.into(), false);
+        test_run_activation(crate::shell::CmdExe.into(), true);
     }
 
     #[test]

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2224,10 +2224,9 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
- "async-compression",
  "bytes",
  "chrono",
  "digest",
@@ -2235,14 +2234,11 @@ dependencies = [
  "fs-err",
  "futures",
  "fxhash",
- "hex",
  "indexmap 2.2.6",
  "itertools",
  "memchr",
  "memmap2",
- "nom",
  "once_cell",
- "pin-project-lite",
  "rattler_conda_types",
  "rattler_digest",
  "rattler_networking",
@@ -2252,15 +2248,11 @@ dependencies = [
  "regex",
  "reqwest",
  "reqwest-middleware",
- "serde",
- "serde_json",
- "serde_with",
  "smallvec",
  "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tracing",
  "url",
  "uuid",
@@ -2268,13 +2260,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.20.5"
+version = "0.21.0"
 dependencies = [
  "chrono",
  "fxhash",
  "glob",
  "hex",
- "indexmap 2.2.6",
  "itertools",
  "lazy-regex",
  "nom",
@@ -2286,7 +2277,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_with",
- "serde_yaml",
  "smallvec",
  "strum",
  "thiserror",
@@ -2296,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "blake2",
  "digest",
@@ -2310,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.19.6"
+version = "0.19.7"
 dependencies = [
  "fs-err",
  "rattler_conda_types",
@@ -2323,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "chrono",
  "fxhash",
@@ -2331,11 +2321,11 @@ dependencies = [
  "itertools",
  "pep440_rs",
  "pep508_rs",
+ "percent-encoding",
  "purl",
  "rattler_conda_types",
  "rattler_digest",
  "serde",
- "serde-json-python-formatter",
  "serde_json",
  "serde_with",
  "serde_yaml",
@@ -2345,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "0.19.2"
+version = "0.19.3"
 dependencies = [
  "quote",
  "syn 2.0.59",
@@ -2353,7 +2343,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2365,10 +2355,7 @@ dependencies = [
  "http",
  "itertools",
  "keyring",
- "lazy_static",
- "libc",
  "netrc-rs",
- "once_cell",
  "reqwest",
  "reqwest-middleware",
  "retry-policies",
@@ -2381,12 +2368,11 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "bzip2",
  "chrono",
  "futures-util",
- "itertools",
  "num_cpus",
  "rattler_conda_types",
  "rattler_digest",
@@ -2406,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.19.6"
+version = "0.19.7"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2420,7 +2406,6 @@ dependencies = [
  "itertools",
  "json-patch",
  "libc",
- "md-5",
  "memmap2",
  "ouroboros",
  "pin-project-lite",
@@ -2444,7 +2429,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.19.6"
+version = "0.20.0"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.2.6",
@@ -2459,17 +2444,14 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "0.20.5"
+version = "0.20.6"
 dependencies = [
- "anyhow",
  "chrono",
  "futures",
- "hex",
  "itertools",
  "rattler_conda_types",
  "rattler_digest",
  "resolvo",
- "serde",
  "tempfile",
  "thiserror",
  "tracing",
@@ -2478,10 +2460,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "0.19.6"
+version = "0.19.7"
 dependencies = [
  "archspec",
- "cfg-if",
  "libloading",
  "nom",
  "once_cell",
@@ -2821,15 +2802,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-json-python-formatter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db62ee54077c67a8cff258c919175f0b3cb78d2b6dcafb0d166ff98dcb21aa5d"
-dependencies = [
- "serde_json",
 ]
 
 [[package]]


### PR DESCRIPTION
This is a more general fix for https://github.com/prefix-dev/pixi/pull/1224 .

The basic idea is that you can "canonicalize" a `UrlOrPath`. If the stored Url represents an absolute path, it is converted into a path instead. This is not completely trivial because the `Url::to_file_path` method behaves differently depending on the architecture. I had to reimplement this method.

When checking the equality of two `UrlOrPath`s they are first canonicalized so that comparing a `file:///...` and a `/..` url and path works properly. 

`UrlOrPath`s are not canonicalized before serialization, this ensures that loading a lock file and saving it again will result in the same lock file. However, when _creating_ a lock file I think it makes sense to canonicalize any instance you create.