### PR TITLE
fix: lenient parsing of 2023.*.*

### DIFF
--- a/crates/rattler_conda_types/src/version_spec/constraint.rs
+++ b/crates/rattler_conda_types/src/version_spec/constraint.rs
@@ -274,10 +274,6 @@ mod test {
                 Version::from_str("1.2").unwrap(),
             ))
         );
-        assert_eq!(
-            Constraint::from_str("1.2.*.*", strictness),
-            Err(ParseConstraintError::RegexConstraintsNotSupported)
-        );
     }
 
     #[rstest]

--- a/crates/rattler_conda_types/src/version_spec/mod.rs
+++ b/crates/rattler_conda_types/src/version_spec/mod.rs
@@ -459,6 +459,12 @@ mod tests {
             VersionSpec::from_str("2023.*", ParseStrictness::Lenient).unwrap()
         );
         assert!(VersionSpec::from_str("2023.*.*", ParseStrictness::Strict).is_err());
+        assert_matches!(
+            VersionSpec::from_str("2023.*.0", ParseStrictness::Lenient).unwrap_err(),
+            ParseVersionSpecError::InvalidConstraint(
+                ParseConstraintError::RegexConstraintsNotSupported
+            )
+        );
     }
 
     #[test]


### PR DESCRIPTION
The version spec `2023.*.*` would previously fail to parse with `RegexConstraintNotSupported`. However, in lenient parsing mode we now parse this as `2023.*`. 