### PR TITLE
fix: print the errors as INFO, leave the error handling up to the caller

### DIFF
--- a/crates/rattler_repodata_gateway/src/fetch/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/mod.rs
@@ -21,7 +21,7 @@ use std::{
 };
 use tempfile::NamedTempFile;
 use tokio_util::io::StreamReader;
-use tracing::instrument;
+use tracing::{instrument, Level};
 use url::Url;
 
 // use fs-err for better error reporting
@@ -301,7 +301,7 @@ async fn repodata_from_file(
 ///
 /// The checks to see if a `.zst` and/or `.bz2` file exist are performed by doing a HEAD request to
 /// the respective URLs. The result of these are cached.
-#[instrument(err, skip_all, fields(subdir_url, cache_path = % cache_path.display()))]
+#[instrument(err(level = Level::INFO), skip_all, fields(subdir_url, cache_path = % cache_path.display()))]
 pub async fn fetch_repo_data(
     subdir_url: Url,
     client: reqwest_middleware::ClientWithMiddleware,

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -29,7 +29,7 @@ pub use repo_data::RepoData;
 use reqwest_middleware::ClientWithMiddleware;
 use subdir::Subdir;
 use tokio::sync::broadcast;
-use tracing::instrument;
+use tracing::{instrument, Level};
 use url::Url;
 
 use crate::{gateway::subdir_builder::SubdirBuilder, Reporter};
@@ -176,7 +176,7 @@ impl GatewayInner {
     /// coalesced, and they will all receive the same subdir. If an error
     /// occurs while creating the subdir all waiting tasks will also return an
     /// error.
-    #[instrument(skip(self, reporter, channel), fields(channel = %channel.base_url), err)]
+    #[instrument(skip(self, reporter, channel), fields(channel = %channel.base_url), err(level = Level::INFO))]
     async fn get_or_create_subdir(
         &self,
         channel: &Channel,


### PR DESCRIPTION
Users get this error when they are using a channel that doesn't have a subdir for their platform:
```
> pixi add pixi-editor
ERROR error=repodata not found
✔ Added pixi-editor >=0.1.0,<0.2
```

This is a result of using `#[instrument(err)]`. This can be avoided by telling the instrument to log errors as something else or not at all. I chose to make them an info level resulting in:
```
> pixi add pixi-editor -vv
...
 INFO resolve_conda{group=default platform=osx-arm64}:get_or_create_subdir{platform=OsxArm64 channel=https://prefix.dev/ruben-arts/}:fetch_repo_data{cache_path=PATH/cache/repodata}: rattler_repodata_gateway::fetch: error=repodata not found
...
```


