### PR TITLE
A `post1` version becomes `inf` in the components

### DIFF
--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -336,6 +336,8 @@ impl Version {
     /// will return the version: `3a.4`.
     pub fn with_segments(&self, segments: impl RangeBounds<usize>) -> Option<Version> {
         // Determine the actual bounds to use
+        // println!("{:?}", self.segments);
+        // println!("{:?}", self.components);
         let segment_count = self.segment_count();
         let start_segment_idx = match segments.start_bound() {
             Bound::Included(idx) => *idx,
@@ -398,6 +400,8 @@ impl Version {
                 .and_then(|idx| flags.with_local_segment_index(idx))
                 .expect("the number of segments must always be smaller so this should never fail");
         }
+        // println!("{:?}", segments);
+        // println!("{:?}", components);
 
         Some(Version {
             components,
@@ -1343,6 +1347,13 @@ mod test {
                 .with_segments(..)
                 .unwrap(),
             Version::from_str("3!4.5a.6b+7.8").unwrap()
+        );
+        assert_eq!(
+            Version::from_str("0.11.0.post1+g1b5f1f6")
+                .unwrap()
+                .with_segments(..3)
+                .unwrap(),
+            Version::from_str("0.11.0+g1b5f1f6").unwrap()
         );
     }
 


### PR DESCRIPTION
There is some weirdness going in with `postX` versions.

The parsing seems to add a component with `inf`, but no segment. This disturbs how we handle `local` versions.

When printing, the components of `0.11.0.post1+abcdefg` look something like

`[0, 11, 0, inf, a, b, c, d, e, f, g]`

When I am trying to get the first 3 segments, I receive an extra `0` in the resulting version (failing test). I think that's related to the `inf` that's added without corresponding segment.