### PR TITLE
chore: bump zip to 2.1.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,5 +151,5 @@ url = { version = "2.5.0" }
 uuid = { version = "1.8.0", default-features = false }
 walkdir = "2.5.0"
 windows-sys = { version = "0.52.0", default-features = false }
-zip = { version = "0.6.6", default-features = false }
+zip = { version = "2.1.3", default-features = false }
 zstd = { version = "0.13.1", default-features = false }

--- a/crates/rattler_package_streaming/src/write.rs
+++ b/crates/rattler_package_streaming/src/write.rs
@@ -308,7 +308,7 @@ pub fn write_conda_package<W: Write + Seek>(
             .expect("1-1-2023 00:00:00 should convert into datetime")
     };
 
-    let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default()
+    let options = zip::write::SimpleFileOptions::default()
         .compression_method(zip::CompressionMethod::Stored)
         .last_modified_time(last_modified_time);
 

--- a/crates/rattler_package_streaming/src/write.rs
+++ b/crates/rattler_package_streaming/src/write.rs
@@ -308,7 +308,7 @@ pub fn write_conda_package<W: Write + Seek>(
             .expect("1-1-2023 00:00:00 should convert into datetime")
     };
 
-    let options = zip::write::FileOptions::default()
+    let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default()
         .compression_method(zip::CompressionMethod::Stored)
         .last_modified_time(last_modified_time);
 


### PR DESCRIPTION
Sometimes fetching packages using rattler fails with ` ZipError: "The file length is not available in the local header"`.

This error comes from the `zip` library here:

https://github.com/zip-rs/zip2/blame/b6e0a0693ba2d07f541cd9017b60df7e65817e48/src/types.rs#L688-L696 

As can be seen in a comment 

```
/* FIXME: these were previously incorrect: add testing! */
        /* flags & (1 << 3) != 0 */
```

Bumping the version of zip has solved our issues and we're able to install the desired packages.