### PR TITLE
fix: run clippy on all targets

### DIFF
--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Run rustfmt
         uses: actions-rust-lang/rustfmt@v1
       - name: Run clippy
-        run: cargo clippy
+        run: cargo clippy --all-targets
 
   build:
     name: ${{ matrix.name }}

--- a/crates/rattler/src/install/clobber_registry.rs
+++ b/crates/rattler/src/install/clobber_registry.rs
@@ -927,8 +927,10 @@ mod tests {
         let packages_dir = tempfile::tempdir().unwrap();
         let cache = PackageCache::new(packages_dir.path());
 
-        let mut install_options = InstallOptions::default();
-        install_options.python_info = Some(python_info.clone());
+        let install_options = InstallOptions {
+            python_info: Some(python_info.clone()),
+            ..Default::default()
+        };
 
         execute_transaction(
             transaction,

--- a/crates/rattler/src/lib.rs
+++ b/crates/rattler/src/lib.rs
@@ -59,7 +59,7 @@ pub(crate) fn get_repodata_record(package_path: impl AsRef<std::path::Path>) -> 
     let index_json = read_package_file::<IndexJson>(&package_path).unwrap();
 
     // find size and hash
-    let size = fs::metadata(&package_path).unwrap().len();
+    let size = fs::metadata(package_path).unwrap().len();
     let sha256 = rattler_digest::compute_file_digest::<Sha256>(&package_path).unwrap();
     let md5 = rattler_digest::compute_file_digest::<Md5>(&package_path).unwrap();
 
@@ -76,7 +76,7 @@ pub(crate) fn get_repodata_record(package_path: impl AsRef<std::path::Path>) -> 
             .and_then(|f| f.to_str())
             .unwrap()
             .to_string(),
-        url: url::Url::from_file_path(&package_path).unwrap(),
+        url: url::Url::from_file_path(package_path).unwrap(),
         channel: "test".to_string(),
     }
 }

--- a/crates/rattler_cache/src/package_cache.rs
+++ b/crates/rattler_cache/src/package_cache.rs
@@ -498,6 +498,7 @@ mod test {
     }
 
     /// A helper middleware function that fails the first two requests.
+    #[allow(clippy::type_complexity)]
     async fn fail_with_half_package(
         State((count, bytes)): State<(Arc<Mutex<i32>>, Arc<Mutex<usize>>)>,
         req: Request<Body>,
@@ -525,7 +526,7 @@ mod test {
             let bytes = buffer.into_iter().take(byte_count).collect::<Vec<u8>>();
             // Create a stream that ends prematurely
             let stream = stream::iter(vec![
-                Ok::<_, Infallible>(Bytes::from_iter(bytes.into_iter())),
+                Ok::<_, Infallible>(bytes.into_iter().collect::<Bytes>()),
                 // The stream ends after sending partial data, simulating a premature close
             ]);
             let body = Body::from_stream(stream);

--- a/crates/rattler_package_streaming/tests/extract.rs
+++ b/crates/rattler_package_streaming/tests/extract.rs
@@ -154,7 +154,7 @@ fn read_package_file(#[case] input: Url, #[case] sha256: &str, #[case] _md5: &st
     );
     assert!(input
         .path_segments()
-        .and_then(|s| s.last())
+        .and_then(std::iter::Iterator::last)
         .unwrap()
         .starts_with(&name));
 }

--- a/crates/rattler_package_streaming/tests/extract.rs
+++ b/crates/rattler_package_streaming/tests/extract.rs
@@ -154,7 +154,7 @@ fn read_package_file(#[case] input: Url, #[case] sha256: &str, #[case] _md5: &st
     );
     assert!(input
         .path_segments()
-        .and_then(std::iter::Iterator::last)
+        .and_then(Iterator::last)
         .unwrap()
         .starts_with(&name));
 }

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -512,7 +512,7 @@ mod test {
         assert_eq!(openssl_records.len(), 1);
 
         // Test if the first repodata subdir contains only the direct url package.
-        let first_subdir = records.iter().next().unwrap();
+        let first_subdir = records.first().unwrap();
         assert_eq!(first_subdir.len, 1);
         let openssl_record = first_subdir
             .iter()
@@ -573,7 +573,7 @@ mod test {
             .await
             .unwrap_err();
 
-        assert_matches!(gateway_error, GatewayError::MatchSpecWithoutName(_))
+        assert_matches!(gateway_error, GatewayError::MatchSpecWithoutName(_));
     }
 
     #[rstest]
@@ -595,7 +595,7 @@ mod test {
             )
             .await;
 
-        assert_matches::assert_matches!(err, Err(GatewayError::SubdirNotFoundError(_)))
+        assert_matches::assert_matches!(err, Err(GatewayError::SubdirNotFoundError(_)));
     }
 
     #[ignore]
