### PR TITLE
fix: issue 717

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -20,10 +20,9 @@ use super::{
     matcher::{StringMatcher, StringMatcherParseError},
     MatchSpec,
 };
-use crate::utils::url::parse_scheme;
 use crate::{
     build_spec::{BuildNumberSpec, ParseBuildNumberSpecError},
-    utils::path::is_path,
+    utils::{path::is_path, url::parse_scheme},
     version_spec::{
         is_start_of_version_constraint,
         version_tree::{recognize_constraint, recognize_version},
@@ -200,7 +199,7 @@ fn parse_bracket_list(input: &str) -> Result<BracketVec<'_>, ParseMatchSpecError
 /// Strips the brackets part of the matchspec returning the rest of the
 /// matchspec and  the contents of the brackets as a `Vec<&str>`.
 fn strip_brackets(input: &str) -> Result<(Cow<'_, str>, BracketVec<'_>), ParseMatchSpecError> {
-    if let Some(matches) = lazy_regex::regex!(r#".*(?:(\[.*\]))"#).captures(input) {
+    if let Some(matches) = lazy_regex::regex!(r#".*(?:(\[.*\]))$"#).captures(input) {
         let bracket_str = matches.get(1).unwrap().as_str();
         let bracket_contents = parse_bracket_list(bracket_str)?;
 
@@ -895,5 +894,13 @@ mod tests {
 
         let err = MatchSpec::from_str("./test/file", Strict).expect_err("Invalid url");
         assert_eq!(err.to_string(), "invalid package path or url");
+    }
+
+    #[test]
+    fn test_issue_717() {
+        assert_matches!(
+            MatchSpec::from_str("ray[default,data] >=2.9.0,<3.0.0", Strict),
+            Err(ParseMatchSpecError::InvalidPackageName(_))
+        );
     }
 }

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__base_url_packages.snap
@@ -1,19 +1,19 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
-assertion_line: 511
 expression: file_urls
 ---
-- channels/dummy/linux-64/foobar-2.1-bla_1.tar.bz2
-- channels/dummy/linux-64/bors-2.1-bla_1.tar.bz2
-- channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_2.conda
+- channels/dummy/linux-64/issue_717-2.1-bla_1.tar.bz2
 - channels/dummy/linux-64/bar-1.0-unix_py36h1af98f8_2.tar.bz2
-- channels/dummy/linux-64/bors-1.0-bla_1.tar.bz2
+- channels/dummy/linux-64/foobar-2.0-bla_1.tar.bz2
 - channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_1.conda
 - channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_1.tar.bz2
-- channels/dummy/linux-64/baz-2.0-unix_py36h1af98f8_2.tar.bz2
 - channels/dummy/linux-64/foo-4.0.2-py36h1af98f8_2.tar.bz2
-- channels/dummy/linux-64/bors-1.1-bla_1.tar.bz2
-- channels/dummy/linux-64/bors-2.0-bla_1.tar.bz2
-- channels/dummy/linux-64/foobar-2.0-bla_1.tar.bz2
 - channels/dummy/linux-64/bors-1.2.1-bla_1.tar.bz2
 - channels/dummy/linux-64/baz-1.0-unix_py36h1af98f8_2.tar.bz2
+- channels/dummy/linux-64/bors-2.1-bla_1.tar.bz2
+- channels/dummy/linux-64/foo-3.0.2-py36h1af98f8_2.conda
+- channels/dummy/linux-64/bors-1.0-bla_1.tar.bz2
+- channels/dummy/linux-64/bors-1.1-bla_1.tar.bz2
+- channels/dummy/linux-64/foobar-2.1-bla_1.tar.bz2
+- channels/dummy/linux-64/baz-2.0-unix_py36h1af98f8_2.tar.bz2
+- channels/dummy/linux-64/bors-2.0-bla_1.tar.bz2

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages-2.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
-assertion_line: 470
 expression: json
 ---
 {
@@ -207,6 +206,23 @@ expression: json
       "license_family": "MIT",
       "md5": "bc13aa58e2092bcb0b97c561373d3905",
       "name": "foobar",
+      "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
+      "size": 414494,
+      "subdir": "linux-64",
+      "timestamp": 1715610974,
+      "version": "2.1"
+    },
+    "issue_717-2.1-bla_1.tar.bz2": {
+      "build": "issue_717",
+      "build_number": 0,
+      "constrains": [
+        "ray[default,data] >=2.9.0,<3.0.0"
+      ],
+      "depends": [],
+      "license": "MIT",
+      "license_family": "MIT",
+      "md5": "bc13aa58e2092bcb0b97c561373d3905",
+      "name": "issue_717",
       "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
       "size": 414494,
       "subdir": "linux-64",

--- a/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
+++ b/crates/rattler_conda_types/src/repo_data/snapshots/rattler_conda_types__repo_data__test__serialize_packages.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/rattler_conda_types/src/repo_data/mod.rs
-assertion_line: 466
 expression: repodata
 ---
 info:
@@ -188,6 +187,21 @@ packages:
     license_family: MIT
     md5: bc13aa58e2092bcb0b97c561373d3905
     name: foobar
+    sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
+    size: 414494
+    subdir: linux-64
+    timestamp: 1715610974
+    version: "2.1"
+  issue_717-2.1-bla_1.tar.bz2:
+    build: issue_717
+    build_number: 0
+    constrains:
+      - "ray[default,data] >=2.9.0,<3.0.0"
+    depends: []
+    license: MIT
+    license_family: MIT
+    md5: bc13aa58e2092bcb0b97c561373d3905
+    name: issue_717
     sha256: 97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a
     size: 414494
     subdir: linux-64

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -480,13 +480,31 @@ impl<'a> DependencyProvider<SolverMatchSpec<'a>> for CondaDependencyProvider<'a>
         let mut parse_match_spec_cache = self.parse_match_spec_cache.borrow_mut();
         for depends in rec.package_record.depends.iter() {
             let version_set_id =
-                parse_match_spec(&self.pool, depends, &mut parse_match_spec_cache).unwrap();
+                match parse_match_spec(&self.pool, depends, &mut parse_match_spec_cache) {
+                    Ok(version_set_id) => version_set_id,
+                    Err(e) => {
+                        let reason = self.pool.intern_string(format!(
+                            "the dependency '{depends}' failed to parse: {e}",
+                        ));
+
+                        return Dependencies::Unknown(reason);
+                    }
+                };
             dependencies.requirements.push(version_set_id);
         }
 
         for constrains in rec.package_record.constrains.iter() {
             let version_set_id =
-                parse_match_spec(&self.pool, constrains, &mut parse_match_spec_cache).unwrap();
+                match parse_match_spec(&self.pool, constrains, &mut parse_match_spec_cache) {
+                    Ok(version_set_id) => version_set_id,
+                    Err(e) => {
+                        let reason = self.pool.intern_string(format!(
+                            "the constrains '{constrains}' failed to parse: {e}",
+                        ));
+
+                        return Dependencies::Unknown(reason);
+                    }
+                };
             dependencies.constrains.push(version_set_id);
         }
 

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -691,6 +691,20 @@ mod resolvo {
     }
 
     #[test]
+    fn test_issue_717() {
+        let result = solve::<rattler_solve::resolvo::Solver>(
+            dummy_channel_json_path(),
+            SimpleSolveTask {
+                specs: &["issue_717"],
+                ..SimpleSolveTask::default()
+            },
+        );
+
+        // We expect an error here. `bors` is pinnend to 1, but we try to install `>=2`.
+        insta::assert_snapshot!(result.unwrap_err());
+    }
+
+    #[test]
     fn test_exclude_newer_error() {
         let date = "2021-12-12T12:12:12Z".parse::<DateTime<Utc>>().unwrap();
 

--- a/crates/rattler_solve/tests/snapshots/backends__resolvo__issue_717.snap
+++ b/crates/rattler_solve/tests/snapshots/backends__resolvo__issue_717.snap
@@ -1,0 +1,7 @@
+---
+source: crates/rattler_solve/tests/backends.rs
+expression: result.unwrap_err()
+---
+Cannot solve the request because of: The following packages are incompatible
+└─ issue_717 * cannot be installed because there are no viable options:
+   └─ issue_717 2.1 is excluded because the constrains 'ray[default,data] >=2.9.0,<3.0.0' failed to parse: 'ray[default,data]' is not a valid package name. Package names can only contain 0-9, a-z, A-Z, -, _, or .

--- a/crates/rattler_solve/tests/snapshots/backends__resolvo__solve_with_error.snap
+++ b/crates/rattler_solve/tests/snapshots/backends__resolvo__solve_with_error.snap
@@ -3,11 +3,10 @@ source: crates/rattler_solve/tests/backends.rs
 expression: err
 ---
 Cannot solve the request because of: The following packages are incompatible
-├─ foobar >=2 can be installed with any of the following options:
-│  └─ foobar 2.0 | 2.1 would require
-│     └─ bors <2.0, which can be installed with any of the following options:
-│        └─ bors 1.2.1
-└─ bors >=2 cannot be installed because there are no viable options:
-   ├─ bors 2.1, which conflicts with the versions reported above.
-   └─ bors 2.0, which conflicts with the versions reported above.
-
+├─ bors >=2 can be installed with any of the following options:
+│  └─ bors 2.0
+└─ foobar >=2 cannot be installed because there are no viable options:
+   └─ foobar 2.0 | 2.1 would require
+      └─ bors <2.0, which cannot be installed because there are no viable options:
+         ├─ bors 1.2.1, which conflicts with the versions reported above.
+         └─ bors 1.0 | 1.1, which conflicts with the versions reported above.

--- a/test-data/channels/dummy/linux-64/repodata.json
+++ b/test-data/channels/dummy/linux-64/repodata.json
@@ -214,6 +214,23 @@
       "subdir": "linux-64",
       "timestamp": 1715610974000,
       "version": "2.1"
+    },
+    "issue_717-2.1-bla_1.tar.bz2": {
+      "build": "issue_717",
+      "build_number": 0,
+      "depends": [],
+      "constrains": [
+        "ray[default,data] >=2.9.0,<3.0.0"
+      ],
+      "license": "MIT",
+      "license_family": "MIT",
+      "md5": "bc13aa58e2092bcb0b97c561373d3905",
+      "name": "issue_717",
+      "sha256": "97ec377d2ad83dfef1194b7aa31b0c9076194e10d995a6e696c9d07dd782b14a",
+      "size": 414494,
+      "subdir": "linux-64",
+      "timestamp": 1715610974000,
+      "version": "2.1"
     }
   },
   "packages.conda": {},


### PR DESCRIPTION
Fixes #717 
Fixes https://github.com/prefix-dev/pixi/issues/1469

This fixes parsing of `ray[default,data] >=2.9.0,<3.0.0` to fail with `InvalidPackageName` instead of `InvalidBracket`.