### PR TITLE
fix: skip over implicit `0` components when copying

### DIFF
--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -336,6 +336,8 @@ impl Version {
     /// will return the version: `3a.4`.
     pub fn with_segments(&self, segments: impl RangeBounds<usize>) -> Option<Version> {
         // Determine the actual bounds to use
+        // println!("{:?}", self.segments);
+        // println!("{:?}", self.components);
         let segment_count = self.segment_count();
         let start_segment_idx = match segments.start_bound() {
             Bound::Included(idx) => *idx,
@@ -398,6 +400,8 @@ impl Version {
                 .and_then(|idx| flags.with_local_segment_index(idx))
                 .expect("the number of segments must always be smaller so this should never fail");
         }
+        // println!("{:?}", segments);
+        // println!("{:?}", components);
 
         Some(Version {
             components,
@@ -1343,6 +1347,13 @@ mod test {
                 .with_segments(..)
                 .unwrap(),
             Version::from_str("3!4.5a.6b+7.8").unwrap()
+        );
+        assert_eq!(
+            Version::from_str("0.11.0.post1+g1b5f1f6")
+                .unwrap()
+                .with_segments(..3)
+                .unwrap(),
+            Version::from_str("0.11.0+g1b5f1f6").unwrap()
         );
     }
 

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -336,8 +336,6 @@ impl Version {
     /// will return the version: `3a.4`.
     pub fn with_segments(&self, segments: impl RangeBounds<usize>) -> Option<Version> {
         // Determine the actual bounds to use
-        // println!("{:?}", self.segments);
-        // println!("{:?}", self.components);
         let segment_count = self.segment_count();
         let start_segment_idx = match segments.start_bound() {
             Bound::Included(idx) => *idx,

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -380,7 +380,10 @@ impl Version {
             };
             segments.push(segment);
 
-            for component in segment_iter.components() {
+            // We skip over implicit default `0` components because we also copy
+            // the implicit default flag so it would result in double-`0`s.
+            let implicit_default = usize::from(segment_iter.has_implicit_default());
+            for component in segment_iter.components().skip(implicit_default) {
                 components.push(component.clone());
             }
         }
@@ -389,7 +392,9 @@ impl Version {
         let local_start_idx = segments.len();
         for segment_iter in self.local_segments() {
             segments.push(segment_iter.segment);
-            for component in segment_iter.components() {
+
+            let implicit_default = usize::from(segment_iter.has_implicit_default());
+            for component in segment_iter.components().skip(implicit_default) {
                 components.push(component.clone());
             }
         }
@@ -400,8 +405,6 @@ impl Version {
                 .and_then(|idx| flags.with_local_segment_index(idx))
                 .expect("the number of segments must always be smaller so this should never fail");
         }
-        // println!("{:?}", segments);
-        // println!("{:?}", components);
 
         Some(Version {
             components,

--- a/crates/rattler_conda_types/src/version/parse.rs
+++ b/crates/rattler_conda_types/src/version/parse.rs
@@ -258,7 +258,7 @@ fn version_part_parser<'i>(
             Ok((rest, Some(separator))) => (rest, separator),
 
             Err(nom::Err::Error(_)) => {
-                // If an error occured we convert it to a segment separator not found error instead.
+                // If an error occurred we convert it to a segment separator not found error instead.
                 break Err(nom::Err::Error(
                     ParseVersionErrorKind::ExpectedSegmentSeparator,
                 ));
@@ -284,7 +284,7 @@ fn version_part_parser<'i>(
         let (rest, segment) = match segment_parser(components, rest) {
             Ok(result) => result,
             Err(nom::Err::Error(_)) => {
-                // If parsing of a segment failed, check if perhaps the seperator is followed by an
+                // If parsing of a segment failed, check if perhaps the separator is followed by an
                 // underscore or dash.
                 match trailing_dash_underscore_parser(rest, dash_or_underscore)? {
                     (rest, (Some(component), dash_or_underscore)) => {


### PR DESCRIPTION
We copied the implicit components twice:

- once as flag on the segment
- and once as a materialized component from the SegmentIter

This should fix the double-zeros :)