### PR TITLE
fix: call on_download_start also for file URLs

### DIFF
--- a/crates/rattler_package_streaming/src/reqwest/tokio.rs
+++ b/crates/rattler_package_streaming/src/reqwest/tokio.rs
@@ -25,6 +25,10 @@ async fn get_reader(
     expected_sha256: Option<Sha256Hash>,
     reporter: Option<Arc<dyn DownloadReporter>>,
 ) -> Result<impl tokio::io::AsyncRead, ExtractError> {
+    if let Some(reporter) = &reporter {
+        reporter.on_download_start();
+    }
+
     if url.scheme() == "file" {
         let file =
             tokio::fs::File::open(url.to_file_path().expect("Could not convert to file path"))
@@ -39,10 +43,6 @@ async fn get_reader(
         if let Some(sha256) = expected_sha256 {
             // This is used by the OCI registry middleware to verify the sha256 of the response
             request = request.header("X-Expected-Sha256", format!("{sha256:x}"));
-        }
-
-        if let Some(reporter) = &reporter {
-            reporter.on_download_start();
         }
 
         let response = request


### PR DESCRIPTION
We hit a debug assert in `rattler-build` where we download files from `file:///` URLs.

Logs: https://github.com/prefix-dev/rattler-build/actions/runs/9283979823/job/25545353376

```
thread 'tokio-runtime-worker' panicked at /home/runner/.cargo/git/checkouts/rattler-c5fe433b5d5eb3e2/8eccee4/crates/rattler/src/package_cache.rs:383:14:
on_download_start was not called
stack backtrace:
   0: rust_begin_unwind
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/panicking.rs:645:5
   1: core::panicking::panic_fmt
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panicking.rs:72:14
   2: core::panicking::panic_display
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panicking.rs:178:5
   3: core::panicking::panic_str
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/panicking.rs:152:5
   4: core::option::expect_failed
             at /rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/core/src/option.rs:1985:5
   5: <rattler::package_cache::PassthroughReporter as rattler_package_streaming::DownloadReporter>::on_download_complete
   6: rattler::package_cache::validate_or_fetch_to_cache::{{closure}}
   7: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
   8: rattler::package_cache::PackageCache::get_or_fetch::{{closure}}::{{closure}}
   9: tokio::runtime::task::core::Core<T,S>::poll
  10: tokio::runtime::task::harness::Harness<T,S>::poll
  11: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
  12: tokio::runtime::scheduler::multi_thread::worker::Context::run
  13: tokio::runtime::context::scoped::Scoped<T>::set
  14: tokio::runtime::context::runtime::enter_runtime
  15: tokio::runtime::scheduler::multi_thread::worker::run
  16: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
  17: tokio::runtime::task::core::Core<T,S>::poll
  18: tokio::runtime::task::harness::Harness<T,S>::poll
  19: tokio::runtime::blocking::pool::Inner::run
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

```

This might fix it!