### PR TITLE
fix: use total duration of timedelta objects

### DIFF
--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -92,7 +92,7 @@ async def solve(
             pinned_packages=[package._record for package in pinned_packages or []],
             virtual_packages=[v_package._generic_virtual_package for v_package in virtual_packages or []],
             channel_priority=channel_priority.value,
-            timeout=timeout.microseconds if timeout else None,
+            timeout=timeout.total_seconds() * 10e6 if timeout else None,
             exclude_newer_timestamp_ms=int(exclude_newer.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
             if exclude_newer
             else None,

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -92,7 +92,7 @@ async def solve(
             pinned_packages=[package._record for package in pinned_packages or []],
             virtual_packages=[v_package._generic_virtual_package for v_package in virtual_packages or []],
             channel_priority=channel_priority.value,
-            timeout=timeout.total_seconds() * 10e6 if timeout else None,
+            timeout=int(timeout.total_seconds() * 10e6) if timeout else None,
             exclude_newer_timestamp_ms=int(exclude_newer.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
             if exclude_newer
             else None,

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -92,7 +92,7 @@ async def solve(
             pinned_packages=[package._record for package in pinned_packages or []],
             virtual_packages=[v_package._generic_virtual_package for v_package in virtual_packages or []],
             channel_priority=channel_priority.value,
-            timeout=int(timeout.total_seconds() * 10e6) if timeout else None,
+            timeout=int(timeout / datetime.timedelta(microseconds=1)) if timeout else None,
             exclude_newer_timestamp_ms=int(exclude_newer.replace(tzinfo=datetime.timezone.utc).timestamp() * 1000)
             if exclude_newer
             else None,


### PR DESCRIPTION
This PR fixes a bug where the py-rattler solver timeout did not use the entire duration of the timedelta object. 

edit: With this fix, it should work. The hack I was using to get around this bug doesn't work and so the solver thought I passed a timeout of zero.