### PR TITLE
feat: expose `HasPrefixEntry` for public use

### DIFF
--- a/crates/rattler_conda_types/src/package/has_prefix.rs
+++ b/crates/rattler_conda_types/src/package/has_prefix.rs
@@ -15,10 +15,14 @@ use std::{
     sync::OnceLock,
 };
 
+/// Representation of an entry in `info/has_prefix`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HasPrefixEntry {
+    /// The prefix placeholder in the file
     pub prefix: Cow<'static, str>,
+    /// The file's mode
     pub file_mode: FileMode,
+    /// The file's relative path respective to the environment's prefix
     pub relative_path: PathBuf,
 }
 

--- a/crates/rattler_conda_types/src/package/mod.rs
+++ b/crates/rattler_conda_types/src/package/mod.rs
@@ -24,6 +24,7 @@ pub use {
     entry_point::EntryPoint,
     files::Files,
     has_prefix::HasPrefix,
+    has_prefix::HasPrefixEntry,
     index::IndexJson,
     link::{LinkJson, NoArchLinks, PythonEntryPoints},
     no_link::NoLink,


### PR DESCRIPTION
I was using rattler's `HasPrefix` to read info/has_prefix, and I couldn't unpack the `HasPrefixEntry` structs contained within, because it isn't `pub`:

```rust
let has_prefix = HasPrefix.from_str(...)?;
has_prefix.files.into_iter()
    .map(|HasPrefixEntry { relative_path, file_mode, prefix }| {
        // do stuff with relative_path, file_mode, and prefix
    }
    .collect()
```

I went thru src/package/mod.rs, and I don't think making `HasPrefixEntry` public is bad semantics. `HasPrefix` is `pub` for downstream consumption, so I think `HasPrefixEntry` should be as well? Correct me if I'm wrong, this is my first contrib to rattler :) 
