### PR TITLE
refactor: introducing the installer

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -28,7 +28,7 @@ console = { workspace = true, features = ["windows-console-colors"] }
 futures = { workspace = true }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.25.0", default-features = false }
+rattler = { path="../rattler", version = "0.25.0", default-features = false, features = ["indicatif"] }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.23.1", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.7", default-features = false }
 rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.20.1", default-features = false, features = ["gateway"] }

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -254,7 +254,7 @@ pub async fn create(opt: Opt) -> anyhow::Result<()> {
         .with_download_client(download_client)
         .with_target_platform(install_platform)
         .with_installed_packages(installed_packages)
-        .execute_link_scripts(true)
+        .with_execute_link_scripts(true)
         .with_reporter(
             IndicatifReporter::builder()
                 .with_multi_progress(global_multi_progress())

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -15,6 +15,7 @@ default = ['native-tls']
 native-tls = ['reqwest/native-tls', 'rattler_package_streaming/native-tls']
 rustls-tls = ['reqwest/rustls-tls', 'rattler_package_streaming/rustls-tls']
 cli-tools = ['dep:clap']
+indicatif = ['dep:indicatif', 'dep:console']
 
 [dependencies]
 anyhow = { workspace = true }
@@ -27,6 +28,7 @@ fs-err = { workspace = true }
 futures = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true }
+indicatif = { workspace = true, optional = true }
 itertools = { workspace = true }
 memchr = { workspace = true }
 memmap2 = { workspace = true }
@@ -50,6 +52,7 @@ tokio-stream = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 uuid = { workspace = true, features = ["v4", "fast-rng"] }
+console = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -31,16 +31,18 @@ itertools = { workspace = true }
 memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.23.1", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.7", default-features = false }
-rattler_shell = { path="../rattler_shell", version = "0.20.4", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.10", default-features = false, features = ["reqwest"] }
+parking_lot = { workspace = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.23.1", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.20.7", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.20.4", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.20.10", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }
 reqwest-middleware = { workspace = true }
 smallvec = { workspace = true }
+simple_spawn_blocking = { path = "../simple_spawn_blocking", version = "1.0", default-features = false }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "io-util", "macros"] }

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -44,7 +44,7 @@ regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }
 reqwest-middleware = { workspace = true }
 smallvec = { workspace = true }
-simple_spawn_blocking = { path = "../simple_spawn_blocking", version = "1.0", default-features = false }
+simple_spawn_blocking = { path = "../simple_spawn_blocking", version = "1.0", default-features = false, features = ["tokio"] }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "io-util", "macros"] }

