### PR TITLE
fix: Support version components with leading zeros

### DIFF
--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -763,7 +763,10 @@ impl Component {
 
     /// Checks whether a component is [`Component::Numeral`]
     pub fn is_numeric(&self) -> bool {
-        matches!(self, Component::Numeral(_))
+        matches!(
+            self,
+            Component::Numeral(_) | Component::NumeralWithLeadingZeros(_)
+        )
     }
 
     /// Checks whether the component is a zero.
@@ -860,10 +863,9 @@ impl Debug for Component {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Component::Numeral(n) => write!(f, "{n}"),
-            Component::NumeralWithLeadingZeros(NumeralWithLeadingZeros {
-                leading_zeros,
-                numeral,
-            }) => write!(f, "{z}{n}", z = "0".repeat(*leading_zeros), n = numeral),
+            Component::NumeralWithLeadingZeros(NumeralWithLeadingZeros { numeral, .. }) => {
+                write!(f, "{n}", n = numeral)
+            }
             Component::Iden(s) => write!(f, "'{s}'"),
             Component::Post => write!(f, "inf"),
             Component::Dev => write!(f, "'DEV'"),

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -676,8 +676,8 @@ impl<'v, I: Iterator<Item = SegmentIter<'v>> + 'v> fmt::Display for SegmentForma
 
 #[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct NumeralWithLeadingZeros {
-    leading_zeros: usize,
-    numeral: u64,
+    pub leading_zeros: usize,
+    pub numeral: u64,
 }
 
 /// Either a number, literal or the infinity.

--- a/crates/rattler_conda_types/src/version/parse.rs
+++ b/crates/rattler_conda_types/src/version/parse.rs
@@ -145,15 +145,15 @@ fn numeral_with_leading_zeros_parser(
 
     let mut leading_zeros = input.chars().take_while(|c| c == &'0').count();
     match u64::from_str(digits) {
-        Ok(value) => {
-            if value == 0 {
+        Ok(numeral) => {
+            if numeral == 0 {
                 leading_zeros -= 1;
             }
             Ok((
                 rest,
                 NumeralWithLeadingZeros {
-                    numeral: value,
                     leading_zeros,
+                    numeral,
                 },
             ))
         }

--- a/crates/rattler_conda_types/src/version/snapshots/rattler_conda_types__version__parse__test__parse.snap
+++ b/crates/rattler_conda_types/src/version/snapshots/rattler_conda_types__version__parse__test__parse.snap
@@ -43,13 +43,13 @@ expression: index_map
         },
     ),
     "1-2-3_": Error(
-        "cannot use both underscores and dashes as version segment seperators",
+        "cannot use both underscores and dashes as version segment separators",
     ),
     "1-2_3": Error(
-        "cannot use both underscores and dashes as version segment seperators",
+        "cannot use both underscores and dashes as version segment separators",
     ),
     "1-_": Error(
-        "cannot use both underscores and dashes as version segment seperators",
+        "cannot use both underscores and dashes as version segment separators",
     ),
     "1.0.1-": Version(
         Version {
@@ -69,6 +69,12 @@ expression: index_map
             local: [],
         },
     ),
+    "1.000": Version(
+        Version {
+            version: [[0], [1], [0, 000]],
+            local: [],
+        },
+    ),
     "1@2": Error(
         "encountered more characters but expected none",
     ),
@@ -79,7 +85,7 @@ expression: index_map
         },
     ),
     "1_-": Error(
-        "cannot use both underscores and dashes as version segment seperators",
+        "cannot use both underscores and dashes as version segment separators",
     ),
     "1_2_3": Version(
         Version {

--- a/py-rattler/src/version/component.rs
+++ b/py-rattler/src/version/component.rs
@@ -20,6 +20,11 @@ impl From<Component> for PyComponent {
         match value {
             Component::Iden(v) => Self::String(v.to_string()),
             Component::Numeral(n) => Self::Number(n),
+            Component::NumeralWithLeadingZeros(v) => Self::String(format!(
+                "{z}{n}",
+                z = "0".repeat(v.leading_zeros),
+                n = v.numeral
+            )),
             Component::Dev => Self::String("dev".to_string()),
             Component::Post => Self::String("post".to_string()),
             Component::UnderscoreOrDash { .. } => Self::String("_".to_string()),


### PR DESCRIPTION
Some conda packages have versions with components which look like numbers but have leading zeros. For instance:
- [font-ttf-inconsolata](https://prefix.dev/channels/conda-forge/packages/font-ttf-inconsolata) has version `3.000`
- [libre2-11](https://prefix.dev/channels/conda-forge/packages/libre2-11) has version `2023.09.01`

When parsing the above versions with `Version`, we would get `3.0` and `2023.9.1` respectively. This is incorrect as we should aim not to lose any information in the process of parsing a version string.

We also can't just treat version components with leading zeros strings because lexicographic comparison would be unintuitive for them. I believe that we should treat these components in a special way: as numbers with leading zeros. Hence, I introduce a new component type, `NumeralWithLeadingZeros`, which sorts just like `Numeral` but can be used to recover the original version string from it.

I also fixed an unrelated typo `seperators` -> `separators`.
