### PR TITLE
fix: lenient and strict parsing of equality signs

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -79,7 +79,7 @@ use matcher::StringMatcher;
 /// assert_eq!(spec.version, Some(VersionSpec::from_str("1.0", Strict).unwrap()));
 /// assert_eq!(spec.build, Some(StringMatcher::from_str("py27_0").unwrap()));
 ///
-/// let spec = MatchSpec::from_str("foo=1.0=py27_0", Strict).unwrap();
+/// let spec = MatchSpec::from_str("foo 1.0 py27_0", Strict).unwrap();
 /// assert_eq!(spec.name, Some(PackageName::new_unchecked("foo")));
 /// assert_eq!(spec.version, Some(VersionSpec::from_str("==1.0", Strict).unwrap()));
 /// assert_eq!(spec.build, Some(StringMatcher::from_str("py27_0").unwrap()));

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -525,6 +525,8 @@ fn matchspec_parser(
     Ok(match_spec)
 }
 
+/// HERE BE DRAGONS!
+///
 /// In some circumstainces we strip the `=` or `==` parts of the version string.
 /// This is for conda legacy reasons. This function implements that behavior and
 /// returns the stripped/updated version.

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
-assertion_line: 794
+assertion_line: 890
 expression: evaluated
 ---
 /home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2:
@@ -32,7 +32,7 @@ foo=1.0=py27_0:
   build: py27_0
 foo==1.0=py27_0:
   name: foo
-  version: "==1.0"
+  version: 1.0.*
   build: py27_0
 "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda":
   url: "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda"
@@ -42,6 +42,9 @@ python 3.8.* *_cpython:
   name: python
   version: 3.8.*
   build: "*_cpython"
+python ==2.7.*.*|>=3.6:
+  name: python
+  version: 2.7.*|>=3.6
 pytorch=*=cuda*:
   name: pytorch
   version: "*"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
-assertion_line: 890
+assertion_line: 904
 expression: evaluated
 ---
 /home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2:
@@ -32,7 +32,7 @@ foo=1.0=py27_0:
   build: py27_0
 foo==1.0=py27_0:
   name: foo
-  version: 1.0.*
+  version: "==1.0"
   build: py27_0
 "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda":
   url: "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda"
@@ -45,6 +45,9 @@ python 3.8.* *_cpython:
 python ==2.7.*.*|>=3.6:
   name: python
   version: 2.7.*|>=3.6
+python=3.9:
+  name: python
+  version: 3.9.*
 pytorch=*=cuda*:
   name: pytorch
   version: "*"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -1,0 +1,47 @@
+---
+source: crates/rattler_conda_types/src/match_spec/parse.rs
+assertion_line: 890
+expression: evaluated
+---
+/home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2:
+  url: "file:///home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2"
+"C:\\Users\\user\\conda-bld\\linux-64\\foo-1.0-py27_0.tar.bz2":
+  url: "file:///C:/Users/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2"
+blas *.* mkl:
+  name: blas
+  version: "*"
+  build: mkl
+"conda-forge::foo[version=1.0.*, build_number=\">6\"]":
+  name: foo
+  version: 1.0.*
+  build_number:
+    op: Gt
+    rhs: 6
+  channel:
+    base_url: "https://conda.anaconda.org/conda-forge/"
+    name: conda-forge
+"conda-forge::foo[version=1.0.*]":
+  name: foo
+  version: 1.0.*
+  channel:
+    base_url: "https://conda.anaconda.org/conda-forge/"
+    name: conda-forge
+foo=1.0=py27_0:
+  error: "'foo=1.0=py27_0' is not a valid package name. Package names can only contain 0-9, a-z, A-Z, -, _, or ."
+foo==1.0=py27_0:
+  error: "'foo==1.0=py27_0' is not a valid package name. Package names can only contain 0-9, a-z, A-Z, -, _, or ."
+"https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda":
+  url: "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda"
+"https://repo.prefix.dev/ruben-arts/linux-64/boost-cpp-1.78.0-h75c5d50_1.tar.bz2":
+  url: "https://repo.prefix.dev/ruben-arts/linux-64/boost-cpp-1.78.0-h75c5d50_1.tar.bz2"
+python 3.8.* *_cpython:
+  name: python
+  version: 3.8.*
+  build: "*_cpython"
+python ==2.7.*.*|>=3.6:
+  error: "invalid version constraint: regex constraints are not supported"
+pytorch=*=cuda*:
+  error: "'pytorch=*=cuda*' is not a valid package name. Package names can only contain 0-9, a-z, A-Z, -, _, or ."
+"x264 >=1!164.3095,<1!165":
+  name: x264
+  version: ">=1!164.3095,<1!165"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
-assertion_line: 890
+assertion_line: 904
 expression: evaluated
 ---
 /home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2:
