### PR TITLE
fix: errors should not contain trailing punctuation

### DIFF
--- a/crates/rattler/src/cli/auth.rs
+++ b/crates/rattler/src/cli/auth.rs
@@ -56,24 +56,24 @@ pub enum AuthenticationCLIError {
 
     /// Basic authentication needs a username and a password. The password is
     /// missing here.
-    #[error("Password must be provided when using basic authentication.")]
+    #[error("Password must be provided when using basic authentication")]
     MissingPassword,
 
     /// Authentication has not been provided in the input parameters.
-    #[error("No authentication method provided.")]
+    #[error("No authentication method provided")]
     NoAuthenticationMethod,
 
     /// Bad authentication method when using prefix.dev
-    #[error("Authentication with prefix.dev requires a token. Use `--token` to provide one.")]
+    #[error("Authentication with prefix.dev requires a token. Use `--token` to provide one")]
     PrefixDevBadMethod,
 
     /// Bad authentication method when using anaconda.org
-    #[error("Authentication with anaconda.org requires a conda token. Use `--conda-token` to provide one.")]
+    #[error("Authentication with anaconda.org requires a conda token. Use `--conda-token` to provide one")]
     AnacondaOrgBadMethod,
 
     /// Wrapper for errors that are generated from the underlying storage system
     /// (keyring or file system)
-    #[error("Failed to interact with the authentication storage system.")]
+    #[error("Failed to interact with the authentication storage system")]
     StorageError(#[source] anyhow::Error),
 }
 

--- a/crates/rattler_lock/src/parse/mod.rs
+++ b/crates/rattler_lock/src/parse/mod.rs
@@ -19,7 +19,7 @@ pub enum ParseCondaLockError {
     #[error(transparent)]
     ParseError(#[from] serde_yaml::Error),
 
-    #[error("found newer lockfile format version {lock_file_version}, but only up to including version {max_supported_version} is supported.")]
+    #[error("found newer lockfile format version {lock_file_version}, but only up to including version {max_supported_version} is supported")]
     IncompatibleVersion {
         lock_file_version: u64,
         max_supported_version: FileFormatVersion,

--- a/crates/rattler_lock/src/parse/mod.rs
+++ b/crates/rattler_lock/src/parse/mod.rs
@@ -79,6 +79,6 @@ mod test {
         .err()
         .unwrap();
 
-        insta::assert_snapshot!(format!("{}", err), @"found newer lockfile format version 1000, but only up to including version 5 is supported.");
+        insta::assert_snapshot!(format!("{}", err), @"found newer lockfile format version 1000, but only up to including version 5 is supported");
     }
 }

--- a/crates/rattler_networking/src/authentication_storage/backends/file.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/file.rs
@@ -36,7 +36,7 @@ pub enum FileStorageError {
     IOError(#[from] std::io::Error),
 
     /// Failed to lock the file storage file
-    #[error("failed to lock file storage file {0}.")]
+    #[error("failed to lock file storage file {0}")]
     FailedToLock(String, #[source] std::io::Error),
 
     /// An error occurred when (de)serializing the credentials


### PR DESCRIPTION
See https://doc.rust-lang.org/std/error/trait.Error.html