### PR TITLE
chore: release

### DIFF
--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.31.1", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.2", default-features = false }
+rattler = { path="../rattler", version = "0.32.0", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.3", default-features = false }
 rattler_networking = { path="../rattler_networking", version = "0.22.3", default-features = false, features = ["gcs", "s3"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.36", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.3.7", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.2", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.3.8", default-features = false }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.37", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.3.8", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.3", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.3.9", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0](https://github.com/conda/rattler/compare/rattler-v0.31.1...rattler-v0.32.0) - 2025-02-18
+
+### Fixed
+
+- use new PackageRecord when issuing reinstallation in `Transaction::from_current_and_desired` (#1070)
+- clobber issue where path was not correctly searched for in clobbered paths (#1066)
+
 ## [0.31.1](https://github.com/conda/rattler/compare/rattler-v0.31.0...rattler-v0.31.1) - 2025-02-06
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.31.1"
+version = "0.32.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.3.8", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.2", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.3.9", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.22.3", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.18", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.27", default-features = false, features = ["reqwest"] }
+rattler_shell = { path = "../rattler_shell", version = "0.22.19", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.28", default-features = false, features = ["reqwest"] }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9](https://github.com/conda/rattler/compare/rattler_cache-v0.3.8...rattler_cache-v0.3.9) - 2025-02-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.3.8](https://github.com/conda/rattler/compare/rattler_cache-v0.3.7...rattler_cache-v0.3.8) - 2025-02-06
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.8"
+version = "0.3.9"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -18,10 +18,10 @@ fs-err.workspace = true
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.30.2", path = "../rattler_conda_types", default-features = false }
+rattler_conda_types = { version = "0.30.3", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.5", path = "../rattler_digest", default-features = false }
 rattler_networking = { version = "0.22.3", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.27", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { version = "0.22.28", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 tracing.workspace = true

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.30.2...rattler_conda_types-v0.30.3) - 2025-02-18
+
+### Added
+
+- write prefix record atomically (#1063)
+
 ## [0.30.2](https://github.com/conda/rattler/compare/rattler_conda_types-v0.30.1...rattler_conda_types-v0.30.2) - 2025-02-06
 
 ### Other

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.30.2"
+version = "0.30.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.12](https://github.com/conda/rattler/compare/rattler_index-v0.20.11...rattler_index-v0.20.12) - 2025-02-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.20.11](https://github.com/conda/rattler/compare/rattler_index-v0.20.10...rattler_index-v0.20.11) - 2025-02-06
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.20.11"
+version = "0.20.12"
 edition.workspace = true
 authors = []
 description = "A crate that indexes directories containing conda packages to create local conda channels"
@@ -12,9 +12,9 @@ readme.workspace = true
 
 [dependencies]
 fs-err = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.3", default-features = false }
 rattler_digest = { path="../rattler_digest", version = "1.0.5", default-features = false }
-rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.27", default-features = false }
+rattler_package_streaming = { path="../rattler_package_streaming", version = "0.22.28", default-features = false }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.43](https://github.com/conda/rattler/compare/rattler_lock-v0.22.42...rattler_lock-v0.22.43) - 2025-02-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.42](https://github.com/conda/rattler/compare/rattler_lock-v0.22.41...rattler_lock-v0.22.42) - 2025-02-06
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.42"
+version = "0.22.43"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,7 +15,7 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
 file_url = { path = "../file_url", version = "0.2.2" }
 pep508_rs = { workspace = true }

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.28](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.27...rattler_package_streaming-v0.22.28) - 2025-02-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.27](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.26...rattler_package_streaming-v0.22.27) - 2025-02-06
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.27"
+version = "0.22.28"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,7 +16,7 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
 rattler_networking = { path = "../rattler_networking", version = "0.22.3", default-features = false }
 rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.37](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.36...rattler_repodata_gateway-v0.21.37) - 2025-02-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.21.36](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.35...rattler_repodata_gateway-v0.21.36) - 2025-02-06
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.36"
+version = "0.21.37"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -36,7 +36,7 @@ memmap2 = { workspace = true, optional = true }
 ouroboros = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.2", default-features = false, optional = true }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.3", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false, features = ["tokio", "serde"] }
 rattler_networking = { path = "../rattler_networking", version = "0.22.3", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
@@ -55,7 +55,7 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 retry-policies = { workspace = true }
-rattler_cache = { version = "0.3.8", path = "../rattler_cache" }
+rattler_cache = { version = "0.3.9", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.6", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.19](https://github.com/conda/rattler/compare/rattler_shell-v0.22.18...rattler_shell-v0.22.19) - 2025-02-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.22.18](https://github.com/conda/rattler/compare/rattler_shell-v0.22.17...rattler_shell-v0.22.18) - 2025-02-06
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.18"
+version = "0.22.19"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -15,7 +15,7 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.3", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true , optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.8](https://github.com/conda/rattler/compare/rattler_solve-v1.3.7...rattler_solve-v1.3.8) - 2025-02-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [1.3.7](https://github.com/conda/rattler/compare/rattler_solve-v1.3.6...rattler_solve-v1.3.7) - 2025-02-06
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.3.7"
+version = "1.3.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,7 +11,7 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.2", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.30.3", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.5", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.2...rattler_virtual_packages-v2.0.3) - 2025-02-18
+
+### Fixed
+
+- do not try to call `ldd` on non-linux systems (#1064)
+
 ## [2.0.2](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.1...rattler_virtual_packages-v2.0.2) - 2025-02-06
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.2"
+version = "2.0.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.30.2", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.30.3", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `rattler`: 0.31.1 -> 0.32.0 (⚠ API breaking changes)
* `rattler_conda_types`: 0.30.2 -> 0.30.3 (✓ API compatible changes)
* `rattler_virtual_packages`: 2.0.2 -> 2.0.3 (✓ API compatible changes)
* `rattler_cache`: 0.3.8 -> 0.3.9
* `rattler_package_streaming`: 0.22.27 -> 0.22.28
* `rattler_shell`: 0.22.18 -> 0.22.19
* `rattler_lock`: 0.22.42 -> 0.22.43
* `rattler_repodata_gateway`: 0.21.36 -> 0.21.37
* `rattler_solve`: 1.3.7 -> 1.3.8
* `rattler_index`: 0.20.11 -> 0.20.12

### ⚠ `rattler` breaking changes

```text
--- failure enum_tuple_variant_changed_kind: An enum tuple variant changed kind ---

Description:
A public enum's exhaustive tuple variant has changed to a different kind of enum variant, breaking possible instantiations and patterns.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/enum_tuple_variant_changed_kind.ron

Failed in:
  variant TransactionOperation::Reinstall in /tmp/.tmpBEx31H/rattler/crates/rattler/src/install/transaction.rs:38
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler`

<blockquote>

## [0.32.0](https://github.com/conda/rattler/compare/rattler-v0.31.1...rattler-v0.32.0) - 2025-02-18

### Fixed

- use new PackageRecord when issuing reinstallation in `Transaction::from_current_and_desired` (#1070)
- clobber issue where path was not correctly searched for in clobbered paths (#1066)
</blockquote>

## `rattler_conda_types`

<blockquote>

## [0.30.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.30.2...rattler_conda_types-v0.30.3) - 2025-02-18

### Added

- write prefix record atomically (#1063)
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.3](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.2...rattler_virtual_packages-v2.0.3) - 2025-02-18

### Fixed

- do not try to call `ldd` on non-linux systems (#1064)
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.9](https://github.com/conda/rattler/compare/rattler_cache-v0.3.8...rattler_cache-v0.3.9) - 2025-02-18

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.28](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.27...rattler_package_streaming-v0.22.28) - 2025-02-18

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_shell`

<blockquote>

## [0.22.19](https://github.com/conda/rattler/compare/rattler_shell-v0.22.18...rattler_shell-v0.22.19) - 2025-02-18

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_lock`

<blockquote>

## [0.22.43](https://github.com/conda/rattler/compare/rattler_lock-v0.22.42...rattler_lock-v0.22.43) - 2025-02-18

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.21.37](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.36...rattler_repodata_gateway-v0.21.37) - 2025-02-18

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_solve`

<blockquote>

## [1.3.8](https://github.com/conda/rattler/compare/rattler_solve-v1.3.7...rattler_solve-v1.3.8) - 2025-02-18

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_index`

<blockquote>

## [0.20.12](https://github.com/conda/rattler/compare/rattler_index-v0.20.11...rattler_index-v0.20.12) - 2025-02-18

### Other

- updated the following local packages: rattler_conda_types
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).