### PR TITLE
feat: bump characters in versions as well (9d -> 10a) and add `alpha`

### DIFF
--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -327,7 +327,7 @@ impl Version {
 
                 if let Some(last_iden_component) = last_iden_component {
                     *last_iden_component = "a".into();
-                }                
+                }
             }
 
             let has_implicit_default =
@@ -1306,14 +1306,14 @@ mod test {
                 .unwrap()
                 .bump(VersionBumpType::Last)
                 .unwrap(),
-            Version::from_str("1.2l").unwrap()
+            Version::from_str("1.2a").unwrap()
         );
         assert_eq!(
             Version::from_str("5!1.alpha+3.4")
                 .unwrap()
                 .bump(VersionBumpType::Last)
                 .unwrap(),
-            Version::from_str("5!1.1alpha+3.4").unwrap()
+            Version::from_str("5!1.1a+3.4").unwrap()
         );
     }
 
@@ -1487,14 +1487,14 @@ mod test {
                 .unwrap()
                 .bump(VersionBumpType::Minor)
                 .unwrap(),
-            Version::from_str("2.2l").unwrap()
+            Version::from_str("2.2a").unwrap()
         );
         assert_eq!(
             Version::from_str("5!1.alpha+3.4")
                 .unwrap()
                 .bump(VersionBumpType::Minor)
                 .unwrap(),
-            Version::from_str("5!1.1alpha+3.4").unwrap()
+            Version::from_str("5!1.1a+3.4").unwrap()
         );
     }
 
@@ -1522,14 +1522,14 @@ mod test {
                 .unwrap()
                 .bump(VersionBumpType::Patch)
                 .unwrap(),
-            Version::from_str("2.1l.6alpha").unwrap()
+            Version::from_str("2.1l.6a").unwrap()
         );
         assert_eq!(
             Version::from_str("5!1.8.alpha+3.4")
                 .unwrap()
                 .bump(VersionBumpType::Patch)
                 .unwrap(),
-            Version::from_str("5!1.8.1alpha+3.4").unwrap()
+            Version::from_str("5!1.8.1a+3.4").unwrap()
         );
     }
 

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -318,6 +318,16 @@ impl Version {
                     .next_back()
                     .expect("every segment must at least contain a single numeric component");
                 *last_numeral_component += 1;
+
+                // If the segment ends with an ascii character, make it `a` instead of whatever it says
+                let last_iden_component = segment_components
+                    .iter_mut()
+                    .filter_map(Component::as_iden_mut)
+                    .next_back();
+
+                if let Some(last_iden_component) = last_iden_component {
+                    *last_iden_component = "a".into();
+                }                
             }
 
             let has_implicit_default =
@@ -766,6 +776,22 @@ impl Component {
     pub fn as_number_mut(&mut self) -> Option<&mut u64> {
         match self {
             Component::Numeral(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Returns a component as iden value
+    pub fn as_iden(&self) -> Option<&Box<str>> {
+        match self {
+            Component::Iden(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    /// Returns a component as mutable iden value
+    pub fn as_iden_mut(&mut self) -> Option<&mut Box<str>> {
+        match self {
+            Component::Iden(value) => Some(value),
             _ => None,
         }
     }
@@ -1562,6 +1588,13 @@ mod test {
                 .bump(VersionBumpType::Segment(-3))
                 .unwrap(),
             Version::from_str("2.1.9").unwrap()
+        );
+        assert_eq!(
+            Version::from_str("9d")
+                .unwrap()
+                .bump(VersionBumpType::Segment(0))
+                .unwrap(),
+            Version::from_str("10a").unwrap()
         );
     }
 


### PR DESCRIPTION
As part of the work for compatible `pin` expressions in `conda-build` we might also have to bump characters, as well as adding `0a0` segments when appropriate. 

I am currently working out the details, but this is one step :)