### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -28,11 +28,11 @@ console = { workspace = true, features = ["windows-console-colors"] }
 futures = { workspace = true }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.23.0", default-features = false }
+rattler = { path="../rattler", version = "0.23.1", default-features = false }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.2", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.8", default-features = false, features = ["sparse"] }
-rattler_solve = { path="../rattler_solve", version = "0.20.7", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_networking = { path="../rattler_networking", version = "0.20.3", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.9", default-features = false, features = ["sparse"] }
+rattler_solve = { path="../rattler_solve", version = "0.21.0", default-features = false, features = ["resolvo", "libsolv_c"] }
 rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.8", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1](https://github.com/mamba-org/rattler/compare/rattler-v0.23.0...rattler-v0.23.1) - 2024-04-25
+
+### Other
+- updated the following local packages: rattler_networking
+
 ## [0.23.0](https://github.com/mamba-org/rattler/compare/rattler-v0.22.0...rattler-v0.23.0) - 2024-04-25
 
 ### Added

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.23.0"
+version = "0.23.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -33,9 +33,9 @@ memmap2 = { workspace = true }
 once_cell = { workspace = true }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.2", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.3", default-features = false }
 rattler_shell = { path="../rattler_shell", version = "0.20.1", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.5", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.6", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 fs-err = { workspace = true }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.5", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.6", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.20.2...rattler_networking-v0.20.3) - 2024-04-25
+
+### Added
+- Add GCS support for rattler auth ([#605](https://github.com/mamba-org/rattler/pull/605))
+
 ## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.20.1...rattler_networking-v0.20.2) - 2024-04-19
 
 ### Added

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.20.2"
+version = "0.20.3"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.6](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.5...rattler_package_streaming-v0.20.6) - 2024-04-25
+
+### Other
+- updated the following local packages: rattler_networking
+
 ## [0.20.5](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.4...rattler_package_streaming-v0.20.5) - 2024-04-25
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.20.5"
+version = "0.20.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -17,7 +17,7 @@ futures-util = { workspace = true }
 num_cpus = { workspace = true }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.22.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.2", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.3", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.9](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.8...rattler_repodata_gateway-v0.19.9) - 2024-04-25
+
+### Other
+- updated the following local packages: rattler_networking
+
 ## [0.19.8](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.7...rattler_repodata_gateway-v0.19.8) - 2024-04-25
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.19.8"
+version = "0.19.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -39,7 +39,7 @@ superslice = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 json-patch = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
-rattler_networking = { path="../rattler_networking", version = "0.20.2", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.3", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.7...rattler_solve-v0.21.0) - 2024-04-25
+
+### Added
+- add channel priority to solve task and expose to python solve ([#598](https://github.com/mamba-org/rattler/pull/598))
+
 ## [0.20.7](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.6...rattler_solve-v0.20.7) - 2024-04-25
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.20.7"
+version = "0.21.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"


### PR DESCRIPTION
## 🤖 New release
* `rattler_networking`: 0.20.2 -> 0.20.3 (✓ API compatible changes)
* `rattler_solve`: 0.20.7 -> 0.21.0 (⚠️ API breaking changes)
* `rattler`: 0.23.0 -> 0.23.1
* `rattler_package_streaming`: 0.20.5 -> 0.20.6
* `rattler_repodata_gateway`: 0.19.8 -> 0.19.9

### ⚠️ `rattler_solve` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SolverTask.channel_priority in /tmp/.tmpVCBSg7/rattler/crates/rattler_solve/src/lib.rs:123

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.30.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rattler_solve::libsolv_c::cache_repodata now takes 3 parameters instead of 2, in /tmp/.tmpVCBSg7/rattler/crates/rattler_solve/src/libsolv_c/input.rs:300
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_networking`
<blockquote>

## [0.20.3](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.20.2...rattler_networking-v0.20.3) - 2024-04-25

### Added
- Add GCS support for rattler auth ([#605](https://github.com/mamba-org/rattler/pull/605))
</blockquote>

## `rattler_solve`
<blockquote>

## [0.21.0](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.20.7...rattler_solve-v0.21.0) - 2024-04-25

### Added
- add channel priority to solve task and expose to python solve ([#598](https://github.com/mamba-org/rattler/pull/598))
</blockquote>

## `rattler`
<blockquote>

## [0.23.1](https://github.com/mamba-org/rattler/compare/rattler-v0.23.0...rattler-v0.23.1) - 2024-04-25

### Other
- updated the following local packages: rattler_networking
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.20.6](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.5...rattler_package_streaming-v0.20.6) - 2024-04-25

### Other
- updated the following local packages: rattler_networking
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.19.9](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.8...rattler_repodata_gateway-v0.19.9) - 2024-04-25

### Other
- updated the following local packages: rattler_networking
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).