### PR TITLE
feat: removed Ord and more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ regex = "1.10.4"
 reqwest = { version = "0.12.3", default-features = false }
 reqwest-middleware = "0.3.0"
 reqwest-retry = "0.5.0"
-resolvo = { version = "0.4.0" }
+resolvo = { version = "0.4.1" }
 retry-policies = { version = "0.3.0", default-features = false }
 rmp-serde = { version = "1.2.0" }
 rstest = { version = "0.19.0" }

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -20,8 +20,8 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false, features = ["serde"] }
-rattler_macros = { path="../rattler_macros", version = "0.19.3", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false, features = ["serde"] }
+rattler_macros = { path = "../rattler_macros", version = "0.19.3", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -1,31 +1,32 @@
-//! Defines [`RepoData`]. `RepoData` stores information of all packages present in a subdirectory
-//! of a channel. It provides indexing functionality.
+//! Defines [`RepoData`]. `RepoData` stores information of all packages present
+//! in a subdirectory of a channel. It provides indexing functionality.
 
 pub mod patches;
 pub mod sharded;
 mod topological_sort;
 
-use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::{Display, Formatter};
-use std::path::Path;
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet},
+    fmt::{Display, Formatter},
+    path::Path,
+};
 
 use fxhash::{FxHashMap, FxHashSet};
-
 use rattler_digest::{serde::SerializableHash, Md5Hash, Sha256Hash};
+use rattler_macros::sorted;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none, OneOrMany};
 use thiserror::Error;
 use url::Url;
-
-use rattler_macros::sorted;
 
 use crate::{
     build_spec::BuildNumber, package::IndexJson, utils::serde::DeserializeFromStrUnchecked,
     Channel, NoArchType, PackageName, PackageUrl, Platform, RepoDataRecord, VersionWithSource,
 };
 
-/// [`RepoData`] is an index of package binaries available on in a subdirectory of a Conda channel.
+/// [`RepoData`] is an index of package binaries available on in a subdirectory
+/// of a Conda channel.
 // Note: we cannot use the sorted macro here, because the `packages` and `conda_packages` fields are
 // serialized in a special way. Therefore we do it manually.
 #[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
@@ -37,8 +38,9 @@ pub struct RepoData {
     #[serde(serialize_with = "sort_map_alphabetically")]
     pub packages: FxHashMap<String, PackageRecord>,
 
-    /// The conda packages contained in the repodata.json file (under a different key for
-    /// backwards compatibility with previous conda versions)
+    /// The conda packages contained in the repodata.json file (under a
+    /// different key for backwards compatibility with previous conda
+    /// versions)
     #[serde(
         default,
         rename = "packages.conda",
@@ -46,7 +48,8 @@ pub struct RepoData {
     )]
     pub conda_packages: FxHashMap<String, PackageRecord>,
 
-    /// removed packages (files are still accessible, but they are not installable like regular packages)
+    /// removed packages (files are still accessible, but they are not
+    /// installable like regular packages)
     #[serde(
         default,
         serialize_with = "sort_set_alphabetically",
@@ -70,12 +73,12 @@ pub struct ChannelInfo {
     pub base_url: Option<String>,
 }
 