--- a/crates/rattler/src/install/clobber_registry.rs
+++ b/crates/rattler/src/install/clobber_registry.rs
@@ -29,7 +29,7 @@ fn clobber_template(package_name: &PackageName) -> String {
 
 impl ClobberRegistry {
     /// Create a new clobber registry that is initialized with the given prefix records.
-    pub fn from_prefix_records(prefix_records: &[PrefixRecord]) -> Self {
+    pub fn from_prefix_records<'i>(prefix_records: impl IntoIterator<Item=&'i PrefixRecord>) -> Self {
         let mut registry = Self::default();
 
         let mut temp_clobbers = Vec::new();

--- a/crates/rattler/src/install/clobber_registry.rs
+++ b/crates/rattler/src/install/clobber_registry.rs
@@ -29,7 +29,9 @@ fn clobber_template(package_name: &PackageName) -> String {
 
 impl ClobberRegistry {
     /// Create a new clobber registry that is initialized with the given prefix records.
-    pub fn from_prefix_records<'i>(prefix_records: impl IntoIterator<Item=&'i PrefixRecord>) -> Self {
+    pub fn from_prefix_records<'i>(
+        prefix_records: impl IntoIterator<Item = &'i PrefixRecord>,
+    ) -> Self {
         let mut registry = Self::default();
 
         let mut temp_clobbers = Vec::new();

--- a/crates/rattler/src/install/driver.rs
+++ b/crates/rattler/src/install/driver.rs
@@ -1,18 +1,19 @@
 use super::clobber_registry::ClobberRegistry;
-use super::link_script::PrePostLinkResult;
+use super::link_script::{PrePostLinkError, PrePostLinkResult};
 use super::unlink::{recursively_remove_empty_directories, UnlinkError};
-use super::{InstallError, Transaction};
+use super::{Transaction};
 use indexmap::IndexSet;
 use itertools::Itertools;
 use rattler_conda_types::prefix_record::PathType;
 use rattler_conda_types::{PackageRecord, PrefixRecord};
+use simple_spawn_blocking::tokio::run_blocking_task;
+use simple_spawn_blocking::Cancelled;
 use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::MutexGuard;
 use std::sync::{Arc, Mutex};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore};
-use tokio::task::JoinError;
 
 /// Packages can mostly be installed in isolation and therefor in parallel. However, when installing
 /// a large number of packages at the same time the different installation tasks start competing for
@@ -65,7 +66,10 @@ impl InstallDriverBuilder {
 
     /// Sets the prefix records that are present in the current environment.
     /// This is used to initialize the clobber registry.
-    pub fn with_prefix_records(self, prefix_records: &[PrefixRecord]) -> Self {
+    pub fn with_prefix_records<'i>(
+        self,
+        prefix_records: impl IntoIterator<Item = &'i PrefixRecord>,
+    ) -> Self {
         Self {
             clobber_registry: Some(ClobberRegistry::from_prefix_records(prefix_records)),
             ..self
@@ -119,7 +123,7 @@ impl InstallDriver {
         &self,
         transaction: &Transaction<Old, New>,
         target_prefix: &Path,
-    ) -> Result<Option<PrePostLinkResult>, InstallError> {
+    ) -> Result<Option<PrePostLinkResult>, PrePostLinkError> {
         if self.execute_link_scripts {
             match self.run_pre_unlink_scripts(transaction, target_prefix) {
                 Ok(res) => {
@@ -139,26 +143,19 @@ impl InstallDriver {
     /// more IO resources than the system has available.
     pub async fn run_blocking_io_task<
         T: Send + 'static,
-        E: Send + Into<InstallError> + 'static,
+        E: Send + From<Cancelled> + 'static,
         F: FnOnce() -> Result<T, E> + Send + 'static,
     >(
         &self,
         f: F,
-    ) -> Result<T, InstallError> {
-        let _permit = self
-            .acquire_io_permit()
-            .await
-            .map_err(|_err| InstallError::Cancelled)?;
+    ) -> Result<T, E> {
+        let permit = self.acquire_io_permit().await.map_err(|_err| Cancelled)?;
 
-        // Execute the task as a blocking task
-        match tokio::task::spawn_blocking(f)
-            .await
-            .map_err(JoinError::try_into_panic)
-        {
-            Ok(result) => result.map_err(Into::into),
-            Err(Ok(payload)) => std::panic::resume_unwind(payload),
-            Err(Err(_err)) => Err(InstallError::Cancelled),
-        }
+        run_blocking_task(move || {
+            let _permit = permit;
+            f()
+        })
+        .await
     }
 
     /// Call this after all packages have been installed to perform any post processing that is
@@ -170,9 +167,9 @@ impl InstallDriver {
         &self,
         transaction: &Transaction<Old, New>,
         target_prefix: &Path,
-    ) -> Result<Option<PrePostLinkResult>, InstallError> {
+    ) -> Result<Option<PrePostLinkResult>, PrePostLinkError> {
         let prefix_records = PrefixRecord::collect_from_prefix(target_prefix)
-            .map_err(InstallError::PostProcessFailed)?;
+            .map_err(PrePostLinkError::FailedToDetectInstalledPackages)?;
 
         let required_packages =
             PackageRecord::sort_topologically(prefix_records.iter().collect::<Vec<_>>());

--- a/crates/rattler/src/install/driver.rs
+++ b/crates/rattler/src/install/driver.rs
@@ -1,7 +1,7 @@
 use super::clobber_registry::ClobberRegistry;
 use super::link_script::{PrePostLinkError, PrePostLinkResult};
 use super::unlink::{recursively_remove_empty_directories, UnlinkError};
-use super::{Transaction};
+use super::Transaction;
 use indexmap::IndexSet;
 use itertools::Itertools;
 use rattler_conda_types::prefix_record::PathType;

--- a/crates/rattler/src/install/installer/error.rs
+++ b/crates/rattler/src/install/installer/error.rs
@@ -1,0 +1,51 @@
+use crate::install::link_script::PrePostLinkError;
+use crate::install::unlink::UnlinkError;
+use crate::install::{InstallError, TransactionError};
+use crate::package_cache::PackageCacheError;
+use simple_spawn_blocking::Cancelled;
+
+/// An error returned by the installer
+#[derive(Debug, thiserror::Error)]
+pub enum InstallerError {
+    /// Failed to determine the currently installed packages.
+    #[error("failed to determine the currently installed packages")]
+    FailedToDetectInstalledPackages(#[source] std::io::Error),
+
+    /// Failed to construct a transaction
+    #[error("failed to construct a transaction")]
+    FailedToConstructTransaction(#[from] TransactionError),
+
+    /// Failed to populate the cache with the package
+    #[error("failed to fetch {0}")]
+    FailedToFetch(String, #[source] PackageCacheError),
+
+    /// Failed to link a certain package
+    #[error("failed to link {0}")]
+    LinkError(String, #[source] InstallError),
+
+    /// Failed to unlink a certain package
+    #[error("failed to unlink {0}")]
+    UnlinkError(String, #[source] UnlinkError),
+
+    /// A generic IO error occured
+    #[error("{0}")]
+    IoError(String, #[source] std::io::Error),
+
+    /// Failed to run a pre-link script
+    #[error("pre-processing failed")]
+    PreProcessingFailed(#[source] PrePostLinkError),
+
+    /// Failed to run a post-link script
+    #[error("post-processing failed")]
+    PostProcessingFailed(#[source] PrePostLinkError),
+
+    /// The operation was cancelled
+    #[error("the operation was cancelled")]
+    Cancelled,
+}
+
+impl From<Cancelled> for InstallerError {
+    fn from(_: Cancelled) -> Self {
+        InstallerError::Cancelled
+    }
+}

--- a/crates/rattler/src/install/installer/indicatif.rs
+++ b/crates/rattler/src/install/installer/indicatif.rs
@@ -1,0 +1,374 @@
+use crate::install::{Reporter, Transaction};
+use indicatif::{HumanBytes, MultiProgress, ProgressFinish, ProgressState};
+use parking_lot::Mutex;
+use rattler_conda_types::{PrefixRecord, RepoDataRecord};
+use std::borrow::Cow;
+use std::fmt::Write;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// A builder to construct an [`IndicatifReporter`].
+#[derive(Clone)]
+pub struct IndicatifReporterBuilder {
+    multi_progress: Option<indicatif::MultiProgress>,
+    progress_chars: Cow<'static, str>,
+    clear_when_done: bool,
+    pending_style: Option<indicatif::ProgressStyle>,
+    default_style: Option<indicatif::ProgressStyle>,
+    default_pending_style: Option<indicatif::ProgressStyle>,
+    download_style: Option<indicatif::ProgressStyle>,
+    finish_style: Option<indicatif::ProgressStyle>,
+}
+
+impl IndicatifReporterBuilder {
+    /// Sets the [`indicatif::MultiProgress`] to use for the progress bars.
+    pub fn with_multi_progress(self, multi_progress: indicatif::MultiProgress) -> Self {
+        Self {
+            multi_progress: Some(multi_progress),
+            ..self
+        }
+    }
+
+    /// Sets whether the progress bars are cleared when the transaction is complete.
+    pub fn clear_when_done(self, clear_when_done: bool) -> Self {
+        Self {
+            clear_when_done,
+            ..self
+        }
+    }
+
+    /// Finish building [`IndicatifReporter`].
+    pub fn finish(self) -> IndicatifReporter {
+        let multi_progress = self.multi_progress.unwrap_or_default();
+
+        let pending_style = indicatif::ProgressStyle::with_template(
+            "{spinner:.dim} {prefix:20!} [{elapsed_precise}] {msg:.dim}",
+        )
+        .expect("failed to create pending style");
+
+        let default_style = indicatif::ProgressStyle::with_template("{spinner:.green} {prefix:20!} [{elapsed_precise}] [{bar:20!.bright.yellow/dim.white}] {pos:>4}/{len:4} {msg:.dim}")
+            .expect("failed to create default style")
+            .progress_chars(&self.progress_chars);
+
+        let default_pending_style = indicatif::ProgressStyle::with_template("{spinner:.dim} {prefix:20!} [{elapsed_precise}] [{bar:20!.bright.yellow/dim.white}] {pos:>4}/{len:4} {msg:.dim}")
+            .expect("failed to create default style")
+            .progress_chars(&self.progress_chars);
+
+        let download_style = indicatif::ProgressStyle::
+            with_template("{spinner:.green} {prefix:20!} [{elapsed_precise}] [{bar:20!.bright.yellow/dim.white}] {bytes:>8} @ {smoothed_bytes_per_sec:8}").expect("failed to create download style")
+            .progress_chars(&self.progress_chars)
+            .with_key(
+                "smoothed_bytes_per_sec",
+                |s: &ProgressState, w: &mut dyn Write| match (s.pos(), s.elapsed().as_millis()) {
+                    (pos, elapsed_ms) if elapsed_ms > 0 => {
+                        write!(w, "{}/s", HumanBytes((pos as f64 * 1000_f64 / elapsed_ms as f64) as u64)).unwrap();
+                    }
+                    _ => write!(w, "-").unwrap(),
+                },
+            );
+
+        let finish_style = indicatif::ProgressStyle::with_template(&format!(
+            "{} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold}}",
+            console::style(console::Emoji("✔", " ")).green()
+        ))
+        .expect("failed to create finish style");
+
+        IndicatifReporter {
+            inner: Arc::new(Mutex::new(IndicatifReporterInner {
+                multi_progress,
+                pending_style: self.pending_style.unwrap_or(pending_style),
+                default_pending_style: self
+                    .default_pending_style
+                    .clone()
+                    .or_else(|| self.default_style.clone())
+                    .unwrap_or(default_pending_style),
+                default_style: self.default_style.unwrap_or(default_style),
+                download_style: self.download_style.unwrap_or(download_style),
+                finish_style: self.finish_style.unwrap_or(finish_style),
+                validation_progress: None,
+                download_progress: None,
+                link_progress: None,
+                total_packages_to_cache: 0,
+                total_packages_cached: 0,
+                total_download_size: 0,
+                clear_when_done: self.clear_when_done,
+                operations_in_progress: 0,
+                bytes_downloaded: Vec::new(),
+                package_sizes: Vec::new(),
+            })),
+        }
+    }
+}
+
+/// A [`Reporter`] implementation to outputs progress bars using indicatif.
+pub struct IndicatifReporter {
+    inner: Arc<Mutex<IndicatifReporterInner>>,
+}
+
+struct IndicatifReporterInner {
+    multi_progress: MultiProgress,
+
+    pending_style: indicatif::ProgressStyle,
+    default_style: indicatif::ProgressStyle,
+    default_pending_style: indicatif::ProgressStyle,
+    download_style: indicatif::ProgressStyle,
+    finish_style: indicatif::ProgressStyle,
+
+    validation_progress: Option<indicatif::ProgressBar>,
+    download_progress: Option<indicatif::ProgressBar>,
+    link_progress: Option<indicatif::ProgressBar>,
+
+    clear_when_done: bool,
+    operations_in_progress: usize,
+
+    total_packages_to_cache: usize,
+    total_packages_cached: usize,
+
+    total_download_size: usize,
+    bytes_downloaded: Vec<usize>,
+
+    package_sizes: Vec<usize>,
+}
+
+impl IndicatifReporter {
+    /// Returns a builder to construct a [`IndicatifReporter`].
+    pub fn builder() -> IndicatifReporterBuilder {
+        IndicatifReporterBuilder {
+            multi_progress: None,
+            progress_chars: Cow::Borrowed("━━╾─"),
+            pending_style: None,
+            default_style: None,
+            default_pending_style: None,
+            download_style: None,
+            finish_style: None,
+            clear_when_done: false,
+        }
+    }
+}
+
+impl Default for IndicatifReporter {
+    fn default() -> Self {
+        Self::builder().finish()
+    }
+}
+
+impl Reporter for IndicatifReporter {
+    fn on_transaction_start(&self, transaction: &Transaction<PrefixRecord, RepoDataRecord>) {
+        let mut inner = self.inner.lock();
+
+        let validation_progress = inner
+            .multi_progress
+            .add(indicatif::ProgressBar::new(0))
+            .with_style(inner.pending_style.clone())
+            .with_prefix("validate cache")
+            .with_finish(ProgressFinish::AndLeave);
+        validation_progress.enable_steady_tick(Duration::from_millis(100));
+
+        let download_progress = inner
+            .multi_progress
+            .insert_after(&validation_progress, indicatif::ProgressBar::new(0))
+            .with_style(inner.pending_style.clone())
+            .with_prefix("download & extract")
+            .with_finish(ProgressFinish::AndLeave);
+        download_progress.enable_steady_tick(Duration::from_millis(100));
+
+        let link_progress = inner
+            .multi_progress
+            .insert_after(&download_progress, indicatif::ProgressBar::new(0))
+            .with_style(inner.pending_style.clone())
+            .with_prefix("update prefix")
+            .with_finish(ProgressFinish::AndLeave);
+        link_progress.enable_steady_tick(Duration::from_millis(100));
+
+        inner.total_packages_to_cache = transaction.packages_to_install();
+        inner.total_packages_cached = 0;
+
+        validation_progress.set_length(transaction.packages_to_install() as u64);
+        download_progress.set_length(0);
+        link_progress.set_length(
+            (transaction.packages_to_install() + transaction.packages_to_uninstall()) as u64,
+        );
+
+        inner.validation_progress = Some(validation_progress);
+        inner.download_progress = Some(download_progress);
+        inner.link_progress = Some(link_progress);
+    }
+
+    fn on_transaction_operation_start(&self, _operation: usize) {}
+
+    fn on_populate_cache_start(&self, operation: usize, record: &RepoDataRecord) -> usize {
+        let mut inner = self.inner.lock();
+
+        // Record the size of the record if we would download it.
+        let new_length = inner.package_sizes.len().max(operation + 1);
+        inner.package_sizes.resize_with(new_length, || 0);
+        inner.package_sizes[operation] = record.package_record.size.unwrap_or_default() as usize;
+
+        operation
+    }
+
+    fn on_validate_start(&self, _cache_entry: usize) -> usize {
+        let inner = self.inner.lock();
+
+        inner
+            .validation_progress
+            .as_ref()
+            .expect("progress bar not set")
+            .set_style(inner.default_style.clone());
+
+        0
+    }
+
+    fn on_validate_complete(&self, _index: usize) {
+        let inner = self.inner.lock();
+        let validation_progress = inner
+            .validation_progress
+            .as_ref()
+            .expect("progress bar not set");
+
+        validation_progress.inc(1);
+        if validation_progress.length() == Some(validation_progress.position()) {
+            validation_progress.set_style(inner.finish_style.clone());
+            validation_progress.finish_using_style();
+        }
+    }
+
+    fn on_download_start(&self, cache_entry: usize) -> usize {
+        let mut inner = self.inner.lock();
+
+        let new_length = inner.package_sizes.len().max(cache_entry + 1);
+        inner.bytes_downloaded.resize_with(new_length, || 0);
+        inner.bytes_downloaded[cache_entry] = 0;
+        inner.total_download_size += inner.package_sizes[cache_entry];
+
+        let download_progress = inner
+            .download_progress
+            .as_ref()
+            .expect("progress bar not set");
+        download_progress.set_style(inner.download_style.clone());
+        download_progress.set_length(inner.total_download_size as u64);
+        cache_entry
+    }
+
+    fn on_download_progress(&self, cache_entry: usize, progress: u64, _total: Option<u64>) {
+        let mut inner = self.inner.lock();
+
+        inner.bytes_downloaded[cache_entry] = progress as usize;
+        inner
+            .download_progress
+            .as_ref()
+            .expect("progress bar not set")
+            .set_position(inner.bytes_downloaded.iter().copied().sum::<usize>() as _);
+    }
+
+    fn on_download_completed(&self, _index: usize) {}
+
+    fn on_populate_cache_complete(&self, _cache_entry: usize) {
+        let mut inner = self.inner.lock();
+
+        inner.total_packages_cached += 1;
+        if inner.total_packages_cached >= inner.total_packages_to_cache {
+            let validation_progress = inner
+                .validation_progress
+                .as_ref()
+                .expect("progress bar not set");
+            validation_progress.set_style(inner.finish_style.clone());
+            validation_progress.finish_using_style();
+
+            let download_progress = inner
+                .download_progress
+                .as_ref()
+                .expect("progress bar not set");
+
+            download_progress.set_style(inner.finish_style.clone());
+            download_progress.finish_using_style();
+        }
+    }
+
+    fn on_unlink_start(&self, _operation: usize, _record: &PrefixRecord) -> usize {
+        let mut inner = self.inner.lock();
+
+        inner.operations_in_progress += 1;
+
+        if inner.operations_in_progress == 1 {
+            inner
+                .link_progress
+                .as_ref()
+                .expect("progress bar not set")
+                .set_style(inner.default_style.clone());
+        }
+
+        0
+    }
+
+    fn on_unlink_complete(&self, _index: usize) {
+        let mut inner = self.inner.lock();
+        let link_progress = inner.link_progress.as_ref().expect("progress bar not set");
+        link_progress.inc(1);
+
+        inner.operations_in_progress -= 1;
+        if inner.operations_in_progress == 0 {
+            let link_progress = inner.link_progress.as_ref().expect("progress bar not set");
+            link_progress.set_style(inner.default_pending_style.clone());
+        }
+    }
+
+    fn on_link_start(&self, _operation: usize, _record: &RepoDataRecord) -> usize {
+        let mut inner = self.inner.lock();
+
+        inner.operations_in_progress += 1;
+        if inner.operations_in_progress == 1 {
+            inner
+                .link_progress
+                .as_ref()
+                .expect("progress bar not set")
+                .set_style(inner.default_style.clone());
+        }
+
+        0
+    }
+
+    fn on_link_complete(&self, _index: usize) {
+        let mut inner = self.inner.lock();
+        let link_progress = inner.link_progress.as_ref().expect("progress bar not set");
+        link_progress.inc(1);
+
+        inner.operations_in_progress -= 1;
+        if inner.operations_in_progress == 0 {
+            let link_progress = inner.link_progress.as_ref().expect("progress bar not set");
+            link_progress.set_style(inner.default_pending_style.clone());
+        }
+    }
+
+    fn on_transaction_operation_complete(&self, _operation: usize) {}
+
+    fn on_transaction_complete(&self) {
+        let inner = self.inner.lock();
+
+        let validation_progress = inner
+            .validation_progress
+            .as_ref()
+            .expect("progress bar not set");
+
+        let download_progress = inner
+            .download_progress
+            .as_ref()
+            .expect("progress bar not set");
+
+        let link_progress = inner.link_progress.as_ref().expect("progress bar not set");
+
+        validation_progress.set_style(inner.finish_style.clone());
+        download_progress.set_style(inner.finish_style.clone());
+        link_progress.set_style(inner.finish_style.clone());
+
+        if inner.clear_when_done {
+            validation_progress.finish_and_clear();
+            download_progress.finish_and_clear();
+            link_progress.finish_and_clear();
+        } else {
+            validation_progress.finish_using_style();
+            download_progress.finish_using_style();
+            link_progress.finish_using_style();
+        }
+    }
+}

--- a/crates/rattler/src/install/installer/indicatif.rs
+++ b/crates/rattler/src/install/installer/indicatif.rs
@@ -451,7 +451,7 @@ impl<F: ProgressFormatter + Send> Reporter for IndicatifReporter<F> {
 
     fn on_transaction_operation_start(&self, _operation: usize) {}
 
-    fn on_populate_cache_start(&self, operation: usize, record: &RepoDataRecord) -> usize {
+    fn on_populate_cache_start(&self, operation: usize, _record: &RepoDataRecord) -> usize {
         let mut inner = self.inner.lock();
 
         inner.populate_cache_started.insert(operation);

--- a/crates/rattler/src/install/installer/indicatif.rs
+++ b/crates/rattler/src/install/installer/indicatif.rs
@@ -61,11 +61,19 @@ pub enum ProgressTrack {
     Linking,
 }
 
+/// Defines the currect status of a progress bar.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum ProgressStatus {
+    /// The progress bar is visible but has not started yet.
     Pending,
+
+    /// The progress bar is showing active work.
     Active,
+
+    /// The progress bar was active but has been paused for the moment.
     Paused,
+
+    /// The progress bar finished.
     Finished,
 }
 
@@ -82,10 +90,13 @@ pub struct ProgressStyleProperties {
     pub progress_type: ProgressType,
 }
 
+/// A trait that can be used to customize the style of different progress bars
+/// of a [`IndicatifReporter`].
 pub trait ProgressFormatter {
     fn format(&self, props: &ProgressStyleProperties) -> indicatif::ProgressStyle;
 }
 
+/// A default implementation of a [`ProgressFormatter`].
 pub struct DefaultProgressFormatter {
     progress_chars: Cow<'static, str>,
     prefix: Cow<'static, str>,

--- a/crates/rattler/src/install/installer/indicatif.rs
+++ b/crates/rattler/src/install/installer/indicatif.rs
@@ -151,6 +151,16 @@ impl ProgressFormatter for DefaultProgressFormatter {
     }
 }
 
+impl DefaultProgressFormatter {
+    /// Sets the prefix all all progress bars.
+    pub fn with_prefix(self, prefix: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            prefix: prefix.into(),
+            ..self
+        }
+    }
+}
+
 impl<F: ProgressFormatter> IndicatifReporterBuilder<F> {
     /// Sets the formatter to use for the progress bars.
     pub fn with_formatter<T: ProgressFormatter>(self, formatter: T) -> IndicatifReporterBuilder<T> {

--- a/crates/rattler/src/install/installer/indicatif.rs
+++ b/crates/rattler/src/install/installer/indicatif.rs
@@ -1,26 +1,132 @@
-use crate::install::{Reporter, Transaction};
-use indicatif::{HumanBytes, MultiProgress, ProgressFinish, ProgressState};
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use indicatif::{HumanBytes, MultiProgress, ProgressFinish, ProgressStyle};
 use parking_lot::Mutex;
 use rattler_conda_types::{PrefixRecord, RepoDataRecord};
-use std::borrow::Cow;
-use std::fmt::Write;
-use std::sync::Arc;
-use std::time::Duration;
+
+use crate::install::{Reporter, Transaction};
 
 /// A builder to construct an [`IndicatifReporter`].
 #[derive(Clone)]
-pub struct IndicatifReporterBuilder {
+pub struct IndicatifReporterBuilder<F: ProgressFormatter> {
     multi_progress: Option<indicatif::MultiProgress>,
-    progress_chars: Cow<'static, str>,
     clear_when_done: bool,
-    pending_style: Option<indicatif::ProgressStyle>,
-    default_style: Option<indicatif::ProgressStyle>,
-    default_pending_style: Option<indicatif::ProgressStyle>,
-    download_style: Option<indicatif::ProgressStyle>,
-    finish_style: Option<indicatif::ProgressStyle>,
+    formatter: F,
 }
 
-impl IndicatifReporterBuilder {
+/// Defines the type of progress-bar.
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum ProgressType {
+    Generic,
+    Bytes,
+}
+
+/// Defines the progress track.
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum ProgressTrack {
+    /// The progress of packages being validated in the cache.
+    Validation,
+
+    /// The progress of downloading and extracting packages to the cache.
+    DownloadAndExtract,
+
+    /// The progress of linking and unlinking extracted packages from the
+    /// cache.
+    Linking,
+}
+
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum ProgressStatus {
+    Pending,
+    Active,
+    Paused,
+    Finished,
+}
+
+/// Defines the properties of the progress bar.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct ProgressStyleProperties {
+    /// True if there is work going on.
+    pub status: ProgressStatus,
+
+    /// The length and position of the progress bar are valid.
+    pub determinate: bool,
+
+    /// The type of progress to show.
+    pub progress_type: ProgressType,
+}
+
+pub trait ProgressFormatter {
+    fn format(&self, props: &ProgressStyleProperties) -> indicatif::ProgressStyle;
+}
+
+pub struct DefaultProgressFormatter {
+    progress_chars: Cow<'static, str>,
+    prefix: Cow<'static, str>,
+}
+
+impl Default for DefaultProgressFormatter {
+    fn default() -> Self {
+        Self {
+            progress_chars: Cow::Borrowed("━━╾─"),
+            prefix: Cow::Borrowed(""),
+        }
+    }
+}
+
+impl ProgressFormatter for DefaultProgressFormatter {
+    fn format(&self, props: &ProgressStyleProperties) -> indicatif::ProgressStyle {
+        let mut result = self.prefix.to_string();
+
+        // Add a spinner
+        match props.status {
+            ProgressStatus::Pending | ProgressStatus::Paused => result.push_str("{spinner:.dim} "),
+            ProgressStatus::Active => result.push_str("{spinner:.green} "),
+            ProgressStatus::Finished => result.push_str(&format!(
+                "{} ",
+                console::style(console::Emoji("✔", " ")).green()
+            )),
+        }
+
+        // Add a prefix
+        result.push_str("{prefix:20!} ");
+
+        // Add progress indicator
+        if props.determinate && props.status != ProgressStatus::Finished {
+            result.push_str("[{elapsed_precise}] [{bar:20!.bright.yellow/dim.white}] ");
+            match props.progress_type {
+                ProgressType::Generic => result.push_str("{human_pos:>4}/{human_len:4} "),
+                ProgressType::Bytes => result.push_str("{bytes:>8} @ {bytes_per_sec:8} "),
+            }
+        } else {
+            result.push_str("");
+        }
+
+        // Add message
+        result.push_str("{msg:.dim}");
+
+        indicatif::ProgressStyle::with_template(&result)
+            .expect("failed to create default style")
+            .progress_chars(&self.progress_chars)
+    }
+}
+
+impl<F: ProgressFormatter> IndicatifReporterBuilder<F> {
+    /// Sets the formatter to use for the progress bars.
+    pub fn with_formatter<T: ProgressFormatter>(self, formatter: T) -> IndicatifReporterBuilder<T> {
+        IndicatifReporterBuilder {
+            multi_progress: self.multi_progress,
+            clear_when_done: self.clear_when_done,
+            formatter,
+        }
+    }
+
     /// Sets the [`indicatif::MultiProgress`] to use for the progress bars.
     pub fn with_multi_progress(self, multi_progress: indicatif::MultiProgress) -> Self {
         Self {
@@ -29,7 +135,8 @@ impl IndicatifReporterBuilder {
         }
     }
 
-    /// Sets whether the progress bars are cleared when the transaction is complete.
+    /// Sets whether the progress bars are cleared when the transaction is
+    /// complete.
     pub fn clear_when_done(self, clear_when_done: bool) -> Self {
         Self {
             clear_when_done,
@@ -38,81 +145,49 @@ impl IndicatifReporterBuilder {
     }
 
     /// Finish building [`IndicatifReporter`].
-    pub fn finish(self) -> IndicatifReporter {
+    pub fn finish(self) -> IndicatifReporter<F> {
         let multi_progress = self.multi_progress.unwrap_or_default();
-
-        let pending_style = indicatif::ProgressStyle::with_template(
-            "{spinner:.dim} {prefix:20!} [{elapsed_precise}] {msg:.dim}",
-        )
-        .expect("failed to create pending style");
-
-        let default_style = indicatif::ProgressStyle::with_template("{spinner:.green} {prefix:20!} [{elapsed_precise}] [{bar:20!.bright.yellow/dim.white}] {pos:>4}/{len:4} {msg:.dim}")
-            .expect("failed to create default style")
-            .progress_chars(&self.progress_chars);
-
-        let default_pending_style = indicatif::ProgressStyle::with_template("{spinner:.dim} {prefix:20!} [{elapsed_precise}] [{bar:20!.bright.yellow/dim.white}] {pos:>4}/{len:4} {msg:.dim}")
-            .expect("failed to create default style")
-            .progress_chars(&self.progress_chars);
-
-        let download_style = indicatif::ProgressStyle::
-            with_template("{spinner:.green} {prefix:20!} [{elapsed_precise}] [{bar:20!.bright.yellow/dim.white}] {bytes:>8} @ {smoothed_bytes_per_sec:8}").expect("failed to create download style")
-            .progress_chars(&self.progress_chars)
-            .with_key(
-                "smoothed_bytes_per_sec",
-                |s: &ProgressState, w: &mut dyn Write| match (s.pos(), s.elapsed().as_millis()) {
-                    (pos, elapsed_ms) if elapsed_ms > 0 => {
-                        write!(w, "{}/s", HumanBytes((pos as f64 * 1000_f64 / elapsed_ms as f64) as u64)).unwrap();
-                    }
-                    _ => write!(w, "-").unwrap(),
-                },
-            );
-
-        let finish_style = indicatif::ProgressStyle::with_template(&format!(
-            "{} {{prefix:20!}} [{{elapsed_precise}}] {{msg:.bold}}",
-            console::style(console::Emoji("✔", " ")).green()
-        ))
-        .expect("failed to create finish style");
 
         IndicatifReporter {
             inner: Arc::new(Mutex::new(IndicatifReporterInner {
                 multi_progress,
-                pending_style: self.pending_style.unwrap_or(pending_style),
-                default_pending_style: self
-                    .default_pending_style
-                    .clone()
-                    .or_else(|| self.default_style.clone())
-                    .unwrap_or(default_pending_style),
-                default_style: self.default_style.unwrap_or(default_style),
-                download_style: self.download_style.unwrap_or(download_style),
-                finish_style: self.finish_style.unwrap_or(finish_style),
+                formatter: self.formatter,
+                style_cache: RefCell::default(),
                 validation_progress: None,
                 download_progress: None,
                 link_progress: None,
                 total_packages_to_cache: 0,
                 total_packages_cached: 0,
+                packages_validating: HashSet::default(),
+                packages_validated: HashSet::default(),
+                packages_downloading: HashSet::default(),
+                packages_downloaded: HashSet::default(),
                 total_download_size: 0,
                 clear_when_done: self.clear_when_done,
                 operations_in_progress: 0,
                 bytes_downloaded: Vec::new(),
                 package_sizes: Vec::new(),
+                start_validating: None,
+                start_downloading: None,
+                start_linking: None,
+                end_validating: None,
+                end_downloading: None,
+                end_linking: None,
             })),
         }
     }
 }
 
 /// A [`Reporter`] implementation to outputs progress bars using indicatif.
-pub struct IndicatifReporter {
-    inner: Arc<Mutex<IndicatifReporterInner>>,
+pub struct IndicatifReporter<F> {
+    inner: Arc<Mutex<IndicatifReporterInner<F>>>,
 }
 
-struct IndicatifReporterInner {
+struct IndicatifReporterInner<F> {
     multi_progress: MultiProgress,
 
-    pending_style: indicatif::ProgressStyle,
-    default_style: indicatif::ProgressStyle,
-    default_pending_style: indicatif::ProgressStyle,
-    download_style: indicatif::ProgressStyle,
-    finish_style: indicatif::ProgressStyle,
+    formatter: F,
+    style_cache: RefCell<HashMap<ProgressStyleProperties, ProgressStyle>>,
 
     validation_progress: Option<indicatif::ProgressBar>,
     download_progress: Option<indicatif::ProgressBar>,
@@ -124,73 +199,73 @@ struct IndicatifReporterInner {
     total_packages_to_cache: usize,
     total_packages_cached: usize,
 
+    packages_validating: HashSet<usize>,
+    packages_validated: HashSet<usize>,
+
+    packages_downloading: HashSet<usize>,
+    packages_downloaded: HashSet<usize>,
+
     total_download_size: usize,
     bytes_downloaded: Vec<usize>,
 
     package_sizes: Vec<usize>,
+
+    start_validating: Option<Instant>,
+    start_downloading: Option<Instant>,
+    start_linking: Option<Instant>,
+
+    end_validating: Option<Instant>,
+    end_downloading: Option<Instant>,
+    end_linking: Option<Instant>,
 }
 
-impl IndicatifReporter {
+impl<F: ProgressFormatter> IndicatifReporterInner<F> {
+    fn style(&self, props: ProgressStyleProperties) -> ProgressStyle {
+        self.style_cache
+            .borrow_mut()
+            .entry(props.clone())
+            .or_insert_with(|| self.formatter.format(&props))
+            .clone()
+    }
+}
+
+impl IndicatifReporter<DefaultProgressFormatter> {
     /// Returns a builder to construct a [`IndicatifReporter`].
-    pub fn builder() -> IndicatifReporterBuilder {
+    pub fn builder() -> IndicatifReporterBuilder<DefaultProgressFormatter> {
         IndicatifReporterBuilder {
             multi_progress: None,
-            progress_chars: Cow::Borrowed("━━╾─"),
-            pending_style: None,
-            default_style: None,
-            default_pending_style: None,
-            download_style: None,
-            finish_style: None,
             clear_when_done: false,
+            formatter: DefaultProgressFormatter::default(),
         }
     }
 }
 
-impl Default for IndicatifReporter {
+impl Default for IndicatifReporter<DefaultProgressFormatter> {
     fn default() -> Self {
         Self::builder().finish()
     }
 }
 
-impl Reporter for IndicatifReporter {
+impl<F: ProgressFormatter + Send> Reporter for IndicatifReporter<F> {
     fn on_transaction_start(&self, transaction: &Transaction<PrefixRecord, RepoDataRecord>) {
         let mut inner = self.inner.lock();
 
-        let validation_progress = inner
-            .multi_progress
-            .add(indicatif::ProgressBar::new(0))
-            .with_style(inner.pending_style.clone())
-            .with_prefix("validate cache")
-            .with_finish(ProgressFinish::AndLeave);
-        validation_progress.enable_steady_tick(Duration::from_millis(100));
-
-        let download_progress = inner
-            .multi_progress
-            .insert_after(&validation_progress, indicatif::ProgressBar::new(0))
-            .with_style(inner.pending_style.clone())
-            .with_prefix("download & extract")
-            .with_finish(ProgressFinish::AndLeave);
-        download_progress.enable_steady_tick(Duration::from_millis(100));
-
         let link_progress = inner
             .multi_progress
-            .insert_after(&download_progress, indicatif::ProgressBar::new(0))
-            .with_style(inner.pending_style.clone())
+            .add(indicatif::ProgressBar::new(0))
+            .with_style(inner.style(ProgressStyleProperties {
+                status: ProgressStatus::Pending,
+                determinate: true,
+                progress_type: ProgressType::Generic,
+            }))
             .with_prefix("update prefix")
             .with_finish(ProgressFinish::AndLeave);
         link_progress.enable_steady_tick(Duration::from_millis(100));
 
-        inner.total_packages_to_cache = transaction.packages_to_install();
-        inner.total_packages_cached = 0;
-
-        validation_progress.set_length(transaction.packages_to_install() as u64);
-        download_progress.set_length(0);
         link_progress.set_length(
             (transaction.packages_to_install() + transaction.packages_to_uninstall()) as u64,
         );
 
-        inner.validation_progress = Some(validation_progress);
-        inner.download_progress = Some(download_progress);
         inner.link_progress = Some(link_progress);
     }
 
@@ -207,46 +282,120 @@ impl Reporter for IndicatifReporter {
         operation
     }
 
-    fn on_validate_start(&self, _cache_entry: usize) -> usize {
-        let inner = self.inner.lock();
+    fn on_validate_start(&self, cache_entry: usize) -> usize {
+        let mut inner = self.inner.lock();
 
-        inner
-            .validation_progress
-            .as_ref()
-            .expect("progress bar not set")
-            .set_style(inner.default_style.clone());
+        inner.packages_validating.insert(cache_entry);
 
-        0
+        inner.start_validating.get_or_insert_with(Instant::now);
+
+        let validation_progress = match &inner.validation_progress {
+            Some(pb) => pb,
+            None => {
+                let place_above = inner
+                    .download_progress
+                    .as_ref()
+                    .or_else(|| inner.link_progress.as_ref())
+                    .expect("progress bar not set");
+
+                let pb = inner
+                    .multi_progress
+                    .insert_before(place_above, indicatif::ProgressBar::new(0))
+                    .with_style(inner.style(ProgressStyleProperties {
+                        status: ProgressStatus::Active,
+                        determinate: true,
+                        progress_type: ProgressType::Generic,
+                    }))
+                    .with_prefix("validate cache")
+                    .with_finish(ProgressFinish::AndLeave);
+                pb.enable_steady_tick(Duration::from_millis(100));
+
+                inner.validation_progress = Some(pb);
+                inner
+                    .validation_progress
+                    .as_ref()
+                    .expect("progress bar not set")
+            }
+        };
+
+        validation_progress.inc_length(1);
+        validation_progress.set_style(inner.style(ProgressStyleProperties {
+            status: ProgressStatus::Active,
+            determinate: true,
+            progress_type: ProgressType::Generic,
+        }));
+
+        cache_entry
     }
 
-    fn on_validate_complete(&self, _index: usize) {
-        let inner = self.inner.lock();
+    fn on_validate_complete(&self, cache_entry: usize) {
+        let mut inner = self.inner.lock();
+
+        inner.packages_validating.remove(&cache_entry);
+        inner.packages_validated.insert(cache_entry);
+
+        inner.end_validating = Some(Instant::now());
+
         let validation_progress = inner
             .validation_progress
             .as_ref()
             .expect("progress bar not set");
 
         validation_progress.inc(1);
-        if validation_progress.length() == Some(validation_progress.position()) {
-            validation_progress.set_style(inner.finish_style.clone());
-            validation_progress.finish_using_style();
+
+        if inner.packages_validating.is_empty() {
+            validation_progress.set_style(inner.style(ProgressStyleProperties {
+                status: ProgressStatus::Paused,
+                determinate: true,
+                progress_type: ProgressType::Generic,
+            }));
         }
     }
 
     fn on_download_start(&self, cache_entry: usize) -> usize {
         let mut inner = self.inner.lock();
 
+        inner.packages_downloading.insert(cache_entry);
+
+        inner.start_downloading.get_or_insert_with(Instant::now);
+
         let new_length = inner.package_sizes.len().max(cache_entry + 1);
         inner.bytes_downloaded.resize_with(new_length, || 0);
         inner.bytes_downloaded[cache_entry] = 0;
         inner.total_download_size += inner.package_sizes[cache_entry];
 
-        let download_progress = inner
-            .download_progress
-            .as_ref()
-            .expect("progress bar not set");
-        download_progress.set_style(inner.download_style.clone());
+        let download_progress = match &inner.download_progress {
+            Some(pb) => pb,
+            None => {
+                let place_above = inner.link_progress.as_ref().expect("progress bar not set");
+
+                let pb = inner
+                    .multi_progress
+                    .insert_before(place_above, indicatif::ProgressBar::new(0))
+                    .with_style(inner.style(ProgressStyleProperties {
+                        status: ProgressStatus::Active,
+                        determinate: true,
+                        progress_type: ProgressType::Generic,
+                    }))
+                    .with_prefix("download & extract")
+                    .with_finish(ProgressFinish::AndLeave);
+                pb.enable_steady_tick(Duration::from_millis(100));
+
+                inner.download_progress = Some(pb);
+                inner
+                    .download_progress
+                    .as_ref()
+                    .expect("progress bar not set")
+            }
+        };
+
+        download_progress.set_style(inner.style(ProgressStyleProperties {
+            status: ProgressStatus::Active,
+            determinate: true,
+            progress_type: ProgressType::Bytes,
+        }));
         download_progress.set_length(inner.total_download_size as u64);
+
         cache_entry
     }
 
@@ -261,32 +410,70 @@ impl Reporter for IndicatifReporter {
             .set_position(inner.bytes_downloaded.iter().copied().sum::<usize>() as _);
     }
 
-    fn on_download_completed(&self, _index: usize) {}
+    fn on_download_completed(&self, cache_entry: usize) {
+        let mut inner = self.inner.lock();
+        inner.end_downloading = Some(Instant::now());
+
+        inner.packages_downloading.remove(&cache_entry);
+        inner.packages_downloaded.insert(cache_entry);
+
+        if inner.packages_downloading.is_empty() {
+            inner
+                .download_progress
+                .as_ref()
+                .expect("progress bar not set")
+                .set_style(inner.style(ProgressStyleProperties {
+                    status: ProgressStatus::Paused,
+                    determinate: true,
+                    progress_type: ProgressType::Bytes,
+                }));
+        }
+    }
 
     fn on_populate_cache_complete(&self, _cache_entry: usize) {
         let mut inner = self.inner.lock();
 
         inner.total_packages_cached += 1;
         if inner.total_packages_cached >= inner.total_packages_to_cache {
-            let validation_progress = inner
-                .validation_progress
-                .as_ref()
-                .expect("progress bar not set");
-            validation_progress.set_style(inner.finish_style.clone());
-            validation_progress.finish_using_style();
+            if let Some(validation_pb) = &inner.validation_progress {
+                validation_pb.set_style(inner.style(ProgressStyleProperties {
+                    status: ProgressStatus::Finished,
+                    determinate: true,
+                    progress_type: ProgressType::Generic,
+                }));
+                validation_pb.finish_using_style();
+                if let (Some(start), Some(end)) = (inner.start_validating, inner.end_validating) {
+                    validation_pb.set_message(format!(
+                        "{} packages in {:?}",
+                        inner.packages_validated.len(),
+                        end - start
+                    ));
+                }
+            }
 
-            let download_progress = inner
-                .download_progress
-                .as_ref()
-                .expect("progress bar not set");
-
-            download_progress.set_style(inner.finish_style.clone());
-            download_progress.finish_using_style();
+            if let Some(download_pb) = &inner.download_progress {
+                download_pb.set_style(inner.style(ProgressStyleProperties {
+                    status: ProgressStatus::Finished,
+                    determinate: true,
+                    progress_type: ProgressType::Bytes,
+                }));
+                download_pb.finish_using_style();
+                if let (Some(start), Some(end)) = (inner.start_downloading, inner.end_downloading) {
+                    download_pb.set_message(format!(
+                        "{} packages ({}) in {:?}",
+                        inner.packages_downloaded.len(),
+                        HumanBytes(inner.bytes_downloaded.iter().sum::<usize>() as u64),
+                        end - start
+                    ));
+                }
+            }
         }
     }
 
     fn on_unlink_start(&self, _operation: usize, _record: &PrefixRecord) -> usize {
         let mut inner = self.inner.lock();
+
+        inner.start_linking.get_or_insert_with(Instant::now);
 
         inner.operations_in_progress += 1;
 
@@ -295,7 +482,11 @@ impl Reporter for IndicatifReporter {
                 .link_progress
                 .as_ref()
                 .expect("progress bar not set")
-                .set_style(inner.default_style.clone());
+                .set_style(inner.style(ProgressStyleProperties {
+                    status: ProgressStatus::Active,
+                    determinate: true,
+                    progress_type: ProgressType::Generic,
+                }));
         }
 
         0
@@ -306,15 +497,23 @@ impl Reporter for IndicatifReporter {
         let link_progress = inner.link_progress.as_ref().expect("progress bar not set");
         link_progress.inc(1);
 
+        inner.end_linking = Some(Instant::now());
+
         inner.operations_in_progress -= 1;
         if inner.operations_in_progress == 0 {
             let link_progress = inner.link_progress.as_ref().expect("progress bar not set");
-            link_progress.set_style(inner.default_pending_style.clone());
+            link_progress.set_style(inner.style(ProgressStyleProperties {
+                status: ProgressStatus::Paused,
+                determinate: true,
+                progress_type: ProgressType::Generic,
+            }));
         }
     }
 
     fn on_link_start(&self, _operation: usize, _record: &RepoDataRecord) -> usize {
         let mut inner = self.inner.lock();
+
+        inner.start_linking.get_or_insert_with(Instant::now);
 
         inner.operations_in_progress += 1;
         if inner.operations_in_progress == 1 {
@@ -322,7 +521,11 @@ impl Reporter for IndicatifReporter {
                 .link_progress
                 .as_ref()
                 .expect("progress bar not set")
-                .set_style(inner.default_style.clone());
+                .set_style(inner.style(ProgressStyleProperties {
+                    status: ProgressStatus::Active,
+                    determinate: true,
+                    progress_type: ProgressType::Generic,
+                }));
         }
 
         0
@@ -333,42 +536,53 @@ impl Reporter for IndicatifReporter {
         let link_progress = inner.link_progress.as_ref().expect("progress bar not set");
         link_progress.inc(1);
 
+        inner.end_linking = Some(Instant::now());
+
         inner.operations_in_progress -= 1;
         if inner.operations_in_progress == 0 {
             let link_progress = inner.link_progress.as_ref().expect("progress bar not set");
-            link_progress.set_style(inner.default_pending_style.clone());
+            link_progress.set_style(inner.style(ProgressStyleProperties {
+                status: ProgressStatus::Paused,
+                determinate: true,
+                progress_type: ProgressType::Generic,
+            }));
         }
     }
 
     fn on_transaction_operation_complete(&self, _operation: usize) {}
 
     fn on_transaction_complete(&self) {
-        let inner = self.inner.lock();
+        let mut inner = self.inner.lock();
 
-        let validation_progress = inner
-            .validation_progress
-            .as_ref()
-            .expect("progress bar not set");
+        if let (Some(link_pb), Some(start), Some(end)) =
+            (&inner.link_progress, inner.start_linking, inner.end_linking)
+        {
+            link_pb.set_message(format!("took {:?}", end - start));
+        }
 
-        let download_progress = inner
-            .download_progress
-            .as_ref()
-            .expect("progress bar not set");
-
-        let link_progress = inner.link_progress.as_ref().expect("progress bar not set");
-
-        validation_progress.set_style(inner.finish_style.clone());
-        download_progress.set_style(inner.finish_style.clone());
-        link_progress.set_style(inner.finish_style.clone());
-
-        if inner.clear_when_done {
-            validation_progress.finish_and_clear();
-            download_progress.finish_and_clear();
-            link_progress.finish_and_clear();
-        } else {
-            validation_progress.finish_using_style();
-            download_progress.finish_using_style();
-            link_progress.finish_using_style();
+        for (pb, track) in [
+            (inner.validation_progress.take(), ProgressTrack::Validation),
+            (
+                inner.download_progress.take(),
+                ProgressTrack::DownloadAndExtract,
+            ),
+            (inner.link_progress.take(), ProgressTrack::Linking),
+        ] {
+            let Some(pb) = pb else { continue };
+            pb.set_style(inner.style(ProgressStyleProperties {
+                status: ProgressStatus::Finished,
+                determinate: true,
+                progress_type: if track == ProgressTrack::DownloadAndExtract {
+                    ProgressType::Bytes
+                } else {
+                    ProgressType::Generic
+                },
+            }));
+            if inner.clear_when_done {
+                pb.finish_and_clear();
+            } else {
+                pb.finish_using_style();
+            }
         }
     }
 }

--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -11,7 +11,10 @@ use std::{
 pub use error::InstallerError;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryFutureExt};
 #[cfg(feature = "indicatif")]
-pub use indicatif::{DefaultProgressFormatter, IndicatifReporter, IndicatifReporterBuilder, ProgressFormatter};
+pub use indicatif::{
+    DefaultProgressFormatter, IndicatifReporter, IndicatifReporterBuilder, Placement,
+    ProgressFormatter,
+};
 use rattler_conda_types::{
     prefix_record::{Link, LinkType},
     Platform, PrefixRecord, RepoDataRecord,

--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -11,7 +11,7 @@ use std::{
 pub use error::InstallerError;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt, TryFutureExt};
 #[cfg(feature = "indicatif")]
-pub use indicatif::{IndicatifReporter, IndicatifReporterBuilder};
+pub use indicatif::{DefaultProgressFormatter, IndicatifReporter, IndicatifReporterBuilder, ProgressFormatter};
 use rattler_conda_types::{
     prefix_record::{Link, LinkType},
     Platform, PrefixRecord, RepoDataRecord,

--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -110,6 +110,10 @@ impl Installer {
     }
 
     /// Sets whether to execute link scripts or not.
+    ///
+    /// By default, link scripts are not executed. Link scripts can run
+    /// arbitrary code during the installation phase which makes them a security
+    /// risk.
     #[must_use]
     pub fn with_execute_link_scripts(self, execute: bool) -> Self {
         Self {
@@ -119,6 +123,10 @@ impl Installer {
     }
 
     /// Sets whether to execute link scripts or not.
+    ///
+    /// By default, link scripts are not executed. Link scripts can run
+    /// arbitrary code during the installation phase which makes them a security
+    /// risk.
     pub fn set_execute_link_scripts(&mut self, execute: bool) -> &mut Self {
         self.execute_link_scripts = execute;
         self

--- a/crates/rattler/src/install/installer/reporter.rs
+++ b/crates/rattler/src/install/installer/reporter.rs
@@ -1,0 +1,34 @@
+use rattler_conda_types::{PrefixRecord, RepoDataRecord};
+
+/// A trait for reporting progress of the installation process.
+pub trait Reporter: Send + Sync {
+    /// Called when the transaction starts
+    fn on_transaction_start(&self, total: usize);
+
+    /// Called when validation of a package starts
+    fn on_validate_start(&self, record: &RepoDataRecord) -> usize;
+    /// Called when validation completex
+    fn on_validate_complete(&self, index: usize);
+
+    /// Called when a download starts
+    fn on_download_start(&self, record: &RepoDataRecord) -> usize;
+    /// Called with regular updates on the download progress
+    fn on_download_progress(&self, index: usize, progress: u64, total: Option<u64>);
+    /// Called when a download completes
+    fn on_download_completed(&self, index: usize);
+
+    /// Called when an unlink operation started.
+    fn on_unlink_start(&self, operation: usize, record: &PrefixRecord) -> usize;
+
+    /// Called when an unlink operation started.
+    fn on_unlink_complete(&self, index: usize) -> usize;
+
+    /// Called when linking of a package has started
+    fn on_link_start(&self, operation: usize, record: &RepoDataRecord) -> usize;
+
+    /// Called when linking of a package compelted.
+    fn on_link_complete(&self, index: usize);
+
+    /// Called when the transaction completes
+    fn on_transaction_complete(&self);
+}

--- a/crates/rattler/src/install/installer/reporter.rs
+++ b/crates/rattler/src/install/installer/reporter.rs
@@ -1,47 +1,98 @@
-use crate::install::Transaction;
 use rattler_conda_types::{PrefixRecord, RepoDataRecord};
+
+use crate::install::Transaction;
 
 /// A trait for reporting progress of the installation process.
 pub trait Reporter: Send + Sync {
-    /// Called when the transaction starts
+    /// Called when the transaction starts. This is the first method called.
     fn on_transaction_start(&self, transaction: &Transaction<PrefixRecord, RepoDataRecord>);
 
-    /// Called when a transaction operation starts
+    /// Called when a transaction operation starts. During the operation the
+    /// cache is populated, previous installations are uninstalled and new
+    /// installations are linked.
+    ///
+    /// The `operation` is the index of the operation in the transaction passed
+    /// to `on_transaction_start`.
     fn on_transaction_operation_start(&self, operation: usize);
 
-    /// Called when starting to populate the cache for a package
+    /// Called when starting to populate the cache for a package. This is called
+    /// for any new package that will be installed. Before installation any
+    /// package is first added to the cache.
+    ///
+    /// The `operation` is the index of the operation in the transaction passed
+    /// to `on_transaction_start`.
     fn on_populate_cache_start(&self, operation: usize, record: &RepoDataRecord) -> usize;
 
-    /// Called when validation of a package starts
+    /// Called when validation of a package starts. If a package is already
+    /// present in the cache, the contents of the package is validated
+    /// against its manifest, this is done to ensure that the package is not
+    /// corrupted.
     fn on_validate_start(&self, cache_entry: usize) -> usize;
-    /// Called when validation completex
+
+    /// Called when validation completes. If the package is valid, the package
+    /// is immediately used and no downloading is required.
+    ///
+    /// The `validate_idx` is the value return by `on_validate_start` for the
+    /// corresponding package.
     fn on_validate_complete(&self, validate_idx: usize);
 
-    /// Called when a download starts
+    /// Called when a download starts. If a package is not present in the cache
+    /// or the package in the cache is corrupt, the package is downloaded. This
+    /// function is called right before that happens.
+    ///
+    /// The value returned by this function is passed as the `download_idx` to
+    /// `on_download_progress` and `on_download_complete`.
+    ///
+    /// The `cache_entry` is the value return by `on_populate_cache_start` for
+    /// the corresponding package.
     fn on_download_start(&self, cache_entry: usize) -> usize;
-    /// Called with regular updates on the download progress
+
+    /// Called with regular updates on the download progress.
+    ///
+    /// The `download_idx` is the value return by `on_download_start` for the
+    /// corresponding download.
     fn on_download_progress(&self, download_idx: usize, progress: u64, total: Option<u64>);
-    /// Called when a download completes
+
+    /// Called when a download completes.
+    ///
+    /// The `download_idx` is the value return by `on_download_start` for the
+    /// corresponding download.
     fn on_download_completed(&self, download_idx: usize);
 
-    /// Called when starting to populate the cache for a package
+    /// Called when the cache for a package was populated
+    ///
+    /// The `cache_entry` is the value return by `on_populate_cache_start` for
+    /// the corresponding package.
     fn on_populate_cache_complete(&self, cache_entry: usize);
 
     /// Called when an unlink operation started.
+    ///
+    /// The `operation` is the index of the operation in the transaction passed
+    /// to `on_transaction_start`.
     fn on_unlink_start(&self, operation: usize, record: &PrefixRecord) -> usize;
 
-    /// Called when an unlink operation started.
+    /// Called when an unlink operation completed.
+    ///
+    /// The `index` is the value return by `on_unlink_start` for the
+    /// corresponding package.
     fn on_unlink_complete(&self, index: usize);
 
     /// Called when linking of a package has started
+    ///
+    /// The `operation` is the index of the operation in the transaction passed
+    /// to `on_transaction_start`.
     fn on_link_start(&self, operation: usize, record: &RepoDataRecord) -> usize;
 
     /// Called when linking of a package compelted.
+    ///
+    /// The `index` is the value return by `on_link_start` for the corresponding
+    /// package.
     fn on_link_complete(&self, index: usize);
 
-    /// Called when a transaction operation finishes
+    /// Called when a transaction operation finishes.
     fn on_transaction_operation_complete(&self, operation: usize);
 
-    /// Called when the transaction completes
+    /// Called when the transaction completes. Unless an error occurs, this is
+    /// the last function that is called.
     fn on_transaction_complete(&self);
 }

--- a/crates/rattler/src/install/installer/reporter.rs
+++ b/crates/rattler/src/install/installer/reporter.rs
@@ -1,33 +1,46 @@
+use crate::install::Transaction;
 use rattler_conda_types::{PrefixRecord, RepoDataRecord};
 
 /// A trait for reporting progress of the installation process.
 pub trait Reporter: Send + Sync {
     /// Called when the transaction starts
-    fn on_transaction_start(&self, total: usize);
+    fn on_transaction_start(&self, transaction: &Transaction<PrefixRecord, RepoDataRecord>);
+
+    /// Called when a transaction operation starts
+    fn on_transaction_operation_start(&self, operation: usize);
+
+    /// Called when starting to populate the cache for a package
+    fn on_populate_cache_start(&self, operation: usize, record: &RepoDataRecord) -> usize;
 
     /// Called when validation of a package starts
-    fn on_validate_start(&self, record: &RepoDataRecord) -> usize;
+    fn on_validate_start(&self, cache_entry: usize) -> usize;
     /// Called when validation completex
-    fn on_validate_complete(&self, index: usize);
+    fn on_validate_complete(&self, validate_idx: usize);
 
     /// Called when a download starts
-    fn on_download_start(&self, record: &RepoDataRecord) -> usize;
+    fn on_download_start(&self, cache_entry: usize) -> usize;
     /// Called with regular updates on the download progress
-    fn on_download_progress(&self, index: usize, progress: u64, total: Option<u64>);
+    fn on_download_progress(&self, download_idx: usize, progress: u64, total: Option<u64>);
     /// Called when a download completes
-    fn on_download_completed(&self, index: usize);
+    fn on_download_completed(&self, download_idx: usize);
+
+    /// Called when starting to populate the cache for a package
+    fn on_populate_cache_complete(&self, cache_entry: usize);
 
     /// Called when an unlink operation started.
     fn on_unlink_start(&self, operation: usize, record: &PrefixRecord) -> usize;
 
     /// Called when an unlink operation started.
-    fn on_unlink_complete(&self, index: usize) -> usize;
+    fn on_unlink_complete(&self, index: usize);
 
     /// Called when linking of a package has started
     fn on_link_start(&self, operation: usize, record: &RepoDataRecord) -> usize;
 
     /// Called when linking of a package compelted.
     fn on_link_complete(&self, index: usize);
+
+    /// Called when a transaction operation finishes
+    fn on_transaction_operation_complete(&self, operation: usize);
 
     /// Called when the transaction completes
     fn on_transaction_complete(&self);

--- a/crates/rattler/src/install/link_script.rs
+++ b/crates/rattler/src/install/link_script.rs
@@ -4,6 +4,7 @@ use std::{
     collections::{HashMap, HashSet},
     path::Path,
 };
+use thiserror::Error;
 
 use rattler_conda_types::{PackageName, PackageRecord, Platform, PrefixRecord};
 use rattler_shell::shell::{Bash, CmdExe, ShellEnum};
@@ -64,11 +65,20 @@ impl ToString for LinkScriptType {
 }
 
 /// Records the results of running pre/post link scripts
+#[derive(Debug, Clone)]
 pub struct PrePostLinkResult {
     /// Messages from the link scripts
     pub messages: HashMap<PackageName, String>,
     /// Packages that failed to run the link scripts
     pub failed_packages: Vec<PackageName>,
+}
+
+/// An error that can occur during pre-, post-link script execution.
+#[derive(Debug, Error)]
+pub enum PrePostLinkError {
+    /// Failed to determine the currently installed packages.
+    #[error("failed to determine the installed packages")]
+    FailedToDetectInstalledPackages(#[source] std::io::Error),
 }
 
 /// Run the link scripts for a given package

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -43,7 +43,10 @@ pub use apple_codesign::AppleCodeSignBehavior;
 pub use driver::InstallDriver;
 use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
 #[cfg(feature = "indicatif")]
-pub use installer::{DefaultProgressFormatter, IndicatifReporter, ProgressFormatter, IndicatifReporterBuilder};
+pub use installer::{
+    DefaultProgressFormatter, IndicatifReporter, IndicatifReporterBuilder, Placement,
+    ProgressFormatter,
+};
 pub use installer::{Installer, InstallerError, Reporter};
 use itertools::Itertools;
 pub use link::{link_file, LinkFileError, LinkMethod};

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -29,6 +29,8 @@ mod test_utils;
 
 pub use crate::install::entry_point::{get_windows_launcher, python_entry_point_template};
 pub use driver::InstallDriver;
+#[cfg(feature = "indicatif")]
+pub use installer::{IndicatifReporter, IndicatifReporterBuilder};
 pub use installer::{Installer, InstallerError, Reporter};
 pub use link::{link_file, LinkFileError, LinkMethod};
 use rattler_conda_types::prefix_record::PathsEntry;
@@ -769,7 +771,12 @@ mod test {
                     // Populate the cache
                     let package_info = ArchiveIdentifier::try_from_url(&package_url).unwrap();
                     let package_dir = package_cache
-                        .get_or_fetch_from_url(package_info, package_url.clone(), client.clone())
+                        .get_or_fetch_from_url(
+                            package_info,
+                            package_url.clone(),
+                            client.clone(),
+                            None,
+                        )
                         .await
                         .unwrap();
 

--- a/crates/rattler/src/install/test_utils.rs
+++ b/crates/rattler/src/install/test_utils.rs
@@ -89,6 +89,7 @@ pub async fn execute_operation(
                 install_record.url.clone(),
                 download_client.clone(),
                 default_retry_policy(),
+                None,
             )
             .map_ok(|cache_dir| Some((install_record.clone(), cache_dir)))
             .map_err(anyhow::Error::from)

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -89,6 +89,11 @@ impl<Old, New> Transaction<Old, New> {
             .iter()
             .filter_map(TransactionOperation::record_to_remove)
     }
+
+    /// Returns the number of records to install.
+    pub fn packages_to_uninstall(&self) -> usize {
+        self.removed_packages().count()
+    }
 }
 
 impl<Old: AsRef<New>, New> Transaction<Old, New> {
@@ -97,6 +102,11 @@ impl<Old: AsRef<New>, New> Transaction<Old, New> {
         self.operations
             .iter()
             .filter_map(TransactionOperation::record_to_install)
+    }
+
+    /// Returns the number of records to install.
+    pub fn packages_to_install(&self) -> usize {
+        self.installed_packages().count()
     }
 }
 

--- a/crates/rattler/src/install/transaction.rs
+++ b/crates/rattler/src/install/transaction.rs
@@ -10,6 +10,10 @@ pub enum TransactionError {
     /// An error that happens if the python version could not be parsed.
     #[error(transparent)]
     PythonInfoError(#[from] PythonInfoError),
+
+    /// The operation was cancelled
+    #[error("the operation was cancelled")]
+    Cancelled,
 }
 
 /// Describes an operation to perform
@@ -62,6 +66,7 @@ impl<Old, New> TransactionOperation<Old, New> {
 }
 
 /// Describes the operations to perform to bring an environment from one state into another.
+#[derive(Debug)]
 pub struct Transaction<Old, New> {
     /// A list of operations to update an environment
     pub operations: Vec<TransactionOperation<Old, New>>,
@@ -155,7 +160,7 @@ impl<Old: AsRef<PackageRecord>, New: AsRef<PackageRecord>> Transaction<Old, New>
                         old: old_record,
                         new: record,
                     });
-                } else if needs_python_relink {
+                } else if needs_python_relink && old_record.as_ref().noarch.is_python() {
                     // when the python version changed, we need to relink all noarch packages
                     // to recompile the bytecode
                     operations.push(TransactionOperation::Reinstall(old_record));

--- a/crates/rattler/src/package_cache.rs
+++ b/crates/rattler/src/package_cache.rs
@@ -1,6 +1,14 @@
-//! This module provides functionality to cache extracted Conda packages. See [`PackageCache`].
+//! This module provides functionality to cache extracted Conda packages. See
+//! [`PackageCache`].
 
-use crate::validation::validate_package_directory;
+use std::{
+    error::Error,
+    fmt::{Display, Formatter},
+    future::Future,
+    path::PathBuf,
+    sync::Arc,
+};
+
 use chrono::Utc;
 use fxhash::FxHashMap;
 use itertools::Itertools;
@@ -10,18 +18,14 @@ use rattler_digest::Sha256Hash;
 use rattler_networking::retry_policies::{DoNotRetryPolicy, RetryDecision, RetryPolicy};
 use rattler_package_streaming::{DownloadReporter, ExtractError};
 use reqwest::StatusCode;
-use std::{
-    error::Error,
-    fmt::{Display, Formatter},
-    future::Future,
-    path::PathBuf,
-    sync::Arc,
-};
 use tokio::sync::broadcast;
 use tracing::Instrument;
 use url::Url;
 
-/// A trait that can be implemented to report progress of the download and validation process.
+use crate::validation::validate_package_directory;
+
+/// A trait that can be implemented to report progress of the download and
+/// validation process.
 pub trait CacheReporter: Send + Sync {
     /// Called when validation starts
     fn on_validate_start(&self) -> usize;
@@ -37,10 +41,11 @@ pub trait CacheReporter: Send + Sync {
 
 /// A [`PackageCache`] manages a cache of extracted Conda packages on disk.
 ///
-/// The store does not provide an implementation to get the data into the store. Instead this is
-/// left up to the user when the package is requested. If the package is found in the cache it is
-/// returned immediately. However, if the cache is stale a user defined function is called to
-/// populate the cache. This separates the corners between caching and fetching of the content.
+/// The store does not provide an implementation to get the data into the store.
+/// Instead this is left up to the user when the package is requested. If the
+/// package is found in the cache it is returned immediately. However, if the
+/// cache is stale a user defined function is called to populate the cache. This
+/// separates the corners between caching and fetching of the content.
 #[derive(Clone)]
 pub struct PackageCache {
     inner: Arc<Mutex<PackageCacheInner>>,
@@ -104,7 +109,8 @@ struct Package {
     inflight: Option<broadcast::Sender<Result<PathBuf, PackageCacheError>>>,
 }
 
-/// An error that might be returned from one of the caching function of the [`PackageCache`].
+/// An error that might be returned from one of the caching function of the
+/// [`PackageCache`].
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum PackageCacheError {
     /// An error occurred while fetching the package.
@@ -125,13 +131,14 @@ impl PackageCache {
 
     /// Returns the directory that contains the specified package.
     ///
-    /// If the package was previously successfully fetched and stored in the cache the directory
-    /// containing the data is returned immediately. If the package was not previously fetch the
-    /// filesystem is checked to see if a directory with valid package content exists. Otherwise,
-    /// the user provided `fetch` function is called to populate the cache.
+    /// If the package was previously successfully fetched and stored in the
+    /// cache the directory containing the data is returned immediately. If
+    /// the package was not previously fetch the filesystem is checked to
+    /// see if a directory with valid package content exists. Otherwise, the
+    /// user provided `fetch` function is called to populate the cache.
     ///
-    /// If the package is already being fetched by another task/thread the request is coalesced. No
-    /// duplicate fetch is performed.
+    /// If the package is already being fetched by another task/thread the
+    /// request is coalesced. No duplicate fetch is performed.
     pub async fn get_or_fetch<F, Fut, E>(
         &self,
         pkg: impl Into<CacheKey>,
@@ -204,8 +211,9 @@ impl PackageCache {
 
     /// Returns the directory that contains the specified package.
     ///
-    /// This is a convenience wrapper around `get_or_fetch` which fetches the package from the given
-    /// URL if the package could not be found in the cache.
+    /// This is a convenience wrapper around `get_or_fetch` which fetches the
+    /// package from the given URL if the package could not be found in the
+    /// cache.
     pub async fn get_or_fetch_from_url(
         &self,
         pkg: impl Into<CacheKey>,
@@ -219,8 +227,9 @@ impl PackageCache {
 
     /// Returns the directory that contains the specified package.
     ///
-    /// This is a convenience wrapper around `get_or_fetch` which fetches the package from the given
-    /// URL if the package could not be found in the cache.
+    /// This is a convenience wrapper around `get_or_fetch` which fetches the
+    /// package from the given URL if the package could not be found in the
+    /// cache.
     pub async fn get_or_fetch_from_url_with_retry(
         &self,
         pkg: impl Into<CacheKey>,
@@ -292,8 +301,8 @@ impl PackageCache {
     }
 }
 
-/// Validates that the package that is currently stored is a valid package and otherwise calls the
-/// `fetch` method to populate the cache.
+/// Validates that the package that is currently stored is a valid package and
+/// otherwise calls the `fetch` method to populate the cache.
 async fn validate_or_fetch_to_cache<F, Fut, E>(
     path: PathBuf,
     fetch: F,
@@ -305,9 +314,10 @@ where
     E: std::error::Error + Send + Sync + 'static,
 {
     // If the directory already exists validate the contents of the package
-    let reporter = reporter.as_deref().map(|r| (r, r.on_validate_start()));
     if path.is_dir() {
         let path_inner = path.clone();
+
+        let reporter = reporter.as_deref().map(|r| (r, r.on_validate_start()));
 
         let validation_result =
             tokio::task::spawn_blocking(move || validate_package_directory(&path_inner)).await;
@@ -337,8 +347,6 @@ where
                 }
             }
         }
-    } else if let Some((reporter, index)) = reporter {
-        reporter.on_validate_complete(index);
     }
 
     // Otherwise, defer to populate method to fill our cache.
@@ -379,8 +387,10 @@ impl DownloadReporter for PassthroughReporter {
 
 #[cfg(test)]
 mod test {
-    use super::PackageCache;
-    use crate::{get_test_data_dir, validation::validate_package_directory};
+    use std::{
+        convert::Infallible, fs::File, future::IntoFuture, net::SocketAddr, path::Path, sync::Arc,
+    };
+
     use assert_matches::assert_matches;
     use axum::{
         body::Body,
@@ -396,14 +406,14 @@ mod test {
     use futures::stream;
     use rattler_conda_types::package::{ArchiveIdentifier, PackageFile, PathsJson};
     use rattler_networking::retry_policies::{DoNotRetryPolicy, ExponentialBackoffBuilder};
-    use std::{
-        convert::Infallible, fs::File, future::IntoFuture, net::SocketAddr, path::Path, sync::Arc,
-    };
     use tempfile::tempdir;
     use tokio::sync::Mutex;
     use tokio_stream::StreamExt;
     use tower_http::services::ServeDir;
     use url::Url;
+
+    use super::PackageCache;
+    use crate::{get_test_data_dir, validation::validate_package_directory};
 
     #[tokio::test]
     pub async fn test_package_cache() {
@@ -442,8 +452,8 @@ mod test {
         // Validate the contents of the package
         let (_, current_paths) = validate_package_directory(&package_dir).unwrap();
 
-        // Make sure that the paths are the same as what we would expect from the original tar
-        // archive.
+        // Make sure that the paths are the same as what we would expect from the
+        // original tar archive.
         assert_eq!(current_paths, paths);
     }
 
@@ -518,7 +528,8 @@ mod test {
         // Construct a service that serves raw files from the test directory
         let service = get_service(ServeDir::new(static_dir));
 
-        // Construct a router that returns data from the static dir but fails the first try.
+        // Construct a router that returns data from the static dir but fails the first
+        // try.
         let request_count = Arc::new(Mutex::new(0));
         let router = Router::new().route_service("/*key", service);
 
@@ -533,9 +544,10 @@ mod test {
             )),
         };
 
-        // Construct the server that will listen on localhost but with a *random port*. The random
-        // port is very important because it enables creating multiple instances at the same time.
-        // We need this to be able to run tests in parallel.
+        // Construct the server that will listen on localhost but with a *random port*.
+        // The random port is very important because it enables creating
+        // multiple instances at the same time. We need this to be able to run
+        // tests in parallel.
         let addr = SocketAddr::new([127, 0, 0, 1].into(), 0);
         let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
         let addr = listener.local_addr().unwrap();

--- a/crates/rattler/src/validation.rs
+++ b/crates/rattler/src/validation.rs
@@ -10,14 +10,13 @@
 //! `paths.json` file is missing these deprecated files are used instead to reconstruct a
 //! [`PathsJson`] object. See [`PathsJson::from_deprecated_package_directory`] for more information.
 
+use digest::Digest;
 use rattler_conda_types::package::{IndexJson, PackageFile, PathType, PathsEntry, PathsJson};
-use rattler_digest::compute_file_digest;
+use rattler_digest::Sha256;
 use std::{
-    fs::Metadata,
     io::ErrorKind,
     path::{Path, PathBuf},
 };
-use rattler_lock::PackageHashes::Sha256;
 
 /// An error that is returned by [`validate_package_directory`] if the contents of the directory seems to be
 /// corrupted.
@@ -148,7 +147,6 @@ fn validate_package_entry(
 fn validate_package_hard_link_entry(
     path: PathBuf,
     entry: &PathsEntry,
-    metadata: Metadata,
 ) -> Result<(), PackageEntryValidationError> {
     debug_assert!(entry.path_type == PathType::HardLink);
 
@@ -178,7 +176,7 @@ fn validate_package_hard_link_entry(
         if size_in_bytes != actual_file_len {
             return Err(PackageEntryValidationError::IncorrectSize(
                 size_in_bytes,
-                metadata.len(),
+                actual_file_len,
             ));
         }
     }

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -19,13 +19,17 @@ rustls-tls = ['reqwest/rustls-tls', "google-cloud-auth?/rustls-tls"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+bytes = { workspace = true }
 chrono = { workspace = true }
 dirs = { workspace = true }
 fslock = { workspace = true }
+futures = { workspace = true }
+google-cloud-auth = { workspace = true, default-features = false, optional = true }
 http = { workspace = true }
 itertools = { workspace = true }
 keyring = { workspace = true }
 netrc-rs = { workspace = true }
+pin-project-lite = {  workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 reqwest-middleware = { workspace = true }
 retry-policies = { workspace = true }
@@ -34,7 +38,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-google-cloud-auth = { workspace = true, default-features = false, optional = true }
 
 [target.'cfg( target_arch = "wasm32" )'.dependencies]
 getrandom = { workspace = true, features = ["js"] }

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -78,3 +78,13 @@ pub struct ExtractResult {
     /// The Md5 hash of the extracted archive.
     pub md5: Md5Hash,
 }
+
+/// A trait that can be implemented to report download progress.
+pub trait DownloadReporter: Send + Sync {
+    /// Called when the download starts.
+    fn on_download_start(&self);
+    /// Called when the download makes progress.
+    fn on_download_progress(&self, bytes_downloaded: u64, total_bytes: Option<u64>);
+    /// Called when the download finishes.
+    fn on_download_complete(&self);
+}

--- a/crates/rattler_package_streaming/src/reqwest/tokio.rs
+++ b/crates/rattler_package_streaming/src/reqwest/tokio.rs
@@ -1,7 +1,7 @@
 //! Functionality to stream and extract packages directly from a [`reqwest::Url`] within a [`tokio`]
 //! async context.
 
-use crate::{ExtractError, ExtractResult, DownloadReporter};
+use crate::{DownloadReporter, ExtractError, ExtractResult};
 use futures_util::stream::TryStreamExt;
 use rattler_conda_types::package::ArchiveType;
 use rattler_digest::Sha256Hash;
@@ -81,6 +81,7 @@ async fn get_reader(
 ///     ClientWithMiddleware::from(Client::new()),
 ///     Url::parse("https://conda.anaconda.org/conda-forge/win-64/python-3.11.0-hcf16a7b_0_cpython.tar.bz2").unwrap(),
 ///     Path::new("/tmp"),
+///     None,
 ///     None)
 ///     .await
 ///     .unwrap();
@@ -97,7 +98,7 @@ pub async fn extract_tar_bz2(
     // The `response` is used to stream in the package data
     let result = crate::tokio::async_read::extract_tar_bz2(reader, destination).await?;
     if let Some(reporter) = &reporter {
-        reporter.on_download_complete()
+        reporter.on_download_complete();
     }
     Ok(result)
 }
@@ -116,6 +117,7 @@ pub async fn extract_tar_bz2(
 ///     ClientWithMiddleware::from(Client::new()),
 ///     Url::parse("https://conda.anaconda.org/conda-forge/linux-64/python-3.10.8-h4a9ceb5_0_cpython.conda").unwrap(),
 ///     Path::new("/tmp"),
+///     None,
 ///     None)
 ///     .await
 ///     .unwrap();
@@ -132,7 +134,7 @@ pub async fn extract_conda(
     let reader = get_reader(url.clone(), client, expected_sha256, reporter.clone()).await?;
     let result = crate::tokio::async_read::extract_conda(reader, destination).await?;
     if let Some(reporter) = &reporter {
-        reporter.on_download_complete()
+        reporter.on_download_complete();
     }
     Ok(result)
 }
@@ -152,6 +154,7 @@ pub async fn extract_conda(
 ///     ClientWithMiddleware::from(Client::new()),
 ///     Url::parse("https://conda.anaconda.org/conda-forge/linux-64/python-3.10.8-h4a9ceb5_0_cpython.conda").unwrap(),
 ///     Path::new("/tmp"),
+///     None,
 ///     None)
 ///     .await
 ///     .unwrap();

--- a/crates/rattler_package_streaming/src/reqwest/tokio.rs
+++ b/crates/rattler_package_streaming/src/reqwest/tokio.rs
@@ -1,12 +1,13 @@
 //! Functionality to stream and extract packages directly from a [`reqwest::Url`] within a [`tokio`]
 //! async context.
 
-use crate::{ExtractError, ExtractResult};
+use crate::{ExtractError, ExtractResult, DownloadReporter};
 use futures_util::stream::TryStreamExt;
 use rattler_conda_types::package::ArchiveType;
 use rattler_digest::Sha256Hash;
 use reqwest::Response;
 use std::path::Path;
+use std::sync::Arc;
 use tokio::io::BufReader;
 use tokio_util::either::Either;
 use tokio_util::io::StreamReader;
@@ -22,6 +23,7 @@ async fn get_reader(
     url: Url,
     client: reqwest_middleware::ClientWithMiddleware,
     expected_sha256: Option<Sha256Hash>,
+    reporter: Option<Arc<dyn DownloadReporter>>,
 ) -> Result<impl tokio::io::AsyncRead, ExtractError> {
     if url.scheme() == "file" {
         let file =
@@ -39,18 +41,29 @@ async fn get_reader(
             request = request.header("X-Expected-Sha256", format!("{sha256:x}"));
         }
 
+        if let Some(reporter) = &reporter {
+            reporter.on_download_start();
+        }
+
         let response = request
             .send()
             .await
             .and_then(error_for_status)
             .map_err(ExtractError::ReqwestError)?;
 
+        let total_bytes = response.content_length();
+        let mut bytes_received = Box::new(0);
+        let byte_stream = response.bytes_stream().inspect_ok(move |frame| {
+            *bytes_received += frame.len() as u64;
+            if let Some(reporter) = &reporter {
+                reporter.on_download_progress(*bytes_received, total_bytes);
+            }
+        });
+
         // Get the response as a stream
-        Ok(Either::Right(StreamReader::new(
-            response
-                .bytes_stream()
-                .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, err)),
-        )))
+        Ok(Either::Right(StreamReader::new(byte_stream.map_err(
+            |err| std::io::Error::new(std::io::ErrorKind::Other, err),
+        ))))
     }
 }
 
@@ -78,10 +91,15 @@ pub async fn extract_tar_bz2(
     url: Url,
     destination: &Path,
     expected_sha256: Option<Sha256Hash>,
+    reporter: Option<Arc<dyn DownloadReporter>>,
 ) -> Result<ExtractResult, ExtractError> {
-    let reader = get_reader(url.clone(), client, expected_sha256).await?;
+    let reader = get_reader(url.clone(), client, expected_sha256, reporter.clone()).await?;
     // The `response` is used to stream in the package data
-    crate::tokio::async_read::extract_tar_bz2(reader, destination).await
+    let result = crate::tokio::async_read::extract_tar_bz2(reader, destination).await?;
+    if let Some(reporter) = &reporter {
+        reporter.on_download_complete()
+    }
+    Ok(result)
 }
 
 /// Extracts the contents a `.conda` package archive from the specified remote location.
@@ -108,10 +126,15 @@ pub async fn extract_conda(
     url: Url,
     destination: &Path,
     expected_sha256: Option<Sha256Hash>,
+    reporter: Option<Arc<dyn DownloadReporter>>,
 ) -> Result<ExtractResult, ExtractError> {
     // The `response` is used to stream in the package data
-    let reader = get_reader(url.clone(), client, expected_sha256).await?;
-    crate::tokio::async_read::extract_conda(reader, destination).await
+    let reader = get_reader(url.clone(), client, expected_sha256, reporter.clone()).await?;
+    let result = crate::tokio::async_read::extract_conda(reader, destination).await?;
+    if let Some(reporter) = &reporter {
+        reporter.on_download_complete()
+    }
+    Ok(result)
 }
 
 /// Extracts the contents a package archive from the specified remote location. The type of package
@@ -139,11 +162,16 @@ pub async fn extract(
     url: Url,
     destination: &Path,
     expected_sha256: Option<Sha256Hash>,
+    reporter: Option<Arc<dyn DownloadReporter>>,
 ) -> Result<ExtractResult, ExtractError> {
     match ArchiveType::try_from(Path::new(url.path()))
         .ok_or(ExtractError::UnsupportedArchiveType)?
     {
-        ArchiveType::TarBz2 => extract_tar_bz2(client, url, destination, expected_sha256).await,
-        ArchiveType::Conda => extract_conda(client, url, destination, expected_sha256).await,
+        ArchiveType::TarBz2 => {
+            extract_tar_bz2(client, url, destination, expected_sha256, reporter).await
+        }
+        ArchiveType::Conda => {
+            extract_conda(client, url, destination, expected_sha256, reporter).await
+        }
     }
 }

--- a/crates/rattler_package_streaming/tests/extract.rs
+++ b/crates/rattler_package_streaming/tests/extract.rs
@@ -231,6 +231,7 @@ async fn test_extract_url_async(#[case] url: &str, #[case] sha256: &str, #[case]
         url,
         &target_dir,
         None,
+        None,
     )
     .await
     .unwrap();

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -45,6 +45,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 superslice = { workspace = true, optional = true }
+simple_spawn_blocking = { path = "../simple_spawn_blocking", version = "1.0", features = ["tokio"] }
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt", "io-util", "macros"] }

--- a/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
@@ -104,8 +104,8 @@ use url::Url;
 
 pub use crate::fetch::cache::{JLAPFooter, JLAPState, RepoDataState};
 use crate::reporter::ResponseReporterExt;
-use simple_spawn_blocking::{tokio::run_blocking_task, Cancelled};
 use crate::Reporter;
+use simple_spawn_blocking::{tokio::run_blocking_task, Cancelled};
 
 /// File suffix for JLAP file
 pub const JLAP_FILE_SUFFIX: &str = "jlap";

--- a/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/jlap/mod.rs
@@ -104,7 +104,7 @@ use url::Url;
 
 pub use crate::fetch::cache::{JLAPFooter, JLAPState, RepoDataState};
 use crate::reporter::ResponseReporterExt;
-use crate::utils::{run_blocking_task, Cancelled};
+use simple_spawn_blocking::{tokio::run_blocking_task, Cancelled};
 use crate::Reporter;
 
 /// File suffix for JLAP file

--- a/crates/rattler_repodata_gateway/src/gateway/error.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/error.rs
@@ -1,9 +1,9 @@
 use crate::fetch;
 use crate::fetch::{FetchRepoDataError, RepoDataNotFoundError};
-use crate::utils::Cancelled;
 use rattler_conda_types::Channel;
 use rattler_networking::Redact;
 use reqwest_middleware::Error;
+use simple_spawn_blocking::Cancelled;
 use std::fmt::{Display, Formatter};
 use std::io;
 use thiserror::Error;

--- a/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
@@ -2,9 +2,9 @@ use crate::gateway::error::SubdirNotFoundError;
 use crate::gateway::subdir::SubdirClient;
 use crate::gateway::GatewayError;
 use crate::sparse::SparseRepoData;
-use simple_spawn_blocking::{tokio::run_blocking_task};
 use crate::Reporter;
 use rattler_conda_types::{Channel, PackageName, RepoDataRecord};
+use simple_spawn_blocking::tokio::run_blocking_task;
 use std::path::Path;
 use std::sync::Arc;
 

--- a/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
@@ -2,7 +2,7 @@ use crate::gateway::error::SubdirNotFoundError;
 use crate::gateway::subdir::SubdirClient;
 use crate::gateway::GatewayError;
 use crate::sparse::SparseRepoData;
-use crate::utils::run_blocking_task;
+use simple_spawn_blocking::{tokio::run_blocking_task};
 use crate::Reporter;
 use rattler_conda_types::{Channel, PackageName, RepoDataRecord};
 use std::path::Path;

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/index.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/index.rs
@@ -1,6 +1,5 @@
 use super::{token::TokenClient, ShardedRepodata};
 use crate::reporter::ResponseReporterExt;
-use simple_spawn_blocking::{tokio::run_blocking_task};
 use crate::{utils::url_to_cache_filename, GatewayError, Reporter};
 use bytes::Bytes;
 use futures::{FutureExt, TryFutureExt};
@@ -9,6 +8,7 @@ use http_cache_semantics::{AfterResponse, BeforeRequest, CachePolicy, RequestLik
 use reqwest::Response;
 use reqwest_middleware::ClientWithMiddleware;
 use serde::{Deserialize, Serialize};
+use simple_spawn_blocking::tokio::run_blocking_task;
 use std::sync::Arc;
 use std::{io::Write, path::Path, str::FromStr, time::SystemTime};
 use tempfile::NamedTempFile;

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/index.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/index.rs
@@ -1,6 +1,6 @@
 use super::{token::TokenClient, ShardedRepodata};
 use crate::reporter::ResponseReporterExt;
-use crate::utils::run_blocking_task;
+use simple_spawn_blocking::{tokio::run_blocking_task};
 use crate::{utils::url_to_cache_filename, GatewayError, Reporter};
 use bytes::Bytes;
 use futures::{FutureExt, TryFutureExt};

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -1,6 +1,6 @@
 use crate::gateway::error::SubdirNotFoundError;
 use crate::reporter::ResponseReporterExt;
-use crate::utils::run_blocking_task;
+use simple_spawn_blocking::{tokio::run_blocking_task};
 use crate::Reporter;
 use crate::{fetch::FetchRepoDataError, gateway::subdir::SubdirClient, GatewayError};
 use futures::TryFutureExt;

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -1,6 +1,5 @@
 use crate::gateway::error::SubdirNotFoundError;
 use crate::reporter::ResponseReporterExt;
-use simple_spawn_blocking::{tokio::run_blocking_task};
 use crate::Reporter;
 use crate::{fetch::FetchRepoDataError, gateway::subdir::SubdirClient, GatewayError};
 use futures::TryFutureExt;
@@ -8,6 +7,7 @@ use http::header::CACHE_CONTROL;
 use http::{HeaderValue, StatusCode};
 use rattler_conda_types::{Channel, PackageName, RepoDataRecord, Shard, ShardedRepodata};
 use reqwest_middleware::ClientWithMiddleware;
+use simple_spawn_blocking::tokio::run_blocking_task;
 use std::{borrow::Cow, path::PathBuf, sync::Arc};
 use token::TokenClient;
 use url::Url;

--- a/crates/rattler_repodata_gateway/src/reporter.rs
+++ b/crates/rattler_repodata_gateway/src/reporter.rs
@@ -1,8 +1,8 @@
+use crate::utils::BodyStreamExt;
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
 use std::future::Future;
 use url::Url;
-use crate::utils::BodyStreamExt;
 
 /// A trait that enables being notified of download progress.
 pub trait Reporter: Send + Sync {

--- a/crates/rattler_repodata_gateway/src/reporter.rs
+++ b/crates/rattler_repodata_gateway/src/reporter.rs
@@ -1,8 +1,8 @@
-use crate::utils::BodyStreamExt;
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
 use std::future::Future;
 use url::Url;
+use crate::utils::BodyStreamExt;
 
 /// A trait that enables being notified of download progress.
 pub trait Reporter: Send + Sync {

--- a/crates/rattler_repodata_gateway/src/utils/body.rs
+++ b/crates/rattler_repodata_gateway/src/utils/body.rs
@@ -12,6 +12,7 @@ use std::{
 /// A helper trait to convert a stream of bytes coming from a request body into
 /// another type.
 pub trait BodyStreamExt<E>: Sized {
+    /// Reads the contents of a body stream as bytes.
     fn bytes(self) -> BytesCollect<Self, E>;
 
     /// Read the contents of a body stream as text.

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -431,7 +431,6 @@ impl<'a> DependencyProvider<SolverMatchSpec<'a>> for CondaDependencyProvider<'a>
                 }
             }
         };
-
         solvables.sort_by(|&p1, &p2| {
             conda_util::compare_candidates(p1, p2, solver, &mut highest_version_spec, strategy)
         });

--- a/crates/simple_spawn_blocking/Cargo.toml
+++ b/crates/simple_spawn_blocking/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "simple_spawn_blocking"
+version = "1.0.0"
+description = "A simple crate to make spawning blocking tasks more ergonomic"
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+
+
+[dependencies]
+tokio = { version = "1" , default-features = false, optional = true}

--- a/crates/simple_spawn_blocking/Cargo.toml
+++ b/crates/simple_spawn_blocking/Cargo.toml
@@ -10,4 +10,4 @@ edition.workspace = true
 
 
 [dependencies]
-tokio = { version = "1" , default-features = false, optional = true}
+tokio = { version = "1", default-features = false, features = ["rt"], optional = true }

--- a/crates/simple_spawn_blocking/src/lib.rs
+++ b/crates/simple_spawn_blocking/src/lib.rs
@@ -1,0 +1,8 @@
+//! A simpel crate that makes it more ergonomic to spawn blocking tasks and
+//! await their completion.
+
+#[cfg(feature = "tokio")]
+pub mod tokio;
+
+/// A marker type that is used to signal that a task was cancelled.
+pub struct Cancelled;

--- a/crates/simple_spawn_blocking/src/tokio.rs
+++ b/crates/simple_spawn_blocking/src/tokio.rs
@@ -1,0 +1,22 @@
+use crate::Cancelled;
+use tokio::task::JoinError;
+
+/// Run a blocking task to completion. If the task is cancelled, the function
+/// will return an error converted from `Error`.
+///
+/// Any panic that occurs in the blocking task will be propagated.
+pub async fn run_blocking_task<T, E, F>(f: F) -> Result<T, E>
+where
+    F: FnOnce() -> Result<T, E> + Send + 'static,
+    T: Send + 'static,
+    E: From<Cancelled> + Send + 'static,
+{
+    match tokio::task::spawn_blocking(f)
+        .await
+        .map_err(JoinError::try_into_panic)
+    {
+        Ok(result) => result,
+        Err(Err(_err)) => Err(E::from(Cancelled)),
+        Err(Ok(payload)) => std::panic::resume_unwind(payload),
+    }
+}

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -785,7 +785,7 @@ checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "file_url"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "itertools",
  "percent-encoding",
@@ -2484,7 +2484,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2499,6 +2499,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "once_cell",
+ "parking_lot",
  "rattler_conda_types",
  "rattler_digest",
  "rattler_networking",
@@ -2508,6 +2509,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.3",
  "reqwest-middleware",
+ "simple_spawn_blocking",
  "smallvec",
  "tempfile",
  "thiserror",
@@ -2520,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "chrono",
  "file_url",
@@ -2563,7 +2565,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.19.11"
+version = "0.19.12"
 dependencies = [
  "fs-err",
  "rattler_conda_types",
@@ -2576,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "chrono",
  "file_url",
@@ -2607,20 +2609,23 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.20.6"
+version = "0.20.7"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.0",
+ "bytes",
  "chrono",
  "dirs",
  "fslock",
+ "futures",
  "getrandom",
  "google-cloud-auth",
  "http 1.1.0",
  "itertools",
  "keyring",
  "netrc-rs",
+ "pin-project-lite",
  "reqwest 0.12.3",
  "reqwest-middleware",
  "retry-policies",
@@ -2633,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.20.9"
+version = "0.20.10"
 dependencies = [
  "bzip2",
  "chrono",
@@ -2657,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2693,6 +2698,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "simple_spawn_blocking",
  "superslice",
  "tempfile",
  "thiserror",
@@ -2706,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.20.3"
+version = "0.20.4"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.2.6",
@@ -2721,7 +2727,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "chrono",
  "futures",
@@ -2737,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "0.19.10"
+version = "0.19.11"
 dependencies = [
  "archspec",
  "libloading",
@@ -3325,6 +3331,13 @@ dependencies = [
  "num-traits",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "simple_spawn_blocking"
+version = "1.0.0"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -474,6 +474,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +651,12 @@ checksum = "d98e71ae4df57d214182a2e5cb90230c0192c6ddfcaa05c36453d46a54713e10"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1470,6 +1489,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
+dependencies = [
+ "console",
+ "instant",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,6 +1933,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -2489,12 +2527,14 @@ dependencies = [
  "anyhow",
  "bytes",
  "chrono",
+ "console",
  "digest",
  "dirs",
  "fs-err",
  "futures",
  "fxhash",
  "indexmap 2.2.6",
+ "indicatif",
  "itertools",
  "memchr",
  "memmap2",

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.82"
 chrono = { version = "0.4" }
 futures = "0.3.30"
 
-rattler = { path = "../crates/rattler", default-features = false }
+rattler = { path = "../crates/rattler", default-features = false, features = ["indicatif"] }
 rattler_repodata_gateway = { path = "../crates/rattler_repodata_gateway", default-features = false, features = [
     "sparse",
     "gateway",

--- a/py-rattler/docs/installer.md
+++ b/py-rattler/docs/installer.md
@@ -1,0 +1,3 @@
+# install
+
+::: rattler.install.installer

--- a/py-rattler/docs/linker.md
+++ b/py-rattler/docs/linker.md
@@ -1,3 +1,0 @@
-# link
-
-::: rattler.linker.linker

--- a/py-rattler/mkdocs.yml
+++ b/py-rattler/mkdocs.yml
@@ -102,7 +102,7 @@ nav:
           - PackageHashes: package_hashes.md
           - PypiPackageData: pypi_package_data.md
           - PypiPackageEnvironmentData: pypi_package_environment_data.md
-      - metadata: 
+      - metadata:
           - AboutJson: about_json.md
           - RunExportsJson: run_exports_json.md
           - PathsJson: paths_json.md

--- a/py-rattler/mkdocs.yml
+++ b/py-rattler/mkdocs.yml
@@ -91,7 +91,7 @@ nav:
       - core:
           - fetch: fetch_repo_data.md
           - solve: solver.md
-          - link: linker.md
+          - install: install.md
       - channel:
           - ChannelConfig: channel_config.md
           - Channel: channel.md
@@ -143,7 +143,7 @@ nav:
           - ActivationVariables: activation_variables.md
           - Shell: shell.md
           - PathModificationBehavior: path_modification_behavior.md
-      - exceptions: 
+      - exceptions:
           - ActivationError: activation_error.md
           - CacheDirError: cache_dir_error.md
           - DetectVirtualPackageError: detect_virtual_package_error.md

--- a/py-rattler/rattler/__init__.py
+++ b/py-rattler/rattler/__init__.py
@@ -26,7 +26,7 @@ from rattler.package import (
 from rattler.prefix import PrefixRecord, PrefixPaths, PrefixPathsEntry, PrefixPathType
 from rattler.platform import Platform
 from rattler.utils.rattler_version import get_rattler_version as _get_rattler_version
-from rattler.linker import link
+from rattler.install import install
 from rattler.index import index
 from rattler.lock import (
     LockFile,
@@ -73,7 +73,7 @@ __all__ = [
     "PypiPackageEnvironmentData",
     "solve",
     "Platform",
-    "link",
+    "install",
     "index",
     "AboutJson",
     "RunExportsJson",

--- a/py-rattler/rattler/install/__init__.py
+++ b/py-rattler/rattler/install/__init__.py
@@ -1,0 +1,3 @@
+from rattler.install.installer import install
+
+__all__ = ["install"]

--- a/py-rattler/rattler/install/installer.py
+++ b/py-rattler/rattler/install/installer.py
@@ -7,10 +7,10 @@ from rattler.platform.platform import Platform
 from rattler.prefix.prefix_record import PrefixRecord
 from rattler.repo_data.record import RepoDataRecord
 
-from rattler.rattler import py_link
+from rattler.rattler import py_install
 
 
-async def link(
+async def install(
     records: List[RepoDataRecord],
     target_prefix: os.PathLike[str],
     cache_dir: Optional[os.PathLike[str]] = None,
@@ -34,13 +34,13 @@ async def link(
     -------
     ```python
     >>> import asyncio
-    >>> from rattler import solve, link
+    >>> from rattler import solve, install
     >>> async def main():
     ...     # Solve an environment with python 3.9 for the current platform
     ...     records = await solve(channels=["conda-forge"], specs=["python=3.9"])
     ...
     ...     # Link the environment in the directory `my-env`.
-    ...     await link(records, target_prefix="my-env")
+    ...     await install(records, target_prefix="my-env")
     ...
     ...     # That's it! The environment is now created.
     >>> asyncio.run(main())
@@ -67,7 +67,7 @@ async def link(
                 client will be used.
     """
 
-    await py_link(
+    await py_install(
         records=records,
         target_prefix=target_prefix,
         cache_dir=cache_dir,

--- a/py-rattler/rattler/linker/__init__.py
+++ b/py-rattler/rattler/linker/__init__.py
@@ -1,3 +1,0 @@
-from rattler.linker.linker import link
-
-__all__ = ["link"]

--- a/py-rattler/rattler/linker/linker.py
+++ b/py-rattler/rattler/linker/linker.py
@@ -11,42 +11,69 @@ from rattler.rattler import py_link
 
 
 async def link(
-    dependencies: List[RepoDataRecord],
+    records: List[RepoDataRecord],
     target_prefix: os.PathLike[str],
-    cache_dir: os.PathLike[str],
+    cache_dir: Optional[os.PathLike[str]] = None,
     installed_packages: Optional[List[PrefixRecord]] = None,
     platform: Optional[Platform] = None,
-    execute_link_scripts: bool = True,
+    execute_link_scripts: bool = False,
+    show_progress: bool = True,
+    client: Optional[AuthenticatedClient] = None,
 ) -> None:
     """
     Create an environment by downloading and linking the `dependencies` in
     the `target_prefix` directory.
 
+    !!! warning
+
+        When `execute_link_scripts` is set to `True` the post-link and pre-unlink scripts of
+        packages will be executed. These scripts are not sandboxed and can be used to execute
+        arbitraty code. It is therefor discouraged to enable executing link scripts.
+
+    Example
+    -------
+    ```python
+    >>> import asyncio
+    >>> from rattler import solve, link
+    >>> async def main():
+    ...     # Solve an environment with python 3.9 for the current platform
+    ...     records = await solve(channels=["conda-forge"], specs=["python=3.9"])
+    ...
+    ...     # Link the environment in the directory `my-env`.
+    ...     await link(records, target_prefix="my-env")
+    ...
+    ...     # That's it! The environment is now created.
+    >>> asyncio.run(main())
+
+    ```
+
     Arguments:
-        dependencies: A list of solved `RepoDataRecord`s.
+        records: A list of solved `RepoDataRecord`s.
         target_prefix: Path to the directory where the environment should
-                       be created.
+                be created.
         cache_dir: Path to directory where the dependencies will be
-                   downloaded and cached.
+                downloaded and cached.
         installed_packages: A list of `PrefixRecord`s which are
-                                      already installed in the
-                                      `target_prefix`. This can be obtained
-                                      by loading `PrefixRecord`s from
-                                      `{target_prefix}/conda-meta/`.
+                already installed in the `target_prefix`. This can be obtained by loading
+                `PrefixRecord`s from `{target_prefix}/conda-meta/`.
+                If `None` is specified then the `target_prefix` will be scanned for installed
+                packages.
         platform: Target platform to create and link the
-                            environment. Defaults to current platform.
+                environment. Defaults to current platform.
         execute_link_scripts: Wether to execute the post-link and pre-unlink scripts
-                              that may be part of a package. Defaults to True.
+                that may be part of a package. Defaults to False.
+        show_progress: If set to `True` a progress bar will be shown on the CLI.
+        client: An authenticated client to use for downloading packages. If not specified a default
+                client will be used.
     """
-    platform = platform or Platform.current()
-    client = AuthenticatedClient()
 
     await py_link(
-        dependencies,
-        target_prefix,
-        cache_dir,
-        installed_packages or [],
-        platform._inner,
-        client._client,
-        execute_link_scripts,
+        records=records,
+        target_prefix=target_prefix,
+        cache_dir=cache_dir,
+        installed_packages=installed_packages,
+        platform=platform._inner if platform is not None else None,
+        client=client._client if client is not None else None,
+        execute_link_scripts=execute_link_scripts,
+        show_progress=show_progress,
     )

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -19,9 +19,9 @@ SolveStrategy = Literal["highest", "lowest", "lowest-direct"]
 
 async def solve(
     channels: List[Channel | str],
-    platforms: List[Platform | PlatformLiteral],
     specs: List[MatchSpec | str],
-    gateway: Gateway,
+    gateway: Gateway = Gateway(),
+    platforms: Optional[List[Platform | PlatformLiteral]] = None,
     locked_packages: Optional[List[RepoDataRecord]] = None,
     pinned_packages: Optional[List[RepoDataRecord]] = None,
     virtual_packages: Optional[List[GenericVirtualPackage]] = None,
@@ -35,30 +35,31 @@ async def solve(
     that should be present in the environment.
 
     Arguments:
-        specs: A list of matchspec to solve.
         channels: The channels to query for the packages.
-        platforms: The platforms to query for the packages.
+        specs: A list of matchspec to solve.
+        platforms: The platforms to query for the packages. If `None` the current platform and
+                `noarch` is used.
         gateway: The gateway to use for acquiring repodata.
         locked_packages: Records of packages that are previously selected.
-                         If the solver encounters multiple variants of a single
-                         package (identified by its name), it will sort the records
-                         and select the best possible version. However, if there
-                         exists a locked version it will prefer that variant instead.
-                         This is useful to reduce the number of packages that are
-                         updated when installing new packages. Usually you add the
-                         currently installed packages or packages from a lock-file here.
+                 If the solver encounters multiple variants of a single
+                 package (identified by its name), it will sort the records
+                 and select the best possible version. However, if there
+                 exists a locked version it will prefer that variant instead.
+                 This is useful to reduce the number of packages that are
+                 updated when installing new packages. Usually you add the
+                 currently installed packages or packages from a lock-file here.
         pinned_packages: Records of packages that are previously selected and CANNOT
-                         be changed. If the solver encounters multiple variants of
-                         a single package (identified by its name), it will sort the
-                         records and select the best possible version. However, if
-                         there is a variant available in the `pinned_packages` field it
-                         will always select that version no matter what even if that
-                         means other packages have to be downgraded.
+                 be changed. If the solver encounters multiple variants of
+                 a single package (identified by its name), it will sort the
+                 records and select the best possible version. However, if
+                 there is a variant available in the `pinned_packages` field it
+                 will always select that version no matter what even if that
+                 means other packages have to be downgraded.
         virtual_packages: A list of virtual packages considered active.
         channel_priority: (Default = ChannelPriority.Strict) When `ChannelPriority.Strict`
-                         the channel that the package is first found in will be used as
-                         the only channel for that package. When `ChannelPriority.Disabled`
-                         it will search for every package in every channel.
+                 the channel that the package is first found in will be used as
+                 the only channel for that package. When `ChannelPriority.Disabled`
+                 it will search for every package in every channel.
         timeout:    The maximum time the solver is allowed to run.
         exclude_newer: Exclude any record that is newer than the given datetime.
         strategy: The strategy to use when multiple versions of a package are available.
@@ -72,6 +73,8 @@ async def solve(
     Returns:
         Resolved list of `RepoDataRecord`s.
     """
+
+    platforms = platforms if platforms is not None else [Platform.current(), Platform("noarch")]
 
     return [
         RepoDataRecord._from_py_record(solved_package)

--- a/py-rattler/src/error.rs
+++ b/py-rattler/src/error.rs
@@ -1,8 +1,6 @@
-use std::error::Error;
-use std::io;
+use std::{error::Error, io};
 
-use pyo3::exceptions::PyException;
-use pyo3::{create_exception, PyErr};
+use pyo3::{create_exception, exceptions::PyException, PyErr};
 use rattler::install::TransactionError;
 use rattler_conda_types::{
     ConvertSubdirError, InvalidPackageNameError, ParseArchError, ParseChannelError,
@@ -10,8 +8,7 @@ use rattler_conda_types::{
 };
 use rattler_lock::{ConversionError, ParseCondaLockError};
 use rattler_package_streaming::ExtractError;
-use rattler_repodata_gateway::fetch::FetchRepoDataError;
-use rattler_repodata_gateway::GatewayError;
+use rattler_repodata_gateway::{fetch::FetchRepoDataError, GatewayError};
 use rattler_shell::activation::ActivationError;
 use rattler_solve::SolveError;
 use rattler_virtual_packages::DetectVirtualPackageError;
@@ -68,6 +65,8 @@ pub enum PyRattlerError {
     ActivationScriptFormatError(std::fmt::Error),
     #[error(transparent)]
     GatewayError(#[from] GatewayError),
+    #[error(transparent)]
+    InstallerError(#[from] rattler::install::InstallerError),
 }
 
 fn pretty_print_error(mut err: &dyn Error) -> String {
@@ -146,6 +145,9 @@ impl From<PyRattlerError> for PyErr {
             PyRattlerError::GatewayError(err) => {
                 GatewayException::new_err(pretty_print_error(&err))
             }
+            PyRattlerError::InstallerError(err) => {
+                InstallerException::new_err(pretty_print_error(&err))
+            }
         }
     }
 }
@@ -174,3 +176,4 @@ create_exception!(exceptions, EnvironmentCreationException, PyException);
 create_exception!(exceptions, ExtractException, PyException);
 create_exception!(exceptions, ActivationScriptFormatException, PyException);
 create_exception!(exceptions, GatewayException, PyException);
+create_exception!(exceptions, InstallerException, PyException);

--- a/py-rattler/src/installer.rs
+++ b/py-rattler/src/installer.rs
@@ -16,7 +16,7 @@ use crate::{
 // TODO: Accept functions to report progress
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-pub fn py_link<'a>(
+pub fn py_install<'a>(
     py: Python<'a>,
     records: Vec<&'a PyAny>,
     target_prefix: PathBuf,

--- a/py-rattler/src/lib.rs
+++ b/py-rattler/src/lib.rs
@@ -3,7 +3,7 @@ mod channel;
 mod error;
 mod generic_virtual_package;
 mod index;
-mod linker;
+mod installer;
 mod lock;
 mod match_spec;
 mod meta;
@@ -24,6 +24,8 @@ mod virtual_package;
 mod index_json;
 mod run_exports_json;
 
+use std::ops::Deref;
+
 use about_json::PyAboutJson;
 use channel::{PyChannel, PyChannelConfig, PyChannelPriority};
 use error::{
@@ -35,18 +37,24 @@ use error::{
     VersionBumpException,
 };
 use generic_virtual_package::PyGenericVirtualPackage;
+use index::py_index;
 use index_json::PyIndexJson;
+use installer::py_install;
 use lock::{
     PyEnvironment, PyLockChannel, PyLockFile, PyLockedPackage, PyPackageHashes, PyPypiPackageData,
     PyPypiPackageEnvironmentData,
 };
 use match_spec::PyMatchSpec;
+use meta::get_rattler_version;
 use nameless_match_spec::PyNamelessMatchSpec;
 use networking::{authenticated_client::PyAuthenticatedClient, py_fetch_repo_data};
 use no_arch_type::PyNoArchType;
 use package_name::PyPackageName;
 use paths_json::{PyFileMode, PyPathType, PyPathsEntry, PyPathsJson, PyPrefixPlaceholder};
+use platform::{PyArch, PyPlatform};
 use prefix_paths::{PyPrefixPathType, PyPrefixPaths, PyPrefixPathsEntry};
+use pyo3::prelude::*;
+use record::PyRecord;
 use repo_data::{
     gateway::{PyGateway, PySourceConfig},
     patch_instructions::PyPatchInstructions,
@@ -54,20 +62,12 @@ use repo_data::{
     PyRepoData,
 };
 use run_exports_json::PyRunExportsJson;
-use std::ops::Deref;
-use version::PyVersion;
-
-use pyo3::prelude::*;
-
-use crate::error::GatewayException;
-use index::py_index;
-use linker::py_link;
-use meta::get_rattler_version;
-use platform::{PyArch, PyPlatform};
-use record::PyRecord;
 use shell::{PyActivationResult, PyActivationVariables, PyActivator, PyShellEnum};
 use solver::py_solve;
+use version::PyVersion;
 use virtual_package::PyVirtualPackage;
+
+use crate::error::GatewayException;
 
 /// A struct to make it easy to wrap a type as a python type.
 #[repr(transparent)]
@@ -144,7 +144,7 @@ fn rattler(py: Python<'_>, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_function(wrap_pyfunction!(get_rattler_version, m).unwrap())
         .unwrap();
-    m.add_function(wrap_pyfunction!(py_link, m).unwrap())
+    m.add_function(wrap_pyfunction!(py_install, m).unwrap())
         .unwrap();
     m.add_function(wrap_pyfunction!(py_index, m).unwrap())
         .unwrap();

--- a/py-rattler/tests/unit/test_install.py
+++ b/py-rattler/tests/unit/test_install.py
@@ -3,11 +3,11 @@ from pathlib import Path
 
 import pytest
 
-from rattler import solve, link, Gateway, Channel
+from rattler import solve, install, Gateway, Channel
 
 
 @pytest.mark.asyncio
-async def test_link(gateway: Gateway, conda_forge_channel: Channel, tmp_path: Path) -> None:
+async def test_install(gateway: Gateway, conda_forge_channel: Channel, tmp_path: Path) -> None:
     cache_dir = tmp_path / "cache"
     env_dir = tmp_path / "env"
 
@@ -18,7 +18,7 @@ async def test_link(gateway: Gateway, conda_forge_channel: Channel, tmp_path: Pa
         gateway=gateway,
     )
 
-    await link(solved_data, env_dir, cache_dir)
+    await install(solved_data, env_dir, cache_dir)
 
     assert os.path.exists(env_dir / "conda_build_config.yaml")
     assert os.path.exists(env_dir / "share/conda-forge/migrations/pypy37.yaml")

--- a/py-rattler/tests/unit/test_link.py
+++ b/py-rattler/tests/unit/test_link.py
@@ -13,9 +13,9 @@ async def test_link(gateway: Gateway, conda_forge_channel: Channel, tmp_path: Pa
 
     solved_data = await solve(
         [conda_forge_channel],
-        ["noarch"],
         ["conda-forge-pinning"],
-        gateway,
+        platforms=["noarch"],
+        gateway=gateway,
     )
 
     await link(solved_data, env_dir, cache_dir)

--- a/py-rattler/tests/unit/test_solver.py
+++ b/py-rattler/tests/unit/test_solver.py
@@ -15,9 +15,9 @@ from rattler import (
 async def test_solve(gateway: Gateway, conda_forge_channel: Channel) -> None:
     solved_data = await solve(
         [conda_forge_channel],
-        ["linux-64"],
         ["python", "sqlite"],
-        gateway,
+        platforms=["linux-64"],
+        gateway=gateway,
     )
 
     assert isinstance(solved_data, list)
@@ -37,9 +37,9 @@ async def test_solve_exclude_newer(
     """
     solved_data = await solve(
         [dummy_channel],
-        ["linux-64"],
         ["foo"],
-        gateway,
+        platforms=["linux-64"],
+        gateway=gateway,
     )
 
     assert isinstance(solved_data, list)
@@ -50,9 +50,9 @@ async def test_solve_exclude_newer(
     # Now solve again but with a datetime that is before the version 4.0.2
     solved_data = await solve(
         [dummy_channel],
-        ["linux-64"],
         ["foo"],
-        gateway,
+        platforms=["linux-64"],
+        gateway=gateway,
         exclude_newer=datetime.datetime.fromisoformat("2021-01-01"),
     )
 
@@ -61,13 +61,14 @@ async def test_solve_exclude_newer(
     assert len(solved_data) == 1
     assert str(solved_data[0].version) == "3.0.2"
 
+
 @pytest.mark.asyncio
 async def test_solve_lowest(gateway: Gateway, dummy_channel: Channel) -> None:
     solved_data = await solve(
         [dummy_channel],
-        ["linux-64"],
         ["foobar"],
-        gateway,
+        platforms=["linux-64"],
+        gateway=gateway,
         strategy="lowest",
     )
 
@@ -80,13 +81,14 @@ async def test_solve_lowest(gateway: Gateway, dummy_channel: Channel) -> None:
     assert solved_data[1].name.normalized == "bors"
     assert str(solved_data[1].version) == "1.0"
 
+
 @pytest.mark.asyncio
 async def test_solve_lowest_direct(gateway: Gateway, dummy_channel: Channel) -> None:
     solved_data = await solve(
         [dummy_channel],
-        ["linux-64"],
         ["foobar"],
-        gateway,
+        platforms=["linux-64"],
+        gateway=gateway,
         strategy="lowest-direct",
     )
 
@@ -99,22 +101,24 @@ async def test_solve_lowest_direct(gateway: Gateway, dummy_channel: Channel) -> 
     assert solved_data[1].name.normalized == "bors"
     assert str(solved_data[1].version) == "1.2.1"
 
+
 @pytest.mark.asyncio
 async def test_solve_channel_priority_disabled(
-    gateway: Gateway, pytorch_channel: Channel, conda_forge_channel: Channel
+        gateway: Gateway, pytorch_channel: Channel, conda_forge_channel: Channel
 ) -> None:
     solved_data = await solve(
         [conda_forge_channel, pytorch_channel],
-        ["linux-64"],
         ["pytorch-cpu=0.4.1=py36_cpu_1"],
-        gateway,
+        platforms=["linux-64"],
+        gateway=gateway,
         channel_priority=ChannelPriority.Disabled,
     )
 
     assert isinstance(solved_data, list)
     assert isinstance(solved_data[0], RepoDataRecord)
     assert (
-        list(filter(lambda r: r.file_name.startswith("pytorch-cpu-0.4.1-py36_cpu_1"), solved_data))[0].channel
-        == pytorch_channel.base_url
+            list(filter(lambda r: r.file_name.startswith("pytorch-cpu-0.4.1-py36_cpu_1"),
+                        solved_data))[0].channel
+            == pytorch_channel.base_url
     )
     assert len(solved_data) == 32


### PR DESCRIPTION
This PR introduces the `Installer` which handles executing transactions and more. The installer can be observed with the `Reporter` trait. A default implementation is provided which uses indicatif.