### PR TITLE
feat: Add to_path() method to ExplicitEnvironmentSpec

### DIFF
--- a/crates/rattler_conda_types/src/explicit_environment_spec.rs
+++ b/crates/rattler_conda_types/src/explicit_environment_spec.rs
@@ -153,7 +153,7 @@ impl ExplicitEnvironmentSpec {
 
     /// Converts an [`ExplicitEnvironmentSpec`] to a string representing a valid explicit
     /// environment file
-    pub fn to_string(&self) -> String {
+    pub fn to_spec_string(&self) -> String {
         let mut s = String::new();
 
         if let Some(plat) = &self.platform {
@@ -171,7 +171,7 @@ impl ExplicitEnvironmentSpec {
 
     /// Writes an explicit environment spec to file
     pub fn to_path(&self, path: impl AsRef<Path>) -> Result<(), std::io::Error> {
-        let s = self.to_string();
+        let s = self.to_spec_string();
 
         fs::write(path, s)?;
 
@@ -276,9 +276,9 @@ mod test {
     #[case::ros_noetic_linux_64("explicit-envs/ros-noetic_linux-64.txt")]
     #[case::vs2015_runtime_win_64("explicit-envs/vs2015_runtime_win-64.txt")]
     #[case::xtensor_linux_64("explicit-envs/xtensor_linux-64.txt")]
-    fn test_to_string(#[case] path: &str) {
+    fn test_to_spec_string(#[case] path: &str) {
         let env = ExplicitEnvironmentSpec::from_path(&get_test_data_dir().join(path)).unwrap();
-        let env_cmp = ExplicitEnvironmentSpec::from_str(&env.to_string()).unwrap();
+        let env_cmp = ExplicitEnvironmentSpec::from_str(&env.to_spec_string()).unwrap();
 
         assert_eq!(env.platform, env_cmp.platform);
         assert_eq!(


### PR DESCRIPTION
Based on feedback from @baszalmstra on discord, I added a `to_path` method to the `ExplicitEnvironmentSpec` struct so that it could be dumped to file. This would be a first step in a `pixi export` PR to be submitted later. 

This is my first rust-based PR to a project (although I've fooled around with it a bit on my own), so feedback is very welcome. For testing, `ExplicitEnvironmentSpec` and `ExplicitEnvironmentEntry` didn't implement `PartialEq`, so I just unrolled the content. This isn't ideal, but I didn't want to start poking around on the main struct definitions, but I can if that's preferred. 