### PR TITLE
fix: improve progress bar duration display

### DIFF
--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -27,6 +27,7 @@ dirs = { workspace = true }
 fs-err = { workspace = true }
 futures = { workspace = true }
 fxhash = { workspace = true }
+humantime = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true, optional = true }
 itertools = { workspace = true }

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2533,6 +2533,7 @@ dependencies = [
  "fs-err",
  "futures",
  "fxhash",
+ "humantime",
  "indexmap 2.2.6",
  "indicatif",
  "itertools 0.12.1",


### PR DESCRIPTION
Small fixes to the installer progress bars.

* Gray out progress bar if its not active
* Format durations better (rounded to ms)