### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -28,11 +28,11 @@ console = { workspace = true, features = ["windows-console-colors"] }
 futures = { workspace = true }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.26.3", default-features = false, features = ["indicatif"] }
+rattler = { path="../rattler", version = "0.26.4", default-features = false, features = ["indicatif"] }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.25.2", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.8", default-features = false }
 rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.20.5", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "0.24.1", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_solve = { path="../rattler_solve", version = "0.24.2", default-features = false, features = ["resolvo", "libsolv_c"] }
 rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.15", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.4](https://github.com/mamba-org/rattler/compare/rattler-v0.26.3...rattler-v0.26.4) - 2024-06-06
+
+### Other
+- updated the following local packages: rattler_shell
+
 ## [0.26.3](https://github.com/baszalmstra/rattler/compare/rattler-v0.26.2...rattler-v0.26.3) - 2024-06-04
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.26.3"
+version = "0.26.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -39,7 +39,7 @@ rattler_cache = { path = "../rattler_cache", version = "0.1.0", default-features
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.2", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.20.8", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.20.8", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.20.9", default-features = false }
 rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.21.3", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.17](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.16...rattler_index-v0.19.17) - 2024-06-06
+
+### Other
+- make package_record_from_* functions public ([#726](https://github.com/mamba-org/rattler/pull/726))
+
 ## [0.19.16](https://github.com/baszalmstra/rattler/compare/rattler_index-v0.19.15...rattler_index-v0.19.16) - 2024-06-04
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.16"
+version = "0.19.17"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.12](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.11...rattler_lock-v0.22.12) - 2024-06-06
+
+### Added
+- serialize packages from lock file individually ([#728](https://github.com/mamba-org/rattler/pull/728))
+
 ## [0.22.11](https://github.com/baszalmstra/rattler/compare/rattler_lock-v0.22.10...rattler_lock-v0.22.11) - 2024-06-04
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.11"
+version = "0.22.12"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.9](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.8...rattler_shell-v0.20.9) - 2024-06-06
+
+### Other
+- make `prefix_paths_entries` pub ([#729](https://github.com/mamba-org/rattler/pull/729))
+
 ## [0.20.8](https://github.com/baszalmstra/rattler/compare/rattler_shell-v0.20.7...rattler_shell-v0.20.8) - 2024-06-04
 
 ### Fixed

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.20.8"
+version = "0.20.9"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.24.1...rattler_solve-v0.24.2) - 2024-06-06
+
+### Added
+- serialize packages from lock file individually ([#728](https://github.com/mamba-org/rattler/pull/728))
+
 ## [0.24.1](https://github.com/baszalmstra/rattler/compare/rattler_solve-v0.24.0...rattler_solve-v0.24.1) - 2024-06-04
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.24.1"
+version = "0.24.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"


### PR DESCRIPTION
## 🤖 New release
* `rattler_shell`: 0.20.8 -> 0.20.9
* `rattler_lock`: 0.22.11 -> 0.22.12
* `rattler_solve`: 0.24.1 -> 0.24.2
* `rattler_index`: 0.19.16 -> 0.19.17
* `rattler`: 0.26.3 -> 0.26.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_shell`
<blockquote>

## [0.20.9](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.8...rattler_shell-v0.20.9) - 2024-06-06

### Other
- make `prefix_paths_entries` pub ([#729](https://github.com/mamba-org/rattler/pull/729))
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.12](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.11...rattler_lock-v0.22.12) - 2024-06-06

### Added
- serialize packages from lock file individually ([#728](https://github.com/mamba-org/rattler/pull/728))
</blockquote>

## `rattler_solve`
<blockquote>

## [0.24.2](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.24.1...rattler_solve-v0.24.2) - 2024-06-06

### Added
- serialize packages from lock file individually ([#728](https://github.com/mamba-org/rattler/pull/728))
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.17](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.16...rattler_index-v0.19.17) - 2024-06-06

### Other
- make package_record_from_* functions public ([#726](https://github.com/mamba-org/rattler/pull/726))
</blockquote>

## `rattler`
<blockquote>

## [0.26.4](https://github.com/mamba-org/rattler/compare/rattler-v0.26.3...rattler-v0.26.4) - 2024-06-06

### Other
- updated the following local packages: rattler_shell
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).