### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -28,12 +28,12 @@ console = { workspace = true, features = ["windows-console-colors"] }
 futures = { workspace = true }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.24.0", default-features = false }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.22.1", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.5", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.19.11", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "0.21.1", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.9", default-features = false }
+rattler = { path="../rattler", version = "0.24.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.23.0", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.6", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.20.0", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "0.21.2", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.10", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1](https://github.com/mamba-org/rattler/compare/rattler-v0.24.0...rattler-v0.24.1) - 2024-05-13
+
+### Other
+- updated the following local packages: rattler_conda_types, rattler_digest, rattler_package_streaming, rattler_networking
+
 ## [0.24.0](https://github.com/mamba-org/rattler/compare/rattler-v0.23.2...rattler-v0.24.0) - 2024-05-06
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.24.0"
+version = "0.24.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -31,11 +31,11 @@ itertools = { workspace = true }
 memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.22.1", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.5", default-features = false }
-rattler_shell = { path="../rattler_shell", version = "0.20.2", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.8", default-features = false, features = ["reqwest"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.23.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.6", default-features = false }
+rattler_shell = { path="../rattler_shell", version = "0.20.3", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.9", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.22.1...rattler_conda_types-v0.23.0) - 2024-05-13
+
+### Added
+- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))
+
+### Other
+- update README.md
+
 ## [0.22.1](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.22.0...rattler_conda_types-v0.22.1) - 2024-05-06
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.22.1"
+version = "0.23.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -20,7 +20,7 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false, features = ["serde"] }
+rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false, features = ["serde"] }
 rattler_macros = { path="../rattler_macros", version = "0.19.3", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_digest-v0.19.3...rattler_digest-v0.19.4) - 2024-05-13
+
+### Added
+- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))
+
+### Other
+- update README.md
+
 ## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_digest-v0.19.2...rattler_digest-v0.19.3) - 2024-04-19
 
 ### Other

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "0.19.3"
+version = "0.19.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.11](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.10...rattler_index-v0.19.11) - 2024-05-13
+
+### Other
+- updated the following local packages: rattler_conda_types, rattler_digest, rattler_package_streaming
+
 ## [0.19.10](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.9...rattler_index-v0.19.10) - 2024-05-06
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.10"
+version = "0.19.11"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.22.1", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.8", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.23.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.9", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.6](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.5...rattler_lock-v0.22.6) - 2024-05-13
+
+### Added
+- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))
+
+### Other
+- update README.md
+
 ## [0.22.5](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.4...rattler_lock-v0.22.5) - 2024-05-06
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.5"
+version = "0.22.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,8 +15,8 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.22.1", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "0.19.3", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.23.0", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false }
 file_url = { path = "../file_url", version = "0.1.0" }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.6](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.20.5...rattler_networking-v0.20.6) - 2024-05-13
+
+### Added
+- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))
+- add AuthenticationStorage::from_file() ([#645](https://github.com/mamba-org/rattler/pull/645))
+
+### Other
+- update README.md
+
 ## [0.20.5](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.20.4...rattler_networking-v0.20.5) - 2024-05-06
 
 ### Added

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.20.5"
+version = "0.20.6"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.9](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.8...rattler_package_streaming-v0.20.9) - 2024-05-13
+
+### Added
+- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))
+
+### Fixed
+- set last modified for zip archive ([#649](https://github.com/mamba-org/rattler/pull/649))
+
+### Other
+- update README.md
+
 ## [0.20.8](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.7...rattler_package_streaming-v0.20.8) - 2024-05-06
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.20.8"
+version = "0.20.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -15,9 +15,9 @@ bzip2 = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.22.1", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.5", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.23.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.6", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.11...rattler_repodata_gateway-v0.20.0) - 2024-05-13
+
+### Added
+- add clear subdir cache function to repodata gateway ([#650](https://github.com/mamba-org/rattler/pull/650))
+- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))
+
+### Other
+- update README.md
+
 ## [0.19.11](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.10...rattler_repodata_gateway-v0.19.11) - 2024-05-06
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.19.11"
+version = "0.20.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -35,9 +35,9 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.22.1", default-features = false, optional = true }
-rattler_digest = { path = "../rattler_digest", version = "0.19.3", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.20.5", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.23.0", default-features = false, optional = true }
+rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false, features = ["tokio", "serde"] }
+rattler_networking = { path = "../rattler_networking", version = "0.20.6", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -69,7 +69,7 @@ rstest = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower-http = { workspace = true, features = ["fs", "compression-gzip", "trace"] }
 tracing-test = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.22.0", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.23.0", default-features = false }
 
 [features]
 default = ['native-tls']

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.2...rattler_shell-v0.20.3) - 2024-05-13
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.1...rattler_shell-v0.20.2) - 2024-05-06
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.20.2"
+version = "0.20.3"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.22.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.23.0", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.2](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.21.1...rattler_solve-v0.21.2) - 2024-05-13
+
+### Added
+- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))
+
+### Other
+- update README.md
+
 ## [0.21.1](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.21.0...rattler_solve-v0.21.1) - 2024-05-06
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.21.1"
+version = "0.21.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,8 +11,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.22.1", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.23.0", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.10](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.9...rattler_virtual_packages-v0.19.10) - 2024-05-13
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.9](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.8...rattler_virtual_packages-v0.19.9) - 2024-05-06
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "0.19.9"
+version = "0.19.10"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.22.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.23.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler_conda_types`: 0.22.1 -> 0.23.0 (⚠️ API breaking changes)
* `rattler_digest`: 0.19.3 -> 0.19.4 (✓ API compatible changes)
* `rattler_package_streaming`: 0.20.8 -> 0.20.9 (✓ API compatible changes)
* `rattler_networking`: 0.20.5 -> 0.20.6 (✓ API compatible changes)
* `rattler_lock`: 0.22.5 -> 0.22.6 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.19.11 -> 0.20.0 (⚠️ API breaking changes)
* `rattler_solve`: 0.21.1 -> 0.21.2 (✓ API compatible changes)
* `rattler`: 0.24.0 -> 0.24.1
* `rattler_shell`: 0.20.2 -> 0.20.3
* `rattler_virtual_packages`: 0.19.9 -> 0.19.10
* `rattler_index`: 0.19.10 -> 0.19.11

### ⚠️ `rattler_conda_types` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/enum_variant_added.ron

Failed in:
  variant ParseChannelError:NonAbsoluteRootDir in /tmp/.tmp0TYRfv/rattler/crates/rattler_conda_types/src/channel/mod.rs:334
  variant ParseChannelError:NotUtf8RootDir in /tmp/.tmp0TYRfv/rattler/crates/rattler_conda_types/src/channel/mod.rs:338

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rattler_conda_types::Channel::from_url now takes 1 parameters instead of 3, in /tmp/.tmp0TYRfv/rattler/crates/rattler_conda_types/src/channel/mod.rs:183
  rattler_conda_types::Channel::from_name now takes 2 parameters instead of 3, in /tmp/.tmp0TYRfv/rattler/crates/rattler_conda_types/src/channel/mod.rs:225
```