-/// A single record in the Conda repodata. A single record refers to a single binary distribution
-/// of a package on a Conda channel.
+/// A single record in the Conda repodata. A single record refers to a single
+/// binary distribution of a package on a Conda channel.
 #[serde_as]
 #[skip_serializing_none]
 #[sorted]
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd, Clone, Hash)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone, Hash)]
 pub struct PackageRecord {
     /// Optionally the architecture the package supports
     pub arch: Option<String>,
@@ -86,10 +89,11 @@ pub struct PackageRecord {
     /// The build number of the package
     pub build_number: BuildNumber,
 
-    /// Additional constraints on packages. `constrains` are different from `depends` in that packages
-    /// specified in `depends` must be installed next to this package, whereas packages specified in
-    /// `constrains` are not required to be installed, but if they are installed they must follow these
-    /// constraints.
+    /// Additional constraints on packages. `constrains` are different from
+    /// `depends` in that packages specified in `depends` must be installed
+    /// next to this package, whereas packages specified in `constrains` are
+    /// not required to be installed, but if they are installed they must follow
+    /// these constraints.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub constrains: Vec<String>,
 
@@ -97,8 +101,9 @@ pub struct PackageRecord {
     #[serde(default)]
     pub depends: Vec<String>,
 
-    /// Features are a deprecated way to specify different feature sets for the conda solver. This is not
-    /// supported anymore and should not be used. Instead, `mutex` packages should be used to specify
+    /// Features are a deprecated way to specify different feature sets for the
+    /// conda solver. This is not supported anymore and should not be used.
+    /// Instead, `mutex` packages should be used to specify
     /// mutually exclusive features.
     pub features: Option<String>,
 
@@ -122,25 +127,28 @@ pub struct PackageRecord {
     #[serde_as(deserialize_as = "DeserializeFromStrUnchecked")]
     pub name: PackageName,
 
-    /// If this package is independent of architecture this field specifies in what way. See
-    /// [`NoArchType`] for more information.
+    /// If this package is independent of architecture this field specifies in
+    /// what way. See [`NoArchType`] for more information.
     #[serde(skip_serializing_if = "NoArchType::is_none")]
     pub noarch: NoArchType,
 
     /// Optionally the platform the package supports
     pub platform: Option<String>, // Note that this does not match the [`Platform`] enum..
 
-    /// Package identifiers of packages that are equivalent to this package but from other
-    /// ecosystems.
+    /// Package identifiers of packages that are equivalent to this package but
+    /// from other ecosystems.
     /// starting from 0.23.2, this field became [`Option<Vec<PackageUrl>>`].
     /// This was done to support older lockfiles,
     /// where we didn't differentiate between empty purl and missing one.
-    /// Now, None:: means that the purl is missing, and it will be tried to filled in.
-    /// So later it can be one of the following:
-    /// [`Some(vec![])`] means that the purl is empty and package is not pypi one.
-    /// [`Some([`PackageUrl`])`] means that it is a pypi package.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub purls: Option<Vec<PackageUrl>>,
+    /// Now, None:: means that the purl is missing, and it will be tried to
+    /// filled in. So later it can be one of the following:
+    /// [`Some(vec![])`] means that the purl is empty and package is not pypi
+    /// one. [`Some([`PackageUrl`])`] means that it is a pypi package.
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+    )]
+    pub purls: Option<BTreeSet<PackageUrl>>,
 
     /// Optionally a SHA256 hash of the package archive
     #[serde_as(as = "Option<SerializableHash::<rattler_digest::Sha256>>")]
@@ -157,8 +165,9 @@ pub struct PackageRecord {
     #[serde_as(as = "Option<crate::utils::serde::Timestamp>")]
     pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
 
-    /// Track features are nowadays only used to downweight packages (ie. give them less priority). To
-    /// that effect, the number of track features is counted (number of commas) and the package is downweighted
+    /// Track features are nowadays only used to downweight packages (ie. give
+    /// them less priority). To that effect, the number of track features is
+    /// counted (number of commas) and the package is downweighted
     /// by the number of track_features.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[serde_as(as = "OneOrMany<_>")]
@@ -201,8 +210,8 @@ impl RepoData {
         self.info.as_ref().and_then(|i| i.base_url.as_deref())
     }
 
-    /// Builds a [`Vec<RepoDataRecord>`] from the packages in a [`RepoData`] given the source of the
-    /// data.
+    /// Builds a [`Vec<RepoDataRecord>`] from the packages in a [`RepoData`]
+    /// given the source of the data.
     pub fn into_repo_data_records(self, channel: &Channel) -> Vec<RepoDataRecord> {
         let mut records = Vec::with_capacity(self.packages.len() + self.conda_packages.len());
         let channel_name = channel.canonical_name();
@@ -273,7 +282,8 @@ fn add_trailing_slash(url: &Url) -> Cow<'_, Url> {
 }
 
 impl PackageRecord {
-    /// A simple helper method that constructs a `PackageRecord` with the bare minimum values.
+    /// A simple helper method that constructs a `PackageRecord` with the bare
+    /// minimum values.
     pub fn new(name: PackageName, version: impl Into<VersionWithSource>, build: String) -> Self {
         Self {
             arch: None,
@@ -302,8 +312,9 @@ impl PackageRecord {
 
     /// Sorts the records topologically.
     ///
-    /// This function is deterministic, meaning that it will return the same result regardless of
-    /// the order of `records` and of the `depends` vector inside the records.
+    /// This function is deterministic, meaning that it will return the same
+    /// result regardless of the order of `records` and of the `depends`
+    /// vector inside the records.
     ///
     /// Note that this function only works for packages with unique names.
     pub fn sort_topologically<T: AsRef<PackageRecord> + Clone>(records: Vec<T>) -> Vec<T> {
@@ -338,8 +349,8 @@ pub enum ConvertSubdirError {
 /// # Why can we not use `Platform::FromStr`?
 ///
 /// We cannot use the [`Platform`] `FromStr` directly because `x86` and `x86_64`
-/// are different architecture strings. Also some combinations have been removed,
-/// because they have not been found.
+/// are different architecture strings. Also some combinations have been
+/// removed, because they have not been found.
 fn determine_subdir(
     platform: Option<String>,
     arch: Option<String>,
@@ -377,7 +388,8 @@ fn determine_subdir(
 }
 
 impl PackageRecord {
-    /// Builds a [`PackageRecord`] from a [`IndexJson`] and optionally a size, sha256 and md5 hash.
+    /// Builds a [`PackageRecord`] from a [`IndexJson`] and optionally a size,
+    /// sha256 and md5 hash.
     pub fn from_index_json(
         index: IndexJson,
         size: Option<u64>,
@@ -435,10 +447,12 @@ fn sort_set_alphabetically<S: serde::Serializer>(
 
 #[cfg(test)]
 mod test {
-    use crate::repo_data::{compute_package_url, determine_subdir};
     use fxhash::FxHashMap;
 
-    use crate::{Channel, ChannelConfig, RepoData};
+    use crate::{
+        repo_data::{compute_package_url, determine_subdir},
+        Channel, ChannelConfig, RepoData,
+    };
 
     // isl-0.12.2-1.tar.bz2
     // gmp-5.1.2-6.tar.bz2

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -144,10 +144,7 @@ pub struct PackageRecord {
     /// filled in. So later it can be one of the following:
     /// [`Some(vec![])`] means that the purl is empty and package is not pypi
     /// one. [`Some([`PackageUrl`])`] means that it is a pypi package.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub purls: Option<BTreeSet<PackageUrl>>,
 
     /// Optionally a SHA256 hash of the package archive

--- a/crates/rattler_conda_types/src/repo_data/patches.rs
+++ b/crates/rattler_conda_types/src/repo_data/patches.rs
@@ -1,9 +1,9 @@
 #![allow(clippy::option_option)]
 
-use std::collections::BTreeSet;
 use fxhash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none, OneOrMany};
+use std::collections::BTreeSet;
 use std::io;
 use std::path::Path;
 

--- a/crates/rattler_conda_types/src/repo_data/patches.rs
+++ b/crates/rattler_conda_types/src/repo_data/patches.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::option_option)]
 
+use std::collections::BTreeSet;
 use fxhash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none, OneOrMany};
@@ -97,7 +98,7 @@ pub struct PackageRecordPatch {
 
     /// Package identifiers of packages that are equivalent to this package but from other
     /// ecosystems.
-    pub purls: Option<Vec<PackageUrl>>,
+    pub purls: Option<BTreeSet<PackageUrl>>,
 }
 
 /// Repodata patch instructions for a single subdirectory. See [`RepoDataPatch`] for more

--- a/crates/rattler_conda_types/src/repo_data_record.rs
+++ b/crates/rattler_conda_types/src/repo_data_record.rs
@@ -6,7 +6,7 @@ use url::Url;
 
 /// Information about a package from repodata. It includes a [`crate::PackageRecord`] but it also stores
 /// the source of the data (like the url and the channel).
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Ord, PartialOrd, Clone, Hash)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone, Hash)]
 pub struct RepoDataRecord {
     /// The data stored in the repodata.json.
     #[serde(flatten)]

--- a/crates/rattler_lock/src/builder.rs
+++ b/crates/rattler_lock/src/builder.rs
@@ -11,9 +11,9 @@ use pep508_rs::ExtraName;
 use rattler_conda_types::Platform;
 
 use crate::{
-    file_format_version::FileFormatVersion, Channel, CondaPackageData,
-    EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner, Package, PypiIndexes,
-    PypiPackageData, PypiPackageEnvironmentData,
+    file_format_version::FileFormatVersion, Channel, CondaPackageData, EnvironmentData,
+    EnvironmentPackageData, LockFile, LockFileInner, Package, PypiIndexes, PypiPackageData,
+    PypiPackageEnvironmentData,
 };
 
 /// A struct to incrementally build a lock-file.
@@ -180,14 +180,12 @@ impl LockFileBuilder {
             Package::Conda(p) => {
                 self.add_conda_package(environment, platform, p.package_data().clone())
             }
-            Package::Pypi(p) => {
-                self.add_pypi_package(
-                    environment,
-                    platform,
-                    p.package_data().clone(),
-                    p.environment_data().clone(),
-                )
-            }
+            Package::Pypi(p) => self.add_pypi_package(
+                environment,
+                platform,
+                p.package_data().clone(),
+                p.environment_data().clone(),
+            ),
         }
     }
 

--- a/crates/rattler_lock/src/conda.rs
+++ b/crates/rattler_lock/src/conda.rs
@@ -2,7 +2,6 @@ use rattler_conda_types::{PackageRecord, RepoDataRecord};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
 use std::cmp::Ordering;
-use std::hash::Hash;
 use url::Url;
 
 /// A locked conda dependency is just a [`PackageRecord`] with some additional information on where

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -115,7 +115,7 @@ pub struct CondaLockedPackageV3 {
     #[serde_as(as = "Option<crate::utils::serde::Timestamp>")]
     pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub purls: Vec<PackageUrl>,
+    pub purls: BTreeSet<PackageUrl>,
 }
 
 /// A function that enables parsing of lock files version 3 or lower.

--- a/crates/rattler_lock/src/utils/serde/raw_conda_package_data.rs
+++ b/crates/rattler_lock/src/utils/serde/raw_conda_package_data.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::borrow::Cow;
 use std::cmp::Ordering;
+use std::collections::BTreeSet;
 use url::Url;
 
 fn is_default<T: Default + Eq>(value: &T) -> bool {
@@ -86,7 +87,7 @@ pub(crate) struct RawCondaPackageData<'a> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license_family: Cow<'a, Option<String>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub purls: Cow<'a, Option<Vec<PackageUrl>>>,
+    pub purls: Cow<'a, Option<BTreeSet<PackageUrl>>>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub size: Cow<'a, Option<u64>>,

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -72,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9db67cd9cf4f56a10d2cbae6a3b552e5bd36701fd37b74a18c14a231bdf446c7"
 dependencies = [
  "cfg-if",
- "itertools",
+ "itertools 0.12.1",
  "libc",
  "serde",
  "serde_json",
@@ -784,7 +784,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 name = "file_url"
 version = "0.1.1"
 dependencies = [
- "itertools",
+ "itertools 0.12.1",
  "percent-encoding",
  "typed-path",
  "url",
@@ -1514,6 +1514,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,7 +2010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b645dcde5f119c2c454a92d0dfa271a2a3b205da92e4292a68ead4bdbfde1f33"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
@@ -2486,7 +2495,7 @@ dependencies = [
  "futures",
  "fxhash",
  "indexmap 2.2.6",
- "itertools",
+ "itertools 0.12.1",
  "memchr",
  "memmap2",
  "once_cell",
@@ -2518,7 +2527,7 @@ dependencies = [
  "fxhash",
  "glob",
  "hex",
- "itertools",
+ "itertools 0.12.1",
  "lazy-regex",
  "nom",
  "purl",
@@ -2573,7 +2582,7 @@ dependencies = [
  "file_url",
  "fxhash",
  "indexmap 2.2.6",
- "itertools",
+ "itertools 0.12.1",
  "pep440_rs",
  "pep508_rs",
  "purl",
@@ -2609,7 +2618,7 @@ dependencies = [
  "getrandom",
  "google-cloud-auth",
  "http 1.1.0",
- "itertools",
+ "itertools 0.12.1",
  "keyring",
  "netrc-rs",
  "reqwest 0.12.4",
@@ -2666,7 +2675,7 @@ dependencies = [
  "http-cache-semantics",
  "humansize",
  "humantime",
- "itertools",
+ "itertools 0.12.1",
  "json-patch",
  "libc",
  "md-5",
@@ -2701,7 +2710,7 @@ version = "0.20.4"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.2.6",
- "itertools",
+ "itertools 0.12.1",
  "rattler_conda_types",
  "serde_json",
  "shlex",
@@ -2716,7 +2725,7 @@ version = "0.22.0"
 dependencies = [
  "chrono",
  "futures",
- "itertools",
+ "itertools 0.12.1",
  "rattler_conda_types",
  "rattler_digest",
  "resolvo",
@@ -2920,15 +2929,15 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2016584c3fd9df0fd859a7dcbc7fafdc7fdd2d87b53a576e8e63e62fad140e33"
+checksum = "d299d168910c5d71f3c0f5441abe38ca4a6ae21f70fae909bfc6bead28f6620f"
 dependencies = [
  "bitvec",
  "elsa",
  "event-listener 5.3.0",
  "futures",
- "itertools",
+ "itertools 0.13.0",
  "petgraph",
  "tracing",
 ]


### PR DESCRIPTION
* Turns `purls` into a BtreeSet to ensure consistent ordering (fixes https://github.com/prefix-dev/pixi/issues/1367)
* Removed `Ord` and `PartialOrd` from `PackageRecord`. It doesnt make sense.
* Bumped `resolvo` to remove `Ord` constraint from `Version`. 
* Conversion from `CondaPackage` and `PypiPackage` to Package.
* The ability to add packages to the lock file builder from another environment.