### PR TITLE
feat: adds pypi indexes to the lock-file

### DIFF
--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 serde_with = { workspace = true, features = ["indexmap_2"] }
+serde_repr = { workspace = true }
 thiserror = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 purl = { workspace = true, features = ["serde"] }

--- a/crates/rattler_lock/src/file_format_version.rs
+++ b/crates/rattler_lock/src/file_format_version.rs
@@ -1,0 +1,74 @@
+use crate::ParseCondaLockError;
+use serde::de::Error;
+use serde_repr::{Deserialize_repr, Serialize_repr};
+use std::fmt::{Display, Formatter};
+
+/// The different version of the lock-file format.
+#[derive(
+    Copy, Clone, PartialEq, Eq, Hash, Debug, Ord, PartialOrd, Serialize_repr, Deserialize_repr,
+)]
+#[repr(u16)]
+pub enum FileFormatVersion {
+    /// Initial version
+    V1 = 1,
+
+    /// Dependencies are now arrays instead of maps
+    V2 = 2,
+
+    /// Pip has been renamed to pypi
+    V3 = 3,
+
+    /// Complete overhaul of the lock-file with support for multienv.
+    V4 = 4,
+
+    /// pypi indexes should be part of the file now.
+    V5 = 5,
+}
+
+impl Display for FileFormatVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", *self as u16)
+    }
+}
+
+impl FileFormatVersion {
+    /// The latest version this crate supports.
+    pub const LATEST: Self = FileFormatVersion::V5;
+
+    /// Returns true if the pypi indexes should be present in the lock file if
+    /// there are pypi packages present.
+    pub fn should_pypi_indexes_be_present(self) -> bool {
+        self >= FileFormatVersion::V5
+    }
+}
+
+impl Default for FileFormatVersion {
+    fn default() -> Self {
+        Self::LATEST
+    }
+}
+
+impl TryFrom<u64> for FileFormatVersion {
+    type Error = ParseCondaLockError;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        Ok(match value {
+            0 => {
+                return Err(ParseCondaLockError::ParseError(serde_yaml::Error::custom(
+                    "`version` field in lock file is not an integer",
+                )))
+            }
+            1 => Self::V1,
+            2 => Self::V2,
+            3 => Self::V3,
+            4 => Self::V4,
+            5 => Self::V5,
+            _ => {
+                return Err(ParseCondaLockError::IncompatibleVersion {
+                    lock_file_version: value,
+                    max_supported_version: FileFormatVersion::LATEST,
+                })
+            }
+        })
+    }
+}

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -621,6 +621,7 @@ mod test {
     #[case("v4/pypi-matplotlib-lock.yml")]
     #[case("v4/turtlesim-lock.yml")]
     #[case("v4/path-based-lock.yml")]
+    #[case("v5/flat-index-lock.yml")]
     fn test_parse(#[case] file_name: &str) {
         let path = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../test-data/conda-lock")

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -93,7 +93,7 @@ pub use file_format_version::FileFormatVersion;
 pub use hash::PackageHashes;
 pub use parse::ParseCondaLockError;
 pub use pypi::{PypiPackageData, PypiPackageEnvironmentData, PypiSourceTreeHashable};
-pub use pypi_indexes::{FlatIndexUrlOrPath, PypiIndexes};
+pub use pypi_indexes::{FindLinksUrlOrPath, PypiIndexes};
 pub use url_or_path::UrlOrPath;
 
 /// The name of the default environment in a [`LockFile`]. This is the environment name that is used

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -78,18 +78,22 @@ use url::Url;
 mod builder;
 mod channel;
 mod conda;
+mod file_format_version;
 mod hash;
 mod parse;
 mod pypi;
+mod pypi_indexes;
 mod url_or_path;
 mod utils;
 
 pub use builder::LockFileBuilder;
 pub use channel::Channel;
 pub use conda::{CondaPackageData, ConversionError};
+pub use file_format_version::FileFormatVersion;
 pub use hash::PackageHashes;
 pub use parse::ParseCondaLockError;
 pub use pypi::{PypiPackageData, PypiPackageEnvironmentData, PypiSourceTreeHashable};
+pub use pypi_indexes::{FlatIndexUrlOrPath, PypiIndexes};
 pub use url_or_path::UrlOrPath;
 
 /// The name of the default environment in a [`LockFile`]. This is the environment name that is used
@@ -110,6 +114,7 @@ pub struct LockFile {
 /// Internal data structure that stores the lock-file data.
 #[derive(Default)]
 struct LockFileInner {
+    version: FileFormatVersion,
     environments: Vec<EnvironmentData>,
     conda_packages: Vec<CondaPackageData>,
     pypi_packages: Vec<PypiPackageData>,
@@ -137,6 +142,9 @@ enum EnvironmentPackageData {
 struct EnvironmentData {
     /// The channels used to solve the environment. Note that the order matters.
     channels: Vec<Channel>,
+
+    /// The pypi indexes used to solve the environment.
+    indexes: Option<PypiIndexes>,
 
     /// For each individual platform this environment supports we store the package identifiers
     /// associated with the environment.
@@ -201,6 +209,11 @@ impl LockFile {
                 )
             })
     }
+
+    /// Returns the version of the lock-file.
+    pub fn version(&self) -> FileFormatVersion {
+        self.inner.version
+    }
 }
 
 /// Information about a specific environment in the lock-file.
@@ -227,6 +240,15 @@ impl Environment {
     /// priority channel.
     pub fn channels(&self) -> &[Channel] {
         &self.data().channels
+    }
+
+    /// Returns the Pypi indexes that were used to solve this environment.
+    ///
+    /// If there are no pypi packages in the lock-file this will return `None`.
+    ///
+    /// Starting with version `5` of the format this should not be optional.
+    pub fn pypi_indexes(&self) -> Option<&PypiIndexes> {
+        self.data().indexes.as_ref()
     }
 
     /// Returns all the packages for a specific platform in this environment.
@@ -355,6 +377,11 @@ impl Environment {
                 })
                 .collect(),
         )
+    }
+
+    /// Returns the version of the lock-file that contained this environment.
+    pub fn version(&self) -> FileFormatVersion {
+        self.inner.version
     }
 }
 

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -1,6 +1,7 @@
 //! A module that enables parsing of lock files version 3 or lower.
 
 use super::ParseCondaLockError;
