### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -28,12 +28,12 @@ console = { workspace = true, features = ["windows-console-colors"] }
 futures = { workspace = true }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.26.1", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.0", default-features = false }
+rattler = { path="../rattler", version = "0.26.2", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.25.1", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.8", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.20.3", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "0.23.2", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.13", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.20.4", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "0.24.0", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.14", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.2](https://github.com/mamba-org/rattler/compare/rattler-v0.26.1...rattler-v0.26.2) - 2024-06-03
+
+### Other
+- updated the following local packages: rattler_conda_types, rattler_package_streaming
+
 ## [0.26.1](https://github.com/mamba-org/rattler/compare/rattler-v0.26.0...rattler-v0.26.1) - 2024-05-28
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.26.1"
+version = "0.26.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -35,11 +35,11 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.0", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.20.8", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.20.6", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.21.1", default-features = false, features = ["reqwest"] }
+rattler_shell = { path = "../rattler_shell", version = "0.20.7", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.21.2", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.25.0...rattler_conda_types-v0.25.1) - 2024-06-03
+
+### Added
+- add a `with_alpha` function that adds `0a0` to the version ([#696](https://github.com/mamba-org/rattler/pull/696))
+
 ## [0.25.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.24.0...rattler_conda_types-v0.25.0) - 2024-05-28
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.15](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.14...rattler_index-v0.19.15) - 2024-06-03
+
+### Other
+- updated the following local packages: rattler_conda_types, rattler_package_streaming
+
 ## [0.19.14](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.13...rattler_index-v0.19.14) - 2024-05-28
 
 ### Added

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.14"
+version = "0.19.15"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.25.1", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.21.1", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.21.2", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.10](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.9...rattler_lock-v0.22.10) - 2024-06-03
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.9](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.8...rattler_lock-v0.22.9) - 2024-05-28
 
 ### Added

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.9"
+version = "0.22.10"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.0", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false }
 file_url = { path = "../file_url", version = "0.1.1" }
 pep508_rs = { workspace = true, features = ["serde"] }

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.2](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.21.1...rattler_package_streaming-v0.21.2) - 2024-06-03
+
+### Fixed
+- call on_download_start also for file URLs ([#708](https://github.com/mamba-org/rattler/pull/708))
+
 ## [0.21.1](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.21.0...rattler_package_streaming-v0.21.1) - 2024-05-28
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.21.1"
+version = "0.21.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -15,7 +15,7 @@ bzip2 = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.25.1", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.8", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.4](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.20.3...rattler_repodata_gateway-v0.20.4) - 2024-06-03
+
+### Other
+- updated the following local packages: rattler_conda_types, rattler_conda_types
+
 ## [0.20.3](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.20.2...rattler_repodata_gateway-v0.20.3) - 2024-05-28
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.20.3"
+version = "0.20.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -35,7 +35,7 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.0", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.1", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false, features = ["tokio", "serde"] }
 rattler_networking = { path = "../rattler_networking", version = "0.20.8", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
@@ -70,7 +70,7 @@ rstest = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower-http = { workspace = true, features = ["fs", "compression-gzip", "trace"] }
 tracing-test = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.0", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.1", default-features = false }
 
 [features]
 default = ['native-tls']

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.7](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.6...rattler_shell-v0.20.7) - 2024-06-03
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.20.6](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.5...rattler_shell-v0.20.6) - 2024-05-28
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.20.6"
+version = "0.20.7"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.25.1", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.23.2...rattler_solve-v0.24.0) - 2024-06-03
+
+### Added
+- add constraints to solve ([#713](https://github.com/mamba-org/rattler/pull/713))
+
 ## [0.23.2](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.23.1...rattler_solve-v0.23.2) - 2024-05-28
 
 ### Fixed

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.23.2"
+version = "0.24.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.25.1", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.14](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.13...rattler_virtual_packages-v0.19.14) - 2024-06-03
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.13](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.12...rattler_virtual_packages-v0.19.13) - 2024-05-28
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "0.19.13"
+version = "0.19.14"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.0", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.25.1", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler_conda_types`: 0.25.0 -> 0.25.1
* `rattler_package_streaming`: 0.21.1 -> 0.21.2
* `rattler_solve`: 0.23.2 -> 0.24.0
* `rattler`: 0.26.1 -> 0.26.2
* `rattler_shell`: 0.20.6 -> 0.20.7
* `rattler_lock`: 0.22.9 -> 0.22.10
* `rattler_repodata_gateway`: 0.20.3 -> 0.20.4
* `rattler_virtual_packages`: 0.19.13 -> 0.19.14
* `rattler_index`: 0.19.14 -> 0.19.15

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_conda_types`
<blockquote>

## [0.25.1](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.25.0...rattler_conda_types-v0.25.1) - 2024-06-03

### Added
- add a `with_alpha` function that adds `0a0` to the version ([#696](https://github.com/mamba-org/rattler/pull/696))
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.21.2](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.21.1...rattler_package_streaming-v0.21.2) - 2024-06-03

### Fixed
- call on_download_start also for file URLs ([#708](https://github.com/mamba-org/rattler/pull/708))
</blockquote>

## `rattler_solve`
<blockquote>

## [0.24.0](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.23.2...rattler_solve-v0.24.0) - 2024-06-03

### Added
- add constraints to solve ([#713](https://github.com/mamba-org/rattler/pull/713))
</blockquote>

## `rattler`
<blockquote>

## [0.26.2](https://github.com/mamba-org/rattler/compare/rattler-v0.26.1...rattler-v0.26.2) - 2024-06-03

### Other
- updated the following local packages: rattler_conda_types, rattler_package_streaming
</blockquote>

## `rattler_shell`
<blockquote>

## [0.20.7](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.6...rattler_shell-v0.20.7) - 2024-06-03

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.10](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.9...rattler_lock-v0.22.10) - 2024-06-03

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.20.4](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.20.3...rattler_repodata_gateway-v0.20.4) - 2024-06-03

### Other
- updated the following local packages: rattler_conda_types, rattler_conda_types
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [0.19.14](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.13...rattler_virtual_packages-v0.19.14) - 2024-06-03

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.15](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.14...rattler_index-v0.19.15) - 2024-06-03

### Other
- updated the following local packages: rattler_conda_types, rattler_package_streaming
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).