### PR TITLE
feat: add a `with_alpha` function that adds `0a0` to the version

### DIFF
--- a/crates/rattler_conda_types/src/version/bump.rs
+++ b/crates/rattler_conda_types/src/version/bump.rs
@@ -41,7 +41,7 @@ impl Version {
     ///
     /// For example, `1.0.0` will become `1.0.0.0a0`.
     /// If the last version element contains a character, it's not modified (e.g. `1.0.0a` will remain `1.0.0a`).
-    pub fn add_alpha(&self) -> Cow<'_, Self> {
+    pub fn with_alpha(&self) -> Cow<'_, Self> {
         let last_segment = self.segments().last().expect("at least one segment");
         // check if there is an iden component in the last segment
         let has_iden = last_segment.components().any(|c| c.as_iden().is_some());
@@ -291,7 +291,7 @@ mod test {
                 .unwrap()
                 .bump(VersionBumpType::Segment(idx))
                 .unwrap()
-                .add_alpha()
+                .with_alpha()
                 .into_owned(),
             Version::from_str(expected).unwrap()
         );

--- a/crates/rattler_conda_types/src/version/bump.rs
+++ b/crates/rattler_conda_types/src/version/bump.rs
@@ -78,11 +78,11 @@ impl Version {
 
     /// Remove the local segment from the version if it exists.
     /// Returns a new version without the local segment.
-    /// 
+    ///
     /// For example, `1.0.0+3.4` will become `1.0.0`.
     pub fn remove_local(&self) -> Cow<'_, Self> {
         if let Some(local_segment_index) = self.local_segment_index() {
-            let mut segments = self.segments[0..local_segment_index].to_vec();
+            let segments = self.segments[0..local_segment_index].to_vec();
             let components_offset = segments.iter().map(|s| s.len() as usize).sum::<usize>()
                 + usize::from(self.has_epoch());
             let mut components = self.components.clone();

--- a/crates/rattler_conda_types/src/version/bump.rs
+++ b/crates/rattler_conda_types/src/version/bump.rs
@@ -35,10 +35,22 @@ pub enum VersionBumpError {
 }
 
 impl Version {
+    /// Bumps the version according to the specified bump type and returns the new version.
+    /// This function will add an alpha specifier to the version (e.g. `1.0.0` will bump to `1.0.1.0a0`) to exclude
+    /// any alpha releases.
+    pub fn bump_with_alpha(&self, bump_type: VersionBumpType) -> Result<Self, VersionBumpError> {
+        self.bump_impl(bump_type, true)
+    }
+
+    /// Bumps the version according to the specified bump type and returns the new version.
+    pub fn bump(&self, bump_type: VersionBumpType) -> Result<Self, VersionBumpError> {
+        self.bump_impl(bump_type, false)
+    }
+
     /// Returns a new version after bumping it according to the specified bump type.
     /// Note: if a version ends with a character, the next bigger version will use `a` as the character.
     /// For example: `1.1l` -> `1.2a`, but also `1.1.0alpha` -> `1.1.1a`.
-    pub fn bump(&self, bump_type: VersionBumpType) -> Result<Self, VersionBumpError> {
+    fn bump_impl(&self, bump_type: VersionBumpType, with_alpha: bool) -> Result<Self, VersionBumpError> {
         // Sanity check whether the version has enough segments for this bump type.
         let segment_count = self.segment_count();
         let segment_to_bump = match bump_type {
@@ -108,6 +120,10 @@ impl Version {
                 if let Some(last_iden_component) = last_iden_component {
                     *last_iden_component = "a".into();
                 }
+            }
+
+            if with_alpha {
+                
             }
 
             let has_implicit_default =

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "chrono",
  "futures",

--- a/py-rattler/rattler/version/version.py
+++ b/py-rattler/rattler/version/version.py
@@ -149,6 +149,26 @@ class Version:
         """
         return Version._from_py_version(self._version.bump_segment(index))
 
+    def with_alpha(self) -> Version:
+        """
+        Returns a new version where the last segment of this version has
+        been bumped with an alpha character. If the last segment contains a
+        character, nothing is added.
+
+        Examples
+        --------
+        ```python
+        >>> v = Version('1.0')
+        >>> v.with_alpha()
+        Version("1.0.0a0")
+        >>> v = Version('1.0.f')
+        >>> v.with_alpha()
+        Version("1.0.f")
+        >>>
+        ```
+        """
+        return Version._from_py_version(self._version.with_alpha())
+
     def extend_to_length(self, length: int) -> Version:
         """
         Returns a new version that is extended with `0s` to the specified length.

--- a/py-rattler/rattler/version/version.py
+++ b/py-rattler/rattler/version/version.py
@@ -169,6 +169,25 @@ class Version:
         """
         return Version._from_py_version(self._version.with_alpha())
 
+    def remove_local(self) -> Version:
+        """
+        Returns a new version where the local segment of the version has been removed.
+        Leaves the version unchanged if it does not have a local segment.
+
+        Examples
+        --------
+        ```python
+        >>> v = Version('1.0+3.4')
+        >>> v.remove_local()
+        Version("1.0")
+        >>> v = Version('1.0')
+        >>> v.remove_local()
+        Version("1.0")
+        >>>
+        ```
+        """
+        return Version._from_py_version(self._version.remove_local())
+
     def extend_to_length(self, length: int) -> Version:
         """
         Returns a new version that is extended with `0s` to the specified length.

--- a/py-rattler/src/version/mod.rs
+++ b/py-rattler/src/version/mod.rs
@@ -184,6 +184,13 @@ impl PyVersion {
             .map_err(PyRattlerError::from)?)
     }
 
+    /// Returns a new version where the last segment is an "alpha" segment (ie. `.0a0`)
+    pub fn with_alpha(&self) -> Self {
+        Self {
+            inner: self.inner.with_alpha().into_owned(),
+        }
+    }
+
     /// Compute the hash of the version.
     fn __hash__(&self) -> u64 {
         let mut hasher = DefaultHasher::new();

--- a/py-rattler/src/version/mod.rs
+++ b/py-rattler/src/version/mod.rs
@@ -191,6 +191,13 @@ impl PyVersion {
         }
     }
 
+    /// Returns a new version where the local segment is removed (e.g. `1.0+local` -> `1.0`)
+    pub fn remove_local(&self) -> Self {
+        Self {
+            inner: self.inner.remove_local().into_owned(),
+        }
+    }
+
     /// Compute the hash of the version.
     fn __hash__(&self) -> u64 {
         let mut hasher = DefaultHasher::new();


### PR DESCRIPTION
I also added a `remove_local` function that removes the local segments of a version.