### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -28,12 +28,12 @@ console = { workspace = true, features = ["windows-console-colors"] }
 futures = { workspace = true }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.26.4", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.2", default-features = false }
+rattler = { path="../rattler", version = "0.26.5", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.0", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.8", default-features = false }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.20.5", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "0.24.2", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.15", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.20.6", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "0.25.0", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.16", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.5](https://github.com/mamba-org/rattler/compare/rattler-v0.26.4...rattler-v0.26.5) - 2024-06-11
+
+### Other
+- updated the following local packages: rattler_conda_types, rattler_shell
+
 ## [0.26.4](https://github.com/mamba-org/rattler/compare/rattler-v0.26.3...rattler-v0.26.4) - 2024-06-06
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.26.4"
+version = "0.26.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -35,12 +35,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.1.0", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.2", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.1.1", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.20.8", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.20.9", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.21.3", default-features = false, features = ["reqwest"] }
+rattler_shell = { path = "../rattler_shell", version = "0.21.0", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.21.4", default-features = false, features = ["reqwest"] }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = ["stream", "json", "gzip"] }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/mamba-org/rattler/compare/rattler_cache-v0.1.0...rattler_cache-v0.1.1) - 2024-06-11
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.1.0](https://github.com/baszalmstra/rattler/releases/tag/rattler_cache-v0.1.0) - 2024-06-04
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.1.0"
+version = "0.1.1"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -16,10 +16,10 @@ dirs.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.25.2", path = "../rattler_conda_types", default-features = false }
+rattler_conda_types = { version = "0.26.0", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "0.19.4", path = "../rattler_digest", default-features = false }
 rattler_networking = { version = "0.20.8", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.21.3", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { version = "0.21.4", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.25.2...rattler_conda_types-v0.26.0) - 2024-06-11
+
+### Fixed
+- lenient and strict parsing of equality signs ([#738](https://github.com/mamba-org/rattler/pull/738))
+- This fixes parsing of `ray[default,data] >=2.9.0,<3.0.0` ([#732](https://github.com/mamba-org/rattler/pull/732))
+
 ## [0.25.2](https://github.com/baszalmstra/rattler/compare/rattler_conda_types-v0.25.1...rattler_conda_types-v0.25.2) - 2024-06-04
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.25.2"
+version = "0.26.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -21,7 +21,7 @@ lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
 rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false, features = ["serde"] }
-rattler_macros = { path = "../rattler_macros", version = "0.19.3", default-features = false }
+rattler_macros = { path = "../rattler_macros", version = "0.19.4", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.18](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.17...rattler_index-v0.19.18) - 2024-06-11
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.17](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.16...rattler_index-v0.19.17) - 2024-06-06
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.19.17"
+version = "0.19.18"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.21.3", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.21.4", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 walkdir = { workspace = true }

--- a/crates/rattler_libsolv_c/CHANGELOG.md
+++ b/crates/rattler_libsolv_c/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_libsolv_c-v0.19.3...rattler_libsolv_c-v0.19.4) - 2024-06-11
+
+### Other
+- update README.md
+
 ## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_libsolv_c-v0.19.2...rattler_libsolv_c-v0.19.3) - 2024-04-19
 
 ### Other

--- a/crates/rattler_libsolv_c/Cargo.toml
+++ b/crates/rattler_libsolv_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_libsolv_c"
-version = "0.19.3"
+version = "0.19.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Bindings for libsolv"

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.13](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.12...rattler_lock-v0.22.13) - 2024-06-11
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.12](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.11...rattler_lock-v0.22.12) - 2024-06-06
 
 ### Added

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.12"
+version = "0.22.13"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.0", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false }
 file_url = { path = "../file_url", version = "0.1.2" }
 pep508_rs = { workspace = true, features = ["serde"] }

--- a/crates/rattler_macros/CHANGELOG.md
+++ b/crates/rattler_macros/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_macros-v0.19.3...rattler_macros-v0.19.4) - 2024-06-11
+
+### Other
+- update README.md
+
 ## [0.19.3](https://github.com/mamba-org/rattler/compare/rattler_macros-v0.19.2...rattler_macros-v0.19.3) - 2024-04-19
 
 ### Other

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_macros"
-version = "0.19.3"
+version = "0.19.4"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate that provideds some procedural macros for the rattler project"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.4](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.21.3...rattler_package_streaming-v0.21.4) - 2024-06-11
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.21.3](https://github.com/baszalmstra/rattler/compare/rattler_package_streaming-v0.21.2...rattler_package_streaming-v0.21.3) - 2024-06-04
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.21.3"
+version = "0.21.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -15,7 +15,7 @@ bzip2 = { workspace = true }
 chrono = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.8", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.6](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.20.5...rattler_repodata_gateway-v0.20.6) - 2024-06-11
+
+### Other
+- document gateway features ([#737](https://github.com/mamba-org/rattler/pull/737))
+
 ## [0.20.5](https://github.com/baszalmstra/rattler/compare/rattler_repodata_gateway-v0.20.4...rattler_repodata_gateway-v0.20.5) - 2024-06-04
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.20.5"
+version = "0.20.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -35,7 +35,7 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.2", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.0", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "0.19.4", default-features = false, features = ["tokio", "serde"] }
 rattler_networking = { path = "../rattler_networking", version = "0.20.8", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
@@ -70,7 +70,7 @@ rstest = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower-http = { workspace = true, features = ["fs", "compression-gzip", "trace"] }
 tracing-test = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.25.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.0", default-features = false }
 fslock = { workspace = true }
 
 [features]

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.9...rattler_shell-v0.21.0) - 2024-06-11
+
+### Added
+- allow passing custom environment to run_activation ([#743](https://github.com/mamba-org/rattler/pull/743))
+
 ## [0.20.9](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.8...rattler_shell-v0.20.9) - 2024-06-06
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.20.9"
+version = "0.21.0"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -14,7 +14,7 @@ readme.workspace = true
 enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.0", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true, optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.24.2...rattler_solve-v0.25.0) - 2024-06-11
+
+### Fixed
+- This fixes parsing of `ray[default,data] >=2.9.0,<3.0.0` ([#732](https://github.com/mamba-org/rattler/pull/732))
+
+### Other
+- bump resolvo to 0.6.0 ([#733](https://github.com/mamba-org/rattler/pull/733))
+- Document all features on docs.rs ([#734](https://github.com/mamba-org/rattler/pull/734))
+
 ## [0.24.2](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.24.1...rattler_solve-v0.24.2) - 2024-06-06
 
 ### Added

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.24.2"
+version = "0.25.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.0", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "0.19.4", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 url = { workspace = true }
 tempfile = { workspace = true }
-rattler_libsolv_c = { path="../rattler_libsolv_c", version = "0.19.3", default-features = false, optional = true }
+rattler_libsolv_c = { path="../rattler_libsolv_c", version = "0.19.4", default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.16](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.15...rattler_virtual_packages-v0.19.16) - 2024-06-11
+
+### Other
+- updated the following local packages: rattler_conda_types
+
 ## [0.19.15](https://github.com/baszalmstra/rattler/compare/rattler_virtual_packages-v0.19.14...rattler_virtual_packages-v0.19.15) - 2024-06-04
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "0.19.15"
+version = "0.19.16"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.25.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.26.0", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
## 🤖 New release
* `rattler_conda_types`: 0.25.2 -> 0.26.0
* `rattler_macros`: 0.19.3 -> 0.19.4
* `rattler_shell`: 0.20.9 -> 0.21.0
* `rattler_repodata_gateway`: 0.20.5 -> 0.20.6
* `rattler_solve`: 0.24.2 -> 0.25.0
* `rattler_libsolv_c`: 0.19.3 -> 0.19.4
* `rattler`: 0.26.4 -> 0.26.5
* `rattler_cache`: 0.1.0 -> 0.1.1
* `rattler_package_streaming`: 0.21.3 -> 0.21.4
* `rattler_lock`: 0.22.12 -> 0.22.13
* `rattler_virtual_packages`: 0.19.15 -> 0.19.16
* `rattler_index`: 0.19.17 -> 0.19.18

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_conda_types`
<blockquote>

## [0.26.0](https://github.com/mamba-org/rattler/compare/rattler_conda_types-v0.25.2...rattler_conda_types-v0.26.0) - 2024-06-11

### Fixed
- lenient and strict parsing of equality signs ([#738](https://github.com/mamba-org/rattler/pull/738))
- This fixes parsing of `ray[default,data] >=2.9.0,<3.0.0` ([#732](https://github.com/mamba-org/rattler/pull/732))
</blockquote>

## `rattler_macros`
<blockquote>

## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_macros-v0.19.3...rattler_macros-v0.19.4) - 2024-06-11

### Other
- update README.md
</blockquote>

## `rattler_shell`
<blockquote>

## [0.21.0](https://github.com/mamba-org/rattler/compare/rattler_shell-v0.20.9...rattler_shell-v0.21.0) - 2024-06-11

### Added
- allow passing custom environment to run_activation ([#743](https://github.com/mamba-org/rattler/pull/743))
</blockquote>

## `rattler_repodata_gateway`
<blockquote>

## [0.20.6](https://github.com/mamba-org/rattler/compare/rattler_repodata_gateway-v0.20.5...rattler_repodata_gateway-v0.20.6) - 2024-06-11

### Other
- document gateway features ([#737](https://github.com/mamba-org/rattler/pull/737))
</blockquote>

## `rattler_solve`
<blockquote>

## [0.25.0](https://github.com/mamba-org/rattler/compare/rattler_solve-v0.24.2...rattler_solve-v0.25.0) - 2024-06-11

### Fixed
- This fixes parsing of `ray[default,data] >=2.9.0,<3.0.0` ([#732](https://github.com/mamba-org/rattler/pull/732))

### Other
- bump resolvo to 0.6.0 ([#733](https://github.com/mamba-org/rattler/pull/733))
- Document all features on docs.rs ([#734](https://github.com/mamba-org/rattler/pull/734))
</blockquote>

## `rattler_libsolv_c`
<blockquote>

## [0.19.4](https://github.com/mamba-org/rattler/compare/rattler_libsolv_c-v0.19.3...rattler_libsolv_c-v0.19.4) - 2024-06-11

### Other
- update README.md
</blockquote>

## `rattler`
<blockquote>

## [0.26.5](https://github.com/mamba-org/rattler/compare/rattler-v0.26.4...rattler-v0.26.5) - 2024-06-11

### Other
- updated the following local packages: rattler_conda_types, rattler_shell
</blockquote>

## `rattler_cache`
<blockquote>

## [0.1.1](https://github.com/mamba-org/rattler/compare/rattler_cache-v0.1.0...rattler_cache-v0.1.1) - 2024-06-11

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_package_streaming`
<blockquote>

## [0.21.4](https://github.com/mamba-org/rattler/compare/rattler_package_streaming-v0.21.3...rattler_package_streaming-v0.21.4) - 2024-06-11

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_lock`
<blockquote>

## [0.22.13](https://github.com/mamba-org/rattler/compare/rattler_lock-v0.22.12...rattler_lock-v0.22.13) - 2024-06-11

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_virtual_packages`
<blockquote>

## [0.19.16](https://github.com/mamba-org/rattler/compare/rattler_virtual_packages-v0.19.15...rattler_virtual_packages-v0.19.16) - 2024-06-11

### Other
- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_index`
<blockquote>

## [0.19.18](https://github.com/mamba-org/rattler/compare/rattler_index-v0.19.17...rattler_index-v0.19.18) - 2024-06-11

### Other
- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).