@@ -667,7 +667,7 @@ mod test {
 
         // Run the query once. We expect some activity.
         query.clone().execute().await.unwrap();
-        assert!(downloads.urls.len() > 0, "there should be some urls");
+        assert!(!downloads.urls.is_empty(), "there should be some urls");
         downloads.urls.clear();
 
         // Run the query a second time.
@@ -681,7 +681,7 @@ mod test {
         gateway.clear_repodata_cache(&local_channel.channel(), Default::default());
         query.clone().execute().await.unwrap();
         assert!(
-            downloads.urls.len() > 0,
+            !downloads.urls.is_empty(),
             "after clearing the cache there should be new urls fetched"
         );
     }

--- a/crates/rattler_repodata_gateway/src/utils/mod.rs
+++ b/crates/rattler_repodata_gateway/src/utils/mod.rs
@@ -64,7 +64,7 @@ pub(crate) mod test {
     }
 
     pub(crate) async fn fetch_repo_data(subdir: &str) -> Result<(), reqwest::Error> {
-        let path = test_dir().join(format!("channels/conda-forge/{}/repodata.json", subdir));
+        let path = test_dir().join(format!("channels/conda-forge/{subdir}/repodata.json"));
 
         // Early out if the file already eixsts
         if path.exists() {
@@ -92,8 +92,7 @@ pub(crate) mod test {
         // Download the file and persist after download
         let mut file = NamedTempFile::new_in(parent_dir).unwrap();
         let data = reqwest::get(format!(
-            "https://rattler-test.pixi.run/test-data/channels/conda-forge/{}/repodata.json",
-            subdir
+            "https://rattler-test.pixi.run/test-data/channels/conda-forge/{subdir}/repodata.json"
         ))
         .await?;
         tokio::fs::write(&mut file, data.bytes().await?)

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -843,9 +843,7 @@ mod resolvo {
             ..SolverTask::from_iter([&repo_data])
         };
 
-        let pkgs = rattler_solve::resolvo::Solver
-            .solve(task)
-            .unwrap();
+        let pkgs = rattler_solve::resolvo::Solver.solve(task).unwrap();
 
         assert_eq!(pkgs.len(), 1);
         assert_eq!(pkgs[0].package_record.name.as_normalized(), "_libgcc_mutex");
@@ -878,9 +876,7 @@ mod resolvo {
             ..SolverTask::from_iter([&repo_data])
         };
 
-        let solve_error = rattler_solve::resolvo::Solver
-            .solve(task)
-            .unwrap_err();
+        let solve_error = rattler_solve::resolvo::Solver.solve(task).unwrap_err();
 
         assert!(matches!(solve_error, SolveError::Unsolvable(_)));
     }

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -843,7 +843,7 @@ mod resolvo {
             ..SolverTask::from_iter([&repo_data])
         };
 
-        let pkgs = rattler_solve::resolvo::Solver::default()
+        let pkgs = rattler_solve::resolvo::Solver
             .solve(task)
             .unwrap();
 
@@ -878,7 +878,7 @@ mod resolvo {
             ..SolverTask::from_iter([&repo_data])
         };
 
-        let solve_error = rattler_solve::resolvo::Solver::default()
+        let solve_error = rattler_solve::resolvo::Solver
             .solve(task)
             .unwrap_err();
 

--- a/crates/rattler_virtual_packages/src/linux.rs
+++ b/crates/rattler_virtual_packages/src/linux.rs
@@ -125,6 +125,6 @@ mod test {
     #[cfg(target_os = "linux")]
     pub fn doesnt_crash() {
         let version = super::try_detect_linux_version();
-        println!("Linux {:?}", version);
+        println!("Linux {version:?}");
     }
 }


### PR DESCRIPTION
I've noticed that vscode showed clippy warnings.
Turned out we don't run clippy on all targets
