### PR TITLE
refactor: expose `VersionWithSource`

### DIFF
--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.22.1"
+version = "0.23.0"
 dependencies = [
  "chrono",
  "file_url",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "0.19.3"
+version = "0.19.4"
 dependencies = [
  "blake2",
  "digest",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.19.10"
+version = "0.19.11"
 dependencies = [
  "fs-err",
  "rattler_conda_types",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.5"
+version = "0.22.6"
 dependencies = [
  "chrono",
  "file_url",
@@ -2603,7 +2603,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.20.5"
+version = "0.20.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.20.8"
+version = "0.20.9"
 dependencies = [
  "bzip2",
  "chrono",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.19.11"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2702,7 +2702,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.2.6",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "chrono",
  "futures",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "0.19.9"
+version = "0.19.10"
 dependencies = [
  "archspec",
  "libloading",

--- a/py-rattler/rattler/repo_data/package_record.py
+++ b/py-rattler/rattler/repo_data/package_record.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 import os
 from typing import List, Optional
+
+from rattler import VersionWithSource
 from rattler.match_spec.match_spec import MatchSpec
 from rattler.package.no_arch_type import NoArchType
 from rattler.package.package_name import PackageName
 from rattler.rattler import PyRecord
-from rattler.version.version import Version
 
 
 class PackageRecord:
@@ -433,7 +434,7 @@ class PackageRecord:
         return self._record.track_features
 
     @property
-    def version(self) -> Version:
+    def version(self) -> VersionWithSource:
         """
         The version of the package.
 
@@ -445,11 +446,11 @@ class PackageRecord:
         ...     "../test-data/conda-meta/libsqlite-3.40.0-hcfcfb64_0.json"
         ... )
         >>> record.version
-        Version("3.40.0")
+        VersionWithSource(version="3.40.0", source="3.40.0")
         >>>
         ```
         """
-        return Version._from_py_version(self._record.version)
+        return VersionWithSource._from_py_version(*self._record.version)
 
     def __str__(self) -> str:
         """

--- a/py-rattler/rattler/version/version.py
+++ b/py-rattler/rattler/version/version.py
@@ -17,6 +17,8 @@ class Version:
     Version comparison is case-insensitive.
     """
 
+    _version: PyVersion
+
     def __init__(self, version: str) -> None:
         if isinstance(version, str):
             self._version = PyVersion(version)

--- a/py-rattler/src/record.rs
+++ b/py-rattler/src/record.rs
@@ -223,12 +223,12 @@ impl PyRecord {
 
     /// The version of the package.
     #[getter]
-    pub fn version(&self) -> PyVersion {
-        self.as_package_record()
-            .version
-            .clone()
-            .into_version()
-            .into()
+    pub fn version(&self) -> (PyVersion, String) {
+        let version = &self.as_package_record().version;
+        (
+            version.version().clone().into(),
+            version.as_str().into_owned(),
+        )
     }
 
     /// The filename of the package.

--- a/py-rattler/tests/unit/test_version.py
+++ b/py-rattler/tests/unit/test_version.py
@@ -1,5 +1,5 @@
 import pytest
-from rattler import Version
+from rattler import Version, VersionWithSource
 
 
 def test_version_dash_normalisation() -> None:
@@ -17,3 +17,8 @@ def test_version_dash_normalisation() -> None:
 
     with pytest.raises(Exception):
         Version("1-.0dev+3.4-")
+
+
+def test_compare_with_source() -> None:
+    """Tests that comparing a Version with a VersionWithSource works as expected."""
+    assert Version("1.0") == VersionWithSource("1.00")


### PR DESCRIPTION
`VersionWithSource` already existed. I refactor this to make it derive from `Version`. `PackageRecord` now returns a `VersionWithSource` for the `version` field. This will retain version string information. 

Note that comparing two `VersionWithSource` only compares the versions, not the sources.

Fixes #656