### PR TITLE
feat: solve strategies

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
@@ -5,6 +5,7 @@ expression: file_urls
 ---
 - channels/dummy/linux-64/foobar-2.1-bla_1.tar.bz2
 - channels/dummy/linux-64/bors-2.1-bla_1.tar.bz2
+- channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_2.conda
 - channels/dummy/linux-64/bar-1.0-unix_py36h1af98f8_2.tar.bz2
 - channels/dummy/linux-64/bors-1.0-bla_1.tar.bz2
 - channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_1.conda

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
@@ -153,6 +153,20 @@ expression: json
       "timestamp": 1605110689658,
       "version": "3.0.2"
     },
+    "foo-3.0.2-py36h1af98f8_2.conda": {
+      "build": "py36h1af98f8_2",
+      "build_number": 2,
+      "depends": [],
+      "license": "MIT",
+      "license_family": "MIT",
+      "md5": "fb731d9290f0bcbf3a054665f33ec94f",
+      "name": "foo",
+      "sha256": "67a63bec3fd3205170eaad532d487595b8aaceb9814d13c6858d7bac3ef24cd4",
+      "size": 414494,
+      "subdir": "linux-64",
+      "timestamp": 1715610974,
+      "version": "3.0.2"
+    },
     "foo-4.0.2-py36h1af98f8_2.tar.bz2": {
       "build": "py36h1af98f8_2",
       "build_number": 1,

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
@@ -139,6 +139,19 @@ packages:
     subdir: linux-64
     timestamp: 1605110689658
     version: 3.0.2
+  foo-3.0.2-py36h1af98f8_2.conda:
+    build: py36h1af98f8_2
+    build_number: 2
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: fb731d9290f0bcbf3a054665f33ec94f
+    name: foo
+    sha256: 67a63bec3fd3205170eaad532d487595b8aaceb9814d13c6858d7bac3ef24cd4
+    size: 414494
+    subdir: linux-64
+    timestamp: 1715610974
+    version: 3.0.2
   foo-4.0.2-py36h1af98f8_2.tar.bz2:
     build: py36h1af98f8_2
     build_number: 1

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -126,6 +126,9 @@ pub struct SolverTask<TAvailablePackagesIterator> {
 
     /// Exclude any package that has a timestamp newer than the specified timestamp.
     pub exclude_newer: Option<DateTime<Utc>>,
+
+    /// The solve strategy.
+    pub strategy: SolveStrategy,
 }
 
 impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
@@ -141,8 +144,29 @@ impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
             timeout: None,
             channel_priority: ChannelPriority::default(),
             exclude_newer: None,
+            strategy: SolveStrategy::default(),
         }
     }
+}
+
+/// Represents the strategy to use when solving dependencies
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+pub enum SolveStrategy {
+    /// Resolve the highest version of each package.
+    #[default]
+    Highest,
+
+    /// Resolve the lowest compatible version for each package.
+    ///
+    /// All candidates with the same version are still ordered the same as
+    /// with `Default`. This ensures that the candidate with the highest build
+    /// number is used and downprioritization still works.
+    LowestVersion,
+
+    /// Resolve the lowest compatible version for direct dependencies but the
+    /// highest for transitive dependencies. This is similar to `LowestVersion`
+    /// but only for direct dependencies.
+    LowestVersionDirect,
 }
 
 /// A representation of a collection of [`RepoDataRecord`] usable by a [`SolverImpl`]

--- a/crates/rattler_solve/src/libsolv_c/mod.rs
+++ b/crates/rattler_solve/src/libsolv_c/mod.rs
@@ -1,6 +1,6 @@
 //! Provides an solver implementation based on the [`rattler_libsolv_c`] crate.
 
-use crate::{ChannelPriority, IntoRepoData, SolverRepoData};
+use crate::{ChannelPriority, IntoRepoData, SolveStrategy, SolverRepoData};
 use crate::{SolveError, SolverTask};
 pub use input::cache_repodata;
 use input::{add_repodata_records, add_solv_file, add_virtual_packages};