### ⚠️ `rattler_repodata_gateway` breaking changes

```
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rattler_repodata_gateway::fetch::jlap::patch_repo_data now takes 5 parameters instead of 4, in /tmp/.tmp0TYRfv/rattler/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs:412

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rattler_repodata_gateway::fetch::jlap::JLAPResponse::apply now takes 4 parameters instead of 3, in /tmp/.tmp0TYRfv/rattler/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs:312

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/struct_missing.ron

Failed in:
  struct rattler_repodata_gateway::fetch::DownloadProgress, previously in file /tmp/.tmpRam5A0/rattler_repodata_gateway/src/fetch/mod.rs:202
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_conda_types`
<blockquote>

## [0.23.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.22.1...rattler_conda_types-v0.23.0) - 2024-05-13

### Added
- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))

### Other
- update README.md
</blockquote>

## `rattler_digest`
<blockquote>

## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_digest-v0.19.3...rattler_digest-v0.19.4) - 2024-05-13

### Added
- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))

### Other
- update README.md
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.20.9](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.8...rattler_package_streaming-v0.20.9) - 2024-05-13

### Added
- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))

### Fixed
- set last modified for zip archive ([#649](https://github.com/mamba-org/rattler/pull/649))

### Other
- update README.md
</blockquote>

## `rattler_networking`
<blockquote>

## [0.20.6](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.20.5...rattler_networking-v0.20.6) - 2024-05-13

### Added
- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))
- add AuthenticationStorage::from_file() ([#645](https://github.com/mamba-org/rattler/pull/645))

### Other
- update README.md
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.6](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.5...rattler_lock-v0.22.6) - 2024-05-13

### Added
- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))

### Other
- update README.md
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.20.0](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.19.11...rattler_repodata_gateway-v0.20.0) - 2024-05-13

### Added
- add clear subdir cache function to repodata gateway ([#650](https://github.com/mamba-org/rattler/pull/650))
- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))

### Other
- update README.md
</blockquote>

## `rattler_solve`
<blockquote>

## [0.21.2](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.21.1...rattler_solve-v0.21.2) - 2024-05-13

### Added
- high level repodata access ([#560](https://github.com/mamba-org/rattler/pull/560))

### Other
- update README.md
</blockquote>

## `rattler`
<blockquote>

## [0.24.1](https://github.com/mamba-org/rattler/compare/rattler-v0.24.0...rattler-v0.24.1) - 2024-05-13

### Other
- updated the following local packages: rattler_conda_types, rattler_digest, rattler_package_streaming, rattler_networking
</blockquote>

## `rattler_shell`
<blockquote>

## [0.20.3](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.2...rattler_shell-v0.20.3) - 2024-05-13

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [0.19.10](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.9...rattler_virtual_packages-v0.19.10) - 2024-05-13

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.11](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.10...rattler_index-v0.19.11) - 2024-05-13

### Other
- updated the following local packages: rattler_conda_types, rattler_digest, rattler_package_streaming
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).