### PR TITLE
feat: clear gateway subdirs

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -22,6 +22,7 @@ use file_url::url_to_path;
 use local_subdir::LocalSubdirClient;
 use rattler_conda_types::{Channel, MatchSpec, Platform};
 use reqwest_middleware::ClientWithMiddleware;
+use std::collections::HashSet;
 use std::{
     path::PathBuf,
     sync::{Arc, Weak},
@@ -56,12 +57,16 @@ impl Default for Gateway {
 /// A selection of subdirectories.
 #[derive(Default, Clone, Debug)]
 pub enum SubdirSelection {
+    /// Select all subdirectories
     #[default]
     All,
-    Some(Vec<String>),
+
+    /// Select these specific subdirectories
+    Some(HashSet<String>),
 }
 
 impl SubdirSelection {
+    /// Returns `true` if the given subdirectory is part of the selection.
     pub fn contains(&self, subdir: &str) -> bool {
         match self {
             SubdirSelection::All => true,

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -53,6 +53,23 @@ impl Default for Gateway {
     }
 }
 
+/// A selection of subdirectories.
+#[derive(Default, Clone, Debug)]
+pub enum SubdirSelection {
+    #[default]
+    All,
+    Some(Vec<String>),
+}
+
+impl SubdirSelection {
+    pub fn contains(&self, subdir: &str) -> bool {
+        match self {
+            SubdirSelection::All => true,
+            SubdirSelection::Some(subdirs) => subdirs.contains(&subdir.to_string()),
+        }
+    }
+}
+
 impl Gateway {
     /// Constructs a simple gateway with the default configuration. Use [`Gateway::builder`] if you
     /// want more control over how the gateway is constructed.
@@ -86,6 +103,17 @@ impl Gateway {
             platforms.into_iter().collect(),
             specs.into_iter().map(Into::into).collect(),
         )
+    }
+
+    /// Clears any in-memory cache for the given channel.
+    ///
+    /// Any subsequent query will re-fetch any required data from the source.
+    ///
+    /// This method does not clear any on-disk cache.
+    pub fn clear_repodata_cache(&self, channel: &Channel, subdirs: SubdirSelection) {
+        self.inner
+            .subdirs
+            .retain(|key, _| key.0 != *channel || !subdirs.contains(key.1.as_str()));
     }
 }
 
@@ -289,13 +317,16 @@ enum PendingOrFetched<T> {
 
 #[cfg(test)]
 mod test {
+    use crate::fetch::CacheAction;
     use crate::gateway::Gateway;
     use crate::utils::simple_channel_server::SimpleChannelServer;
-    use crate::GatewayError;
+    use crate::{GatewayError, Reporter, SourceConfig};
+    use dashmap::DashSet;
     use rattler_conda_types::{Channel, ChannelConfig, PackageName, Platform};
     use rstest::rstest;
     use std::path::{Path, PathBuf};
     use std::str::FromStr;
+    use std::sync::Arc;
     use std::time::Instant;
     use url::Url;
 
@@ -402,5 +433,61 @@ mod test {
 
         let total_records: usize = records.iter().map(|r| r.len()).sum();
         assert_eq!(total_records, 84242);
+    }
+
+    #[tokio::test]
+    async fn test_clear_cache() {
+        let local_channel = remote_conda_forge().await;
+
+        // Create a gateway with a custom channel configuration that disables caching.
+        let gateway = Gateway::builder()
+            .with_channel_config(super::ChannelConfig {
+                default: SourceConfig {
+                    cache_action: CacheAction::NoCache,
+                    ..Default::default()
+                },
+                ..Default::default()
+            })
+            .finish();
+
+        #[derive(Default)]
+        struct Downloads {
+            urls: DashSet<Url>,
+        }
+        let downloads = Arc::new(Downloads::default());
+        impl Reporter for Arc<Downloads> {
+            fn on_download_complete(&self, url: &Url, _index: usize) {
+                self.urls.insert(url.clone());
+            }
+        }
+
+        // Construct a simpel query
+        let query = gateway
+            .query(
+                vec![local_channel.channel()],
+                vec![Platform::Linux64, Platform::NoArch],
+                vec![PackageName::from_str("python").unwrap()].into_iter(),
+            )
+            .with_reporter(downloads.clone());
+
+        // Run the query once. We expect some activity.
+        query.clone().execute().await.unwrap();
+        assert!(downloads.urls.len() > 0, "there should be some urls");
+        downloads.urls.clear();
+
+        // Run the query a second time.
+        query.clone().execute().await.unwrap();
+        assert!(
+            downloads.urls.is_empty(),
+            "there should be NO new url fetches"
+        );
+
+        // Now clear the cache and run the query again.
+        gateway.clear_repodata_cache(&local_channel.channel(), Default::default());
+        query.clone().execute().await.unwrap();
+        assert!(
+            downloads.urls.len() > 0,
+            "after clearing the cache there should be new urls fetched"
+        );
     }
 }

--- a/crates/rattler_repodata_gateway/src/lib.rs
+++ b/crates/rattler_repodata_gateway/src/lib.rs
@@ -71,4 +71,6 @@ pub use reporter::Reporter;
 mod gateway;
 
 #[cfg(feature = "gateway")]
-pub use gateway::{ChannelConfig, Gateway, GatewayBuilder, GatewayError, RepoData, SourceConfig};
+pub use gateway::{
+    ChannelConfig, Gateway, GatewayBuilder, GatewayError, RepoData, SourceConfig, SubdirSelection,
+};

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -506,25 +506,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +787,7 @@ version = "0.1.0"
 dependencies = [
  "itertools",
  "percent-encoding",
+ "typed-path",
  "url",
 ]
 
@@ -2556,6 +2538,7 @@ dependencies = [
  "strum",
  "thiserror",
  "tracing",
+ "typed-path",
  "url",
 ]
 
@@ -2601,7 +2584,6 @@ dependencies = [
  "purl",
  "rattler_conda_types",
  "rattler_digest",
- "rayon",
  "serde",
  "serde_json",
  "serde_repr",
@@ -2701,7 +2683,6 @@ dependencies = [
  "rattler_conda_types",
  "rattler_digest",
  "rattler_networking",
- "rayon",
  "reqwest 0.12.3",
  "reqwest-middleware",
  "rmp-serde",
@@ -2712,7 +2693,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tokio-rayon",
  "tokio-util",
  "tracing",
  "url",
@@ -2765,26 +2745,6 @@ dependencies = [
  "serde",
  "thiserror",
  "tracing",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -3680,16 +3640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-rayon"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf33a76e0b1dd03b778f83244137bd59887abf25c0e87bc3e7071105f457693"
-dependencies = [
- "rayon",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3827,6 +3777,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6069e2cc1d241fd4ff5fa067e8882996fcfce20986d078696e05abccbcf27b43"
 
 [[package]]
 name = "typenum"

--- a/py-rattler/rattler/repo_data/gateway.py
+++ b/py-rattler/rattler/repo_data/gateway.py
@@ -173,6 +173,35 @@ class Gateway:
         # Convert the records into python objects
         return [[RepoDataRecord._from_py_record(record) for record in records] for records in py_records]
 
+    def clear_repodata_cache(
+        self, channel: Channel | str, subdirs: Optional[List[Platform | PlatformLiteral]] = None
+    ) -> None:
+        """
+        Clears any in-memory cache for the given channel.
+
+        Any subsequent query will re-fetch any required data from the source.
+
+        This method does not clear any on-disk cache.
+
+        Arguments:
+            channel: The channel to clear the cache for.
+            subdirs: A selection of subdirectories to clear, if `None` is specified
+                     all subdirectories of the channel are cleared.
+
+        Examples
+        --------
+        >>> gateway = Gateway()
+        >>> gateway.clear_repodata_cache("conda-forge", ["linux-64"])
+        >>> gateway.clear_repodata_cache("robostack")
+        >>>
+        """
+        self._gateway.clear_repodata_cache(
+            channel._channel if isinstance(channel, Channel) else Channel(channel)._channel,
+            {subdir._inner if isinstance(subdir, Platform) else Platform(subdir)._inner for subdir in subdirs}
+            if subdirs is not None
+            else None,
+        )
+
     def __repr__(self) -> str:
         """
         Returns a representation of the Gateway.


### PR DESCRIPTION
Adds functionality to the gateway to selectively clear the in-memory cache. This might be useful if you know the state on disk changed (like when manually reindexing).