### PR TITLE
fix: VersionSpec starts with, with trailing zeros

### DIFF
--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -331,6 +331,7 @@ impl VersionSpec {
 #[cfg(test)]
 mod tests {
     use assert_matches::assert_matches;
+    use rstest::rstest;
 
     use crate::version_spec::parse::ParseConstraintError;
     use crate::version_spec::{
@@ -426,6 +427,17 @@ mod tests {
     #[test]
     fn issue_204() {
         assert!(VersionSpec::from_str(">=3.8<3.9", ParseStrictness::Strict).is_err());
+    }
+
+    #[rstest]
+    #[case("2.38.*", true)]
+    #[case("2.38.0.*", true)]
+    #[case("2.38.0.1*", false)]
+    #[case("2.38.0a.*", false)]
+    fn issue_685(#[case] spec: &str, #[case] starts_with: bool) {
+        let spec = VersionSpec::from_str(spec, ParseStrictness::Strict).unwrap();
+        let version = &Version::from_str("2.38").unwrap();
+        assert_eq!(spec.matches(version), starts_with);
     }
 
     #[test]


### PR DESCRIPTION
This fixes an issue where if we check if a version a starts with b, we should ignore any trailing zero segments in b. This is because a version `1` is the same as `1.0` and `1.0.0.0.0`. So in that sense `1` starts with `1.0` as well. 

Im personally not extremely happy with this because I think its complex to understand, but this seems to be the way its implemented in conda and mamba.

Fixes #685