### PR TITLE
fix: direct_url query for windows

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -432,7 +432,12 @@ mod test {
             .query(
                 vec![index.clone()],
                 vec![Platform::Win64],
-                vec![MatchSpec::from_str("https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_1.conda", Strict).unwrap()].into_iter(),
+                vec![MatchSpec::from_str(
+                    "https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_1.conda",
+                    Strict,
+                )
+                .unwrap()]
+                .into_iter(),
             )
             .recursive(true)
             .await

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -431,8 +431,8 @@ mod test {
         let records = gateway
             .query(
                 vec![index.clone()],
-                vec![Platform::Linux64],
-                vec![MatchSpec::from_str("https://conda.anaconda.org/conda-forge/linux-64/openssl-3.0.4-h166bdaf_2.tar.bz2", Strict).unwrap()].into_iter(),
+                vec![Platform::Win64],
+                vec![MatchSpec::from_str("https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_1.conda", Strict).unwrap()].into_iter(),
             )
             .recursive(true)
             .await
@@ -449,7 +449,7 @@ mod test {
             .query(
                 vec![index],
                 vec![Platform::Linux64],
-                vec![MatchSpec::from_str("openssl 3.0.4 h166bdaf_2", Strict).unwrap()].into_iter(),
+                vec![MatchSpec::from_str("openssl 3.3.1 h2466b09_1", Strict).unwrap()].into_iter(),
             )
             .recursive(true)
             .await
@@ -485,7 +485,7 @@ mod test {
         let index = local_conda_forge().await;
 
         let openssl_url =
-            "https://conda.anaconda.org/conda-forge/linux-64/openssl-3.0.4-h166bdaf_2.tar.bz2";
+            "https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.1-h2466b09_1.conda";
         let records = gateway
             .query(
                 vec![index.clone()],


### PR DESCRIPTION
Fixes `direct_url` tests on windows. The issue was that the packages used in the test use symlinks, which arent available by default. This PR changes to use the Windows version of `openssl` which doesnt include symlinks.