### PR TITLE
feat: exclude repodata records based on timestamp

### DIFF
--- a/crates/file_url/src/lib.rs
+++ b/crates/file_url/src/lib.rs
@@ -205,7 +205,7 @@ mod tests {
     )]
     #[case::percent_encoding("//foo/ba r", Some("file://foo/ba%20r"))]
     fn test_file_path_to_url(#[case] path: &str, #[case] expected: Option<&str>) {
-        let expected = expected.map(|s| s.to_string());
+        let expected = expected.map(std::string::ToString::to_string);
         assert_eq!(
             super::file_path_to_url(path).map(|u| u.to_string()).ok(),
             expected

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -22,7 +22,7 @@ use rattler_networking::{
 use rattler_repodata_gateway::{Gateway, RepoData};
 use rattler_solve::{
     libsolv_c::{self},
-    resolvo, ChannelPriority, RepoDataIter, SolverImpl, SolverTask,
+    resolvo, SolverImpl, SolverTask,
 };
 use reqwest::Client;
 use std::future::IntoFuture;
@@ -199,13 +199,11 @@ pub async fn create(opt: Opt) -> anyhow::Result<()> {
         .collect();
 
     let solver_task = SolverTask {
-        available_packages: repo_data.iter().map(RepoDataIter).collect::<Vec<_>>(),
         locked_packages,
         virtual_packages,
         specs,
-        pinned_packages: Vec::new(),
         timeout: opt.timeout.map(Duration::from_millis),
-        channel_priority: ChannelPriority::Strict,
+        ..SolverTask::from_iter(&repo_data)
     };
 
     // Next, use a solver to solve this specific problem. This provides us with all the operations

--- a/crates/rattler/src/cli/auth.rs
+++ b/crates/rattler/src/cli/auth.rs
@@ -47,7 +47,7 @@ pub struct Args {
     subcommand: Subcommand,
 }
 
-/// Authentication errors that can be returned by the AuthenticationCLIError
+/// Authentication errors that can be returned by the `AuthenticationCLIError`
 #[derive(thiserror::Error, Debug)]
 pub enum AuthenticationCLIError {
     /// An error occured when the input repository URL is parsed
@@ -87,7 +87,7 @@ fn get_url(url: &str) -> Result<String, AuthenticationCLIError> {
 
     let host = if host.matches('.').count() == 1 {
         // use wildcard for top-level domains
-        format!("*.{}", host)
+        format!("*.{host}")
     } else {
         host
     };
@@ -97,7 +97,7 @@ fn get_url(url: &str) -> Result<String, AuthenticationCLIError> {
 
 fn login(args: LoginArgs, storage: AuthenticationStorage) -> Result<(), AuthenticationCLIError> {
     let host = get_url(&args.host)?;
-    println!("Authenticating with {}", host);
+    println!("Authenticating with {host}");
 
     let auth = if let Some(conda_token) = args.conda_token {
         Authentication::CondaToken(conda_token)
@@ -131,7 +131,7 @@ fn login(args: LoginArgs, storage: AuthenticationStorage) -> Result<(), Authenti
 fn logout(args: LogoutArgs, storage: AuthenticationStorage) -> Result<(), AuthenticationCLIError> {
     let host = get_url(&args.host)?;
 
-    println!("Removing authentication for {}", host);
+    println!("Removing authentication for {host}");
 
     storage
         .delete(&host)

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
+assertion_line: 511
 expression: file_urls
 ---
-- "channels/dummy/linux-64/baz-2.0-unix_py36h1af98f8_2\u0000.tar.bz2"
-- "channels/dummy/linux-64/baz-1.0-unix_py36h1af98f8_2\u0000.tar.bz2"
+- channels/dummy/linux-64/foobar-2.1-bla_1.tar.bz2
 - channels/dummy/linux-64/bors-2.1-bla_1.tar.bz2
 - channels/dummy/linux-64/bar-1.0-unix_py36h1af98f8_2.tar.bz2
 - channels/dummy/linux-64/bors-1.0-bla_1.tar.bz2
 - channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_1.conda
 - channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_1.tar.bz2
-- channels/dummy/linux-64/bors-1.1-bla_1.tar.bz2
+- channels/dummy/linux-64/baz-2.0-unix_py36h1af98f8_2.tar.bz2
 - channels/dummy/linux-64/foo-4.0.2-py36h1af98f8_2.tar.bz2
+- channels/dummy/linux-64/bors-1.1-bla_1.tar.bz2
 - channels/dummy/linux-64/bors-2.0-bla_1.tar.bz2
 - channels/dummy/linux-64/foobar-2.0-bla_1.tar.bz2
-- channels/dummy/linux-64/foobar-2.1-bla_1.tar.bz2
 - channels/dummy/linux-64/bors-1.2.1-bla_1.tar.bz2
-
+- channels/dummy/linux-64/baz-1.0-unix_py36h1af98f8_2.tar.bz2

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
-assertion_line: 460
+assertion_line: 470
 expression: json
 ---
 {
@@ -25,8 +25,8 @@ expression: json
       "timestamp": 1605110689658,
       "version": "1.2.3"
     },
-    "baz-1.0-unix_py36h1af98f8_2\u0000.tar.bz2": {
-      "build": "unix_py36h1af98f8_2\u0000",
+    "baz-1.0-unix_py36h1af98f8_2.tar.bz2": {
+      "build": "unix_py36h1af98f8_2",
       "build_number": 1,
       "depends": [
         "__unix"
@@ -41,8 +41,8 @@ expression: json
       "timestamp": 1605110689658,
       "version": "1.2.3"
     },
-    "baz-2.0-unix_py36h1af98f8_2\u0000.tar.bz2": {
-      "build": "unix_py36h1af98f8_2\u0000",
+    "baz-2.0-unix_py36h1af98f8_2.tar.bz2": {
+      "build": "unix_py36h1af98f8_2",
       "build_number": 1,
       "depends": [],
       "license": "MIT",
@@ -52,7 +52,7 @@ expression: json
       "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
       "size": 414494,
       "subdir": "linux-64",
-      "timestamp": 1605110689658,
+      "timestamp": 1715610974,
       "version": "2.0"
     },
     "bors-1.0-bla_1.tar.bz2": {
@@ -108,7 +108,7 @@ expression: json
       "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
       "size": 414494,
       "subdir": "linux-64",
-      "timestamp": 1605110689658,
+      "timestamp": 1715610974,
       "version": "2.0"
     },
     "bors-2.1-bla_1.tar.bz2": {
@@ -122,7 +122,7 @@ expression: json
       "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
       "size": 414494,
       "subdir": "linux-64",
-      "timestamp": 1605110689658,
+      "timestamp": 1715610974,
       "version": "2.1"
     },
     "foo-3.0.2-py36h1af98f8_1.conda": {
@@ -136,7 +136,7 @@ expression: json
       "sha256": "67a63bec3fd3205170eaad532d487595b8aaceb9814d13c6858d7bac3ef24cd4",
       "size": 414494,
       "subdir": "linux-64",
-      "timestamp": 1605110689658,
+      "timestamp": 1715610974,
       "version": "3.0.2"
     },
     "foo-3.0.2-py36h1af98f8_1.tar.bz2": {
@@ -164,7 +164,7 @@ expression: json
       "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
       "size": 414494,
       "subdir": "linux-64",
-      "timestamp": 1605110689658,
+      "timestamp": 1715610974,
       "version": "4.0.2"
     },
     "foobar-2.0-bla_1.tar.bz2": {
@@ -196,7 +196,7 @@ expression: json
       "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
       "size": 414494,
       "subdir": "linux-64",
-      "timestamp": 1605110689658,
+      "timestamp": 1715610974,
       "version": "2.1"
     }
   },

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
+assertion_line: 466
 expression: repodata
 ---
 info:
@@ -20,8 +21,8 @@ packages:
     subdir: linux-64
     timestamp: 1605110689658
     version: 1.2.3
-  "baz-1.0-unix_py36h1af98f8_2\u0000.tar.bz2":
-    build: "unix_py36h1af98f8_2\u0000"
+  baz-1.0-unix_py36h1af98f8_2.tar.bz2:
+    build: unix_py36h1af98f8_2
     build_number: 1
     depends:
       - __unix
@@ -34,8 +35,8 @@ packages:
     subdir: linux-64
     timestamp: 1605110689658
     version: 1.2.3
-  "baz-2.0-unix_py36h1af98f8_2\u0000.tar.bz2":
-    build: "unix_py36h1af98f8_2\u0000"
+  baz-2.0-unix_py36h1af98f8_2.tar.bz2:
+    build: unix_py36h1af98f8_2
     build_number: 1
     depends: []
     license: MIT
@@ -45,7 +46,7 @@ packages:
     sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
     size: 414494
     subdir: linux-64
-    timestamp: 1605110689658
+    timestamp: 1715610974
     version: "2.0"
   bors-1.0-bla_1.tar.bz2:
     build: bla_1
@@ -97,7 +98,7 @@ packages:
     sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
     size: 414494
     subdir: linux-64
-    timestamp: 1605110689658
+    timestamp: 1715610974
     version: "2.0"
   bors-2.1-bla_1.tar.bz2:
     build: bla_1
@@ -110,7 +111,7 @@ packages:
     sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
     size: 414494
     subdir: linux-64
-    timestamp: 1605110689658
+    timestamp: 1715610974
     version: "2.1"
   foo-3.0.2-py36h1af98f8_1.conda:
     build: py36h1af98f8_1
@@ -123,7 +124,7 @@ packages:
     sha256: 67a63bec3fd3205170eaad532d487595b8aaceb9814d13c6858d7bac3ef24cd4
     size: 414494
     subdir: linux-64
-    timestamp: 1605110689658
+    timestamp: 1715610974
     version: 3.0.2
   foo-3.0.2-py36h1af98f8_1.tar.bz2:
     build: py36h1af98f8_1
@@ -149,7 +150,7 @@ packages:
     sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
     size: 414494
     subdir: linux-64
-    timestamp: 1605110689658
+    timestamp: 1715610974
     version: 4.0.2
   foobar-2.0-bla_1.tar.bz2:
     build: bla_1
@@ -177,8 +178,7 @@ packages:
     sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
     size: 414494
     subdir: linux-64
-    timestamp: 1605110689658
+    timestamp: 1715610974
     version: "2.1"
 packages.conda: {}
 repodata_version: 2
-

--- a/crates/rattler_networking/src/mirror_middleware.rs
+++ b/crates/rattler_networking/src/mirror_middleware.rs
@@ -199,10 +199,10 @@ mod test {
         let state = String::from(name);
 
         // Construct a router that returns data from the static dir but fails the first try.
-        let router = if !broken {
-            Router::new().route("/count", get(count)).with_state(state)
-        } else {
+        let router = if broken {
             Router::new().route("/count", get(broken_return))
+        } else {
+            Router::new().route("/count", get(count)).with_state(state)
         };
 
         let addr = SocketAddr::new([127, 0, 0, 1].into(), 0);

--- a/crates/rattler_package_streaming/tests/extract.rs
+++ b/crates/rattler_package_streaming/tests/extract.rs
@@ -210,7 +210,7 @@ async fn test_extract_conda_async(#[case] input: &str, #[case] sha256: &str, #[c
     assert_eq!(&format!("{:x}", result.md5), md5);
 }
 
-#[cfg(all(feature = "reqwest"))]
+#[cfg(feature = "reqwest")]
 #[apply(url_archives)]
 #[tokio::test]
 async fn test_extract_url_async(#[case] url: &str, #[case] sha256: &str, #[case] md5: &str) {

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -325,7 +325,7 @@ mod test {
     use crate::fetch::CacheAction;
     use crate::gateway::Gateway;
     use crate::utils::simple_channel_server::SimpleChannelServer;
-    use crate::{GatewayError, Reporter, SourceConfig};
+    use crate::{GatewayError, RepoData, Reporter, SourceConfig};
     use dashmap::DashSet;
     use rattler_conda_types::{Channel, ChannelConfig, PackageName, Platform};
     use rstest::rstest;
@@ -362,7 +362,7 @@ mod test {
             .await
             .unwrap();
 
-        let total_records: usize = records.iter().map(|r| r.len()).sum();
+        let total_records: usize = records.iter().map(RepoData::len).sum();
         assert_eq!(total_records, 45060);
     }
 
@@ -382,7 +382,7 @@ mod test {
             .await
             .unwrap();
 
-        let total_records: usize = records.iter().map(|r| r.len()).sum();
+        let total_records: usize = records.iter().map(RepoData::len).sum();
         assert_eq!(total_records, 45060);
     }
 
@@ -436,7 +436,7 @@ mod test {
         let end = Instant::now();
         println!("{} records in {:?}", records.len(), end - start);
 
-        let total_records: usize = records.iter().map(|r| r.len()).sum();
+        let total_records: usize = records.iter().map(RepoData::len).sum();
         assert_eq!(total_records, 84242);
     }
 

--- a/crates/rattler_shell/src/shell/mod.rs
+++ b/crates/rattler_shell/src/shell/mod.rs
@@ -631,7 +631,7 @@ impl ShellEnum {
 
         while let Some(parent_process_id) = system_info
             .process(current_pid)
-            .and_then(|process| process.parent())
+            .and_then(sysinfo::Process::parent)
         {
             // Get the name of the parent process
             system_info.refresh_process(parent_process_id);
@@ -873,7 +873,7 @@ mod tests {
     #[test]
     fn test_from_parent_process_doenst_crash() {
         let shell = ShellEnum::from_parent_process();
-        println!("Detected shell: {:?}", shell);
+        println!("Detected shell: {shell:?}");
     }
 
     #[test]

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -37,7 +37,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 url = { workspace = true }
 
 [features]
-default = ["libsolv_c"]
+default = ["resolvo"]
 libsolv_c = ["rattler_libsolv_c", "libc"]
 resolvo = ["dep:resolvo", "dep:futures"]
 

--- a/crates/rattler_solve/benches/bench.rs
+++ b/crates/rattler_solve/benches/bench.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, SamplingM
 use rattler_conda_types::ParseStrictness::Strict;
 use rattler_conda_types::{Channel, ChannelConfig, MatchSpec};
 use rattler_repodata_gateway::sparse::SparseRepoData;
-use rattler_solve::{ChannelPriority, SolverImpl, SolverTask};
+use rattler_solve::{SolverImpl, SolverTask};
 
 fn conda_json_path() -> String {
     format!(
@@ -63,13 +63,8 @@ fn bench_solve_environment(c: &mut Criterion, specs: Vec<&str>) {
         b.iter(|| {
             rattler_solve::libsolv_c::Solver
                 .solve(black_box(SolverTask {
-                    available_packages: &available_packages,
-                    locked_packages: vec![],
-                    pinned_packages: vec![],
-                    virtual_packages: vec![],
                     specs: specs.clone(),
-                    timeout: None,
-                    channel_priority: ChannelPriority::Strict,
+                    ..SolverTask::from_iter(&available_packages)
                 }))
                 .unwrap()
         });
@@ -80,13 +75,8 @@ fn bench_solve_environment(c: &mut Criterion, specs: Vec<&str>) {
         b.iter(|| {
             rattler_solve::resolvo::Solver
                 .solve(black_box(SolverTask {
-                    available_packages: &available_packages,
-                    locked_packages: vec![],
-                    pinned_packages: vec![],
-                    virtual_packages: vec![],
                     specs: specs.clone(),
-                    timeout: None,
-                    channel_priority: ChannelPriority::Strict,
+                    ..SolverTask::from_iter(&available_packages)
                 }))
                 .unwrap()
         });

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -8,6 +8,7 @@ pub mod libsolv_c;
 #[cfg(feature = "resolvo")]
 pub mod resolvo;
 
+use chrono::{DateTime, Utc};
 use rattler_conda_types::{GenericVirtualPackage, MatchSpec, RepoDataRecord};
 use std::fmt;
 
@@ -71,10 +72,11 @@ impl fmt::Display for SolveError {
 }
 
 /// Represents the channel priority option to use during solves.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
 pub enum ChannelPriority {
     /// The channel that the package is first found in will be used as the only channel
     /// for that package.
+    #[default]
     Strict,
 
     // Conda also has "Flexible" as an option, where packages present in multiple channels
@@ -121,6 +123,26 @@ pub struct SolverTask<TAvailablePackagesIterator> {
     /// The channel priority to solve with, either [`ChannelPriority::Strict`] or
     /// [`ChannelPriority::Disabled`]
     pub channel_priority: ChannelPriority,
+
+    /// Exclude any package that has a timestamp newer than the specified timestamp.
+    pub exclude_newer: Option<DateTime<Utc>>,
+}
+
+impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
+    for SolverTask<Vec<RepoDataIter<I>>>
+{
+    fn from_iter<T: IntoIterator<Item = I>>(iter: T) -> Self {
+        Self {
+            available_packages: iter.into_iter().map(|iter| RepoDataIter(iter)).collect(),
+            locked_packages: Vec::new(),
+            pinned_packages: Vec::new(),
+            virtual_packages: Vec::new(),
+            specs: Vec::new(),
+            timeout: None,
+            channel_priority: ChannelPriority::default(),
+            exclude_newer: None,
+        }
+    }
 }
 
 /// A representation of a collection of [`RepoDataRecord`] usable by a [`SolverImpl`]

--- a/crates/rattler_solve/src/libsolv_c/input.rs
+++ b/crates/rattler_solve/src/libsolv_c/input.rs
@@ -313,7 +313,7 @@ pub fn cache_repodata(
     // Add repodata to a new pool + repo
     let pool = Pool::default();
     let repo = Repo::new(&pool, url, channel_priority.unwrap_or(0));
-    add_repodata_records(&pool, &repo, data);
+    add_repodata_records(&pool, &repo, data, None);
 
     // Export repo to .solv in memory
     let mut stream_ptr = std::ptr::null_mut();

--- a/crates/rattler_solve/src/libsolv_c/mod.rs
+++ b/crates/rattler_solve/src/libsolv_c/mod.rs
@@ -172,7 +172,12 @@ impl super::SolverImpl for Solver {
             if let Some(solv_file) = repodata.solv_file {
                 add_solv_file(&pool, &repo, solv_file);
             } else {
-                add_repodata_records(&pool, &repo, repodata.records.iter().copied());
+                add_repodata_records(
+                    &pool,
+                    &repo,
+                    repodata.records.iter().copied(),
+                    task.exclude_newer.as_ref(),
+                );
             }
 
             // Keep our own info about repodata_records
@@ -182,7 +187,7 @@ impl super::SolverImpl for Solver {
 
         // Create a special pool for records that are already installed or locked.
         let repo = Repo::new(&pool, "locked", highest_priority);
-        let installed_solvables = add_repodata_records(&pool, &repo, &task.locked_packages);
+        let installed_solvables = add_repodata_records(&pool, &repo, &task.locked_packages, None);
 
         // Also add the installed records to the repodata
         repo_mapping.insert(repo.id(), repo_mapping.len());
@@ -190,7 +195,7 @@ impl super::SolverImpl for Solver {
 
         // Create a special pool for records that are pinned and cannot be changed.
         let repo = Repo::new(&pool, "pinned", highest_priority);
-        let pinned_solvables = add_repodata_records(&pool, &repo, &task.pinned_packages);
+        let pinned_solvables = add_repodata_records(&pool, &repo, &task.pinned_packages, None);
 
         // Also add the installed records to the repodata
         repo_mapping.insert(repo.id(), repo_mapping.len());

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -1,6 +1,7 @@
 //! Provides an solver implementation based on the [`resolvo`] crate.
 
 use crate::{ChannelPriority, IntoRepoData, SolveError, SolverRepoData, SolverTask};
+use chrono::{DateTime, Utc};
 use rattler_conda_types::package::ArchiveType;
 use rattler_conda_types::{
     GenericVirtualPackage, MatchSpec, NamelessMatchSpec, PackageRecord, ParseMatchSpecError,
@@ -170,6 +171,7 @@ pub(crate) struct CondaDependencyProvider<'a> {
 }
 
 impl<'a> CondaDependencyProvider<'a> {
+    #[allow(clippy::too_many_arguments)]
     pub fn from_solver_task(
         repodata: impl IntoIterator<Item = RepoData<'a>>,
         favored_records: &'a [RepoDataRecord],
@@ -178,6 +180,7 @@ impl<'a> CondaDependencyProvider<'a> {
         match_specs: &[MatchSpec],
         stop_time: Option<std::time::SystemTime>,
         channel_priority: ChannelPriority,
+        exclude_newer: Option<DateTime<Utc>>,
     ) -> Self {
         let pool = Rc::new(Pool::default());
         let mut records: HashMap<NameId, Candidates> = HashMap::default();
@@ -205,43 +208,61 @@ impl<'a> CondaDependencyProvider<'a> {
             // different archive types. This can happen if you have two variants of the same package but
             // with different extensions. We prefer `.conda` packages over `.tar.bz`.
             //
-            // Its important to insert the records in the same same order as how they were presented to this
+            // Its important to insert the records in the same order as how they were presented to this
             // function to ensure that each solve is deterministic. Iterating over HashMaps is not
             // deterministic at runtime so instead we store the values in a Vec as we iterate over the
             // records. This guarentees that the order of records remains the same over runs.
             let mut ordered_repodata = Vec::with_capacity(repo_datas.records.len());
-            let mut package_to_type: HashMap<&str, (ArchiveType, usize)> =
+            let mut package_to_type: HashMap<&str, (ArchiveType, usize, bool)> =
                 HashMap::with_capacity(repo_datas.records.len());
 
             for record in repo_datas.records {
+                // Determine if this record will be excluded.
+                let excluded = matches!((&exclude_newer, &record.package_record.timestamp),
+                    (Some(exclude_newer), Some(record_timestamp))
+                        if record_timestamp > exclude_newer);
+
                 let (file_name, archive_type) = ArchiveType::split_str(&record.file_name)
                     .unwrap_or((&record.file_name, ArchiveType::TarBz2));
                 match package_to_type.get_mut(file_name) {
                     None => {
                         let idx = ordered_repodata.len();
                         ordered_repodata.push(record);
-                        package_to_type.insert(file_name, (archive_type, idx));
+                        package_to_type.insert(file_name, (archive_type, idx, excluded));
                     }
-                    Some((prev_archive_type, idx)) => match archive_type.cmp(prev_archive_type) {
-                        Ordering::Greater => {
-                            // A previous package has a worse package "type", we'll use the current record
-                            // instead.
+                    Some((prev_archive_type, idx, previous_excluded)) => {
+                        if *previous_excluded && !excluded {
+                            // The previous package would have been excluded by the solver. If the
+                            // current record won't be excluded we should always use that.
                             *prev_archive_type = archive_type;
                             ordered_repodata[*idx] = record;
-                        }
-                        Ordering::Less => {
-                            // A previous package that we already stored is actually a package of a better
-                            // "type" so we'll just use that instead (.conda > .tar.bz)
-                        }
-                        Ordering::Equal => {
-                            if record != ordered_repodata[*idx] {
-                                unreachable!(
-                                    "found duplicate record with different values for {}",
-                                    &record.file_name
-                                );
+                            *previous_excluded = false;
+                        } else if excluded && !*previous_excluded {
+                            // The previous package would not have been excluded by the solver but
+                            // this one will, so we'll keep the previous one regardless of the type.
+                        } else {
+                            match archive_type.cmp(prev_archive_type) {
+                                Ordering::Greater => {
+                                    // A previous package has a worse package "type", we'll use the current record
+                                    // instead.
+                                    *prev_archive_type = archive_type;
+                                    ordered_repodata[*idx] = record;
+                                }
+                                Ordering::Less => {
+                                    // A previous package that we already stored is actually a package of a better
+                                    // "type" so we'll just use that instead (.conda > .tar.bz)
+                                }
+                                Ordering::Equal => {
+                                    if record != ordered_repodata[*idx] {
+                                        unreachable!(
+                                            "found duplicate record with different values for {}",
+                                            &record.file_name
+                                        );
+                                    }
+                                }
                             }
                         }
-                    },
+                    }
                 }
             }
 
@@ -252,6 +273,19 @@ impl<'a> CondaDependencyProvider<'a> {
                     pool.intern_solvable(package_name, SolverPackageRecord::Record(record));
                 let candidates = records.entry(package_name).or_default();
                 candidates.candidates.push(solvable_id);
+
+                // Filter out any records that are newer than a specific date.
+                match (&exclude_newer, &record.package_record.timestamp) {
+                    (Some(exclude_newer), Some(record_timestamp))
+                        if record_timestamp > exclude_newer =>
+                    {
+                        let reason = pool.intern_string(format!(
+                            "the package is uploaded after the cutoff date of {exclude_newer}"
+                        ));
+                        candidates.excluded.push((solvable_id, reason));
+                    }
+                    _ => {}
+                }
 
                 // Add to excluded when package is not in the specified channel.
                 if !channel_specific_specs.is_empty() {
@@ -449,6 +483,7 @@ impl super::SolverImpl for Solver {
             task.specs.clone().as_ref(),
             stop_time,
             task.channel_priority,
+            task.exclude_newer,
         );
         let pool = provider.pool.clone();
 

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -573,7 +573,7 @@ mod libsolv_c {
                 specs,
                 pinned_packages: Vec::new(),
                 timeout: None,
-                channel_priority: ChannelPriority::default,
+                channel_priority: ChannelPriority::default(),
                 exclude_newer: None,
             })
             .unwrap();

--- a/crates/rattler_solve/tests/snapshots/backends__resolvo__exclude_newer_error.snap
+++ b/crates/rattler_solve/tests/snapshots/backends__resolvo__exclude_newer_error.snap
@@ -1,0 +1,8 @@
+---
+source: crates/rattler_solve/tests/backends.rs
+assertion_line: 663
+expression: result.unwrap_err()
+---
+Cannot solve the request because of: The following packages are incompatible
+└─ foo >=4 cannot be installed because there are no viable options:
+   └─ foo 4.0.2 is excluded because the package is uploaded after the cutoff date of 2021-12-12 12:12:12 UTC

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -448,8 +448,10 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.5",
 ]
 
@@ -2313,6 +2315,7 @@ name = "py-rattler"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "futures",
  "openssl",
  "pep508_rs",
@@ -2344,6 +2347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
 dependencies = [
  "cfg-if",
+ "chrono",
  "indoc",
  "inventory",
  "libc",

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -17,6 +17,7 @@ vendored-openssl = ["openssl", "openssl/vendored"]
 
 [dependencies]
 anyhow = "1.0.82"
+chrono = { version = "0.4" }
 futures = "0.3.30"
 
 rattler = { path = "../crates/rattler", default-features = false }
@@ -35,12 +36,11 @@ rattler_solve = { path = "../crates/rattler_solve", default-features = false, fe
 rattler_index = { path = "../crates/rattler_index" }
 rattler_lock = { path = "../crates/rattler_lock", default-features = false }
 rattler_package_streaming = { path = "../crates/rattler_package_streaming", default-features = false }
-
 pyo3 = { version = "0.20", features = [
     "abi3-py38",
     "extension-module",
     "multiple-pymethods",
-
+    "chrono"
 ] }
 pyo3-asyncio = { version = "0.20", features = ["tokio-runtime"] }
 tokio = { version = "1.37" }

--- a/py-rattler/pixi.toml
+++ b/py-rattler/pixi.toml
@@ -65,6 +65,6 @@ docs = { cmd = "mkdocs serve" }
 build-docs = { cmd = "mkdocs build" }
 
 [environments]
-build = { features = ["build"], solve-group = "default" }
+#build = { features = ["build"], solve-group = "default" }
 test = { features = ["build", "test"], solve-group = "default" }
 docs = ["docs"]

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -24,6 +24,7 @@ async def solve(
     virtual_packages: Optional[List[GenericVirtualPackage]] = None,
     timeout: Optional[datetime.timedelta] = None,
     channel_priority: ChannelPriority = ChannelPriority.Strict,
+    exclude_newer: Optional[datetime.datetime] = None,
 ) -> List[RepoDataRecord]:
     """
     Resolve the dependencies and return the `RepoDataRecord`s
@@ -55,6 +56,7 @@ async def solve(
                          the only channel for that package. When `ChannelPriority.Disabled`
                          it will search for every package in every channel.
         timeout:    The maximum time the solver is allowed to run.
+        exclude_newer: Exclude any record that is newer than the given datetime.
 
     Returns:
         Resolved list of `RepoDataRecord`s.
@@ -77,5 +79,8 @@ async def solve(
             virtual_packages=[v_package._generic_virtual_package for v_package in virtual_packages or []],
             channel_priority=channel_priority.value,
             timeout=timeout.microseconds if timeout else None,
+            exclude_newer_timestamp_ms=int(exclude_newer.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
+            if exclude_newer
+            else None,
         )
     ]

--- a/py-rattler/src/error.rs
+++ b/py-rattler/src/error.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::io;
 
 use pyo3::exceptions::PyException;
@@ -69,55 +70,78 @@ pub enum PyRattlerError {
     GatewayError(#[from] GatewayError),
 }
 
+fn pretty_print_error(mut err: &dyn Error) -> String {
+    let mut result = err.to_string();
+    while let Some(source) = err.source() {
+        result.push_str(&format!("\nCaused by: {}", source));
+        err = source;
+    }
+    result
+}
+
 impl From<PyRattlerError> for PyErr {
     fn from(value: PyRattlerError) -> Self {
         match value {
             PyRattlerError::InvalidVersion(err) => {
-                InvalidVersionException::new_err(err.to_string())
+                InvalidVersionException::new_err(pretty_print_error(&err))
             }
             PyRattlerError::InvalidMatchSpec(err) => {
-                InvalidMatchSpecException::new_err(err.to_string())
+                InvalidMatchSpecException::new_err(pretty_print_error(&err))
             }
             PyRattlerError::InvalidPackageName(err) => {
-                InvalidPackageNameException::new_err(err.to_string())
+                InvalidPackageNameException::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::InvalidUrl(err) => InvalidUrlException::new_err(err.to_string()),
+            PyRattlerError::InvalidUrl(err) => {
+                InvalidUrlException::new_err(pretty_print_error(&err))
+            }
             PyRattlerError::InvalidChannel(err) => {
-                InvalidChannelException::new_err(err.to_string())
+                InvalidChannelException::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::ActivationError(err) => ActivationException::new_err(err.to_string()),
+            PyRattlerError::ActivationError(err) => {
+                ActivationException::new_err(pretty_print_error(&err))
+            }
             PyRattlerError::ParsePlatformError(err) => {
-                ParsePlatformException::new_err(err.to_string())
+                ParsePlatformException::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::ParseArchError(err) => ParseArchException::new_err(err.to_string()),
+            PyRattlerError::ParseArchError(err) => {
+                ParseArchException::new_err(pretty_print_error(&err))
+            }
             PyRattlerError::FetchRepoDataError(err) => {
-                FetchRepoDataException::new_err(err.to_string())
+                FetchRepoDataException::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::CacheDirError(err) => CacheDirException::new_err(err.to_string()),
+            PyRattlerError::CacheDirError(err) => {
+                CacheDirException::new_err(pretty_print_error(err.as_ref()))
+            }
             PyRattlerError::DetectVirtualPackageError(err) => {
-                DetectVirtualPackageException::new_err(err.to_string())
+                DetectVirtualPackageException::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::IoError(err) => IoException::new_err(err.to_string()),
-            PyRattlerError::SolverError(err) => SolverException::new_err(err.to_string()),
-            PyRattlerError::TransactionError(err) => TransactionException::new_err(err.to_string()),
+            PyRattlerError::IoError(err) => IoException::new_err(pretty_print_error(&err)),
+            PyRattlerError::SolverError(err) => SolverException::new_err(pretty_print_error(&err)),
+            PyRattlerError::TransactionError(err) => {
+                TransactionException::new_err(pretty_print_error(&err))
+            }
             PyRattlerError::LinkError(err) => LinkException::new_err(err),
             PyRattlerError::ConverSubdirError(err) => {
-                ConvertSubdirException::new_err(err.to_string())
+                ConvertSubdirException::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::VersionBumpError(err) => VersionBumpException::new_err(err.to_string()),
+            PyRattlerError::VersionBumpError(err) => {
+                VersionBumpException::new_err(pretty_print_error(&err))
+            }
             PyRattlerError::ParseCondaLockError(err) => {
-                ParseCondaLockException::new_err(err.to_string())
+                ParseCondaLockException::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::ConversionError(err) => ConversionException::new_err(err.to_string()),
+            PyRattlerError::ConversionError(err) => {
+                ConversionException::new_err(pretty_print_error(&err))
+            }
             PyRattlerError::RequirementError(err) => RequirementException::new_err(err),
             PyRattlerError::EnvironmentCreationError(err) => {
                 EnvironmentCreationException::new_err(err)
             }
-            PyRattlerError::ExtractError(err) => ExtractException::new_err(err.to_string()),
+            PyRattlerError::ExtractError(err) => ExtractException::new_err(pretty_print_error(&err)),
             PyRattlerError::ActivationScriptFormatError(err) => {
-                ActivationScriptFormatException::new_err(err.to_string())
+                ActivationScriptFormatException::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::GatewayError(err) => GatewayException::new_err(err.to_string()),
+            PyRattlerError::GatewayError(err) => GatewayException::new_err(pretty_print_error(&err)),
         }
     }
 }

--- a/py-rattler/src/error.rs
+++ b/py-rattler/src/error.rs
@@ -137,11 +137,15 @@ impl From<PyRattlerError> for PyErr {
             PyRattlerError::EnvironmentCreationError(err) => {
                 EnvironmentCreationException::new_err(err)
             }
-            PyRattlerError::ExtractError(err) => ExtractException::new_err(pretty_print_error(&err)),
+            PyRattlerError::ExtractError(err) => {
+                ExtractException::new_err(pretty_print_error(&err))
+            }
             PyRattlerError::ActivationScriptFormatError(err) => {
                 ActivationScriptFormatException::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::GatewayError(err) => GatewayException::new_err(pretty_print_error(&err)),
+            PyRattlerError::GatewayError(err) => {
+                GatewayException::new_err(pretty_print_error(&err))
+            }
         }
     }
 }

--- a/py-rattler/tests/conftest.py
+++ b/py-rattler/tests/conftest.py
@@ -23,3 +23,8 @@ def conda_forge_channel(test_data_dir: str) -> Channel:
 @pytest.fixture
 def pytorch_channel(test_data_dir: str) -> Channel:
     return Channel(os.path.join(test_data_dir, "channels/pytorch"))
+
+
+@pytest.fixture
+def dummy_channel(test_data_dir: str) -> Channel:
+    return Channel(os.path.join(test_data_dir, "channels/dummy"))

--- a/py-rattler/tests/unit/test_solver.py
+++ b/py-rattler/tests/unit/test_solver.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 
 from rattler import (
@@ -22,6 +24,42 @@ async def test_solve(gateway: Gateway, conda_forge_channel: Channel) -> None:
     assert isinstance(solved_data[0], RepoDataRecord)
     assert len(solved_data) == 19
 
+
+@pytest.mark.asyncio
+async def test_solve_exclude_newer(
+        gateway: Gateway, dummy_channel: Channel
+) -> None:
+    """Tests the exclude_newer parameter of the solve function.
+
+    The exclude_newer parameter is used to exclude any record that is newer than
+    the given datetime. This test case will exclude the record with version
+    4.0.2 because of the `exclude_newer` argument.
+    """
+    solved_data = await solve(
+        [dummy_channel],
+        ["linux-64"],
+        ["foo"],
+        gateway,
+    )
+
+    assert isinstance(solved_data, list)
+    assert isinstance(solved_data[0], RepoDataRecord)
+    assert len(solved_data) == 1
+    assert str(solved_data[0].version) == "4.0.2"
+
+    # Now solve again but with a datetime that is before the version 4.0.2
+    solved_data = await solve(
+        [dummy_channel],
+        ["linux-64"],
+        ["foo"],
+        gateway,
+        exclude_newer=datetime.datetime.fromisoformat("2021-01-01"),
+    )
+
+    assert isinstance(solved_data, list)
+    assert isinstance(solved_data[0], RepoDataRecord)
+    assert len(solved_data) == 1
+    assert str(solved_data[0].version) == "3.0.2"
 
 @pytest.mark.asyncio
 async def test_solve_channel_priority_disabled(

--- a/test-data/channels/dummy/linux-64/repodata.json
+++ b/test-data/channels/dummy/linux-64/repodata.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5595e82f09b259d06341430f24b8e17509faf19baec90cf80c61ec2ae95085e0
-size 6004
+oid sha256:96bafc092c7633367f27e799ca9fb24106c3a20e5ea7762b015292c3794dceff
+size 5980

--- a/test-data/channels/dummy/linux-64/repodata.json
+++ b/test-data/channels/dummy/linux-64/repodata.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:adf739ba7312a1c7a179b7e9017e8b15e66a1dc08e4151ecca0c88a4f5d7131c
+oid sha256:5595e82f09b259d06341430f24b8e17509faf19baec90cf80c61ec2ae95085e0
 size 6004


### PR DESCRIPTION
Allows setting an `exclude_newer` field on `SolverTask` to exclude any record uploaded after a certain date. This is useful to make repodata from remote source more deterministic.