### PR TITLE
chore: mark some crates 1.0

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -31,8 +31,8 @@ rattler = { path="../rattler", version = "0.27.2", default-features = false, fea
 rattler_conda_types = { path="../rattler_conda_types", version = "0.26.3", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.10", default-features = false }
 rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.3", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "0.25.3", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "0.19.20", default-features = false }
+rattler_solve = { path="../rattler_solve", version = "1.0.0", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "1.0.0", default-features = false }
 rattler_cache = { path="../rattler_cache", version = "0.1.4", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -34,7 +34,7 @@ once_cell = { workspace = true }
 parking_lot = { workspace = true }
 rattler_cache = { path = "../rattler_cache", version = "0.1.4", default-features = false }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.3", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "0.19.5", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.0", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.20.10", default-features = false }
 rattler_shell = { path = "../rattler_shell", version = "0.21.3", default-features = false }
 rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.21.7", default-features = false, features = ["reqwest"] }

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -16,7 +16,7 @@ fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
 rattler_conda_types = { version = "0.26.3", path = "../rattler_conda_types", default-features = false }
-rattler_digest = { version = "0.19.5", path = "../rattler_digest", default-features = false }
+rattler_digest = { version = "1.0.0", path = "../rattler_digest", default-features = false }
 rattler_networking = { version = "0.20.10", path = "../rattler_networking", default-features = false }
 rattler_package_streaming = { version = "0.21.7", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -20,8 +20,8 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { path = "../rattler_digest", version = "0.19.5", default-features = false, features = ["serde"] }
-rattler_macros = { path = "../rattler_macros", version = "0.19.4", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.0", default-features = false, features = ["serde"] }
+rattler_macros = { path = "../rattler_macros", version = "1.0.0", default-features = false }
 regex = { workspace = true }
 simd-json = { workspace = true , features = ["serde_impl"]}
 serde = { workspace = true, features = ["derive", "rc"] }

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "0.19.5"
+version = "1.0.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -13,7 +13,7 @@ readme.workspace = true
 [dependencies]
 fs-err = { workspace = true }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.26.3", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.5", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "1.0.0", default-features = false }
 rattler_package_streaming = { path="../rattler_package_streaming", version = "0.21.7", default-features = false }
 serde_json = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rattler_libsolv_c/Cargo.toml
+++ b/crates/rattler_libsolv_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_libsolv_c"
-version = "0.19.5"
+version = "1.0.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Bindings for libsolv"

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -16,7 +16,7 @@ fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.3", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "0.19.5", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.0", default-features = false }
 file_url = { path = "../file_url", version = "0.1.3" }
 pep508_rs = { workspace = true, features = ["serde"] }
 pep440_rs = { workspace = true, features = ["serde"] }

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_macros"
-version = "0.19.4"
+version = "1.0.0"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate that provideds some procedural macros for the rattler project"

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -16,7 +16,7 @@ chrono = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.26.3", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.5", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "1.0.0", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.20.10", default-features = false }
 reqwest = { workspace = true, features = ["stream"], optional = true }
 reqwest-middleware = { workspace = true, optional = true }

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -35,7 +35,7 @@ ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.26.3", default-features = false, optional = true }
-rattler_digest = { path = "../rattler_digest", version = "0.19.5", default-features = false, features = ["tokio", "serde"] }
+rattler_digest = { path = "../rattler_digest", version = "1.0.0", default-features = false, features = ["tokio", "serde"] }
 rattler_networking = { path = "../rattler_networking", version = "0.20.10", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "0.25.3"
+version = "1.0.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -12,7 +12,7 @@ readme.workspace = true
 
 [dependencies]
 rattler_conda_types = { path="../rattler_conda_types", version = "0.26.3", default-features = false }
-rattler_digest = { path="../rattler_digest", version = "0.19.5", default-features = false }
+rattler_digest = { path="../rattler_digest", version = "1.0.0", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 url = { workspace = true }
 tempfile = { workspace = true }
-rattler_libsolv_c = { path="../rattler_libsolv_c", version = "0.19.5", default-features = false, optional = true }
+rattler_libsolv_c = { path="../rattler_libsolv_c", version = "1.0.0", default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "0.19.20"
+version = "1.0.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.27.0"
+version = "0.27.2"
 dependencies = [
  "anyhow",
  "console",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "digest",
@@ -2741,7 +2741,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.26.1"
+version = "0.26.3"
 dependencies = [
  "chrono",
  "file_url",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "0.19.5"
+version = "1.0.0"
 dependencies = [
  "blake2",
  "digest",
@@ -2788,7 +2788,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.19.19"
+version = "0.19.21"
 dependencies = [
  "fs-err",
  "rattler_conda_types",
@@ -2801,7 +2801,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.14"
+version = "0.22.16"
 dependencies = [
  "chrono",
  "file_url",
@@ -2822,7 +2822,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "0.19.4"
+version = "1.0.0"
 dependencies = [
  "quote",
  "syn 2.0.66",
@@ -2856,7 +2856,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.21.5"
+version = "0.21.7"
 dependencies = [
  "bzip2",
  "chrono",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.1"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2930,7 +2930,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.21.1"
+version = "0.21.3"
 dependencies = [
  "enum_dispatch",
  "indexmap 2.2.6",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "0.25.1"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "futures",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "0.19.18"
+version = "1.0.0"
 dependencies = [
  "archspec",
  "libloading",


### PR DESCRIPTION
This PR marks the following crates as 1.0:

* `rattler_solve`
* `rattler_virtual_packages`
* `rattler_digest`
* `rattler_macros`
* `rattler_libsolv_c`

We mark them as 1.0 because their API has been stable enough for a long time and we also do not foresee any large refactors in the foreseeable future. 