+use crate::file_format_version::FileFormatVersion;
 use crate::{
     Channel, CondaPackageData, EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner,
     PackageHashes, PypiPackageData, PypiPackageEnvironmentData, UrlOrPath,
@@ -117,7 +118,10 @@ pub struct CondaLockedPackageV3 {
 }
 
 /// A function that enables parsing of lock files version 3 or lower.
-pub fn parse_v3_or_lower(document: serde_yaml::Value) -> Result<LockFile, ParseCondaLockError> {
+pub fn parse_v3_or_lower(
+    document: serde_yaml::Value,
+    version: FileFormatVersion,
+) -> Result<LockFile, ParseCondaLockError> {
     let lock_file: LockFileV3 =
         serde_yaml::from_value(document).map_err(ParseCondaLockError::ParseError)?;
 
@@ -201,11 +205,13 @@ pub fn parse_v3_or_lower(document: serde_yaml::Value) -> Result<LockFile, ParseC
     // Construct the default environment
     let default_environment = EnvironmentData {
         channels: lock_file.metadata.channels,
+        indexes: None,
         packages: per_platform,
     };
 
     Ok(LockFile {
         inner: Arc::new(LockFileInner {
+            version,
             conda_packages: conda_packages.into_iter().collect(),
             pypi_packages: pypi_packages.into_iter().collect(),
             pypi_environment_package_datas: pypi_runtime_configs

--- a/crates/rattler_lock/src/pypi_indexes.rs
+++ b/crates/rattler_lock/src/pypi_indexes.rs
@@ -18,13 +18,13 @@ pub struct PypiIndexes {
         skip_serializing_if = "Vec::is_empty",
         with = "serde_yaml::with::singleton_map_recursive"
     )]
-    pub flat_indexes: Vec<FlatIndexUrlOrPath>,
+    pub find_links: Vec<FindLinksUrlOrPath>,
 }
 
 /// A flat index is a static source of
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub enum FlatIndexUrlOrPath {
+pub enum FindLinksUrlOrPath {
     /// Can be a path to a directory or a file containing the flat index
     Path(PathBuf),
 
@@ -32,7 +32,7 @@ pub enum FlatIndexUrlOrPath {
     Url(Url),
 }
 
-impl FlatIndexUrlOrPath {
+impl FindLinksUrlOrPath {
     /// Returns the URL if it is a URL
     pub fn as_url(&self) -> Option<&Url> {
         match self {

--- a/crates/rattler_lock/src/pypi_indexes.rs
+++ b/crates/rattler_lock/src/pypi_indexes.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use std::path::{Path, PathBuf};
+use url::Url;
+
+/// Defines the pypi indexes that were used during solving.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Serialize, Eq, Deserialize, Default)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct PypiIndexes {
+    /// The indexes used to resolve the dependencies.
+    pub indexes: Vec<Url>,
+
+    /// Flat indexes also called `--find-links` in pip
+    /// These are flat listings of distributions
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub flat_indexes: Vec<FlatIndexUrlOrPath>,
+}
+
+/// A flat index is a static source of
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Hash)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum FlatIndexUrlOrPath {
+    /// Can be a path to a directory or a file containing the flat index
+    Path(PathBuf),
+
+    /// Can be a URL to a flat index
+    Url(Url),
+}
+
+impl FlatIndexUrlOrPath {
+    /// Returns the URL if it is a URL
+    pub fn as_url(&self) -> Option<&Url> {
+        match self {
+            Self::Path(_) => None,
+            Self::Url(url) => Some(url),
+        }
+    }
+
+    /// Returns the path if it is a path
+    pub fn as_path(&self) -> Option<&Path> {
+        match self {
+            Self::Path(path) => Some(path),
+            Self::Url(_) => None,
+        }
+    }
+}

--- a/crates/rattler_lock/src/pypi_indexes.rs
+++ b/crates/rattler_lock/src/pypi_indexes.rs
@@ -13,7 +13,11 @@ pub struct PypiIndexes {
 
     /// Flat indexes also called `--find-links` in pip
     /// These are flat listings of distributions
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        skip_serializing_if = "Vec::is_empty",
+        with = "serde_yaml::with::singleton_map_recursive"
+    )]
     pub flat_indexes: Vec<FlatIndexUrlOrPath>,
 }
 

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v0__numpy-conda-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v0__numpy-conda-lock.yml.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
+assertion_line: 629
 expression: conda_lock
 ---
-version: 4
+version: 5
 environments:
   default:
     channels:
@@ -12192,4 +12193,3 @@ packages:
       - libcxx >=14.0.6
       - "libzlib >=1.2.13,<1.3.0a0"
     platform: osx
-

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v0__pypi-matplotlib-conda-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v0__pypi-matplotlib-conda-lock.yml.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
+assertion_line: 629
 expression: conda_lock
 ---
-version: 4
+version: 5
 environments:
   default:
     channels:
@@ -859,4 +860,3 @@ packages:
     depends:
       - libzlib ==1.2.11 h9173be1_1013
     platform: osx
-

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v0__python-conda-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v0__python-conda-lock.yml.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
+assertion_line: 629
 expression: conda_lock
 ---
-version: 4
+version: 5
 environments:
   default:
     channels:
@@ -1289,4 +1290,3 @@ packages:
       - "vc >=14.1,<15"
       - vs2015_runtime >=14.16.27033
     platform: win
-

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v3__robostack-turtlesim-conda-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v3__robostack-turtlesim-conda-lock.yml.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
+assertion_line: 629
 expression: conda_lock
 ---
-version: 4
+version: 5
 environments:
   default:
     channels:
@@ -51036,4 +51037,3 @@ packages:
     license_family: GPL
     size: 95357
     timestamp: 1617437173697
-

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v4__numpy-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v4__numpy-lock.yml.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
+assertion_line: 629
 expression: conda_lock
 ---
-version: 4
+version: 5
 environments:
   default:
     channels:
@@ -12192,4 +12193,3 @@ packages:
       - libcxx >=14.0.6
       - "libzlib >=1.2.13,<1.3.0a0"
     platform: osx
-

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v4__path-based-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v4__path-based-lock.yml.snap
@@ -1,9 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
-assertion_line: 602
+assertion_line: 629
 expression: conda_lock
 ---
-version: 4
+version: 5
 environments:
   default:
     channels:

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v4__pypi-matplotlib-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v4__pypi-matplotlib-lock.yml.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
+assertion_line: 629
 expression: conda_lock
 ---
-version: 4
+version: 5
 environments:
   default:
     channels:
@@ -859,4 +860,3 @@ packages:
     depends:
       - libzlib ==1.2.11 h9173be1_1013
     platform: osx
-

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v4__python-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v4__python-lock.yml.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
+assertion_line: 629
 expression: conda_lock
 ---
-version: 4
+version: 5
 environments:
   default:
     channels:
@@ -1289,4 +1290,3 @@ packages:
       - "vc >=14.1,<15"
       - vs2015_runtime >=14.16.27033
     platform: win
-

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v4__turtlesim-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v4__turtlesim-lock.yml.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_lock/src/lib.rs
+assertion_line: 629
 expression: conda_lock
 ---
-version: 4
+version: 5
 environments:
   default:
     channels:
@@ -51036,4 +51037,3 @@ packages:
     license_family: GPL
     size: 95357
     timestamp: 1617437173697
-

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v5__flat-index-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v5__flat-index-lock.yml.snap
@@ -1,0 +1,261 @@
+---
+source: crates/rattler_lock/src/lib.rs
+expression: conda_lock
+---
+version: 5
+environments:
+  default:
+    channels:
+      - url: "https://conda.anaconda.org/conda-forge/"
+    indexes:
+      - "https://pypi.org/simple"
+    flat-indexes:
+      - path: "./links"
+    packages:
+      osx-arm64:
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda"
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda"
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda"
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2"
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.3-h091b4b1_0.conda"
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda"
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda"
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda"
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda"
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda"
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda"
+        - conda: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda"
+        - conda: "https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2"
+        - pypi: "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl"
+        - pypi: "https://files.pythonhosted.org/packages/3a/52/9f9d17c3b54dc238de384c4cb5a2ef0e27985b42a0e5cc8e8a31d918d48d/charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl"
+        - pypi: "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl"
+        - pypi: "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl"
+        - pypi: "./links/requests-2.31.0-py3-none-any.whl"
+packages:
+  - kind: conda
+    name: bzip2
+    version: 1.0.8
+    build: h93a5062_5
+    build_number: 5
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda"
+    sha256: bfa84296a638bea78a8bb29abc493ee95f2a0218775642474a840411b950fe5f
+    md5: 1bbc659ca658bfd49a481b5ef7a0f40f
+    license: bzip2-1.0.6
+    license_family: BSD
+    size: 122325
+    timestamp: 1699280294368
+  - kind: conda
+    name: ca-certificates
+    version: 2024.2.2
+    build: hf0a4a13_0
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda"
+    sha256: 49bc3439816ac72d0c0e0f144b8cc870fdcc4adec2e861407ec818d8116b2204
+    md5: fb416a1795f18dcc5a038bc2dc54edf9
+    license: ISC
+    size: 155725
+    timestamp: 1706844034242
+  - kind: pypi
+    name: certifi
+    version: 2024.2.2
+    url: "https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl"
+    sha256: dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
+    requires_python: ">=3.6"
+  - kind: pypi
+    name: charset-normalizer
+    version: 3.3.2
+    url: "https://files.pythonhosted.org/packages/3a/52/9f9d17c3b54dc238de384c4cb5a2ef0e27985b42a0e5cc8e8a31d918d48d/charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl"
+    sha256: 55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6
+    requires_python: ">=3.7.0"
+  - kind: pypi
+    name: idna
+    version: "3.7"
+    url: "https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl"
+    sha256: 82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
+    requires_python: ">=3.5"
+  - kind: conda
+    name: libexpat
+    version: 2.6.2
+    build: hebf3989_0
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda"
+    sha256: ba7173ac30064ea901a4c9fb5a51846dcc25512ceb565759be7d18cbf3e5415e
+    md5: e3cde7cfa87f82f7cb13d482d5e0ad09
+    constrains:
+      - expat 2.6.2.*
+    license: MIT
+    license_family: MIT
+    size: 63655
+    timestamp: 1710362424980
+  - kind: conda
+    name: libffi
+    version: 3.4.2
+    build: h3422bc3_5
+    build_number: 5
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2"
+    sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+    md5: 086914b672be056eb70fd4285b6783b6
+    license: MIT
+    license_family: MIT
+    size: 39020
+    timestamp: 1636488587153
+  - kind: conda
+    name: libsqlite
+    version: 3.45.3
+    build: h091b4b1_0
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.3-h091b4b1_0.conda"
+    sha256: 4337f466eb55bbdc74e168b52ec8c38f598e3664244ec7a2536009036e2066cc
+    md5: c8c1186c7f3351f6ffddb97b1f54fc58
+    depends:
+      - "libzlib >=1.2.13,<1.3.0a0"
+    license: Unlicense
+    size: 824794
+    timestamp: 1713367748819
+  - kind: conda
+    name: libzlib
+    version: 1.2.13
+    build: h53f4e23_5
+    build_number: 5
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda"
+    sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
+    md5: 1a47f5236db2e06a320ffa0392f81bd8
+    constrains:
+      - zlib 1.2.13 *_5
+    license: Zlib
+    license_family: Other
+    size: 48102
+    timestamp: 1686575426584
+  - kind: conda
+    name: ncurses
+    version: 6.4.20240210
+    build: h078ce10_0
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda"
+    sha256: 06f0905791575e2cd3aa961493c56e490b3d82ad9eb49f1c332bd338b0216911
+    md5: 616ae8691e6608527d0071e6766dcb81
+    license: X11 AND BSD-3-Clause
+    size: 820249
+    timestamp: 1710866874348
+  - kind: conda
+    name: openssl
+    version: 3.2.1
+    build: h0d3ecfb_1
+    build_number: 1
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda"
+    sha256: 519dc941d7ab0ebf31a2878d85c2f444450e7c5f6f41c4d07252c6bb3417b78b
+    md5: eb580fb888d93d5d550c557323ac5cee
+    depends:
+      - ca-certificates
+    constrains:
+      - pyopenssl >=22.1
+    license: Apache-2.0
+    license_family: Apache
+    size: 2855250
+    timestamp: 1710793435903
+  - kind: conda
+    name: python
+    version: 3.12.0
+    build: h47c9636_0_cpython
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda"
+    sha256: eb66f8f249caa9d5a956c3a407f079e4779d652ebfc2a4b4f50dcea078e84fa8
+    md5: ed8ae98b1b510de68392971b9367d18c
+    depends:
+      - "bzip2 >=1.0.8,<2.0a0"
+      - "libexpat >=2.5.0,<3.0a0"
+      - "libffi >=3.4,<4.0a0"
+      - "libsqlite >=3.43.0,<4.0a0"
+      - "libzlib >=1.2.13,<1.3.0a0"
+      - "ncurses >=6.4,<7.0a0"
+      - "openssl >=3.1.3,<4.0a0"
+      - "readline >=8.2,<9.0a0"
+      - "tk >=8.6.13,<8.7.0a0"
+      - tzdata
+      - "xz >=5.2.6,<6.0a0"
+    constrains:
+      - python_abi 3.12.* *_cp312
+    license: Python-2.0
+    size: 13306758
+    timestamp: 1696322682581
+  - kind: conda
+    name: readline
+    version: "8.2"
+    build: h92ec313_1
+    build_number: 1
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda"
+    sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+    md5: 8cbb776a2f641b943d413b3e19df71f4
+    depends:
+      - "ncurses >=6.3,<7.0a0"
+    license: GPL-3.0-only
+    license_family: GPL
+    size: 250351
+    timestamp: 1679532511311
+  - kind: pypi
+    name: requests
+    version: 2.31.0
+    path: "./links/requests-2.31.0-py3-none-any.whl"
+    requires_dist:
+      - "charset-normalizer <4, >=2"
+      - "idna <4, >=2.5"
+      - "urllib3 <3, >=1.21.1"
+      - certifi >=2017.4.17
+      - "pysocks !=1.5.7, >=1.5.6 ; extra == 'socks'"
+      - "chardet <6, >=3.0.2 ; extra == 'use_chardet_on_py3'"
+    requires_python: ">=3.7"
+  - kind: conda
+    name: tk
+    version: 8.6.13
+    build: h5083fa2_1
+    build_number: 1
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda"
+    sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+    md5: b50a57ba89c32b62428b71a875291c9b
+    depends:
+      - "libzlib >=1.2.13,<1.3.0a0"
+    license: TCL
+    license_family: BSD
+    size: 3145523
+    timestamp: 1699202432999
+  - kind: conda
+    name: tzdata
+    version: 2024a
+    build: h0c530f3_0
+    subdir: noarch
+    noarch: generic
+    url: "https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda"
+    sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+    md5: 161081fc7cec0bfda0d86d7cb595f8d8
+    license: LicenseRef-Public-Domain
+    size: 119815
+    timestamp: 1706886945727
+  - kind: pypi
+    name: urllib3
+    version: 2.2.1
+    url: "https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl"
+    sha256: 450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d
+    requires_dist:
+      - "brotli >=1.0.9 ; platform_python_implementation == 'CPython' and extra == 'brotli'"
+      - "brotlicffi >=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'"
+      - "h2 <5, >=4 ; extra == 'h2'"
+      - "pysocks !=1.5.7, <2.0, >=1.5.6 ; extra == 'socks'"
+      - "zstandard >=0.18.0 ; extra == 'zstd'"
+    requires_python: ">=3.8"
+  - kind: conda
+    name: xz
+    version: 5.2.6
+    build: h57fd34a_0
+    subdir: osx-arm64
+    url: "https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2"
+    sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+    md5: 39c6b54e94014701dd157f4f576ed211
+    license: LGPL-2.1 and GPL-2.0
+    size: 235693
+    timestamp: 1660346961024

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v5__flat-index-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v5__flat-index-lock.yml.snap
@@ -9,7 +9,7 @@ environments:
       - url: "https://conda.anaconda.org/conda-forge/"
     indexes:
       - "https://pypi.org/simple"
-    flat-indexes:
+    find-links:
       - path: "./links"
     packages:
       osx-arm64:

--- a/test-data/conda-lock/v5/flat-index-lock.yml
+++ b/test-data/conda-lock/v5/flat-index-lock.yml
@@ -1,0 +1,257 @@
+version: 5
+environments:
+  default:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    flat-indexes:
+    - path: ./links
+    packages:
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.3-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - pypi: https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/3a/52/9f9d17c3b54dc238de384c4cb5a2ef0e27985b42a0e5cc8e8a31d918d48d/charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl
+      - pypi: ./links/requests-2.31.0-py3-none-any.whl
+packages:
+- kind: conda
+  name: bzip2
+  version: 1.0.8
+  build: h93a5062_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h93a5062_5.conda
+  sha256: bfa84296a638bea78a8bb29abc493ee95f2a0218775642474a840411b950fe5f
+  md5: 1bbc659ca658bfd49a481b5ef7a0f40f
+  license: bzip2-1.0.6
+  license_family: BSD
+  size: 122325
+  timestamp: 1699280294368
+- kind: conda
+  name: ca-certificates
+  version: 2024.2.2
+  build: hf0a4a13_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
+  sha256: 49bc3439816ac72d0c0e0f144b8cc870fdcc4adec2e861407ec818d8116b2204
+  md5: fb416a1795f18dcc5a038bc2dc54edf9
+  license: ISC
+  size: 155725
+  timestamp: 1706844034242
+- kind: pypi
+  name: certifi
+  version: 2024.2.2
+  url: https://files.pythonhosted.org/packages/ba/06/a07f096c664aeb9f01624f858c3add0a4e913d6c96257acb4fce61e7de14/certifi-2024.2.2-py3-none-any.whl
+  sha256: dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1
+  requires_python: '>=3.6'
+- kind: pypi
+  name: charset-normalizer
+  version: 3.3.2
+  url: https://files.pythonhosted.org/packages/3a/52/9f9d17c3b54dc238de384c4cb5a2ef0e27985b42a0e5cc8e8a31d918d48d/charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl
+  sha256: 55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6
+  requires_python: '>=3.7.0'
+- kind: pypi
+  name: idna
+  version: '3.7'
+  url: https://files.pythonhosted.org/packages/e5/3e/741d8c82801c347547f8a2a06aa57dbb1992be9e948df2ea0eda2c8b79e8/idna-3.7-py3-none-any.whl
+  sha256: 82fee1fc78add43492d3a1898bfa6d8a904cc97d8427f683ed8e798d07761aa0
+  requires_python: '>=3.5'
+- kind: conda
+  name: libexpat
+  version: 2.6.2
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+  sha256: ba7173ac30064ea901a4c9fb5a51846dcc25512ceb565759be7d18cbf3e5415e
+  md5: e3cde7cfa87f82f7cb13d482d5e0ad09
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 63655
+  timestamp: 1710362424980
+- kind: conda
+  name: libffi
+  version: 3.4.2
+  build: h3422bc3_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+  sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
+  md5: 086914b672be056eb70fd4285b6783b6
+  license: MIT
+  license_family: MIT
+  size: 39020
+  timestamp: 1636488587153
+- kind: conda
+  name: libsqlite
+  version: 3.45.3
+  build: h091b4b1_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.3-h091b4b1_0.conda
+  sha256: 4337f466eb55bbdc74e168b52ec8c38f598e3664244ec7a2536009036e2066cc
+  md5: c8c1186c7f3351f6ffddb97b1f54fc58
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  license: Unlicense
+  size: 824794
+  timestamp: 1713367748819
+- kind: conda
+  name: libzlib
+  version: 1.2.13
+  build: h53f4e23_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+  sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
+  md5: 1a47f5236db2e06a320ffa0392f81bd8
+  constrains:
+  - zlib 1.2.13 *_5
+  license: Zlib
+  license_family: Other
+  size: 48102
+  timestamp: 1686575426584
+- kind: conda
+  name: ncurses
+  version: 6.4.20240210
+  build: h078ce10_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda
+  sha256: 06f0905791575e2cd3aa961493c56e490b3d82ad9eb49f1c332bd338b0216911
+  md5: 616ae8691e6608527d0071e6766dcb81
+  license: X11 AND BSD-3-Clause
+  size: 820249
+  timestamp: 1710866874348
+- kind: conda
+  name: openssl
+  version: 3.2.1
+  build: h0d3ecfb_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
+  sha256: 519dc941d7ab0ebf31a2878d85c2f444450e7c5f6f41c4d07252c6bb3417b78b
+  md5: eb580fb888d93d5d550c557323ac5cee
+  depends:
+  - ca-certificates
+  constrains:
+  - pyopenssl >=22.1
+  license: Apache-2.0
+  license_family: Apache
+  size: 2855250
+  timestamp: 1710793435903
+- kind: conda
+  name: python
+  version: 3.12.0
+  build: h47c9636_0_cpython
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
+  sha256: eb66f8f249caa9d5a956c3a407f079e4779d652ebfc2a4b4f50dcea078e84fa8
+  md5: ed8ae98b1b510de68392971b9367d18c
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  size: 13306758
+  timestamp: 1696322682581
+- kind: conda
+  name: readline
+  version: '8.2'
+  build: h92ec313_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+  sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
+  md5: 8cbb776a2f641b943d413b3e19df71f4
+  depends:
+  - ncurses >=6.3,<7.0a0
+  license: GPL-3.0-only
+  license_family: GPL
+  size: 250351
+  timestamp: 1679532511311
+- kind: pypi
+  name: requests
+  version: 2.31.0
+  path: ./links/requests-2.31.0-py3-none-any.whl
+  requires_dist:
+  - charset-normalizer<4,>=2
+  - idna<4,>=2.5
+  - urllib3<3,>=1.21.1
+  - certifi>=2017.4.17
+  - pysocks!=1.5.7,>=1.5.6 ; extra == 'socks'
+  - chardet<6,>=3.0.2 ; extra == 'use_chardet_on_py3'
+  requires_python: '>=3.7'
+- kind: conda
+  name: tk
+  version: 8.6.13
+  build: h5083fa2_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
+  depends:
+  - libzlib >=1.2.13,<1.3.0a0
+  license: TCL
+  license_family: BSD
+  size: 3145523
+  timestamp: 1699202432999
+- kind: conda
+  name: tzdata
+  version: 2024a
+  build: h0c530f3_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+  sha256: 7b2b69c54ec62a243eb6fba2391b5e443421608c3ae5dbff938ad33ca8db5122
+  md5: 161081fc7cec0bfda0d86d7cb595f8d8
+  license: LicenseRef-Public-Domain
+  size: 119815
+  timestamp: 1706886945727
+- kind: pypi
+  name: urllib3
+  version: 2.2.1
+  url: https://files.pythonhosted.org/packages/a2/73/a68704750a7679d0b6d3ad7aa8d4da8e14e151ae82e6fee774e6e0d05ec8/urllib3-2.2.1-py3-none-any.whl
+  sha256: 450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d
+  requires_dist:
+  - brotli>=1.0.9 ; platform_python_implementation == 'CPython' and extra == 'brotli'
+  - brotlicffi>=0.8.0 ; platform_python_implementation != 'CPython' and extra == 'brotli'
+  - h2<5,>=4 ; extra == 'h2'
+  - pysocks!=1.5.7,<2.0,>=1.5.6 ; extra == 'socks'
+  - zstandard>=0.18.0 ; extra == 'zstd'
+  requires_python: '>=3.8'
+- kind: conda
+  name: xz
+  version: 5.2.6
+  build: h57fd34a_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+  sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
+  md5: 39c6b54e94014701dd157f4f576ed211
+  license: LGPL-2.1 and GPL-2.0
+  size: 235693
+  timestamp: 1660346961024

--- a/test-data/conda-lock/v5/flat-index-lock.yml
+++ b/test-data/conda-lock/v5/flat-index-lock.yml
@@ -5,7 +5,7 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    flat-indexes:
+    find-links:
     - path: ./links
     packages:
       osx-arm64:


### PR DESCRIPTION
This bumps the lock-file version to `5` because starting from version `5` the pypi indexes are required if there are pypi indices. This ensures that old lock-files are still valid without the indexes but new lock-files should be considered invalid if they dont contain the indexes.