@@ -94,6 +94,12 @@ impl super::SolverImpl for Solver {
         if task.timeout.is_some() {
             return Err(SolveError::UnsupportedOperations(vec![
                 "timeout".to_string()
+            ]));
+        }
+
+        if task.strategy != SolveStrategy::Highest {
+            return Err(SolveError::UnsupportedOperations(vec![
+                "strategy".to_string()
             ]));
         }
 

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -534,6 +534,7 @@ mod libsolv_c {
     };
     #[allow(unused_imports)] // For some reason windows thinks this is an unused import.
     use rattler_solve::ChannelPriority;
+    use rattler_solve::SolveStrategy;
 
     solver_backend_tests!(rattler_solve::libsolv_c::Solver);
 
@@ -575,6 +576,7 @@ mod libsolv_c {
                 timeout: None,
                 channel_priority: ChannelPriority::default(),
                 exclude_newer: None,
+                strategy: SolveStrategy::default(),
             })
             .unwrap();
 

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -528,11 +528,12 @@ macro_rules! solver_backend_tests {
 
 #[cfg(feature = "libsolv_c")]
 mod libsolv_c {
+    #![allow(unused_imports)] // For some reason windows thinks this is an unused import.
+
     use super::{
         dummy_channel_json_path, installed_package, solve, solve_real_world, FromStr,
         GenericVirtualPackage, SimpleSolveTask, SolveError, Version,
     };
-    #[allow(unused_imports)] // For some reason windows thinks this is an unused import.
     use rattler_solve::ChannelPriority;
     use rattler_solve::SolveStrategy;
 
@@ -587,17 +588,17 @@ mod libsolv_c {
         assert_eq!(1, pkgs.len());
         let info = &pkgs[0];
 
-        assert_eq!("foo-3.0.2-py36h1af98f8_1.conda", info.file_name);
+        assert_eq!("foo-3.0.2-py36h1af98f8_2.conda", info.file_name);
         assert_eq!(
-            "https://conda.anaconda.org/conda-forge/linux-64/foo-3.0.2-py36h1af98f8_1.conda",
+            "https://conda.anaconda.org/conda-forge/linux-64/foo-3.0.2-py36h1af98f8_2.conda",
             info.url.to_string()
         );
         assert_eq!("https://conda.anaconda.org/conda-forge/", info.channel);
         assert_eq!("foo", info.package_record.name.as_normalized());
         assert_eq!("linux-64", info.package_record.subdir);
         assert_eq!("3.0.2", info.package_record.version.to_string());
-        assert_eq!("py36h1af98f8_1", info.package_record.build);
-        assert_eq!(1, info.package_record.build_number);
+        assert_eq!("py36h1af98f8_2", info.package_record.build);
+        assert_eq!(2, info.package_record.build_number);
         assert_eq!(
             rattler_digest::parse_digest_from_hex::<rattler_digest::Sha256>(
                 "67a63bec3fd3205170eaad532d487595b8aaceb9814d13c6858d7bac3ef24cd4"

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -5,7 +5,7 @@ use rattler_conda_types::{
     ParseStrictness, RepoData, RepoDataRecord, Version,
 };
 use rattler_repodata_gateway::sparse::SparseRepoData;
-use rattler_solve::{ChannelPriority, SolveError, SolverImpl, SolverTask};
+use rattler_solve::{ChannelPriority, SolveError, SolveStrategy, SolverImpl, SolverTask};
 use std::str::FromStr;
 use std::time::Instant;
 use url::Url;
@@ -344,17 +344,17 @@ macro_rules! solver_backend_tests {
             assert_eq!(1, pkgs.len());
             let info = &pkgs[0];
 
-            assert_eq!("foo-3.0.2-py36h1af98f8_1.conda", info.file_name);
+            assert_eq!("foo-3.0.2-py36h1af98f8_2.conda", info.file_name);
             assert_eq!(
-                "https://conda.anaconda.org/conda-forge/linux-64/foo-3.0.2-py36h1af98f8_1.conda",
+                "https://conda.anaconda.org/conda-forge/linux-64/foo-3.0.2-py36h1af98f8_2.conda",
                 info.url.to_string()
             );
             assert_eq!("https://conda.anaconda.org/conda-forge/", info.channel);
             assert_eq!("foo", info.package_record.name.as_normalized());
             assert_eq!("linux-64", info.package_record.subdir);
             assert_eq!("3.0.2", info.package_record.version.to_string());
-            assert_eq!("py36h1af98f8_1", info.package_record.build);
-            assert_eq!(1, info.package_record.build_number);
+            assert_eq!("py36h1af98f8_2", info.package_record.build);
+            assert_eq!(2, info.package_record.build_number);
             assert_eq!(
                 rattler_digest::parse_digest_from_hex::<rattler_digest::Sha256>(
                     "67a63bec3fd3205170eaad532d487595b8aaceb9814d13c6858d7bac3ef24cd4"
@@ -662,6 +662,85 @@ mod resolvo {
         // We expect an error here. `bors` is pinnend to 1, but we try to install `>=2`.
         insta::assert_snapshot!(result.unwrap_err());
     }
+
+    #[test]
+    fn test_lowest_version_strategy_highest_build_number() {
+        let result = solve::<rattler_solve::resolvo::Solver>(
+            dummy_channel_json_path(),
+            SimpleSolveTask {
+                specs: &["foo"],
+                strategy: rattler_solve::SolveStrategy::LowestVersion,
+                ..SimpleSolveTask::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0].package_record.version,
+            Version::from_str("3.0.2").unwrap()
+        );
+        assert_eq!(
+            result[0].package_record.build_number, 2,
+            "expected the highest build number"
+        );
+    }
+
+    #[test]
+    fn test_lowest_version_strategy_all() {
+        let result = solve::<rattler_solve::resolvo::Solver>(
+            dummy_channel_json_path(),
+            SimpleSolveTask {
+                specs: &["foobar"],
+                strategy: rattler_solve::SolveStrategy::LowestVersion,
+                ..SimpleSolveTask::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].package_record.name.as_normalized(), "foobar");
+        assert_eq!(
+            result[0].package_record.version,
+            Version::from_str("2.0").unwrap(),
+            "expected lowest version of foobar"
+        );
+
+        assert_eq!(result[1].package_record.name.as_normalized(), "bors");
+        assert_eq!(
+            result[1].package_record.version,
+            Version::from_str("1.0").unwrap(),
+            "expected lowest version of bors"
+        );
+    }
+
+    #[test]
+    fn test_lowest_direct_version_strategy() {
+        let result = solve::<rattler_solve::resolvo::Solver>(
+            dummy_channel_json_path(),
+            SimpleSolveTask {
+                specs: &["foobar"],
+                strategy: rattler_solve::SolveStrategy::LowestVersionDirect,
+                ..SimpleSolveTask::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].package_record.name.as_normalized(), "foobar");
+        assert_eq!(
+            result[0].package_record.version,
+            Version::from_str("2.0").unwrap(),
+            "expected lowest version of foobar"
+        );
+
+        assert_eq!(result[1].package_record.name.as_normalized(), "bors");
+        assert_eq!(
+            result[1].package_record.version,
+            Version::from_str("1.2.1").unwrap(),
+            "expected highest compatible version of bors"
+        );
+    }
 }
 
 #[derive(Default)]
@@ -671,6 +750,7 @@ struct SimpleSolveTask<'a> {
     pinned_packages: Vec<RepoDataRecord>,
     virtual_packages: Vec<GenericVirtualPackage>,
     exclude_newer: Option<DateTime<Utc>>,
+    strategy: SolveStrategy,
 }
 
 fn solve<T: SolverImpl + Default>(
@@ -691,6 +771,7 @@ fn solve<T: SolverImpl + Default>(
         specs,
         pinned_packages: task.pinned_packages,
         exclude_newer: task.exclude_newer,
+        strategy: task.strategy,
         ..SolverTask::from_iter([&repo_data])
     };
 

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -18,17 +18,17 @@ SolveStrategy = Literal["highest", "lowest", "lowest-direct"]
 
 
 async def solve(
-        channels: List[Channel | str],
-        platforms: List[Platform | PlatformLiteral],
-        specs: List[MatchSpec | str],
-        gateway: Gateway,
-        locked_packages: Optional[List[RepoDataRecord]] = None,
-        pinned_packages: Optional[List[RepoDataRecord]] = None,
-        virtual_packages: Optional[List[GenericVirtualPackage]] = None,
-        timeout: Optional[datetime.timedelta] = None,
-        channel_priority: ChannelPriority = ChannelPriority.Strict,
-        exclude_newer: Optional[datetime.datetime] = None,
-        strategy: SolveStrategy = "highest",
+    channels: List[Channel | str],
+    platforms: List[Platform | PlatformLiteral],
+    specs: List[MatchSpec | str],
+    gateway: Gateway,
+    locked_packages: Optional[List[RepoDataRecord]] = None,
+    pinned_packages: Optional[List[RepoDataRecord]] = None,
+    virtual_packages: Optional[List[GenericVirtualPackage]] = None,
+    timeout: Optional[datetime.timedelta] = None,
+    channel_priority: ChannelPriority = ChannelPriority.Strict,
+    exclude_newer: Optional[datetime.datetime] = None,
+    strategy: SolveStrategy = "highest",
 ) -> List[RepoDataRecord]:
     """
     Resolve the dependencies and return the `RepoDataRecord`s
@@ -77,26 +77,22 @@ async def solve(
         RepoDataRecord._from_py_record(solved_package)
         for solved_package in await py_solve(
             channels=[
-                channel._channel if isinstance(channel, Channel) else Channel(channel)._channel for
-                channel in channels
+                channel._channel if isinstance(channel, Channel) else Channel(channel)._channel for channel in channels
             ],
             platforms=[
                 platform._inner if isinstance(platform, Platform) else Platform(platform)._inner
                 for platform in platforms
             ],
-            specs=[spec._match_spec if isinstance(spec, MatchSpec) else PyMatchSpec(str(spec), True)
-                   for spec in specs],
+            specs=[spec._match_spec if isinstance(spec, MatchSpec) else PyMatchSpec(str(spec), True) for spec in specs],
             gateway=gateway._gateway,
             locked_packages=[package._record for package in locked_packages or []],
             pinned_packages=[package._record for package in pinned_packages or []],
-            virtual_packages=[v_package._generic_virtual_package for v_package in
-                              virtual_packages or []],
+            virtual_packages=[v_package._generic_virtual_package for v_package in virtual_packages or []],
             channel_priority=channel_priority.value,
             timeout=timeout.microseconds if timeout else None,
-            exclude_newer_timestamp_ms=int(
-                exclude_newer.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
+            exclude_newer_timestamp_ms=int(exclude_newer.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
             if exclude_newer
             else None,
-            strategy=strategy
+            strategy=strategy,
         )
     ]

--- a/py-rattler/src/error.rs
+++ b/py-rattler/src/error.rs
@@ -73,7 +73,7 @@ pub enum PyRattlerError {
 fn pretty_print_error(mut err: &dyn Error) -> String {
     let mut result = err.to_string();
     while let Some(source) = err.source() {
-        result.push_str(&format!("\nCaused by: {}", source));
+        result.push_str(&format!("\nCaused by: {source}"));
         err = source;
     }
     result

--- a/py-rattler/tests/unit/test_solver.py
+++ b/py-rattler/tests/unit/test_solver.py
@@ -62,6 +62,44 @@ async def test_solve_exclude_newer(
     assert str(solved_data[0].version) == "3.0.2"
 
 @pytest.mark.asyncio
+async def test_solve_lowest(gateway: Gateway, dummy_channel: Channel) -> None:
+    solved_data = await solve(
+        [dummy_channel],
+        ["linux-64"],
+        ["foobar"],
+        gateway,
+        strategy="lowest",
+    )
+
+    assert isinstance(solved_data, list)
+    assert len(solved_data) == 2
+
+    assert solved_data[0].name.normalized == "foobar"
+    assert str(solved_data[0].version) == "2.0"
+
+    assert solved_data[1].name.normalized == "bors"
+    assert str(solved_data[1].version) == "1.0"
+
+@pytest.mark.asyncio
+async def test_solve_lowest_direct(gateway: Gateway, dummy_channel: Channel) -> None:
+    solved_data = await solve(
+        [dummy_channel],
+        ["linux-64"],
+        ["foobar"],
+        gateway,
+        strategy="lowest-direct",
+    )
+
+    assert isinstance(solved_data, list)
+    assert len(solved_data) == 2
+
+    assert solved_data[0].name.normalized == "foobar"
+    assert str(solved_data[0].version) == "2.0"
+
+    assert solved_data[1].name.normalized == "bors"
+    assert str(solved_data[1].version) == "1.2.1"
+
+@pytest.mark.asyncio
 async def test_solve_channel_priority_disabled(
     gateway: Gateway, pytorch_channel: Channel, conda_forge_channel: Channel
 ) -> None:

--- a/test-data/channels/dummy/linux-64/repodata.json
+++ b/test-data/channels/dummy/linux-64/repodata.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:96bafc092c7633367f27e799ca9fb24106c3a20e5ea7762b015292c3794dceff
-size 5980
+oid sha256:6f16d1a6808f25793113cd440508af5a8ff2bedc518befb021ecec64855e91e2
+size 6424


### PR DESCRIPTION
Implements solver strategies:

- `Highest` (default): Solve all packages to the highest compatible version.
- `LowestVersion`: Solve all packages to the lowest compatible version. This only looks at the version. This ensures that build number ordering and downprioritization remain functional.
- `LowestVersionDirect`: Solve for the lowest compatible version, similar to `LowestVersion`, but only for direct dependencies. Transitive dependencies are still sorted using the `Highest` strategy.

This is only implemented when using resolvo. When using a non-default strategy with libsolv you will get an `Unsupported` error.

This is also implemented into the binary:

```
> cargo run -- create --dry-run 'python>2' --platform linux-64 --strategy highest
+ _libgcc_mutex 0.1 conda_forge
+ libgomp 13.2.0 h77fa898_7
+ _openmp_mutex 4.5 2_gnu
+ libgcc-ng 13.2.0 h77fa898_7
+ xz 5.2.6 h166bdaf_0
+ tzdata 2024a h0c530f3_0
+ libzlib 1.2.13 hd590300_5
+ tk 8.6.13 noxft_h4845f30_101
+ ncurses 6.5 h59595ed_0
+ readline 8.2 h8228510_1
+ ca-certificates 2024.2.2 hbcca054_0
+ openssl 3.3.0 hd590300_0
+ libxcrypt 4.4.36 hd590300_1
+ libuuid 2.38.1 h0b41bf4_0
+ libsqlite 3.45.3 h2797004_0
+ libnsl 2.0.1 hd590300_0
+ libffi 3.4.2 h7f98852_5
+ libexpat 2.6.2 h59595ed_0
+ ld_impl_linux-64 2.40 h55db66e_0
+ bzip2 1.0.8 hd590300_5
+ python 3.12.3 hab00c5b_0_cpython
```

```
> cargo run -- create --dry-run 'python>2' --platform linux-64 --strategy lowest
+ zlib 1.2.8 3
+ tk 8.5.19 2
+ sqlite 3.13.0 1
+ ncurses 5.9 10
+ readline 6.2 0
+ ca-certificates 2016.2.28 0
+ openssl 1.0.2h 3
+ python 2.6.9 0
```

```
> cargo run -- create --dry-run 'python>2' --platform linux-64 --strategy lowest-direct
+ _libgcc_mutex 0.1 conda_forge
+ libgomp 13.2.0 h77fa898_7
+ _openmp_mutex 4.5 2_gnu
+ libgcc-ng 13.2.0 h77fa898_7
+ libzlib 1.2.13 hd590300_5
+ zlib 1.2.13 hd590300_5
+ tk 8.5.19 2
+ sqlite 3.13.0 1
+ ncurses 5.9 10
+ readline 6.2 0
+ ca-certificates 2024.2.2 hbcca054_0
+ openssl 1.0.2u h516909a_0
+ python 2.6.9 0
```

Note that Im using `python>2` because there is also a `python 1.0.1` on conda-forge.

Fixes #330 