### PR TITLE
chore: enable serialization of enums

### DIFF
--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -23,6 +23,7 @@ tempfile = { workspace = true }
 rattler_libsolv_c = { path="../rattler_libsolv_c", version = "0.19.3", default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -81,6 +81,8 @@ impl fmt::Display for SolveError {
 
 /// Represents the channel priority option to use during solves.
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename-all = "kebab-case"))]
 pub enum ChannelPriority {
     /// The channel that the package is first found in will be used as the only
     /// channel for that package.
@@ -164,6 +166,8 @@ impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
 
 /// Represents the strategy to use when solving dependencies
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename-all = "kebab-case"))]
 pub enum SolveStrategy {
     /// Resolve the highest version of each package.
     #[default]

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -82,7 +82,7 @@ impl fmt::Display for SolveError {
 /// Represents the channel priority option to use during solves.
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename-all = "kebab-case"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum ChannelPriority {
     /// The channel that the package is first found in will be used as the only
     /// channel for that package.
@@ -167,7 +167,7 @@ impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
 /// Represents the strategy to use when solving dependencies
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename-all = "kebab-case"))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum SolveStrategy {
     /// Resolve the highest version of each package.
     #[default]


### PR DESCRIPTION
Adds optional support for `ChannelPriority` and `SolveStrategy` to be serialized with serde.