### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "pin-project",
- "rustix",
+ "rustix 0.38.44",
  "thiserror 1.0.69",
  "tokio",
  "windows-sys 0.52.0",
@@ -254,7 +254,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.44",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -286,7 +286,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
 ]
 
@@ -313,7 +313,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -350,9 +350,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.5.17"
+version = "1.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490aa7465ee685b2ced076bb87ef654a47724a7844e2c7d3af4e749ce5b875dd"
+checksum = "90aff65e86db5fe300752551c1b015ef72b708ac54bded8ef43d0d53cb7cb0b1"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -360,7 +360,7 @@ dependencies = [
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -400,7 +400,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.77.0"
+version = "1.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e87342432a3de0e94e82c99a7cbd9042f99de029ae1f4e368160f9e9929264"
+checksum = "3038614b6cf7dd68d9a7b5b39563d04337eb3678d1d4173e356e927b0356158a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -428,7 +428,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -452,14 +452,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.60.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60186fab60b24376d3e33b9ff0a43485f99efd470e3b75a9160c849741d63d56"
+checksum = "e65ff295979977039a25f5a0bf067a64bc5e6aa38f3cef4037cf42516265553c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -474,14 +474,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.61.0"
+version = "1.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7033130ce1ee13e6018905b7b976c915963755aef299c1521897679d6cd4f8ef"
+checksum = "91430a60f754f235688387b75ee798ef00cfd09709a582be2b7525ebb5306d4f"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -496,14 +496,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.61.0"
+version = "1.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c1cac7677179d622b4448b0d31bcb359185295dc6fca891920cfb17e2b5156"
+checksum = "9276e139d39fff5a0b0c984fc2d30f970f9a202da67234f948fda02e5bea1dbe"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.61.1",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -525,7 +525,7 @@ checksum = "9bfe75fad52793ce6dec0dc3d4b1f388f038b5eb866c8d4d7f3a8e21b5ea5051"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -563,7 +563,7 @@ version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2dc8d842d872529355c72632de49ef8c5a2949a4472f10e802f28cf925770c"
 dependencies = [
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-types",
  "bytes",
  "crc32c",
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.6"
+version = "0.60.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b18559a41e0c909b77625adf2b8c50de480a8041e5e4a3f5f7d177db70abc5a"
+checksum = "461e5e02f9864cba17cff30f007c2e37ade94d01e87cdb5204e44a84e6d38c17"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -595,6 +595,26 @@ name = "aws-smithy-http"
 version = "0.60.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7809c27ad8da6a6a68c454e651d4962479e81472aa19ae99e59f9aba1f9713cc"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6f276f21c7921fe902826618d1423ae5bf74cf8c1b8472aee8434f3dfd31824"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -637,7 +657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d526a12d9ed61fadefda24abe2e682892ba288c2018bcb38b1b4c111d13f6d92"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http",
+ "aws-smithy-http 0.60.12",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -860,7 +880,7 @@ dependencies = [
  "bitflags 2.9.0",
  "libc",
  "log",
- "rustix",
+ "rustix 0.38.44",
  "seccompiler",
 ]
 
@@ -962,9 +982,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytes-utils"
@@ -1620,9 +1640,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
@@ -1646,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "elsa"
-version = "1.11.0"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2343daaeabe09879d4ea058bb4f1e63da3fc07dadc6634e01bda1b3d6a9d9d2b"
+checksum = "9abf33c656a7256451ebb7d0082c5a471820c31269e49d807c538c252352186e"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -1917,7 +1937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c29c30684418547d476f0b48e84f4821639119c483b1eccd566c8cd0cd05f521"
 dependencies = [
  "fs-err",
- "rustix",
+ "rustix 0.38.44",
  "tokio",
  "windows-sys 0.52.0",
 ]
@@ -2304,6 +2324,12 @@ name = "hermit-abi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
 
 [[package]]
 name = "hex"
@@ -2827,11 +2853,11 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.0",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -3070,6 +3096,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
 
 [[package]]
 name = "litemap"
@@ -3389,9 +3421,9 @@ checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "opendal"
@@ -3850,7 +3882,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3869,11 +3901,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.7.35",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -3888,9 +3920,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -4056,7 +4088,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.21",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -4114,7 +4146,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.32.4"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4190,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.13"
+version = "0.3.14"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4228,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.31.3"
+version = "0.31.4"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4275,7 +4307,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "blake2",
  "digest",
@@ -4293,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4321,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_libsolv_c"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "anyhow",
  "cc",
@@ -4333,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.46"
+version = "0.22.47"
 dependencies = [
  "chrono",
  "file_url",
@@ -4360,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "quote",
  "syn",
@@ -4369,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "configparser",
@@ -4398,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.22.8"
+version = "0.22.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4434,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.32"
+version = "0.22.33"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4467,6 +4499,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rattler_pty"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "nix",
+ "signal-hook",
+]
+
+[[package]]
 name = "rattler_redaction"
 version = "0.1.8"
 dependencies = [
@@ -4477,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4541,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_sandbox"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "birdcage",
  "clap",
@@ -4552,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.22"
+version = "0.22.23"
 dependencies = [
  "enum_dispatch",
  "fs-err",
@@ -4571,7 +4612,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -4600,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "archspec",
  "libloading",
@@ -4695,13 +4736,13 @@ dependencies = [
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efd944f26afa2406cbbabff39fac533c9bc24b13d7f1f12e14ae3e7bdc66cdb"
+checksum = "4b86038e146b9a61557e1a2e58cdf2eddc0b46ce141b55541b1c1b9f3189d618"
 dependencies = [
  "cfg-if",
  "libc",
- "rustix",
+ "rustix 1.0.1",
  "windows 0.60.0",
 ]
 
@@ -4929,9 +4970,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5045,7 +5086,20 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dade4812df5c384711475be5fcd8c162555352945401aed22a35bffeab61f657"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.2",
  "windows-sys 0.59.0",
 ]
 
@@ -5291,9 +5345,9 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -5321,9 +5375,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5454,6 +5508,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -5649,9 +5713,9 @@ checksum = "ab16ced94dbd8a46c82fd81e3ed9a8727dac2977ea869d217bcc4ea1f122e81f"
 
 [[package]]
 name = "syn"
-version = "2.0.99"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5772,15 +5836,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.1",
  "windows-sys 0.59.0",
 ]
 
@@ -5867,9 +5931,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -5882,15 +5946,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5942,9 +6006,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6611,7 +6675,7 @@ checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
 dependencies = [
  "either",
  "env_home",
- "rustix",
+ "rustix 0.38.44",
  "winsafe",
 ]
 
@@ -7099,13 +7163,12 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "linux-raw-sys",
- "rustix",
+ "rustix 1.0.1",
 ]
 
 [[package]]
@@ -7216,17 +7279,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
  "zerocopy-derive 0.7.35",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf01143b2dd5d134f11f545cf9f1431b13b749695cb33bcce051e7568f99478"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "zerocopy-derive 0.8.21",
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -7242,9 +7304,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712c8386f4f4299382c9abee219bee7084f78fb939d88b6840fcc1320d5f6da2"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,14 +27,14 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.32.4", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.3", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.22.8", default-features = false, features = ["gcs", "s3"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.22.0", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.4.0", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.6", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.3.13", default-features = false }
-rattler_menuinst = { path="../rattler_menuinst", version = "0.2.2", default-features = false }
+rattler = { path="../rattler", version = "0.33.0", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.4", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.22.9", default-features = false, features = ["gcs", "s3"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.22.1", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.4.1", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.7", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.3.14", default-features = false }
+rattler_menuinst = { path="../rattler_menuinst", version = "0.2.3", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0](https://github.com/conda/rattler/compare/rattler-v0.32.4...rattler-v0.33.0) - 2025-03-10
+
+### Added
+
+- add reinstallation method to installer and transaction ([#1128](https://github.com/conda/rattler/pull/1128))
+
 ## [0.32.4](https://github.com/conda/rattler/compare/rattler-v0.32.3...rattler-v0.32.4) - 2025-03-04
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.32.4"
+version = "0.33.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,13 +32,13 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.3.13", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.3", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.8", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.22", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.32", default-features = false, features = ["reqwest"] }
-rattler_menuinst = { path = "../rattler_menuinst", version = "0.2.2", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.3.14", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.4", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.9", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.23", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.33", default-features = false, features = ["reqwest"] }
+rattler_menuinst = { path = "../rattler_menuinst", version = "0.2.3", default-features = false }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.14](https://github.com/conda/rattler/compare/rattler_cache-v0.3.13...rattler_cache-v0.3.14) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.3.13](https://github.com/conda/rattler/compare/rattler_cache-v0.3.12...rattler_cache-v0.3.13) - 2025-03-04
 
 ### Added

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.13"
+version = "0.3.14"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -21,10 +21,10 @@ fs4 = { workspace = true, features = ["fs-err3-tokio", "tokio"] }
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.31.3", path = "../rattler_conda_types", default-features = false }
-rattler_digest = { version = "1.0.7", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.22.8", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.32", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_conda_types = { version = "0.31.4", path = "../rattler_conda_types", default-features = false }
+rattler_digest = { version = "1.0.8", path = "../rattler_digest", default-features = false }
+rattler_networking = { version = "0.22.9", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.33", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.4](https://github.com/conda/rattler/compare/rattler_conda_types-v0.31.3...rattler_conda_types-v0.31.4) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.31.3](https://github.com/conda/rattler/compare/rattler_conda_types-v0.31.2...rattler_conda_types-v0.31.3) - 2025-03-04
 
 ### Other

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.31.3"
+version = "0.31.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -24,10 +24,10 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false, features = [
+rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false, features = [
   "serde",
 ] }
-rattler_macros = { path = "../rattler_macros", version = "1.0.6", default-features = false }
+rattler_macros = { path = "../rattler_macros", version = "1.0.7", default-features = false }
 rattler_redaction = { version = "0.1.8", path = "../rattler_redaction", default-features = false }
 regex = { workspace = true }
 simd-json = { workspace = true, features = ["serde_impl"] }

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8](https://github.com/conda/rattler/compare/rattler_digest-v1.0.7...rattler_digest-v1.0.8) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.0.7](https://github.com/conda/rattler/compare/rattler_digest-v1.0.6...rattler_digest-v1.0.7) - 2025-02-28
 
 ### Other

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "1.0.7"
+version = "1.0.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.3](https://github.com/conda/rattler/compare/rattler_index-v0.21.2...rattler_index-v0.21.3) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.21.2](https://github.com/conda/rattler/compare/rattler_index-v0.21.1...rattler_index-v0.21.2) - 2025-03-04
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.21.2"
+version = "0.21.3"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."
@@ -44,10 +44,10 @@ opendal = { workspace = true, features = [
   "services-s3",
   "services-fs",
 ], default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.8", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.3" }
-rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.32", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.9", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.4" }
+rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.33", default-features = false }
 reqwest = { workspace = true, default-features = false, features = [
   "http2",
   "macos-system-configuration",

--- a/crates/rattler_libsolv_c/CHANGELOG.md
+++ b/crates/rattler_libsolv_c/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.1.2...rattler_libsolv_c-v1.1.3) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.1.2](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.1.1...rattler_libsolv_c-v1.1.2) - 2025-02-18
 
 ### Other

--- a/crates/rattler_libsolv_c/Cargo.toml
+++ b/crates/rattler_libsolv_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_libsolv_c"
-version = "1.1.2"
+version = "1.1.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Bindings for libsolv"

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.47](https://github.com/conda/rattler/compare/rattler_lock-v0.22.46...rattler_lock-v0.22.47) - 2025-03-10
+
+### Other
+
+- release ([#1137](https://github.com/conda/rattler/pull/1137))
+
 ## [0.22.46](https://github.com/conda/rattler/compare/rattler_lock-v0.22.45...rattler_lock-v0.22.46) - 2025-02-28
 
 ### Fixed

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.46"
+version = "0.22.47"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,8 +15,8 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.3", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.4", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false }
 file_url = { path = "../file_url", version = "0.2.3" }
 pep508_rs = { workspace = true }
 pep440_rs = { workspace = true }

--- a/crates/rattler_macros/CHANGELOG.md
+++ b/crates/rattler_macros/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7](https://github.com/conda/rattler/compare/rattler_macros-v1.0.6...rattler_macros-v1.0.7) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.0.6](https://github.com/conda/rattler/compare/rattler_macros-v1.0.5...rattler_macros-v1.0.6) - 2025-02-18
 
 ### Other

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_macros"
-version = "1.0.6"
+version = "1.0.7"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate that provideds some procedural macros for the rattler project"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.2...rattler_menuinst-v0.2.3) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.2](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.1...rattler_menuinst-v0.2.2) - 2025-03-04
 
 ### Fixed

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"
@@ -15,8 +15,8 @@ dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.3", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.22", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.4", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.23", default-features = false }
 thiserror = { workspace = true }
 unicode-normalization = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.9](https://github.com/conda/rattler/compare/rattler_networking-v0.22.8...rattler_networking-v0.22.9) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.8](https://github.com/conda/rattler/compare/rattler_networking-v0.22.7...rattler_networking-v0.22.8) - 2025-03-04
 
 ### Added

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.22.8"
+version = "0.22.9"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.33](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.32...rattler_package_streaming-v0.22.33) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.32](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.31...rattler_package_streaming-v0.22.32) - 2025-03-04
 
 ### Added

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.32"
+version = "0.22.33"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,9 +16,9 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.3", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.8", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.4", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.9", default-features = false }
 rattler_redaction = { version = "0.1.8", path = "../rattler_redaction", features = [
   "reqwest",
   "reqwest-middleware",

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.1](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.22.0...rattler_repodata_gateway-v0.22.1) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.0](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.21.40...rattler_repodata_gateway-v0.22.0) - 2025-03-04
 
 ### Added

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.22.0"
+version = "0.22.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -34,9 +34,9 @@ json-patch = { workspace = true }
 self_cell = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.3", default-features = false, optional = true }
-rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.22.8", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.4", default-features = false, optional = true }
+rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false, features = ["tokio", "serde"] }
+rattler_networking = { path = "../rattler_networking", version = "0.22.9", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -53,7 +53,7 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 retry-policies = { workspace = true }
-rattler_cache = { version = "0.3.13", path = "../rattler_cache" }
+rattler_cache = { version = "0.3.14", path = "../rattler_cache" }
 rattler_redaction = { version = "0.1.8", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/rattler_sandbox/CHANGELOG.md
+++ b/crates/rattler_sandbox/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.4...rattler_sandbox-v0.1.5) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.4](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.3...rattler_sandbox-v0.1.4) - 2025-02-25
 
 ### Other

--- a/crates/rattler_sandbox/Cargo.toml
+++ b/crates/rattler_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_sandbox"
-version = "0.1.4"
+version = "0.1.5"
 description = "A crate to run executables in a sandbox"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.23](https://github.com/conda/rattler/compare/rattler_shell-v0.22.22...rattler_shell-v0.22.23) - 2025-03-10
+
+### Other
+
+- release ([#1137](https://github.com/conda/rattler/pull/1137))
+
 ## [0.22.22](https://github.com/conda/rattler/compare/rattler_shell-v0.22.21...rattler_shell-v0.22.22) - 2025-02-28
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.22"
+version = "0.22.23"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -15,7 +15,7 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.4", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true , optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1](https://github.com/conda/rattler/compare/rattler_solve-v1.4.0...rattler_solve-v1.4.1) - 2025-03-10
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.4.0](https://github.com/conda/rattler/compare/rattler_solve-v1.3.11...rattler_solve-v1.4.0) - 2025-03-04
 
 ### Added

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.4.0"
+version = "1.4.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,8 +11,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.3", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.7", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.4", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }
@@ -20,7 +20,7 @@ tracing = { workspace = true }
 itertools = { workspace = true }
 url = { workspace = true }
 tempfile = { workspace = true }
-rattler_libsolv_c = { path = "../rattler_libsolv_c", version = "1.1.2", default-features = false, optional = true }
+rattler_libsolv_c = { path = "../rattler_libsolv_c", version = "1.1.3", default-features = false, optional = true }
 resolvo = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.7](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.6...rattler_virtual_packages-v2.0.7) - 2025-03-10
+
+### Other
+
+- release ([#1137](https://github.com/conda/rattler/pull/1137))
+
 ## [2.0.6](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.5...rattler_virtual_packages-v2.0.6) - 2025-02-28
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.6"
+version = "2.0.7"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.3", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.4", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `rattler_digest`: 1.0.7 -> 1.0.8 (✓ API compatible changes)
* `rattler_macros`: 1.0.6 -> 1.0.7
* `rattler_conda_types`: 0.31.3 -> 0.31.4 (✓ API compatible changes)
* `rattler_networking`: 0.22.8 -> 0.22.9 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.32 -> 0.22.33 (✓ API compatible changes)
* `rattler_cache`: 0.3.13 -> 0.3.14 (✓ API compatible changes)
* `rattler_shell`: 0.22.22 -> 0.22.23 (✓ API compatible changes)
* `rattler_menuinst`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `rattler`: 0.32.4 -> 0.33.0 (⚠ API breaking changes)
* `rattler_lock`: 0.22.46 -> 0.22.47 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.22.0 -> 0.22.1 (✓ API compatible changes)
* `rattler_libsolv_c`: 1.1.2 -> 1.1.3 (✓ API compatible changes)
* `rattler_solve`: 1.4.0 -> 1.4.1 (✓ API compatible changes)
* `rattler_virtual_packages`: 2.0.6 -> 2.0.7 (✓ API compatible changes)
* `rattler_index`: 0.21.2 -> 0.21.3 (✓ API compatible changes)
* `rattler_sandbox`: 0.1.4 -> 0.1.5 (✓ API compatible changes)

### ⚠ `rattler` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/method_parameter_count_changed.ron

Failed in:
  rattler::install::Transaction::from_current_and_desired now takes 4 parameters instead of 3, in /tmp/.tmpWfuIrM/rattler/crates/rattler/src/install/transaction.rs:130
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_digest`

<blockquote>

## [1.0.8](https://github.com/conda/rattler/compare/rattler_digest-v1.0.7...rattler_digest-v1.0.8) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_macros`

<blockquote>

## [1.0.7](https://github.com/conda/rattler/compare/rattler_macros-v1.0.6...rattler_macros-v1.0.7) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_conda_types`

<blockquote>

## [0.31.4](https://github.com/conda/rattler/compare/rattler_conda_types-v0.31.3...rattler_conda_types-v0.31.4) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_networking`

<blockquote>

## [0.22.9](https://github.com/conda/rattler/compare/rattler_networking-v0.22.8...rattler_networking-v0.22.9) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.33](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.32...rattler_package_streaming-v0.22.33) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.14](https://github.com/conda/rattler/compare/rattler_cache-v0.3.13...rattler_cache-v0.3.14) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_shell`

<blockquote>

## [0.22.23](https://github.com/conda/rattler/compare/rattler_shell-v0.22.22...rattler_shell-v0.22.23) - 2025-03-10

### Other

- release ([#1137](https://github.com/conda/rattler/pull/1137))
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.3](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.2...rattler_menuinst-v0.2.3) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler`

<blockquote>

## [0.33.0](https://github.com/conda/rattler/compare/rattler-v0.32.4...rattler-v0.33.0) - 2025-03-10

### Added

- add reinstallation method to installer and transaction ([#1128](https://github.com/conda/rattler/pull/1128))
</blockquote>

## `rattler_lock`

<blockquote>

## [0.22.47](https://github.com/conda/rattler/compare/rattler_lock-v0.22.46...rattler_lock-v0.22.47) - 2025-03-10

### Other

- release ([#1137](https://github.com/conda/rattler/pull/1137))
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.22.1](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.22.0...rattler_repodata_gateway-v0.22.1) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_libsolv_c`

<blockquote>

## [1.1.3](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.1.2...rattler_libsolv_c-v1.1.3) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_solve`

<blockquote>

## [1.4.1](https://github.com/conda/rattler/compare/rattler_solve-v1.4.0...rattler_solve-v1.4.1) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.7](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.6...rattler_virtual_packages-v2.0.7) - 2025-03-10

### Other

- release ([#1137](https://github.com/conda/rattler/pull/1137))
</blockquote>

## `rattler_index`

<blockquote>

## [0.21.3](https://github.com/conda/rattler/compare/rattler_index-v0.21.2...rattler_index-v0.21.3) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_sandbox`

<blockquote>

## [0.1.5](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.4...rattler_sandbox-v0.1.5) - 2025-03-10

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).