### PR TITLE
fix: Fix GatewayQuery.query to filter records based on provided specs

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -345,7 +345,7 @@ mod test {
     use rattler_cache::default_cache_dir;
     use rattler_cache::package_cache::PackageCache;
     use rattler_conda_types::{
-        Channel, ChannelConfig, MatchSpec, PackageName, ParseStrictness::Strict, Platform,
+        Channel, ChannelConfig, MatchSpec, PackageName, ParseStrictness::Strict, ParseStrictness::Lenient, Platform,
         RepoDataRecord,
     };
     use rstest::rstest;
@@ -548,6 +548,78 @@ mod test {
             .filter(|record| record.package_record.name.as_normalized() == "openssl")
             .collect();
         assert!(openssl_records.len() > 1);
+    }
+
+    #[tokio::test]
+    async fn test_flter_with_specs() {
+        let gateway = Gateway::new();
+
+        let index = local_conda_forge().await;
+
+        // Try a complex spec
+        let matchspec = MatchSpec::from_str(
+            "openssl=3.*=*_1",
+            Lenient,
+        )
+        .unwrap();
+
+        let records = gateway
+            .query(
+                vec![index.clone()],
+                vec![Platform::Linux64],
+                vec![matchspec].into_iter(),
+            )
+            .recursive(false)
+            .await
+            .unwrap();
+
+        let total_records: usize = records.iter().map(RepoData::len).sum();
+        assert!(total_records == 3);
+
+        // Try another spec
+        let matchspec = MatchSpec::from_str(
+            "openssl=3",
+            Lenient,
+        )
+        .unwrap();
+
+        let records = gateway
+            .query(
+                vec![index.clone()],
+                vec![Platform::Linux64],
+                vec![matchspec].into_iter(),
+            )
+            .recursive(false)
+            .await
+            .unwrap();
+
+        let total_records: usize = records.iter().map(RepoData::len).sum();
+        assert!(total_records == 9);
+
+        // Try with multiple specs
+        let matchspec1 = MatchSpec::from_str(
+            "openssl=3",
+            Lenient,
+        )
+        .unwrap();
+        let matchspec2 = MatchSpec::from_str(
+            "openssl=1",
+            Lenient,
+        )
+        .unwrap();
+
+        let records = gateway
+            .query(
+                vec![index.clone()],
+                vec![Platform::Linux64],
+                vec![matchspec1, matchspec2].into_iter(),
+            )
+            .recursive(false)
+            .await
+            .unwrap();
+
+        let total_records: usize = records.iter().map(RepoData::len).sum();
+        assert!(total_records == 49);
     }
 
     #[tokio::test]

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -345,8 +345,8 @@ mod test {
     use rattler_cache::default_cache_dir;
     use rattler_cache::package_cache::PackageCache;
     use rattler_conda_types::{
-        Channel, ChannelConfig, MatchSpec, PackageName, ParseStrictness::Strict, ParseStrictness::Lenient, Platform,
-        RepoDataRecord,
+        Channel, ChannelConfig, MatchSpec, PackageName, ParseStrictness::Lenient,
+        ParseStrictness::Strict, Platform, RepoDataRecord,
     };
     use rstest::rstest;
     use url::Url;
@@ -557,11 +557,7 @@ mod test {
         let index = local_conda_forge().await;
 
         // Try a complex spec
-        let matchspec = MatchSpec::from_str(
-            "openssl=3.*=*_1",
-            Lenient,
-        )
-        .unwrap();
+        let matchspec = MatchSpec::from_str("openssl=3.*=*_1", Lenient).unwrap();
 
         let records = gateway
             .query(
@@ -577,11 +573,7 @@ mod test {
         assert!(total_records == 3);
 
         // Try another spec
-        let matchspec = MatchSpec::from_str(
-            "openssl=3",
-            Lenient,
-        )
-        .unwrap();
+        let matchspec = MatchSpec::from_str("openssl=3", Lenient).unwrap();
 
         let records = gateway
             .query(
@@ -597,16 +589,8 @@ mod test {
         assert!(total_records == 9);
 
         // Try with multiple specs
-        let matchspec1 = MatchSpec::from_str(
-            "openssl=3",
-            Lenient,
-        )
-        .unwrap();
-        let matchspec2 = MatchSpec::from_str(
-            "openssl=1",
-            Lenient,
-        )
-        .unwrap();
+        let matchspec1 = MatchSpec::from_str("openssl=3", Lenient).unwrap();
+        let matchspec2 = MatchSpec::from_str("openssl=1", Lenient).unwrap();
 
         let records = gateway
             .query(

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -250,7 +250,7 @@ impl GatewayQuery {
 
                         for record in records.iter() {
                             if !request_specs.iter().any(|spec| spec.matches(record)) {
-                                // Do not recurse into records that do not match to root spec.
+                                // Do not return records that do not match to root spec.
                                 continue;
                             }
                             result.len += 1;

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -249,7 +249,7 @@ impl GatewayQuery {
                         let result = &mut result[result_idx];
 
                         for record in records.iter() {
-                            if !request_specs.iter().any(|spec| spec.matches(record)) {
+                            if !self.recursive && !request_specs.iter().any(|spec| spec.matches(record)) {
                                 // Do not return records that do not match to root spec.
                                 continue;
                             }

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -247,8 +247,15 @@ impl GatewayQuery {
                     // Add the records to the result
                     if records.len() > 0 {
                         let result = &mut result[result_idx];
-                        result.len += records.len();
-                        result.shards.push(records);
+
+                        for record in records.iter() {
+                            if !request_specs.iter().any(|spec| spec.matches(record)) {
+                                // Do not recurse into records that do not match to root spec.
+                                continue;
+                            }
+                            result.len += 1;
+                            result.shards.push(Arc::new([record.clone()]));
+                        }
                     }
                 }
 


### PR DESCRIPTION
Fixes #755.

The `query` method of `GatewayQuery` was not filtering records based on the provided specs. It would only filter records to be fetched when doing a recursive query.

This PR fixes that.

Note that I'm learning rust and this might not be the right way to fix this. Please let me know if I can improve this! I'd like to learn.