### PR TITLE
feat: Add missing @property to sha256, sha256_in_prefix in `PrefixPathsEntry`

### DIFF
--- a/py-rattler/rattler/prefix/prefix_paths.py
+++ b/py-rattler/rattler/prefix/prefix_paths.py
@@ -180,6 +180,7 @@ class PrefixPathsEntry(BasePathLike):
         """
         return FileMode._from_py_file_mode(self._inner.file_mode)
 
+    @property
     def sha256(self) -> bytes:
         """
         The sha256 of the path.
@@ -198,6 +199,7 @@ class PrefixPathsEntry(BasePathLike):
         """
         return self._inner.sha256
 
+    @property
     def sha256_in_prefix(self) -> bytes:
         """
         The sha256 of the path in the prefix.


### PR DESCRIPTION
We were missing `@property` for `sha256` and `sha256_in_prefix` for `PrefixPathsEntry`.