### PR TITLE
Proof of concept: RattlerFS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,6 +1984,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "fuser"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53274f494609e77794b627b1a3cddfe45d675a6b2e9ba9c0fdc8d8eee2184369"
+dependencies = [
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "page_size",
+ "pkg-config",
+ "smallvec",
+ "zerocopy 0.8.23",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,6 +3592,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4348,6 +4374,34 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "rattler_fuse"
+version = "0.1.0"
+dependencies = [
+ "fuser",
+]
+
+[[package]]
+name = "rattler_fuse_test"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "fuser",
+ "libc",
+ "memchr",
+ "once_cell",
+ "rattler",
+ "rattler_cache",
+ "rattler_conda_types",
+ "rattler_digest",
+ "rattler_lock",
+ "regex",
+ "reqwest",
+ "reqwest-middleware",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -923,7 +923,10 @@ pub fn link_package_sync(
     Ok(paths)
 }
 
-fn compute_paths(
+/// A helper function that generates the paths for the package files based on
+/// the [PathsJson] and [IndexJson] with any required modifications for noarch
+/// python packages.
+pub fn compute_paths(
     index_json: &IndexJson,
     paths_json: &PathsJson,
     python_info: Option<&PythonInfo>,

--- a/crates/rattler_fuse/Cargo.toml
+++ b/crates/rattler_fuse/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rattler_fuse"
+version = "0.1.0"
+description = "A create for mounting conda environments as a FUSE filesystem"
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+readme.workspace = true
+
+[dependencies]
+fuser = "0.15.1"

--- a/crates/rattler_fuse/src/lib.rs
+++ b/crates/rattler_fuse/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/crates/rattler_fuse_test/Cargo.toml
+++ b/crates/rattler_fuse_test/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "rattler_fuse_test"
+version = "0.1.0"
+categories.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+readme.workspace = true
+
+[dependencies]
+fuser = "0.15.1"
+rattler_lock = { path = "../rattler_lock" }
+rattler_conda_types = { path = "../rattler_conda_types" }
+rattler_cache = { path = "../rattler_cache" }
+rattler = { path = "../rattler" }
+rattler_digest = { path = "../rattler_digest" }
+reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+regex = { workspace = true }
+once_cell = { workspace = true }
+memchr = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+clap = { workspace = true }
+libc = { workspace = true }

--- a/crates/rattler_fuse_test/src/filesystem.rs
+++ b/crates/rattler_fuse_test/src/filesystem.rs
@@ -1,0 +1,180 @@
+use crate::patching::OpenFile;
+use crate::tree::EnvTree;
+use crate::tree_objects::Node;
+use fuser::consts::FOPEN_KEEP_CACHE;
+use fuser::{
+    FileType, Filesystem, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry, ReplyOpen, Request,
+};
+use libc::ENOENT;
+use std::collections::HashMap;
+use std::ffi::OsStr;
+use std::os::unix::ffi::OsStrExt;
+use std::time::Duration;
+use std::vec;
+
+// All data is read-only so it can be cached forever
+const TTL: Duration = Duration::from_secs(365 * 24 * 60 * 60);
+
+pub struct RattlerFS {
+    tree: EnvTree,
+    uid: u32,
+    gid: u32,
+    open_files: HashMap<u64, OpenFile>,
+}
+
+impl RattlerFS {
+    pub fn new(tree: EnvTree, uid: u32, gid: u32) -> RattlerFS {
+        RattlerFS {
+            tree,
+            uid,
+            gid,
+            open_files: HashMap::new(),
+        }
+    }
+}
+
+impl Filesystem for RattlerFS {
+    fn lookup(&mut self, _req: &Request<'_>, parent: u64, name: &OsStr, reply: ReplyEntry) {
+        if let Some(node) = self.tree.find_by_inode(parent) {
+            if let Ok(dir) = node.borrow().as_directory() {
+                if let Some(child) = dir.get_child(name) {
+                    return reply.entry(&TTL, &child.borrow().stat(self.uid, self.gid), 0);
+                }
+            }
+        }
+        reply.error(ENOENT);
+    }
+
+    fn readlink(&mut self, _req: &Request<'_>, ino: u64, reply: ReplyData) {
+        if let Some(node) = self.tree.find_by_inode(ino) {
+            if let Ok(symlink) = node.borrow().as_symlink() {
+                return reply.data(symlink.readlink().as_os_str().as_bytes());
+            }
+        }
+        reply.error(ENOENT);
+    }
+
+    fn getattr(&mut self, _req: &Request<'_>, ino: u64, _fh: Option<u64>, reply: ReplyAttr) {
+        if let Some(node) = self.tree.find_by_inode(ino) {
+            return reply.attr(&TTL, &node.borrow().stat(self.uid, self.gid));
+        }
+        reply.error(ENOENT);
+    }
+
+    fn open(&mut self, _req: &Request<'_>, ino: u64, _flags: i32, reply: ReplyOpen) {
+        let node = self.tree.find_by_inode(ino);
+        match node {
+            Some(node) => {
+                let borrowed = node.borrow();
+                let open_file = borrowed.open();
+                let fd = open_file.fd();
+                self.open_files.insert(fd, open_file);
+                reply.opened(fd, FOPEN_KEEP_CACHE);
+            }
+            None => {
+                reply.error(ENOENT);
+            }
+        }
+    }
+
+    fn release(
+        &mut self,
+        _req: &Request<'_>,
+        _ino: u64,
+        fh: u64,
+        _flags: i32,
+        _lock_owner: Option<u64>,
+        _flush: bool,
+        reply: fuser::ReplyEmpty,
+    ) {
+        if self.open_files.remove(&fh).is_none() {
+            reply.error(ENOENT);
+        } else {
+            reply.ok();
+        }
+    }
+
+    fn read(
+        &mut self,
+        _req: &Request<'_>,
+        _ino: u64,
+        fh: u64,
+        offset: i64,
+        size: u32,
+        _flags: i32,
+        _lock: Option<u64>,
+        reply: ReplyData,
+    ) {
+        let mut buffer = vec![0; size as usize];
+        let f = self.open_files.get_mut(&fh).unwrap();
+        if let Ok(bytes_read) = f.read_at(&mut buffer, offset as u64) {
+            reply.data(&buffer[..bytes_read]);
+        } else {
+            panic!("Failed to read from file");
+        }
+    }
+
+    fn readdir(
+        &mut self,
+        _req: &Request<'_>,
+        ino: u64,
+        _fh: u64,
+        offset: i64,
+        mut reply: ReplyDirectory,
+    ) {
+        let node = self.tree.find_by_inode(ino);
+        match node {
+            Some(node) => {
+                let borrowed = node.borrow();
+                match &*borrowed {
+                    Node::Directory(dir) => {
+                        let entries = dir.children();
+                        if offset <= 0 {
+                            let _ = reply.add(ino, 1, FileType::Directory, ".");
+                        }
+                        if offset <= 1 {
+                            let _ = if ino == self.tree.root_ino() {
+                                reply.add(ino, 2, FileType::Directory, "..")
+                            } else {
+                                match &*borrowed.parent().borrow() {
+                                    Node::Directory(_) => reply.add(
+                                        borrowed.parent().borrow().ino(),
+                                        2,
+                                        FileType::Directory,
+                                        "..",
+                                    ),
+                                    _ => {
+                                        unreachable!()
+                                    }
+                                }
+                            };
+                        }
+                        for (i, entry) in
+                            entries.into_iter().enumerate().skip((offset - 2) as usize)
+                        {
+                            let borrowed = entry.borrow();
+                            let kind: FileType = match &*borrowed {
+                                Node::Directory(_) => FileType::Directory,
+                                Node::File(_) | Node::EntryPoint(_) => FileType::RegularFile,
+                                Node::Symlink(_) => FileType::Symlink,
+                            };
+                            if reply.add(borrowed.ino(), (i + 3) as i64, kind, borrowed.name()) {
+                                break;
+                            }
+                        }
+                        reply.ok();
+                    }
+                    Node::Symlink(_) => {
+                        panic!("TODO Symlink!");
+                    }
+                    Node::File(_) | Node::EntryPoint(_) => {
+                        reply.error(ENOENT);
+                    }
+                }
+            }
+            None => {
+                reply.error(ENOENT);
+            }
+        }
+    }
+}

--- a/crates/rattler_fuse_test/src/main.rs
+++ b/crates/rattler_fuse_test/src/main.rs
@@ -1,0 +1,73 @@
+use crate::filesystem::RattlerFS;
+use clap::{Arg, ArgAction, Command};
+use fuser::MountOption;
+use rattler_cache::default_cache_dir;
+use rattler_lock::DEFAULT_ENVIRONMENT_NAME;
+use std::path::PathBuf;
+use std::vec;
+use tree::EnvTree;
+
+mod filesystem;
+mod patching;
+mod tree;
+mod tree_objects;
+
+#[tokio::main]
+async fn main() {
+    let matches = Command::new("rattler_fuse_test")
+        .arg(
+            Arg::new("lock_file")
+                .required(true)
+                .index(1)
+                .help("Path to the pixi.lock file"),
+        )
+        .arg(
+            Arg::new("mount_point")
+                .required(true)
+                .index(2)
+                .help("Act as a client, and mount FUSE at given path"),
+        )
+        .arg(
+            Arg::new("env_name")
+                .long("env-name")
+                .default_value(DEFAULT_ENVIRONMENT_NAME)
+                .help("Name of the environment to mount"),
+        )
+        .arg(
+            Arg::new("print-tree")
+                .long("print-tree")
+                .action(ArgAction::SetTrue)
+                .help("Print the tree before mounting"),
+        )
+        .get_matches();
+
+    let lock_file_path = PathBuf::from(matches.get_one::<String>("lock_file").unwrap());
+    let cache_dir = default_cache_dir()
+        .unwrap()
+        .join(rattler_cache::PACKAGE_CACHE_DIR);
+    let env_name = matches.get_one::<String>("env_name").unwrap();
+    let target_dir = PathBuf::from(matches.get_one::<String>("mount_point").unwrap());
+    let tree = EnvTree::from_lock_file(&lock_file_path, env_name, &target_dir, &cache_dir)
+        .await
+        .unwrap();
+    if matches.get_flag("print-tree") {
+        tree.print_tree();
+    }
+
+    println!(
+        "Mounting {} from {} at {} with cache dir {}",
+        env_name,
+        lock_file_path.display(),
+        target_dir.display(),
+        cache_dir.display()
+    );
+    let options = vec![
+        MountOption::RO,
+        MountOption::FSName("rattlerfs".to_string()),
+        MountOption::AllowOther,
+        MountOption::AutoUnmount,
+    ];
+    let uid = unsafe { libc::getuid() };
+    let gid = unsafe { libc::getgid() };
+    fuser::mount2(RattlerFS::new(tree, uid, gid), &target_dir, &options).unwrap();
+}

--- a/crates/rattler_fuse_test/src/patching.rs
+++ b/crates/rattler_fuse_test/src/patching.rs
@@ -1,0 +1,746 @@
+use once_cell::sync::Lazy;
+use rattler_conda_types::Platform;
+use regex::Regex;
+use std::borrow::Cow;
+use std::cmp;
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::FileExt;
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::tree_objects::PatchMode;
+
+// Add this near the other constants at the top of the file
+static NEXT_MEMORY_FD: AtomicU64 = AtomicU64::new(0x7FFF_FFFF_0000_0000);
+
+const MAX_SHEBANG_LENGTH_LINUX: usize = 127;
+const MAX_SHEBANG_LENGTH_MACOS: usize = 512;
+
+pub enum OpenFile {
+    NoPatch(std::fs::File),
+    Patched(PatchedFile),
+    InMemory(Vec<u8>),
+}
+
+impl OpenFile {
+    pub fn fd(&self) -> u64 {
+        match self {
+            OpenFile::NoPatch(f) => f.as_raw_fd() as u64,
+            OpenFile::Patched(f) => f.file.as_raw_fd() as u64,
+            OpenFile::InMemory(_) =>
+            // Use pointer address to ensure uniqueness across different in-memory files
+            // Starting from a very high base value to avoid conflicts with real FDs
+            {
+                NEXT_MEMORY_FD.fetch_add(1, Ordering::Relaxed)
+            }
+        }
+    }
+
+    pub fn read_at(&mut self, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
+        let bytes_read = match self {
+            OpenFile::NoPatch(f) => f.read_at(buf, offset).unwrap(),
+            OpenFile::Patched(f) => {
+                f.advance(Some(offset + buf.len() as u64)).unwrap();
+                f.read_at(buf, offset).unwrap()
+            }
+            OpenFile::InMemory(data) => {
+                let end = cmp::min(data.len(), (offset as i64 + buf.len() as i64) as usize);
+                let bytes_read = end - offset as usize;
+                buf[..bytes_read as usize].copy_from_slice(&data[offset as usize..end]);
+                bytes_read
+            }
+        };
+        Ok(bytes_read)
+    }
+
+    pub fn size_change(&mut self) -> i64 {
+        match self {
+            OpenFile::NoPatch(_) | OpenFile::InMemory(_) => 0,
+            OpenFile::Patched(f) => f.size_change(),
+        }
+    }
+}
+
+pub struct PatchedFile {
+    file: std::fs::File,
+    offsets: PatchOffsets,
+    current_pos: Option<u64>,
+    old_prefix: Vec<u8>,
+    new_prefix: Rc<Vec<u8>>,
+    target_platform: Platform,
+}
+
+#[derive(Debug, Default)]
+struct PatchedShebang {
+    original_len: usize,
+    new: Vec<u8>,
+}
+
+#[derive(Debug)]
+enum PatchOffsets {
+    BinPatchOffsets(BinaryPatchOffsets),
+    TextPatchOffsets(TextPatchOffsets),
+}
+
+#[derive(Debug)]
+struct TextPatchOffsets {
+    /// The difference in length between the old and new shebang
+    shebang: Option<PatchedShebang>,
+    /// The difference in length between the old and new prefixes
+    shift: u16,
+    /// The apparent offsets in the file (TODO: Include this in the package cache)
+    offset: Vec<u64>,
+}
+
+#[derive(Debug)]
+struct BinaryPatchOffsets {
+    /// The difference in length between the old and new prefixes
+    shift: u16,
+    /// Each element corrosponds to a string inside the file that needs to be patched
+    /// Each element of the inner vector corrosponds to an instance of the placeholder
+    /// in the string, except the last element which corrosponds to the end of the string
+    offset: Vec<Vec<u64>>,
+    /// State which is used to keep track between buffers in advance
+    advance_state: Option<Vec<u64>>,
+}
+
+impl PatchedShebang {
+    pub fn shift(&self) -> i64 {
+        self.new.len() as i64 - self.original_len as i64
+    }
+}
+
+impl TextPatchOffsets {
+    pub fn new(shift: u16) -> Self {
+        Self {
+            shebang: None,
+            shift,
+            offset: Vec::new(),
+        }
+    }
+
+    /// Find the closest offset that is less than or equal to the given offset.
+    pub fn start_idx(&self, pos: u64) -> Option<usize> {
+        match self.offset.binary_search(&pos) {
+            Ok(idx) => Some(idx),
+            Err(0) => None,
+            Err(idx) => {
+                if idx == 0 {
+                    None
+                } else {
+                    Some(idx - 1)
+                }
+            }
+        }
+    }
+
+    /// Get the offset at the given index
+    pub fn at(&self, idx: usize) -> Option<(u64, u64)> {
+        let apparent_offset = *self.offset.get(idx)?;
+        let shebang = self.shebang.as_ref().expect("Shebang not yet read");
+        let shift = idx as i64 * i64::from(self.shift) + shebang.shift();
+        let real_offset = apparent_offset + shift as u64;
+        Some((apparent_offset, real_offset))
+    }
+
+    /// Insert a new offset into the list of offsets
+    pub fn insert(&mut self, real_offset: u64) {
+        let shift = self.offset.len() as u64 * u64::from(self.shift);
+        let apparent_offset = real_offset - shift;
+
+        assert!(match self.offset.last() {
+            Some(&last) => last <= apparent_offset,
+            None => true,
+        });
+        match self.offset.binary_search(&apparent_offset) {
+            Ok(_) => (),
+            Err(idx) => self.offset.insert(idx, apparent_offset),
+        }
+    }
+}
+
+impl BinaryPatchOffsets {
+    pub fn new(shift: u16) -> Self {
+        Self {
+            shift,
+            offset: Vec::new(),
+            advance_state: None,
+        }
+    }
+
+    /// Find the closest set of offsets that is less than or equal to the given offset.
+    pub fn start_idx(&self, pos: u64) -> Option<usize> {
+        let idx = match self.offset.binary_search_by_key(&pos, |v| v[0]) {
+            Ok(idx) => Some(idx),
+            Err(0) => None,
+            Err(idx) => {
+                if idx == 0 {
+                    None
+                } else {
+                    Some(idx - 1)
+                }
+            }
+        };
+        match idx {
+            Some(idx) => {
+                let end_of_string = *self.offset[idx]
+                    .last()
+                    .expect("There should be at least two elements in the vector");
+                let end_of_string =
+                    end_of_string + u64::from(self.shift) * (self.offset[idx].len() - 1) as u64;
+                if pos > end_of_string {
+                    Some(idx + 1)
+                } else {
+                    Some(idx)
+                }
+            }
+            None => None,
+        }
+    }
+
+    /// Get the offset at the given index
+    pub fn at(&self, idx: usize) -> Option<impl Iterator<Item = (u64, u64)> + '_> {
+        let inner = self.offset.get(idx)?;
+        let shift = u64::from(self.shift);
+        Some(inner.iter().enumerate().map(move |(i, apparent_offset)| {
+            let real_offset = apparent_offset + i as u64 * shift;
+            (*apparent_offset, real_offset)
+        }))
+    }
+
+    /// Insert a new offset into the list of offsets
+    pub fn insert(&mut self, real_offsets: Vec<u64>) {
+        let apparent_offsets: Vec<u64> = real_offsets
+            .iter()
+            .enumerate()
+            .map(|(i, offset)| offset - i as u64 * u64::from(self.shift))
+            .collect();
+        assert!(match self.offset.last() {
+            Some(last) => last[0] <= apparent_offsets[0],
+            None => true,
+        });
+        match self
+            .offset
+            .binary_search_by_key(&apparent_offsets[0], |v| v[0])
+        {
+            Ok(_) => (),
+            Err(idx) => self.offset.insert(idx, apparent_offsets),
+        }
+    }
+}
+
+impl PatchOffsets {
+    pub fn size_change(&self) -> i64 {
+        match self {
+            PatchOffsets::BinPatchOffsets(_) => 0,
+            PatchOffsets::TextPatchOffsets(ref offsets) => {
+                let shebang = offsets.shebang.as_ref().expect("Shebang not yet read");
+                shebang.shift() - (i64::from(offsets.shift) * offsets.offset.len() as i64)
+            }
+        }
+    }
+
+    pub fn shift(&self) -> u16 {
+        match self {
+            PatchOffsets::BinPatchOffsets(offsets) => offsets.shift,
+            PatchOffsets::TextPatchOffsets(offsets) => offsets.shift,
+        }
+    }
+
+    pub fn count(&self) -> usize {
+        match self {
+            PatchOffsets::BinPatchOffsets(offsets) => offsets.offset.iter().map(std::vec::Vec::len).sum(),
+            PatchOffsets::TextPatchOffsets(offsets) => offsets.offset.len(),
+        }
+    }
+}
+
+impl PatchedFile {
+    pub fn open(file: std::fs::File, patch_mode: &PatchMode) -> OpenFile {
+        match patch_mode {
+            PatchMode::Binary(old, new, target_platform) => {
+                let shift = (old.len() - new.len())
+                    .try_into()
+                    .expect("Difference between old and new prefix must be representable as a u16");
+                let patched_file = Self {
+                    file,
+                    offsets: PatchOffsets::BinPatchOffsets(BinaryPatchOffsets::new(shift)),
+                    current_pos: Some(0),
+                    old_prefix: old.clone(),
+                    new_prefix: new.clone(),
+                    target_platform: *target_platform,
+                };
+                OpenFile::Patched(patched_file)
+            }
+            PatchMode::Text(old, new, target_platform) => {
+                let shift = (old.len() - new.len())
+                    .try_into()
+                    .expect("Difference between old and new prefix must be representable as a u16");
+                let patched_file = Self {
+                    file,
+                    offsets: PatchOffsets::TextPatchOffsets(TextPatchOffsets::new(shift)),
+                    current_pos: Some(0),
+                    old_prefix: old.clone(),
+                    new_prefix: new.clone(),
+                    target_platform: *target_platform,
+                };
+                OpenFile::Patched(patched_file)
+            }
+            PatchMode::None => OpenFile::NoPatch(file),
+        }
+    }
+
+    /// Get the size change that would result from applying the patch
+    pub fn size_change(&mut self) -> i64 {
+        self.advance(None).unwrap();
+        self.offsets.size_change()
+    }
+
+    /// Scan the file for occurrences of the old prefix and update the offsets
+    pub fn advance(&mut self, new_pos: Option<u64>) -> std::io::Result<()> {
+        if match (self.current_pos, new_pos) {
+            (None, _) => true,
+            (Some(_), None) => false,
+            (Some(current), Some(desired)) => {
+                current >= desired + u64::from(self.offsets.shift()) * self.offsets.count() as u64
+            }
+        } {
+            return Ok(());
+        }
+        let mut current_pos = match self.current_pos {
+            Some(pos) => pos,
+            None => unreachable!(),
+        };
+
+        let size: usize = 64 * 1024; // This must be longer than the maximum shebang length
+        let mut buffer: Vec<u8> = vec![0; size + self.old_prefix.len() - 1];
+        loop {
+            let bytes_read = self.file.read_at(&mut buffer, current_pos)?;
+
+            // If we've reached the end of the file, stop reading
+            if bytes_read == 0 {
+                self.current_pos = None;
+                break;
+            }
+            let mut buffer = &buffer[..bytes_read];
+
+            match self.offsets {
+                PatchOffsets::TextPatchOffsets(ref mut offsets) => {
+                    let mut real_offset = current_pos;
+                    // Ignore the first line if it's a shebang
+                    assert!(current_pos == 0 || current_pos > MAX_SHEBANG_LENGTH_MACOS as u64);
+                    if current_pos == 0 {
+                        offsets.shebang = Some(
+                            if self.target_platform.is_unix() && buffer.starts_with(b"#!") {
+                                let (first, _) = buffer
+                                    .split_at(buffer.iter().position(|&c| c == b'\n').unwrap_or(0));
+                                let first_line = String::from_utf8_lossy(first);
+                                let prefix_placeholder = String::from_utf8_lossy(&self.old_prefix);
+                                let target_prefix = String::from_utf8_lossy(&self.new_prefix);
+                                let new_shebang = replace_shebang(
+                                    first_line,
+                                    (&prefix_placeholder, &target_prefix),
+                                    &self.target_platform,
+                                );
+                                real_offset += first.len() as u64;
+                                buffer = &buffer[first.len()..];
+                                PatchedShebang {
+                                    original_len: first.len(),
+                                    new: new_shebang.as_bytes().to_vec(),
+                                }
+                            } else {
+                                PatchedShebang::default()
+                            },
+                        );
+                    }
+                    // Update the offsets with any occurrences of the old prefix
+                    for index in memchr::memmem::find_iter(buffer, &self.old_prefix) {
+                        offsets.insert(real_offset + index as u64);
+                    }
+                }
+                PatchOffsets::BinPatchOffsets(ref mut offsets) => {
+                    let finder = memchr::memmem::Finder::new(&self.old_prefix);
+                    let mut real_offset = current_pos;
+
+                    while !buffer.is_empty() {
+                        let mut end = if let Some(state) = &offsets.advance_state {
+                            if state.is_empty() {
+                                buffer.len()
+                            } else {
+                                let mut end = 0;
+                                while end < buffer.len() && buffer[end] != b'\0' {
+                                    end += 1;
+                                }
+                                end
+                            }
+                        } else {
+                            offsets.advance_state = Some(Vec::new());
+                            buffer.len()
+                        };
+                        let these_offsets = offsets
+                            .advance_state
+                            .as_mut()
+                            .expect("Value is initialized at the start of the loop");
+
+                        assert!(end <= buffer.len() && end > 0);
+
+                        if let Some(first_index) = finder.find(&buffer[..end]) {
+                            these_offsets.push(real_offset + first_index as u64);
+                            // Find the end of the c-style string. The nul terminator basically.
+                            end = first_index + self.old_prefix.len();
+                            while end < buffer.len() && buffer[end] != b'\0' {
+                                end += 1;
+                            }
+                            // Find all occurrences of the old prefix in the string
+                            for index in
+                                finder.find_iter(&buffer[first_index + self.old_prefix.len()..end])
+                            {
+                                these_offsets.push(
+                                    (real_offset as usize
+                                        + first_index
+                                        + self.old_prefix.len()
+                                        + index) as u64,
+                                );
+                            }
+                            // If we've found the end of the string, add it to the offsets
+                            if end < buffer.len() {
+                                these_offsets.push(real_offset + end as u64);
+                                let these_offsets = offsets
+                                    .advance_state
+                                    .take()
+                                    .expect("Value is initialized at the start of the loop");
+                                offsets.insert(these_offsets);
+                            }
+                        } else if !these_offsets.is_empty() && end != buffer.len() {
+                            // We have a partial match from the previous buffer and the current buffer
+                            // doesn't contain any more matches
+                            these_offsets.push(real_offset + end as u64);
+                            let these_offsets = offsets
+                                .advance_state
+                                .take()
+                                .expect("Value is initialized at the start of the loop");
+                            offsets.insert(these_offsets);
+                        }
+                        buffer = &buffer[end..];
+                        real_offset += end as u64;
+                    }
+                }
+            }
+
+            current_pos += cmp::min(bytes_read, size) as u64;
+
+            // Break if we've read the desired number of bytes
+            if let Some(pos) = new_pos {
+                if current_pos
+                    >= pos + u64::from(self.offsets.shift()) * self.offsets.count() as u64
+                {
+                    self.current_pos = Some(current_pos);
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Read from the file at the given offset with prefix substitution
+    ///
+    /// This function requires that advance has already been called!
+    pub fn read_at(&self, buf: &mut [u8], offset: u64) -> std::io::Result<usize> {
+        assert!(self.current_pos.unwrap_or(u64::MAX) >= offset + buf.len() as u64);
+
+        let mut bytes_read: usize = 0;
+        match &self.offsets {
+            PatchOffsets::TextPatchOffsets(offsets) => {
+                let mut start_idx = if let Some(idx) = offsets.start_idx(offset) { idx } else {
+                    // Read up until the first offset
+                    let mut apparent_pos = offset;
+                    let mut real_pos = offset;
+                    let mut to_read = match offsets.at(0) {
+                        Some((first_pos, first_pos2)) => {
+                            assert!(first_pos == first_pos2);
+                            cmp::min((first_pos - offset) as usize, buf.len())
+                        }
+                        None => buf.len() - bytes_read,
+                    };
+
+                    // Handle the shebang
+                    if let Some(shebang) = &offsets.shebang {
+                        let n = cmp::min(shebang.new.len(), buf.len() - bytes_read)
+                            - real_pos as usize;
+                        buf[bytes_read..bytes_read + n].copy_from_slice(
+                            &shebang.new[offset as usize..n + offset as usize],
+                        );
+                        bytes_read += n;
+                        to_read -= n;
+                        apparent_pos += n as u64;
+                        real_pos = if shebang.new.len() == apparent_pos as usize {
+                            shebang.original_len as u64
+                        } else {
+                            apparent_pos
+                        };
+                    }
+
+                    // Handle anything else which comes before the first offset
+                    let n = self
+                        .file
+                        .read_at(&mut buf[bytes_read..bytes_read + to_read], real_pos)?;
+                    bytes_read += n;
+                    if n < to_read {
+                        return Ok(bytes_read);
+                    }
+                    0
+                };
+
+                while bytes_read < buf.len() {
+                    let (mut apparent_pos, mut real_pos) = offsets.at(start_idx).unwrap();
+                    let (_, real_next) = offsets.at(start_idx + 1).unwrap_or((u64::MAX, u64::MAX));
+
+                    // First, perform the substitution if necessary
+                    let shift = offset as usize + bytes_read - apparent_pos as usize;
+                    if shift < self.new_prefix.len() {
+                        let new_prefix = &self.new_prefix[shift..];
+
+                        let remaining = buf.len() - bytes_read;
+                        if remaining <= new_prefix.len() {
+                            // We need to copy a suffix from the target path and then stop
+                            buf[bytes_read..].copy_from_slice(&new_prefix[..remaining]);
+                            return Ok(buf.len());
+                        }
+                        buf[bytes_read..bytes_read + new_prefix.len()].copy_from_slice(new_prefix);
+                        bytes_read += new_prefix.len();
+                    } else {
+                        // Need to skip some bytes before copying from the source
+                        real_pos += shift as u64 - self.new_prefix.len() as u64;
+                        apparent_pos += shift as u64 - self.new_prefix.len() as u64;
+                    }
+                    real_pos += self.old_prefix.len() as u64;
+                    apparent_pos += self.new_prefix.len() as u64;
+                    assert!(apparent_pos == offset + bytes_read as u64);
+
+                    // The remaining bytes up until the next offset can be proxied from the file
+                    let read_size =
+                        cmp::min(buf.len() - bytes_read, (real_next - real_pos) as usize);
+                    let n = self
+                        .file
+                        .read_at(&mut buf[bytes_read..bytes_read + read_size], real_pos)?;
+                    bytes_read += n;
+                    start_idx += 1;
+                    assert!(self.current_pos.unwrap_or(u64::MAX) >= real_pos + n as u64);
+                    if n < read_size || start_idx >= offsets.offset.len() {
+                        return Ok(bytes_read);
+                    }
+                }
+            }
+            PatchOffsets::BinPatchOffsets(offsets) => {
+                if offsets.offset.is_empty() {
+                    return self.file.read_at(buf, offset);
+                }
+
+                let mut start_idx = offsets.start_idx(offset).unwrap_or_default();
+
+                // Read up until the first offset
+                let apparent_pos = offset;
+                let to_read = match offsets.at(start_idx) {
+                    Some(mut iter) => {
+                        let (first_pos, first_pos2) = iter
+                            .next()
+                            .expect("Empty iterator of offsets doesn't make sense");
+                        assert!(first_pos == first_pos2);
+                        cmp::min(
+                            first_pos as i64 - offset as i64,
+                            (buf.len() - bytes_read) as i64,
+                        )
+                    }
+                    None => (buf.len() - bytes_read) as i64,
+                };
+                if to_read > 0 {
+                    let to_read = to_read as usize;
+                    let n = self
+                        .file
+                        .read_at(&mut buf[bytes_read..bytes_read + to_read], apparent_pos)?;
+                    bytes_read += n;
+                    if n < to_read {
+                        return Ok(bytes_read);
+                    }
+                }
+
+                while bytes_read < buf.len() {
+                    let iter_vec: Vec<(u64, u64)> = if let Some(iter) = offsets.at(start_idx) { iter.collect() } else {
+                        // We've reached the end of the offsets so we can just read from the file
+                        let start = offset + bytes_read as u64;
+                        bytes_read += self.file.read_at(&mut buf[bytes_read..], start)?;
+                        assert!(self.current_pos.is_none() || bytes_read == buf.len());
+                        return Ok(bytes_read);
+                    };
+                    for window in iter_vec.windows(2) {
+                        let (apparent_pos, mut real_pos) = window[0];
+                        let (next_apparent, next_real) = window[1];
+                        if next_apparent > offset + bytes_read as u64 {
+                            // First, perform the substitution if necessary
+                            let seek = offset + bytes_read as u64 - apparent_pos;
+                            if seek <= self.new_prefix.len() as u64 {
+                                let new_prefix = &self.new_prefix[seek as usize..];
+                                let remaining = cmp::min(buf.len() - bytes_read, new_prefix.len());
+                                buf[bytes_read..bytes_read + remaining].copy_from_slice(new_prefix);
+                                bytes_read += remaining;
+                                if bytes_read == buf.len() {
+                                    return Ok(bytes_read);
+                                }
+                                real_pos += self.old_prefix.len() as u64;
+                            } else {
+                                real_pos += seek + u64::from(offsets.shift);
+                            }
+
+                            // The remaining bytes up until the next offset can be proxied from the file
+                            let read_size =
+                                cmp::min(buf.len() - bytes_read, (next_real - real_pos) as usize);
+                            let n = self
+                                .file
+                                .read_at(&mut buf[bytes_read..bytes_read + read_size], real_pos)?;
+                            bytes_read += n;
+                            assert!(
+                                self.current_pos.unwrap_or(u64::MAX) >= real_pos + n as u64
+                            );
+                        }
+                    }
+
+                    // Pad the buffer with null bytes if we've reached the end of the offsets
+                    let last_apparent = iter_vec
+                        .last()
+                        .expect("Empty iterator of offsets doesn't make sense")
+                        .0;
+                    if last_apparent == offset + bytes_read as u64 {
+                        let n_nulls = cmp::min(
+                            buf.len() - bytes_read,
+                            offsets.shift as usize * (iter_vec.len() - 1),
+                        );
+                        buf[bytes_read..bytes_read + n_nulls].fill(0);
+                        bytes_read += n_nulls;
+                    }
+
+                    if bytes_read == buf.len() {
+                        break;
+                    }
+
+                    // Read until the next cstring
+                    start_idx += 1;
+                    let (apparent_pos, real_pos) = if let Some(mut iter) = offsets.at(start_idx) { iter
+                    .next()
+                    .expect("Empty iterator of offsets doesn't make sense") } else {
+                        let start = offset + bytes_read as u64;
+                        bytes_read += self.file.read_at(&mut buf[bytes_read..], start)?;
+                        assert!(self.current_pos.is_none() || bytes_read == buf.len());
+                        return Ok(bytes_read);
+                    };
+                    assert!(apparent_pos == real_pos);
+                    let read_size = cmp::min(
+                        buf.len() - bytes_read,
+                        apparent_pos as usize - (offset as usize + bytes_read),
+                    );
+                    let n = self.file.read_at(
+                        &mut buf[bytes_read..bytes_read + read_size],
+                        offset + bytes_read as u64,
+                    )?;
+                    assert!(n == read_size, "Read {n} bytes, expected {read_size}");
+                    bytes_read += n;
+                    if bytes_read == buf.len() {
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(bytes_read)
+    }
+}
+
+static SHEBANG_REGEX: Lazy<Regex> = Lazy::new(|| {
+    // ^(#!      pretty much the whole match string
+    // (?:[ ]*)  allow spaces between #! and beginning of
+    //           the executable path
+    // (/(?:\\ |[^ \n\r\t])*)  the executable is the next
+    //                         text block without an
+    //                         escaped space or non-space
+    //                         whitespace character
+    // (.*))$    the rest of the line can contain option
+    //           flags and end whole_shebang group
+    Regex::new(r"^(#!(?:[ ]*)(/(?:\\ |[^ \n\r\t])*)(.*))$").unwrap()
+});
+
+static PYTHON_REGEX: Lazy<Regex> = Lazy::new(|| {
+    // Match string starting with `python`, and optional version number
+    // followed by optional flags.
+    // python matches the string `python`
+    // (?:\d+(?:\.\d+)*)? matches an optional version number
+    Regex::new(r"^python(?:\d+(?:\.\d+)?)?$").unwrap()
+});
+
+/// Finds if the shebang line length is valid.
+fn is_valid_shebang_length(shebang: &str, platform: &Platform) -> bool {
+    if platform.is_linux() {
+        shebang.len() <= MAX_SHEBANG_LENGTH_LINUX
+    } else if platform.is_osx() {
+        shebang.len() <= MAX_SHEBANG_LENGTH_MACOS
+    } else {
+        true
+    }
+}
+
+/// Convert a shebang to use `/usr/bin/env` to find the executable.
+/// This is useful for long shebangs or shebangs with spaces.
+fn convert_shebang_to_env(shebang: Cow<'_, str>) -> Cow<'_, str> {
+    if let Some(captures) = SHEBANG_REGEX.captures(&shebang) {
+        let path = &captures[2];
+        let exe_name = path.rsplit_once('/').map_or(path, |(_, f)| f);
+        if PYTHON_REGEX.is_match(exe_name) {
+            Cow::Owned(format!(
+                "#!/bin/sh\n'''exec' \"{}\"{} \"$0\" \"$@\" #'''",
+                path, &captures[3]
+            ))
+        } else {
+            Cow::Owned(format!("#!/usr/bin/env {}{}", exe_name, &captures[3]))
+        }
+    } else {
+        shebang
+    }
+}
+
+/// Long shebangs and shebangs with spaces are invalid.
+/// Long shebangs are longer than 127 on Linux or 512 on macOS characters.
+/// Shebangs with spaces are replaced with a shebang that uses `/usr/bin/env` to find the executable.
+/// This function replaces long shebangs with a shebang that uses `/usr/bin/env` to find the
+/// executable.
+fn replace_shebang<'a>(
+    shebang: Cow<'a, str>,
+    old_new: (&str, &str),
+    platform: &Platform,
+) -> Cow<'a, str> {
+    // If the new shebang would contain a space, return a `#!/usr/bin/env` shebang
+    assert!(
+        shebang.starts_with("#!"),
+        "Shebang does not start with #! ({shebang})",
+    );
+
+    if old_new.1.contains(' ') {
+        // Doesn't matter if we don't replace anything
+        if !shebang.contains(old_new.0) {
+            return shebang;
+        }
+        // we convert the shebang without spaces to a new shebang, and only then replace
+        // which is relevant for the Python case
+        let new_shebang = convert_shebang_to_env(shebang).replace(old_new.0, old_new.1);
+        return new_shebang.into();
+    }
+
+    let shebang: Cow<'_, str> = shebang.replace(old_new.0, old_new.1).into();
+
+    if !shebang.starts_with("#!") {
+        tracing::warn!("Shebang does not start with #! ({})", shebang);
+        return shebang;
+    }
+
+    if is_valid_shebang_length(&shebang, platform) {
+        shebang
+    } else {
+        convert_shebang_to_env(shebang)
+    }
+}

--- a/crates/rattler_fuse_test/src/tree.rs
+++ b/crates/rattler_fuse_test/src/tree.rs
@@ -1,0 +1,337 @@
+use rattler::install::compute_paths;
+use rattler::install::PythonInfo;
+use rattler_cache::package_cache::PackageCache;
+use rattler_conda_types::package::{
+    ArchiveIdentifier, EntryPoint, FileMode, IndexJson, LinkJson, NoArchLinks, PackageFile,
+    PathType, PathsJson,
+};
+use rattler_conda_types::{PackageRecord, Platform};
+use rattler_lock::LockFile;
+use rattler_lock::LockedPackageRef;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::tree_objects::{
+    Directory, EntryPoint as EntryPoint2, File, Node, NodeRef, NodeWeak, NotADirectoryError,
+    PatchMode, Symlink,
+};
+
+// Static atomic counter for generating unique inode numbers
+static NEXT_INODE: AtomicU64 = AtomicU64::new(1); // Start at 1 as 0 is often reserved
+
+// Function to get the next available inode number
+fn get_next_inode() -> u64 {
+    NEXT_INODE.fetch_add(5, Ordering::Relaxed)
+}
+
+/// A filesystem tree with an inode lookup table
+pub struct EnvTree {
+    root: NodeRef,
+    /// Maps inodes to their corresponding nodes for O(1) lookup
+    inode_map: HashMap<u64, NodeWeak>,
+}
+
+impl EnvTree {
+    pub async fn from_lock_file(
+        path: &Path,
+        env_name: &str,
+        target_dir: &Path,
+        cache_dir: &PathBuf,
+    ) -> Result<EnvTree, Box<dyn std::error::Error>> {
+        let target_dir = Rc::new(target_dir.to_string_lossy().as_bytes().to_vec());
+        let package_cache = PackageCache::new(cache_dir);
+        let client = reqwest_middleware::ClientWithMiddleware::from(reqwest::Client::new());
+
+        let lock_file = LockFile::from_path(path).unwrap();
+        let environment = lock_file.environment(env_name).unwrap();
+        let target_platform = Platform::current();
+        let packages: Vec<_> = environment
+            .packages(target_platform)
+            .expect("the platform for which the explicit lock file was created does not match the current platform")
+            .collect();
+
+        let python_info = find_python_info(
+            packages
+                .iter()
+                .filter_map(|p| p.as_conda().map(rattler_lock::CondaPackageData::record)),
+            target_platform,
+        ).map(Rc::new);
+
+        let mut tree = EnvTree::new();
+        for package in packages {
+            match package {
+                LockedPackageRef::Conda(p) => {
+                    let url: &reqwest::Url = p.location().as_url().unwrap();
+                    let package_info = ArchiveIdentifier::try_from_url(url).unwrap();
+                    // // TODO: crates/rattler/src/install/installer/mod.rs:409
+                    let package_cache_lock = package_cache
+                        .get_or_fetch_from_url(package_info, url.clone(), client.clone(), None)
+                        .await
+                        .unwrap();
+                    let package_dir = package_cache_lock.path();
+
+                    let paths_json =
+                        PathsJson::from_package_directory_with_deprecated_fallback(package_dir)
+                            .unwrap();
+                    let index_json = IndexJson::from_package_directory(package_dir).unwrap();
+
+                    // Error out if this is a noarch python package but the python information is
+                    // missing.
+                    assert!(!(index_json.noarch.is_python() && python_info.is_none()), "No python information found for noarch python package");
+
+                    let link_json = if index_json.noarch.is_python() {
+                        Some(LinkJson::from_package_directory(package_dir).unwrap())
+                    } else {
+                        None
+                    };
+
+                    let final_paths =
+                        compute_paths(&index_json, &paths_json, python_info.as_deref());
+
+                    for (entry, computed_path) in final_paths {
+                        let target = package_dir.join(&entry.relative_path);
+                        match entry.path_type {
+                            PathType::HardLink => {
+                                let patch_mode = match entry.prefix_placeholder {
+                                    Some(placeholder) => match placeholder.file_mode {
+                                        FileMode::Binary => PatchMode::Binary(
+                                            placeholder.placeholder.clone().into_bytes(),
+                                            target_dir.clone(),
+                                            target_platform,
+                                        ),
+                                        FileMode::Text => PatchMode::Text(
+                                            placeholder.placeholder.clone().into_bytes(),
+                                            target_dir.clone(),
+                                            target_platform,
+                                        ),
+                                    },
+                                    None => PatchMode::None,
+                                };
+                                tree.add_file(
+                                    &computed_path,
+                                    target,
+                                    entry.size_in_bytes.unwrap(),
+                                    patch_mode,
+                                )?;
+                            }
+                            PathType::SoftLink => {
+                                tree.add_symlink(&computed_path, target)?;
+                            }
+                            PathType::Directory => panic!("Directory: {path:?}"),
+                        }
+                    }
+
+                    // If this package is a noarch python package we also have to create entry points.
+                    if let Some(link_json) = link_json {
+                        let entry_points = match link_json.noarch {
+                            NoArchLinks::Python(entry_points) => entry_points.entry_points,
+                            NoArchLinks::Generic => {
+                                unreachable!("we only use link.json for noarch: python packages")
+                            }
+                        };
+
+                        let python_info = python_info.clone().expect(
+                            "should be safe because its checked above that this contains a value",
+                        );
+
+                        for entry_point in entry_points {
+                            tree.add_python_entry_point(
+                                &target_dir,
+                                &target_platform,
+                                &entry_point,
+                                &python_info,
+                            )?;
+                        }
+                    }
+                }
+
+                LockedPackageRef::Pypi(p, pe) => {
+                    panic!("Pypi package: {} {:?}", p.location, pe.extras);
+                }
+            }
+        }
+
+        println!("Tree has {} nodes", tree.inode_map.len());
+
+        Ok(tree)
+    }
+
+    fn new() -> Self {
+        let ino = get_next_inode();
+        let root: NodeRef = Rc::new(RefCell::new(Node::Directory(Directory::new(
+            ino,
+            "ROOT".into(),
+            None,
+        ))));
+
+        let mut inode_map = HashMap::new();
+        inode_map.insert(ino, Rc::downgrade(&root));
+
+        EnvTree {
+            root,
+            inode_map,
+        }
+    }
+
+    fn get_directory(&mut self, path: &Path) -> Result<NodeRef, NotADirectoryError> {
+        let mut parent = Rc::clone(&self.root);
+
+        for component in path.iter() {
+            let child = match &mut *parent.borrow_mut() {
+                Node::Directory(dir) => {
+                    if let Some(child) = dir.get_child(component) {
+                        Rc::clone(&child)
+                    } else {
+                        let ino = get_next_inode();
+                        let new_node = Rc::new(RefCell::new(Node::Directory(Directory::new(
+                            ino,
+                            component.into(),
+                            Some(Rc::downgrade(&parent)),
+                        ))));
+                        self.inode_map.insert(ino, Rc::downgrade(&new_node));
+                        dir.add_child(Rc::clone(&new_node));
+                        new_node
+                    }
+                }
+                _ => return Err(NotADirectoryError),
+            };
+            parent = child;
+        }
+
+        Ok(parent)
+    }
+
+    pub fn add_file(
+        &mut self,
+        path: &Path,
+        target: PathBuf,
+        size: u64,
+        patch_mode: PatchMode,
+    ) -> Result<(), NotADirectoryError> {
+        let parent_path = path
+            .parent()
+            .expect("File path must have a parent directory");
+        let file_name = path.file_name().expect("File path must have a basename");
+
+        let parent = self.get_directory(&parent_path.to_path_buf())?;
+        let ino = get_next_inode();
+        let new_node = Rc::new(RefCell::new(Node::File(File::new(
+            ino,
+            file_name.into(),
+            Rc::downgrade(&parent),
+            target,
+            size,
+            patch_mode,
+        ))));
+        self.inode_map.insert(ino, Rc::downgrade(&new_node));
+
+        match &mut *parent.borrow_mut() {
+            Node::Directory(dir) => {
+                dir.add_child(Rc::clone(&new_node));
+            }
+            _ => unreachable!(),
+        };
+
+        Ok(())
+    }
+
+    pub fn add_symlink(
+        &mut self,
+        path: &Path,
+        target: PathBuf,
+    ) -> Result<(), NotADirectoryError> {
+        let parent_path = path
+            .parent()
+            .expect("Symlink path must have a parent directory");
+        let symlink_name = path.file_name().expect("Symlink path must have a basename");
+
+        let parent = self.get_directory(&parent_path.to_path_buf())?;
+        let ino = get_next_inode();
+        let new_node = Rc::new(RefCell::new(Node::Symlink(Symlink::new(
+            ino,
+            symlink_name.into(),
+            Rc::downgrade(&parent),
+            target,
+        ))));
+        self.inode_map.insert(ino, Rc::downgrade(&new_node));
+
+        match &mut *parent.borrow_mut() {
+            Node::Directory(dir) => {
+                dir.add_child(Rc::clone(&new_node));
+            }
+            _ => unreachable!(),
+        };
+
+        Ok(())
+    }
+
+    pub fn add_python_entry_point(
+        &mut self,
+        target_prefix: &Rc<Vec<u8>>,
+        target_plaform: &Platform,
+        entry_point: &EntryPoint,
+        python_info: &Rc<PythonInfo>,
+    ) -> Result<(), NotADirectoryError> {
+        if target_plaform.is_windows() {
+            todo!("Windows entry points not yet supported");
+        }
+
+        let parent = self.get_directory(&python_info.bin_dir.clone())?;
+        let ino = get_next_inode();
+        let new_node = Rc::new(RefCell::new(Node::EntryPoint(EntryPoint2::new(
+            ino,
+            OsString::from(entry_point.command.clone()),
+            Rc::downgrade(&parent),
+            entry_point.module.clone(),
+            entry_point.function.clone(),
+            Rc::clone(target_prefix),
+            Rc::clone(python_info),
+        ))));
+        self.inode_map.insert(ino, Rc::downgrade(&new_node));
+
+        match &mut *parent.borrow_mut() {
+            Node::Directory(dir) => {
+                dir.add_child(Rc::clone(&new_node));
+            }
+            _ => unreachable!(),
+        };
+
+        Ok(())
+    }
+
+    pub fn find_by_inode(&self, ino: u64) -> Option<NodeRef> {
+        let node = self.inode_map.get(&ino)?.upgrade()?;
+        Some(node)
+    }
+
+    pub fn root_ino(&self) -> u64 {
+        self.root.borrow().ino()
+    }
+
+    pub fn print_tree(&self) {
+        self.root.borrow().print_tree(0);
+    }
+}
+
+/// Determine the version of Python used by a set of packages. Returns `None` if
+/// none of the packages refers to a Python installation.
+fn find_python_info(
+    records: impl IntoIterator<Item = impl AsRef<PackageRecord>>,
+    platform: Platform,
+) -> Option<PythonInfo> {
+    records
+        .into_iter()
+        .find(|r| is_python_record(r.as_ref()))
+        .map(|record| PythonInfo::from_python_record(record.as_ref(), platform))
+        .map_or(Ok(None), |info| info.map(Some))
+        .unwrap()
+}
+
+/// Returns true if the specified record refers to Python.
+fn is_python_record(record: &PackageRecord) -> bool {
+    record.name.as_normalized() == "python"
+}

--- a/crates/rattler_fuse_test/src/tree_objects.rs
+++ b/crates/rattler_fuse_test/src/tree_objects.rs
@@ -1,0 +1,398 @@
+use crate::patching::{OpenFile, PatchedFile};
+use fuser::{FileAttr, FileType};
+use rattler::install::python_entry_point_template;
+use rattler::install::PythonInfo;
+use rattler_conda_types::package;
+use rattler_conda_types::Platform;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+use std::fmt;
+use std::os::linux::fs::MetadataExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::rc::{Rc, Weak};
+use std::time::UNIX_EPOCH;
+
+/// Error returned when attempting to treat a non-directory as a directory
+#[derive(Debug)]
+pub struct NotADirectoryError;
+
+pub type NodeRef = Rc<RefCell<Node>>;
+pub type NodeWeak = Weak<RefCell<Node>>;
+
+impl fmt::Display for NotADirectoryError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "not a directory")
+    }
+}
+
+impl std::error::Error for NotADirectoryError {}
+
+#[derive(Debug)]
+pub enum PatchMode {
+    /// The file does not need any patching
+    None,
+    /// The file is a binary file (needs binary prefix replacement)
+    Binary(Vec<u8>, Rc<Vec<u8>>, Platform),
+    /// The file is a text file (needs text prefix replacement)
+    Text(Vec<u8>, Rc<Vec<u8>>, Platform),
+}
+
+impl Clone for PatchMode {
+    fn clone(&self) -> Self {
+        match self {
+            PatchMode::None => PatchMode::None,
+            PatchMode::Binary(bytes, target_path, target_platform) => {
+                PatchMode::Binary(bytes.clone(), target_path.clone(), *target_platform)
+            }
+            PatchMode::Text(text, target_path, target_platform) => {
+                PatchMode::Text(text.clone(), target_path.clone(), *target_platform)
+            }
+        }
+    }
+}
+
+/// Represents the three kinds of nodes in the filesystem tree
+pub enum Node {
+    File(File),
+    Directory(Directory),
+    Symlink(Symlink),
+    EntryPoint(EntryPoint),
+}
+
+/// Represents a File node
+#[derive(Debug)]
+pub struct File {
+    ino: u64,
+    name: OsString,
+    parent: NodeWeak,
+    // File specific attributes
+    target: PathBuf,
+    size: u64,
+    patch_mode: PatchMode,
+}
+
+/// Represents a Directory node
+pub struct Directory {
+    ino: u64,
+    name: OsString,
+    parent: NodeWeak,
+    // Directory specific attributes
+    children: HashMap<OsString, NodeRef>,
+}
+
+/// Represents a Symlink node
+pub struct Symlink {
+    ino: u64,
+    name: OsString,
+    parent: NodeWeak,
+    // Symlink specific attributes
+    target: PathBuf,
+}
+
+/// Represents an entry point node
+pub struct EntryPoint {
+    ino: u64,
+    name: OsString,
+    parent: NodeWeak,
+    // EntryPoint specific attributes
+    target_prefix: Rc<Vec<u8>>,
+    python_info: Rc<PythonInfo>,
+    module: String,
+    function: String,
+}
+
+impl Node {
+    pub fn name(&self) -> &OsStr {
+        match self {
+            Node::File(file) => &file.name,
+            Node::Directory(dir) => &dir.name,
+            Node::Symlink(symlink) => &symlink.name,
+            Node::EntryPoint(entry_point) => &entry_point.name,
+        }
+    }
+
+    pub fn ino(&self) -> u64 {
+        match self {
+            Node::File(file) => file.ino,
+            Node::Directory(dir) => dir.ino,
+            Node::Symlink(symlink) => symlink.ino,
+            Node::EntryPoint(entry_point) => entry_point.ino,
+        }
+    }
+
+    pub fn parent(&self) -> NodeRef {
+        let parent = match self {
+            Node::Directory(dir) => &dir.parent,
+            Node::File(file) => &file.parent,
+            Node::Symlink(symlink) => &symlink.parent,
+            Node::EntryPoint(entry_point) => &entry_point.parent,
+        };
+        parent.upgrade().expect("Parent directory not found")
+    }
+
+    pub fn print_tree(&self, depth: usize) {
+        let indent = "  ".repeat(depth);
+        match self {
+            Node::File(file) => println!(
+                "{}📄 {:?} ({}) -> ({:?})",
+                indent, file.name, file.size, file.target
+            ),
+            Node::EntryPoint(ep) => println!(
+                "{}🐍 {:?} -> ({}.{}())",
+                indent, ep.name, ep.module, ep.function
+            ),
+            Node::Directory(dir) => {
+                println!("{}📂 {:?}", indent, dir.name);
+                for child in dir.children.values() {
+                    child.borrow().print_tree(depth + 1);
+                }
+            }
+            Node::Symlink(symlink) => {
+                println!("{}🔗 {:?} -> {:?}", indent, symlink.name, symlink.target);
+            }
+        }
+    }
+
+    pub fn as_directory(&self) -> Result<&Directory, NotADirectoryError> {
+        match self {
+            Node::Directory(dir) => Ok(dir),
+            _ => Err(NotADirectoryError),
+        }
+    }
+
+    pub fn as_symlink(&self) -> Result<&Symlink, NotADirectoryError> {
+        match self {
+            Node::Symlink(symlink) => Ok(symlink),
+            _ => Err(NotADirectoryError),
+        }
+    }
+
+    pub fn stat(&self, uid: u32, gid: u32) -> FileAttr {
+        match self {
+            Node::Directory(dir) => dir.stat(uid, gid),
+            Node::File(file) => file.stat(uid, gid),
+            Node::Symlink(symlink) => symlink.stat(uid, gid),
+            Node::EntryPoint(entrypoint) => entrypoint.stat(uid, gid),
+        }
+    }
+
+    pub fn open(&self) -> OpenFile {
+        match self {
+            Node::File(file) => file.open(),
+            Node::EntryPoint(entry_point) => {
+                OpenFile::InMemory(entry_point.script().into_bytes())
+            }
+            _ => panic!("Cannot open non-file node"),
+        }
+    }
+}
+
+impl Directory {
+    pub fn new(ino: u64, name: OsString, parent: Option<NodeWeak>) -> Directory {
+        let parent = match parent {
+            Some(parent) => parent,
+            None => Weak::new(),
+        };
+        Directory {
+            ino,
+            name,
+            parent,
+            children: HashMap::new(),
+        }
+    }
+
+    pub fn add_child(&mut self, child: NodeRef) {
+        let child_name = {
+            let child = child.borrow();
+            child.name().to_os_string()
+        };
+        self.children.insert(child_name, child);
+    }
+
+    pub fn get_child(&self, name: &OsStr) -> Option<NodeRef> {
+        self.children.get(name).cloned()
+    }
+
+    pub fn children(&self) -> Vec<NodeRef> {
+        self.children.values().cloned().collect()
+    }
+
+    fn stat(&self, uid: u32, gid: u32) -> FileAttr {
+        FileAttr {
+            ino: self.ino,
+            size: 0,
+            blocks: 0,
+            atime: UNIX_EPOCH,
+            mtime: UNIX_EPOCH,
+            ctime: UNIX_EPOCH,
+            crtime: UNIX_EPOCH,
+            kind: FileType::Directory,
+            perm: 0o755,
+            nlink: 1,
+            uid,
+            gid,
+            rdev: 0,
+            flags: 0,
+            blksize: 512,
+        }
+    }
+}
+
+impl File {
+    pub fn new(
+        ino: u64,
+        name: OsString,
+        parent: NodeWeak,
+        target: PathBuf,
+        size: u64,
+        patch_mode: PatchMode,
+    ) -> File {
+        File {
+            ino,
+            name,
+            parent,
+            target,
+            size,
+            patch_mode,
+        }
+    }
+
+    pub fn open(&self) -> OpenFile {
+        let f = std::fs::File::open(&self.target).unwrap();
+        PatchedFile::open(f, &self.patch_mode)
+    }
+
+    fn stat(&self, uid: u32, gid: u32) -> FileAttr {
+        let metadata =
+            std::fs::symlink_metadata(&self.target).expect("Failed to get metadata for file");
+        let kind = if metadata.file_type().is_symlink() {
+            FileType::Symlink
+        } else {
+            FileType::RegularFile
+        };
+        let size = match &self.patch_mode {
+            PatchMode::None | PatchMode::Binary(_, _, _) => self.size,
+            PatchMode::Text(_, _, _) => {
+                let mut f = self.open();
+                (self.size as i64 + f.size_change()) as u64
+            }
+        };
+        FileAttr {
+            ino: self.ino,
+            size,
+            blocks: metadata.st_blocks(),
+            atime: UNIX_EPOCH,
+            mtime: UNIX_EPOCH,
+            ctime: UNIX_EPOCH,
+            crtime: UNIX_EPOCH,
+            kind,
+            perm: metadata.permissions().mode() as u16,
+            nlink: 1,
+            uid,
+            gid,
+            rdev: 0,
+            flags: 0,
+            blksize: metadata.st_blksize() as u32,
+        }
+    }
+}
+
+impl Symlink {
+    pub fn new(ino: u64, name: OsString, parent: NodeWeak, target: PathBuf) -> Symlink {
+        Symlink {
+            ino,
+            name,
+            parent,
+            target,
+        }
+    }
+
+    pub fn readlink(&self) -> PathBuf {
+        std::fs::read_link(&self.target).expect("Failed to read symlink target")
+    }
+
+    fn stat(&self, uid: u32, gid: u32) -> FileAttr {
+        let metadata =
+            std::fs::symlink_metadata(&self.target).expect("Failed to get metadata for symlink");
+        FileAttr {
+            ino: self.ino,
+            size: metadata.len(),
+            blocks: metadata.st_blocks(),
+            atime: UNIX_EPOCH,
+            mtime: UNIX_EPOCH,
+            ctime: UNIX_EPOCH,
+            crtime: UNIX_EPOCH,
+            kind: FileType::Symlink,
+            perm: metadata.permissions().mode() as u16,
+            nlink: 1,
+            uid,
+            gid,
+            rdev: 0,
+            flags: 0,
+            blksize: metadata.st_blksize() as u32,
+        }
+    }
+}
+
+impl EntryPoint {
+    pub fn new(
+        ino: u64,
+        name: OsString,
+        parent: NodeWeak,
+        module: String,
+        function: String,
+        target_prefix: Rc<Vec<u8>>,
+        python_info: Rc<PythonInfo>,
+    ) -> EntryPoint {
+        EntryPoint {
+            ino,
+            name,
+            parent,
+            target_prefix: Rc::clone(&target_prefix),
+            python_info: Rc::clone(&python_info),
+            module,
+            function,
+        }
+    }
+
+    fn script(&self) -> String {
+        let entry_point = package::EntryPoint {
+            command: self
+                .name
+                .clone()
+                .into_string()
+                .expect("Name should be valid UTF-8"),
+            module: self.module.clone(),
+            function: self.function.clone(),
+        };
+        python_entry_point_template(
+            std::str::from_utf8(self.target_prefix.as_slice())
+                .expect("Invalid UTF-8 in target_prefix"),
+            false,
+            &entry_point,
+            &self.python_info,
+        )
+    }
+
+    fn stat(&self, uid: u32, gid: u32) -> FileAttr {
+        FileAttr {
+            ino: self.ino,
+            size: self.script().len() as u64,
+            blocks: (self.script().len() as u64) / 512 + 1,
+            atime: UNIX_EPOCH,
+            mtime: UNIX_EPOCH,
+            ctime: UNIX_EPOCH,
+            crtime: UNIX_EPOCH,
+            kind: FileType::RegularFile,
+            perm: 0o755,
+            nlink: 1,
+            uid,
+            gid,
+            rdev: 0,
+            flags: 0,
+            blksize: 512,
+        }
+    }
+}

--- a/crates/rattler_menuinst/src/macos.rs
+++ b/crates/rattler_menuinst/src/macos.rs
@@ -406,7 +406,7 @@ impl MacOSMenu {
     }
 
     fn write_pkg_info(&self) -> Result<(), MenuInstError> {
-        let create_pkg_info = |path: &PathBuf, short_name: &str| -> Result<(), MenuInstError> {
+        let create_pkg_info = |path: &Path, short_name: &str| -> Result<(), MenuInstError> {
             let path = path.join("Contents/PkgInfo");
             tracing::debug!("Writing pkg info to {}", path.display());
             let mut f = fs::File::create(&path)?;

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,11 +29,13 @@ pkg-config = "~=0.29.2"
 rust = "~=1.84.0"
 cmake = "~=3.26.4"
 cargo-nextest = ">=0.9.91,<0.10"
+rust-src = ">=1.84.0,<2"
 
 [target.linux-64.dependencies]
 clang = ">=18.1.8,<19.0"
 compilers = ">=1.6.0"
 mold = ">=2.33.0,<3.0"
+libfuse = ">=3.10.0,<4.0"
 [target.linux-64.activation]
 scripts = ["scripts/activate_linux.sh"]
 


### PR DESCRIPTION
This add a proof-of-concet FUSE based filesystem that transparently proxies the data in the package cache on demand.

Inspired by https://github.com/conda/rattler/pull/1162, read there for some of the motivation. Unlike the overlayfs approach, I think this could work on linux, macos and even windows.

Also this is my first time writing rust so it's a bit of a mess but it shows the idea:

```
$ cargo run --bin rattler_fuse_test -- pixi.lock /tmp/cburr/test --env-name default
```

I would imagine this would normally be exposed by some kind of config setting for tools like pixi such that `pixi run xxx` sets up the fuse mount, runs the command and then exists. This works but it does wipe out the kernel filesystem cache every time, so there would be an argument for having a `pixi mount` command or similar.

The main missing functionality is:

- [ ] Compilation of pyc files
- [ ] Post-link scrips
- [ ] Windows entrypoints
- [ ] pip packages
- [ ] The `conda-meta/` directory
- [ ] Nice-to-have: Include the offsets in the JSON files of the package cache to avoid the need to seek through files to find the instances of the prefix.

Post link scripts (and pyc files) could be implemented either with overlayfs or by making RattlerFS writable (presumably as an overlay to another directory).

`.pyc` files could alternatively be done by adding them to the central package cache and compiling them on demand.

And if anyone would like to take over this I'd be happy to let them 😄 