@@ -40,6 +40,8 @@ python 3.8.* *_cpython:
   build: "*_cpython"
 python ==2.7.*.*|>=3.6:
   error: "invalid version constraint: regex constraints are not supported"
+python=3.9:
+  error: "'python=3.9' is not a valid package name. Package names can only contain 0-9, a-z, A-Z, -, _, or ."
 pytorch=*=cuda*:
   error: "'pytorch=*=cuda*' is not a valid package name. Package names can only contain 0-9, a-z, A-Z, -, _, or ."
 "x264 >=1!164.3095,<1!165":

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Lenient.snap
@@ -1,0 +1,7 @@
+---
+source: crates/rattler_conda_types/src/match_spec/parse.rs
+assertion_line: 930
+expression: evaluated
+---
+2.7|>=3.6:
+  version: "==2.7|>=3.6"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_nameless_from_string_Strict.snap
@@ -1,0 +1,7 @@
+---
+source: crates/rattler_conda_types/src/match_spec/parse.rs
+assertion_line: 930
+expression: evaluated
+---
+2.7|>=3.6:
+  version: "==2.7|>=3.6"

--- a/py-rattler/rattler/install/installer.py
+++ b/py-rattler/rattler/install/installer.py
@@ -40,7 +40,7 @@ async def install(
     >>>
     >>> async def main():
     ...     # Solve an environment with python 3.9 for the current platform
-    ...     records = await solve(channels=["conda-forge"], specs=["python=3.9"])
+    ...     records = await solve(channels=["conda-forge"], specs=["python 3.9.*"])
     ...
     ...     # Link the environment in a temporary directory (you can pass any kind of path here).
     ...     await install(records, target_prefix=temp_dir.name)

--- a/py-rattler/tests/unit/test_solver.py
+++ b/py-rattler/tests/unit/test_solver.py
@@ -109,7 +109,7 @@ async def test_solve_channel_priority_disabled(
 ) -> None:
     solved_data = await solve(
         [conda_forge_channel, pytorch_channel],
-        ["pytorch-cpu=0.4.1=py36_cpu_1"],
+        ["pytorch-cpu 0.4.1 py36_cpu_1"],
         platforms=["linux-64"],
         gateway=gateway,
         channel_priority=ChannelPriority.Disabled,


### PR DESCRIPTION
Fixes #736 

This PR introduces strict and lenient parsing of versions in the form of `pytorch=*=*cuda` and `python ==2.7.8.*.*`.

This changes the behavior in strict mode and makes sure that `NamelessMatchSpec` and `MatchSpec` behave the same way while parsing.

In strict mode only spaces are allowed to separate the package name, version, and build string. The form `pytorch=*=*cuda` is no longer allowed and will result in an error. Instead this should be written as `pytorch * *cuda`. This removes any ambiguity about what the equality signs mean. Another form that has been removed in strict mode is the removal of the `==` sign in some specific cases like `python ==2.7`. Finally, the behavior where the version string is appended with a `*` if the version starts with a `=` is removed in strict mode. 