### PR TITLE
feat: return pybytes for sha256 and md5 everywhere and use md5 hash for legacy bz2 md5

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -110,7 +110,8 @@ pub struct PackageRecord {
     pub features: Option<String>,
 
     /// A deprecated md5 hash
-    pub legacy_bz2_md5: Option<String>,
+    #[serde_as(as = "Option<SerializableHash::<rattler_digest::Md5>>")]
+    pub legacy_bz2_md5: Option<Md5Hash>,
 
     /// A deprecated package archive size.
     pub legacy_bz2_size: Option<u64>,

--- a/crates/rattler_lock/src/utils/serde/raw_conda_package_data.rs
+++ b/crates/rattler_lock/src/utils/serde/raw_conda_package_data.rs
@@ -57,7 +57,8 @@ pub(crate) struct RawCondaPackageData<'a> {
     #[serde_as(as = "Option<SerializableHash::<rattler_digest::Md5>>")]
     pub md5: Option<Md5Hash>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub legacy_bz2_md5: Cow<'a, Option<String>>,
+    #[serde_as(as = "Option<SerializableHash::<rattler_digest::Md5>>")]
+    pub legacy_bz2_md5: Option<Md5Hash>,
 
     // Dependencies
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -109,7 +110,7 @@ impl<'a> From<RawCondaPackageData<'a>> for CondaPackageData {
                 constrains: value.constrains.into_owned(),
                 depends: value.depends.into_owned(),
                 features: value.features.into_owned(),
-                legacy_bz2_md5: value.legacy_bz2_md5.into_owned(),
+                legacy_bz2_md5: value.legacy_bz2_md5,
                 legacy_bz2_size: value.legacy_bz2_size.into_owned(),
                 license: value.license.into_owned(),
                 license_family: value.license_family.into_owned(),
@@ -151,7 +152,7 @@ impl<'a> From<&'a CondaPackageData> for RawCondaPackageData<'a> {
             platform: Cow::Borrowed(&value.package_record.platform),
             arch: Cow::Borrowed(&value.package_record.arch),
             md5: value.package_record.md5,
-            legacy_bz2_md5: Cow::Borrowed(&value.package_record.legacy_bz2_md5),
+            legacy_bz2_md5: value.package_record.legacy_bz2_md5,
             sha256: value.package_record.sha256,
             size: Cow::Borrowed(&value.package_record.size),
             legacy_bz2_size: Cow::Borrowed(&value.package_record.legacy_bz2_size),

--- a/py-rattler/rattler/repo_data/package_record.py
+++ b/py-rattler/rattler/repo_data/package_record.py
@@ -242,7 +242,7 @@ class PackageRecord:
         return self._record.features
 
     @property
-    def legacy_bz2_md5(self) -> Optional[str]:
+    def legacy_bz2_md5(self) -> Optional[bytes]:
         """
         A deprecated md5 hash.
         """
@@ -295,7 +295,7 @@ class PackageRecord:
         return self._record.license_family
 
     @property
-    def md5(self) -> Optional[str]:
+    def md5(self) -> Optional[bytes]:
         """
         Optionally a MD5 hash of the package archive.
 
@@ -306,8 +306,8 @@ class PackageRecord:
         >>> record = PrefixRecord.from_path(
         ...     "../test-data/conda-meta/libsqlite-3.40.0-hcfcfb64_0.json"
         ... )
-        >>> record.md5
-        '5E5A97795DE72F8CC3BAF3D9EA6327A2'
+        >>> record.md5.hex()
+        '5e5a97795de72f8cc3baf3d9ea6327a2'
         >>>
         ```
         """
@@ -380,7 +380,7 @@ class PackageRecord:
         return self._record.platform
 
     @property
-    def sha256(self) -> Optional[str]:
+    def sha256(self) -> Optional[bytes]:
         """
         Optionally a SHA256 hash of the package archive.
 
@@ -391,8 +391,8 @@ class PackageRecord:
         >>> record = PrefixRecord.from_path(
         ...     "../test-data/conda-meta/libsqlite-3.40.0-hcfcfb64_0.json"
         ... )
-        >>> record.sha256
-        '4E50B3D90A351C9D47D239D3F90FCE4870DF2526E4F7FEF35203AB3276A6DFC9'
+        >>> record.sha256.hex()
+        '4e50b3d90a351c9d47d239d3f90fce4870df2526e4f7fef35203ab3276a6dfc9'
         >>>
         """
         return self._record.sha256

--- a/py-rattler/src/record.rs
+++ b/py-rattler/src/record.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
 use pyo3::{
-    exceptions::PyTypeError, intern, pyclass, pymethods, FromPyObject, PyAny, PyErr, PyResult,
+    exceptions::PyTypeError, intern, pyclass, pymethods, types::PyBytes, FromPyObject, PyAny,
+    PyErr, PyResult, Python,
 };
 use rattler_conda_types::{
     package::{IndexJson, PackageFile},
@@ -162,8 +163,10 @@ impl PyRecord {
 
     /// Optionally a MD5 hash of the package archive.
     #[getter]
-    pub fn md5(&self) -> Option<String> {
-        self.as_package_record().md5.map(|md5| format!("{md5:X}"))
+    pub fn md5<'a>(&self, py: Python<'a>) -> Option<&'a PyBytes> {
+        self.as_package_record()
+            .md5
+            .map(|md5| PyBytes::new(py, &md5))
     }
 
     /// Package name of the Record.
@@ -180,10 +183,10 @@ impl PyRecord {
 
     /// Optionally a SHA256 hash of the package archive.
     #[getter]
-    pub fn sha256(&self) -> Option<String> {
+    pub fn sha256<'a>(&self, py: Python<'a>) -> Option<&'a PyBytes> {
         self.as_package_record()
             .sha256
-            .map(|sha| format!("{sha:X}"))
+            .map(|sha| PyBytes::new(py, &sha))
     }
 
     /// Optionally the size of the package archive in bytes.

--- a/py-rattler/src/record.rs
+++ b/py-rattler/src/record.rs
@@ -139,8 +139,10 @@ impl PyRecord {
 
     /// A deprecated md5 hash.
     #[getter]
-    pub fn legacy_bz2_md5(&self) -> Option<String> {
-        self.as_package_record().legacy_bz2_md5.clone()
+    pub fn legacy_bz2_md5<'a>(&self, py: Python<'a>) -> Option<&'a PyBytes> {
+        self.as_package_record()
+            .legacy_bz2_md5
+            .map(|md5| PyBytes::new(py, &md5))
     }
 
     /// A deprecated package archive size.


### PR DESCRIPTION
cc @jaimergp 