### PR TITLE
fix: allow version following package in strict mode

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -257,9 +257,7 @@ fn parse_bracket_vec_into_components(
 }
 
 /// Strip the package name from the input.
-fn strip_package_name(
-    input: &str,
-) -> Result<(PackageName, &str), ParseMatchSpecError> {
+fn strip_package_name(input: &str) -> Result<(PackageName, &str), ParseMatchSpecError> {
     let (rest, package_name) =
         take_while1(|c: char| !c.is_whitespace() && !is_start_of_version_constraint(c))(
             input.trim(),

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -79,7 +79,7 @@ pub enum ParseMatchSpecError {
     InvalidVersionAndBuild(String),
 
     /// Invalid build string
-    #[error("The build string '{0}' is not valid it can only contain alphanumeric characters and underscores")]
+    #[error("The build string '{0}' is not valid, it can only contain alphanumeric characters and underscores")]
     InvalidBuildString(String),
 
     /// Invalid version spec

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Lenient.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
-assertion_line: 904
+assertion_line: 917
 expression: evaluated
 ---
 /home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2:
@@ -49,6 +49,9 @@ python 3.8.* *_cpython:
 python ==2.7.*.*|>=3.6:
   name: python
   version: 2.7.*|>=3.6
+python=*:
+  name: python
+  version: "*"
 python=3.9:
   name: python
   version: 3.9.*

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
-assertion_line: 917
+assertion_line: 915
 expression: evaluated
 ---
 /home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2:
@@ -29,9 +29,9 @@ blas *.* mkl:
     base_url: "https://conda.anaconda.org/conda-forge/"
     name: conda-forge
 foo=1.0=py27_0:
-  error: "The build string '=py27_0' is not valid it can only contain alphanumeric characters and underscores"
+  error: "The build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
 foo==1.0=py27_0:
-  error: "The build string '=py27_0' is not valid it can only contain alphanumeric characters and underscores"
+  error: "The build string '=py27_0' is not valid, it can only contain alphanumeric characters and underscores"
 "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda":
   name: py-rattler
   url: "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda"
@@ -50,7 +50,7 @@ python=3.9:
   name: python
   version: 3.9.*
 pytorch=*=cuda*:
-  error: "The build string '=cuda*' is not valid it can only contain alphanumeric characters and underscores"
+  error: "The build string '=cuda*' is not valid, it can only contain alphanumeric characters and underscores"
 "x264 >=1!164.3095,<1!165":
   name: x264
   version: ">=1!164.3095,<1!165"

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__test_from_string_Strict.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
+assertion_line: 917
 expression: evaluated
 ---
 /home/user/conda-bld/linux-64/foo-1.0-py27_0.tar.bz2:
@@ -28,9 +29,9 @@ blas *.* mkl:
     base_url: "https://conda.anaconda.org/conda-forge/"
     name: conda-forge
 foo=1.0=py27_0:
-  error: "'foo=1.0=py27_0' is not a valid package name. Package names can only contain 0-9, a-z, A-Z, -, _, or ."
+  error: "The build string '=py27_0' is not valid it can only contain alphanumeric characters and underscores"
 foo==1.0=py27_0:
-  error: "'foo==1.0=py27_0' is not a valid package name. Package names can only contain 0-9, a-z, A-Z, -, _, or ."
+  error: "The build string '=py27_0' is not valid it can only contain alphanumeric characters and underscores"
 "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda":
   name: py-rattler
   url: "https://conda.anaconda.org/conda-forge/linux-64/py-rattler-0.6.1-py39h8169da8_0.conda"
@@ -43,10 +44,13 @@ python 3.8.* *_cpython:
   build: "*_cpython"
 python ==2.7.*.*|>=3.6:
   error: "invalid version constraint: regex constraints are not supported"
+python=*:
+  error: "invalid version constraint: '*' is incompatible with '=' operator'"
 python=3.9:
-  error: "'python=3.9' is not a valid package name. Package names can only contain 0-9, a-z, A-Z, -, _, or ."
+  name: python
+  version: 3.9.*
 pytorch=*=cuda*:
-  error: "'pytorch=*=cuda*' is not a valid package name. Package names can only contain 0-9, a-z, A-Z, -, _, or ."
+  error: "The build string '=cuda*' is not valid it can only contain alphanumeric characters and underscores"
 "x264 >=1!164.3095,<1!165":
   name: x264
   version: ">=1!164.3095,<1!165"


### PR DESCRIPTION
I thought it was quite annoying that you cant write `python>=3.9` in strict mode. I changed the strict parser to allow package names to be followed by a version operator without a space.  `python=3.9=*` is still invalid.