### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4165,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.32.2"
+version = "0.32.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4241,7 +4241,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4344,7 +4344,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.30"
+version = "0.22.31"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4526,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.21.39"
+version = "0.21.40"
 dependencies = [
  "anyhow",
  "assert_matches",

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,13 +27,13 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.32.2", default-features = false, features = ["indicatif"] }
+rattler = { path="../rattler", version = "0.32.3", default-features = false, features = ["indicatif"] }
 rattler_conda_types = { path="../rattler_conda_types", version = "0.31.1", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.22.6", default-features = false, features = ["gcs", "s3"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.39", default-features = false, features = ["gateway"] }
+rattler_networking = { path="../rattler_networking", version = "0.22.7", default-features = false, features = ["gcs", "s3"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.21.40", default-features = false, features = ["gateway"] }
 rattler_solve = { path="../rattler_solve", version = "1.3.10", default-features = false, features = ["resolvo", "libsolv_c"] }
 rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.5", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.3.11", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.3.12", default-features = false }
 rattler_menuinst = { path="../rattler_menuinst", version = "0.2.0", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.3](https://github.com/conda/rattler/compare/rattler-v0.32.2...rattler-v0.32.3) - 2025-02-28
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.32.2](https://github.com/conda/rattler/compare/rattler-v0.32.1...rattler-v0.32.2) - 2025-02-27
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.32.2"
+version = "0.32.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,12 +32,12 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.3.11", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.3.12", default-features = false }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.7", default-features = false }
 rattler_shell = { path = "../rattler_shell", version = "0.22.21", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.30", default-features = false, features = ["reqwest"] }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.31", default-features = false, features = ["reqwest"] }
 rattler_menuinst = { path = "../rattler_menuinst", version = "0.2.0", default-features = false }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.12](https://github.com/conda/rattler/compare/rattler_cache-v0.3.11...rattler_cache-v0.3.12) - 2025-02-28
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.3.11](https://github.com/conda/rattler/compare/rattler_cache-v0.3.10...rattler_cache-v0.3.11) - 2025-02-27
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.11"
+version = "0.3.12"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -20,8 +20,8 @@ itertools.workspace = true
 parking_lot.workspace = true
 rattler_conda_types = { version = "0.31.1", path = "../rattler_conda_types", default-features = false }
 rattler_digest = { version = "1.0.6", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.22.6", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.30", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_networking = { version = "0.22.7", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.31", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1](https://github.com/conda/rattler/compare/rattler_index-v0.21.0...rattler_index-v0.21.1) - 2025-02-28
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.21.0](https://github.com/conda/rattler/compare/rattler_index-v0.20.13...rattler_index-v0.21.0) - 2025-02-27
 
 ### Added

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.21.0"
+version = "0.21.1"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."
@@ -43,10 +43,10 @@ opendal = { workspace = true, features = [
   "services-s3",
   "services-fs",
 ], default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.7", default-features = false }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1" }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.30", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.31", default-features = false }
 reqwest = { workspace = true, default-features = false, features = [
   "http2",
   "macos-system-configuration",

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.7](https://github.com/conda/rattler/compare/rattler_networking-v0.22.6...rattler_networking-v0.22.7) - 2025-02-28
+
+### Fixed
+
+- R2 key names in tests (#1115)
+
 ## [0.22.6](https://github.com/conda/rattler/compare/rattler_networking-v0.22.5...rattler_networking-v0.22.6) - 2025-02-27
 
 ### Fixed

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.22.6"
+version = "0.22.7"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.31](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.30...rattler_package_streaming-v0.22.31) - 2025-02-28
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.22.30](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.29...rattler_package_streaming-v0.22.30) - 2025-02-27
 
 ### Added

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.30"
+version = "0.22.31"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -18,7 +18,7 @@ futures-util = { workspace = true }
 num_cpus = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.7", default-features = false }
 rattler_redaction = { version = "0.1.7", path = "../rattler_redaction", features = [
   "reqwest",
   "reqwest-middleware",

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.40](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.39...rattler_repodata_gateway-v0.21.40) - 2025-02-28
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.21.39](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.38...rattler_repodata_gateway-v0.21.39) - 2025-02-27
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.21.39"
+version = "0.21.40"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -38,7 +38,7 @@ parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
 rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.1", default-features = false, optional = true }
 rattler_digest = { path = "../rattler_digest", version = "1.0.6", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.22.6", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.7", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -55,7 +55,7 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 retry-policies = { workspace = true }
-rattler_cache = { version = "0.3.11", path = "../rattler_cache" }
+rattler_cache = { version = "0.3.12", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.7", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION



## 🤖 New release

* `rattler_networking`: 0.22.6 -> 0.22.7 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.30 -> 0.22.31
* `rattler_cache`: 0.3.11 -> 0.3.12
* `rattler`: 0.32.2 -> 0.32.3
* `rattler_repodata_gateway`: 0.21.39 -> 0.21.40
* `rattler_index`: 0.21.0 -> 0.21.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_networking`

<blockquote>

## [0.22.7](https://github.com/conda/rattler/compare/rattler_networking-v0.22.6...rattler_networking-v0.22.7) - 2025-02-28

### Fixed

- R2 key names in tests (#1115)
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.31](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.30...rattler_package_streaming-v0.22.31) - 2025-02-28

### Other

- updated the following local packages: rattler_networking
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.12](https://github.com/conda/rattler/compare/rattler_cache-v0.3.11...rattler_cache-v0.3.12) - 2025-02-28

### Other

- updated the following local packages: rattler_networking
</blockquote>

## `rattler`

<blockquote>

## [0.32.3](https://github.com/conda/rattler/compare/rattler-v0.32.2...rattler-v0.32.3) - 2025-02-28

### Other

- updated the following local packages: rattler_networking
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.21.40](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.39...rattler_repodata_gateway-v0.21.40) - 2025-02-28

### Other

- updated the following local packages: rattler_networking
</blockquote>

## `rattler_index`

<blockquote>

## [0.21.1](https://github.com/conda/rattler/compare/rattler_index-v0.21.0...rattler_index-v0.21.1) - 2025-02-28

### Other

- updated the following local packages: rattler_networking
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).