### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -28,12 +28,12 @@ console = { workspace = true, features = ["windows-console-colors"] }
 futures = { workspace = true }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.25.0", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.23.1", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.7", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.20.1", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "0.22.0", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.11", default-features = false }
+rattler = { path="../rattler", version = "0.26.0", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.24.0", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.8", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.20.2", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "0.23.0", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.12", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0](https://github.com/mamba-org/rattler/compare/rattler-v0.25.0...rattler-v0.26.0) - 2024-05-27
+
+### Fixed
+- improve progress bar duration display ([#680](https://github.com/mamba-org/rattler/pull/680))
+
+### Other
+- introducing the installer ([#664](https://github.com/mamba-org/rattler/pull/664))
+- create directories up front ([#533](https://github.com/mamba-org/rattler/pull/533))
+
 ## [0.25.0](https://github.com/mamba-org/rattler/compare/rattler-v0.24.1...rattler-v0.25.0) - 2024-05-14
 
 ### Added

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.25.0"
+version = "0.26.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -35,11 +35,11 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.23.1", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.24.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.20.7", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.20.4", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.20.10", default-features = false, features = ["reqwest"] }
+rattler_networking = { path = "../rattler_networking", version = "0.20.8", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.20.5", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.21.0", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.23.1...rattler_conda_types-v0.24.0) - 2024-05-27
+
+### Added
+- removed Ord and more ([#673](https://github.com/mamba-org/rattler/pull/673))
+- always store purls as a key in lock file ([#669](https://github.com/mamba-org/rattler/pull/669))
+- add solve strategies ([#660](https://github.com/mamba-org/rattler/pull/660))
+
+### Fixed
+- make topological sorting support fully cyclic dependencies ([#678](https://github.com/mamba-org/rattler/pull/678))
+
 ## [0.23.1](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.23.0...rattler_conda_types-v0.23.1) - 2024-05-14
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.23.1"
+version = "0.24.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.13](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.12...rattler_index-v0.19.13) - 2024-05-27
+
+### Added
+- always store purls as a key in lock file ([#669](https://github.com/mamba-org/rattler/pull/669))
+
 ## [0.19.12](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.11...rattler_index-v0.19.12) - 2024-05-14
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.12"
+version = "0.19.13"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.23.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.24.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.20.10", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.21.0", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.8](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.7...rattler_lock-v0.22.8) - 2024-05-27
+
+### Added
+- removed Ord and more ([#673](https://github.com/mamba-org/rattler/pull/673))
+- always store purls as a key in lock file ([#669](https://github.com/mamba-org/rattler/pull/669))
+
 ## [0.22.7](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.6...rattler_lock-v0.22.7) - 2024-05-14
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.7"
+version = "0.22.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.23.1", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.24.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false }
 file_url = { path = "../file_url", version = "0.1.1" }
 pep508_rs = { workspace = true, features = ["serde"] }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.8](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.20.7...rattler_networking-v0.20.8) - 2024-05-27
+
+### Other
+- introducing the installer ([#664](https://github.com/mamba-org/rattler/pull/664))
+
 ## [0.20.7](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.20.6...rattler_networking-v0.20.7) - 2024-05-14
 
 ### Added

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.20.7"
+version = "0.20.8"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.10...rattler_package_streaming-v0.21.0) - 2024-05-27
+
+### Other
+- introducing the installer ([#664](https://github.com/mamba-org/rattler/pull/664))
+
 ## [0.20.10](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.9...rattler_package_streaming-v0.20.10) - 2024-05-14
 
 ### Added

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.20.10"
+version = "0.21.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -15,9 +15,9 @@ bzip2 = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.23.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.24.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.20.7", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.20.8", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }
 serde_json = { workspace = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.20.1...rattler_repodata_gateway-v0.20.2) - 2024-05-27
+
+### Fixed
+- result grouped by subdir instead of channel ([#666](https://github.com/mamba-org/rattler/pull/666))
+
+### Other
+- introducing the installer ([#664](https://github.com/mamba-org/rattler/pull/664))
+
 ## [0.20.1](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.20.0...rattler_repodata_gateway-v0.20.1) - 2024-05-14
 
 ### Added

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.20.1"
+version = "0.20.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -35,9 +35,9 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.23.1", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.24.0", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.20.7", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.20.8", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -70,7 +70,7 @@ rstest = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower-http = { workspace = true, features = ["fs", "compression-gzip", "trace"] }
 tracing-test = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.23.1", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.24.0", default-features = false }
 
 [features]
 default = ['native-tls']

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.5](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.4...rattler_shell-v0.20.5) - 2024-05-27
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.20.4](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.3...rattler_shell-v0.20.4) - 2024-05-14
 
 ### Added

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.20.4"
+version = "0.20.5"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.23.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.24.0", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.22.0...rattler_solve-v0.23.0) - 2024-05-27
+
+### Added
+- removed Ord and more ([#673](https://github.com/mamba-org/rattler/pull/673))
+- always store purls as a key in lock file ([#669](https://github.com/mamba-org/rattler/pull/669))
+- add solve strategies ([#660](https://github.com/mamba-org/rattler/pull/660))
+
+### Fixed
+- result grouped by subdir instead of channel ([#666](https://github.com/mamba-org/rattler/pull/666))
+
+### Other
+- introducing the installer ([#664](https://github.com/mamba-org/rattler/pull/664))
+
 ## [0.22.0](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.21.2...rattler_solve-v0.22.0) - 2024-05-14
 
 ### Added

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.22.0"
+version = "0.23.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.23.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.24.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.12](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.11...rattler_virtual_packages-v0.19.12) - 2024-05-27
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.11](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.10...rattler_virtual_packages-v0.19.11) - 2024-05-14
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "0.19.11"
+version = "0.19.12"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.23.1", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.24.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler`: 0.25.0 -> 0.26.0
* `rattler_conda_types`: 0.23.1 -> 0.24.0
* `rattler_package_streaming`: 0.20.10 -> 0.21.0
* `rattler_networking`: 0.20.7 -> 0.20.8
* `rattler_lock`: 0.22.7 -> 0.22.8
* `rattler_repodata_gateway`: 0.20.1 -> 0.20.2
* `rattler_solve`: 0.22.0 -> 0.23.0
* `rattler_index`: 0.19.12 -> 0.19.13
* `rattler_shell`: 0.20.4 -> 0.20.5
* `rattler_virtual_packages`: 0.19.11 -> 0.19.12

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`
<blockquote>

## [0.26.0](https://github.com/mamba-org/rattler/compare/rattler-v0.25.0...rattler-v0.26.0) - 2024-05-27

### Fixed
- improve progress bar duration display ([#680](https://github.com/mamba-org/rattler/pull/680))

### Other
- introducing the installer ([#664](https://github.com/mamba-org/rattler/pull/664))
- create directories up front ([#533](https://github.com/mamba-org/rattler/pull/533))
</blockquote>

## `rattler_conda_types`
<blockquote>

## [0.24.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.23.1...rattler_conda_types-v0.24.0) - 2024-05-27

### Added
- removed Ord and more ([#673](https://github.com/mamba-org/rattler/pull/673))
- always store purls as a key in lock file ([#669](https://github.com/mamba-org/rattler/pull/669))
- add solve strategies ([#660](https://github.com/mamba-org/rattler/pull/660))

### Fixed
- make topological sorting support fully cyclic dependencies ([#678](https://github.com/mamba-org/rattler/pull/678))
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.21.0](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.20.10...rattler_package_streaming-v0.21.0) - 2024-05-27

### Other
- introducing the installer ([#664](https://github.com/mamba-org/rattler/pull/664))
</blockquote>

## `rattler_networking`
<blockquote>

## [0.20.8](https://github.com/mamba-org/rattler/compare/rattler_networking-v0.20.7...rattler_networking-v0.20.8) - 2024-05-27

### Other
- introducing the installer ([#664](https://github.com/mamba-org/rattler/pull/664))
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.8](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.7...rattler_lock-v0.22.8) - 2024-05-27

### Added
- removed Ord and more ([#673](https://github.com/mamba-org/rattler/pull/673))
- always store purls as a key in lock file ([#669](https://github.com/mamba-org/rattler/pull/669))
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.20.2](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.20.1...rattler_repodata_gateway-v0.20.2) - 2024-05-27

### Fixed
- result grouped by subdir instead of channel ([#666](https://github.com/mamba-org/rattler/pull/666))

### Other
- introducing the installer ([#664](https://github.com/mamba-org/rattler/pull/664))
</blockquote>

## `rattler_solve`
<blockquote>

## [0.23.0](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.22.0...rattler_solve-v0.23.0) - 2024-05-27

### Added
- removed Ord and more ([#673](https://github.com/mamba-org/rattler/pull/673))
- always store purls as a key in lock file ([#669](https://github.com/mamba-org/rattler/pull/669))
- add solve strategies ([#660](https://github.com/mamba-org/rattler/pull/660))

### Fixed
- result grouped by subdir instead of channel ([#666](https://github.com/mamba-org/rattler/pull/666))

### Other
- introducing the installer ([#664](https://github.com/mamba-org/rattler/pull/664))
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.13](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.12...rattler_index-v0.19.13) - 2024-05-27

### Added
- always store purls as a key in lock file ([#669](https://github.com/mamba-org/rattler/pull/669))
</blockquote>

## `rattler_shell`
<blockquote>

## [0.20.5](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.4...rattler_shell-v0.20.5) - 2024-05-27

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [0.19.12](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.11...rattler_virtual_packages-v0.19.12) - 2024-05-27

### Other
- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).