### PR TITLE
fix: check reflink support before linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ plist = "1"
 purl = { version = "0.1.3", features = ["serde"] }
 quote = "1.0.37"
 rand = "0.8.5"
-reflink-copy = "0.1.19"
+reflink-copy = "0.1.20"
 regex = "1.11.1"
 reqwest = { version = "0.12.9", default-features = false }
 reqwest-middleware = "0.4.0"


### PR DESCRIPTION
Rattler first tries creating reflinks, if that fails it falls back to hard-linking followed by copying. However, if reflinking is not support this is a waste of time. This PR adds a better check to see if reflinking is supporting from one directory to another.