### PR TITLE
feat: respect `RATTLER_AUTH_FILE` when using AuthenticationStorage::default()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ sysinfo = "0.30.10"
 tar = "0.4.40"
 tempdir = "0.3.7"
 tempfile = "3.10.1"
+temp-env = "0.3.6"
 test-log = "0.2.15"
 thiserror = "1.0"
 tokio = { version = "1.37.0", default-features = false }

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -47,3 +47,4 @@ tokio = { workspace = true, features = ["macros"] }
 axum = { workspace = true }
 reqwest-retry = { workspace = true }
 sha2 = { workspace = true }
+temp-env = "0.3.6"

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -47,4 +47,4 @@ tokio = { workspace = true, features = ["macros"] }
 axum = { workspace = true }
 reqwest-retry = { workspace = true }
 sha2 = { workspace = true }
-temp-env = "0.3.6"
+temp-env = { workspace = true }

--- a/crates/rattler_networking/src/authentication_middleware.rs
+++ b/crates/rattler_networking/src/authentication_middleware.rs
@@ -404,16 +404,17 @@ mod tests {
     fn test_rattler_auth_file_env_var_handling() -> anyhow::Result<()> {
         let tdir = tempdir()?;
 
-        std::env::set_var(
+        let storage = temp_env::with_var(
             "RATTLER_AUTH_FILE",
-            tdir.path()
-                .to_path_buf()
-                .join("auth.json")
-                .to_str()
-                .unwrap(),
+            Some(
+                tdir.path()
+                    .to_path_buf()
+                    .join("auth.json")
+                    .to_str()
+                    .unwrap(),
+            ),
+            || AuthenticationStorage::from_env().unwrap(),
         );
-        let storage = AuthenticationStorage::default();
-        std::env::remove_var("RATTLER_AUTH_FILE");
 
         let host = "test.example.com";
         let authentication = Authentication::CondaToken("testtoken".to_string());

--- a/crates/rattler_networking/src/authentication_middleware.rs
+++ b/crates/rattler_networking/src/authentication_middleware.rs
@@ -409,7 +409,8 @@ mod tests {
             tdir.path()
                 .to_path_buf()
                 .join("auth.json")
-                .to_str().unwrap(),
+                .to_str()
+                .unwrap(),
         );
         let storage = AuthenticationStorage::default();
         std::env::remove_var("RATTLER_AUTH_FILE");

--- a/crates/rattler_networking/src/authentication_middleware.rs
+++ b/crates/rattler_networking/src/authentication_middleware.rs
@@ -399,4 +399,31 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_rattler_auth_file_env_var_handling() -> anyhow::Result<()> {
+        let tdir = tempdir()?;
+
+        std::env::set_var(
+            "RATTLER_AUTH_FILE",
+            tdir.path()
+                .to_path_buf()
+                .join("auth.json")
+                .to_str().unwrap(),
+        );
+        let storage = AuthenticationStorage::default();
+        std::env::remove_var("RATTLER_AUTH_FILE");
+
+        let host = "test.example.com";
+        let authentication = Authentication::CondaToken("testtoken".to_string());
+        storage.store(host, &authentication)?;
+
+        let file = tdir.path().join("auth.json");
+        assert_eq!(
+            std::fs::read_to_string(file)?,
+            "{\"test.example.com\":{\"CondaToken\":\"testtoken\"}}"
+        );
+
+        Ok(())
+    }
 }

--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -52,7 +52,9 @@ impl AuthenticationStorage {
     }
 
     /// Create a new authentication storage with the default backends
-    /// respecting the `RATTLER_AUTH_FILE` environment variable
+    /// respecting the `RATTLER_AUTH_FILE` environment variable.
+    /// If the variable is set, the file storage backend will be used
+    /// with the path specified in the variable
     pub fn from_env() -> Result<Self> {
         if let Ok(auth_file) = std::env::var("RATTLER_AUTH_FILE") {
             let mut storage = Self::new();

--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -63,11 +63,13 @@ impl AuthenticationStorage {
                 auth_file
             );
 
-            let backend = FileStorage::new(path.to_path_buf()).map_err(|e| anyhow!(
-                "Error creating file storage backend for RATTLER_AUTH_FILE ({}): {}",
-                auth_file,
-                e
-            ))?;
+            let backend = FileStorage::new(path.to_path_buf()).map_err(|e| {
+                anyhow!(
+                    "Error creating file storage backend for RATTLER_AUTH_FILE ({}): {}",
+                    auth_file,
+                    e
+                )
+            })?;
 
             storage.add_backend(Arc::from(backend));
             Ok(storage)

--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -29,6 +29,23 @@ impl Default for AuthenticationStorage {
     fn default() -> Self {
         let mut storage = Self::new();
 
+        if let Ok(auth_file) = std::env::var("RATTLER_AUTH_FILE") {
+            let path = std::path::Path::new(&auth_file);
+
+            tracing::info!(
+                "\"RATTLER_AUTH_FILE\" environment variable set, using file storage at {}",
+                auth_file
+            );
+
+            let backend = FileStorage::new(path.to_path_buf()).unwrap_or_else(|e| {
+                tracing::error!("Failed to create file storage at {}: {}", auth_file, e);
+                FileStorage::default()
+            });
+
+            storage.add_backend(Arc::from(backend));
+            return storage;
+        }
+
         storage.add_backend(Arc::from(KeyringAuthenticationStorage::default()));
         storage.add_backend(Arc::from(FileStorage::default()));
         storage.add_backend(Arc::from(NetRcStorage::from_env().unwrap_or_else(


### PR DESCRIPTION
The environment variable `RATTLER_AUTH_FILE` is currently used by both `pixi` and `rattler-build` to specify an alternative storage location for the `credentials.json` file, which is crucial for authenticating to remote repositories. This feature is particularly valuable in CI or managed environments, where authentication is managed externally and credentials are stored at ephemeral paths.

Currently, both tools handle the `RATTLER_AUTH_FILE` independently, each tool implementing its own method to default to `AuthenticationStorage` when the environment variable is not set. This is evidenced in their respective codebases:

- `rattler-build` implementation: [rattler-build code](https://github.com/prefix-dev/rattler-build/blob/main/src/tool_configuration.rs#L57)
- `pixi` implementation: [pixi code](https://github.com/prefix-dev/pixi/blob/main/src/utils/reqwest.rs#L22)

Despite their similar approaches, this independent handling has led to at least one consistency issue as seen in [pixi issue #1240](https://github.com/prefix-dev/pixi/issues/1240).

To address this and enhance consistency across tools that utilize `RATTLER_AUTH_FILE`, I propose integrating the handling of this environment variable directly into the default implementation (`impl Default`) of `AuthenticationStorage`. This change will ensure that any tool relying on `AuthenticationStorage` will inherently respect the `RATTLER_AUTH_FILE` path if set, without requiring each tool to implement its own handling. The proposed change aligns with the intended use of the environment variable, suggesting a default behavior that could be expected across all tools built on the rattler framework.

This modification will not remove flexibility, as developers can still explicitly construct `AuthenticationStorage` instances without this default behavior if needed.