### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.79.0"
+version = "1.82.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f63ba8f5fca32061c7d62d866ef65470edde38d4c5f8a0ebb8ff40a0521e1c"
+checksum = "e6eab2900764411ab01c8e91a76fd11a63b4e12bc3da97d9e14a0ce1343d86d3"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.62.0"
+version = "1.64.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d5330ad4e8a1ff49e9f26b738611caa72b105c41d41733801d1a36e8f9de936"
+checksum = "02d4bdb0e5f80f0689e61c77ab678b2b9304af329616af38aef5b6b967b8e736"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -467,6 +467,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "fastrand",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -475,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.63.0"
+version = "1.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7956b1a85d49082347a7d17daa2e32df191f3e23c03d47294b99f95413026a78"
+checksum = "acbbb3ce8da257aedbccdcb1aadafbbb6a5fe9adf445db0e1ea897bdc7e22d08"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -489,6 +490,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
+ "fastrand",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -497,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.63.0"
+version = "1.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065c533fbe6f84962af33fcf02b0350b7c1f79285baab5924615d2be3b232855"
+checksum = "96a78a8f50a1630db757b60f679c8226a8a70ee2ab5f5e6e51dc67f6c61c7cfd"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -512,6 +514,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-smithy-xml",
  "aws-types",
+ "fastrand",
  "http 0.2.12",
  "once_cell",
  "regex-lite",
@@ -635,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0497ef5d53065b7cd6a35e9c1654bd1fefeae5c52900d91d1b188b0af0f29324"
+checksum = "8aff1159006441d02e57204bf57a1b890ba68bedb6904ffd2873c1c4c11c546b"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -775,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
 dependencies = [
  "axum-core",
  "bytes",
@@ -804,12 +807,12 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -1163,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1184,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.34"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1478,9 +1481,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1488,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1502,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -1786,9 +1789,9 @@ checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3716d7a920fb4fac5d84e9d4bce8ceb321e9414b4409da61b07b75c1e3d0697"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1867,7 +1870,7 @@ dependencies = [
 
 [[package]]
 name = "file_url"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -1897,9 +1900,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1967,7 +1970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
  "fs-err",
- "rustix 1.0.3",
+ "rustix 1.0.5",
  "tokio",
  "windows-sys 0.59.0",
 ]
@@ -2609,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2619,6 +2622,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2628,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2638,7 +2642,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -2939,10 +2943,11 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -3442,9 +3447,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
@@ -4009,9 +4014,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.3"
+version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf763ab1c7a3aa408be466efc86efe35ed1bd3dd74173ed39d6b0d0a6f0ba148"
+checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
 dependencies = [
  "memchr",
 ]
@@ -4181,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.33.3"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4257,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4295,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.31.5"
+version = "0.31.6"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4343,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "blake2",
  "digest",
@@ -4361,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.22.2"
+version = "0.22.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4401,7 +4406,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.22.48"
+version = "0.22.49"
 dependencies = [
  "chrono",
  "file_url",
@@ -4428,7 +4433,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "quote",
  "syn",
@@ -4437,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
  "configparser",
@@ -4447,7 +4452,7 @@ dependencies = [
  "known-folders",
  "once_cell",
  "plist",
- "quick-xml 0.37.3",
+ "quick-xml 0.37.4",
  "rattler_conda_types",
  "rattler_shell",
  "regex",
@@ -4466,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.22.10"
+version = "0.22.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4502,7 +4507,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.34"
+version = "0.22.35"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4536,7 +4541,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "libc",
  "nix",
@@ -4545,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -4554,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.22.3"
+version = "0.22.4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4618,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_sandbox"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "birdcage",
  "clap",
@@ -4629,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.22.24"
+version = "0.22.25"
 dependencies = [
  "enum_dispatch",
  "fs-err",
@@ -4648,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "chrono",
  "criterion",
@@ -4677,7 +4682,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.8"
+version = "2.0.9"
 dependencies = [
  "archspec",
  "libloading",
@@ -4778,7 +4783,7 @@ checksum = "78c81d000a2c524133cc00d2f92f019d399e57906c3b7119271a2495354fe895"
 dependencies = [
  "cfg-if",
  "libc",
- "rustix 1.0.3",
+ "rustix 1.0.5",
  "windows 0.61.1",
 ]
 
@@ -5128,9 +5133,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -5677,9 +5682,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -5879,7 +5884,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.3",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -6820,15 +6825,6 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
@@ -7342,7 +7338,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.3",
+ "rustix 1.0.5",
 ]
 
 [[package]]

--- a/crates/file_url/CHANGELOG.md
+++ b/crates/file_url/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/conda/rattler/compare/file_url-v0.2.3...file_url-v0.2.4) - 2025-04-03
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.3](https://github.com/conda/rattler/compare/file_url-v0.2.2...file_url-v0.2.3) - 2025-02-18
 
 ### Other

--- a/crates/file_url/Cargo.toml
+++ b/crates/file_url/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_url"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Helper functions to work with file:// urls"

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -27,14 +27,14 @@ clap = { workspace = true, features = ["derive"] }
 console = { workspace = true, features = ["windows-console-colors"] }
 indicatif = { workspace = true }
 once_cell = { workspace = true }
-rattler = { path="../rattler", version = "0.33.3", default-features = false, features = ["indicatif"] }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.5", default-features = false }
-rattler_networking = { path="../rattler_networking", version = "0.22.10", default-features = false, features = ["gcs", "s3"] }
-rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.22.3", default-features = false, features = ["gateway"] }
-rattler_solve = { path="../rattler_solve", version = "1.4.2", default-features = false, features = ["resolvo", "libsolv_c"] }
-rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.8", default-features = false }
-rattler_cache = { path="../rattler_cache", version = "0.3.15", default-features = false }
-rattler_menuinst = { path="../rattler_menuinst", version = "0.2.5", default-features = false }
+rattler = { path="../rattler", version = "0.34.0", default-features = false, features = ["indicatif"] }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.6", default-features = false }
+rattler_networking = { path="../rattler_networking", version = "0.22.11", default-features = false, features = ["gcs", "s3"] }
+rattler_repodata_gateway = { path="../rattler_repodata_gateway", version = "0.22.4", default-features = false, features = ["gateway"] }
+rattler_solve = { path="../rattler_solve", version = "1.4.3", default-features = false, features = ["resolvo", "libsolv_c"] }
+rattler_virtual_packages = { path="../rattler_virtual_packages", version = "2.0.9", default-features = false }
+rattler_cache = { path="../rattler_cache", version = "0.3.16", default-features = false }
+rattler_menuinst = { path="../rattler_menuinst", version = "0.2.6", default-features = false }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0](https://github.com/conda/rattler/compare/rattler-v0.33.3...rattler-v0.34.0) - 2025-04-03
+
+### Added
+
+- Set link options in installer ([#1178](https://github.com/conda/rattler/pull/1178))
+
+### Other
+
+- add the remove_from_backup function and update the prefix ([#1155](https://github.com/conda/rattler/pull/1155))
+
 ## [0.33.3](https://github.com/conda/rattler/compare/rattler-v0.33.2...rattler-v0.33.3) - 2025-03-18
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.33.3"
+version = "0.34.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"
@@ -32,13 +32,13 @@ memchr = { workspace = true }
 memmap2 = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
-rattler_cache = { path = "../rattler_cache", version = "0.3.15", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.5", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.10", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.24", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.34", default-features = false, features = ["reqwest"] }
-rattler_menuinst = { path = "../rattler_menuinst", version = "0.2.5", default-features = false }
+rattler_cache = { path = "../rattler_cache", version = "0.3.16", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.6", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.9", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.11", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.25", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.35", default-features = false, features = ["reqwest"] }
+rattler_menuinst = { path = "../rattler_menuinst", version = "0.2.6", default-features = false }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.16](https://github.com/conda/rattler/compare/rattler_cache-v0.3.15...rattler_cache-v0.3.16) - 2025-04-03
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.3.15](https://github.com/conda/rattler/compare/rattler_cache-v0.3.14...rattler_cache-v0.3.15) - 2025-03-14
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.15"
+version = "0.3.16"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true
@@ -21,10 +21,10 @@ fs4 = { workspace = true, features = ["fs-err3-tokio", "tokio"] }
 fxhash.workspace = true
 itertools.workspace = true
 parking_lot.workspace = true
-rattler_conda_types = { version = "0.31.5", path = "../rattler_conda_types", default-features = false }
-rattler_digest = { version = "1.0.8", path = "../rattler_digest", default-features = false }
-rattler_networking = { version = "0.22.10", path = "../rattler_networking", default-features = false }
-rattler_package_streaming = { version = "0.22.34", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
+rattler_conda_types = { version = "0.31.6", path = "../rattler_conda_types", default-features = false }
+rattler_digest = { version = "1.0.9", path = "../rattler_digest", default-features = false }
+rattler_networking = { version = "0.22.11", path = "../rattler_networking", default-features = false }
+rattler_package_streaming = { version = "0.22.35", path = "../rattler_package_streaming", default-features = false, features = ["reqwest"] }
 reqwest.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["macros"] }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.6](https://github.com/conda/rattler/compare/rattler_conda_types-v0.31.5...rattler_conda_types-v0.31.6) - 2025-04-03
+
+### Fixed
+
+- allow empty info key in repodata.json ([#1181](https://github.com/conda/rattler/pull/1181))
+
+### Other
+
+- add the remove_from_backup function and update the prefix ([#1155](https://github.com/conda/rattler/pull/1155))
+
 ## [0.31.5](https://github.com/conda/rattler/compare/rattler_conda_types-v0.31.4...rattler_conda_types-v0.31.5) - 2025-03-14
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.31.5"
+version = "0.31.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"
@@ -16,7 +16,7 @@ experimental_extras = []
 
 [dependencies]
 chrono = { workspace = true }
-file_url = { path = "../file_url", version = "0.2.3" }
+file_url = { path = "../file_url", version = "0.2.4" }
 fxhash = { workspace = true }
 glob = { workspace = true }
 hex = { workspace = true }
@@ -24,11 +24,11 @@ itertools = { workspace = true }
 lazy-regex = { workspace = true }
 nom = { workspace = true }
 purl = { workspace = true, features = ["serde"] }
-rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false, features = [
+rattler_digest = { path = "../rattler_digest", version = "1.0.9", default-features = false, features = [
   "serde",
 ] }
-rattler_macros = { path = "../rattler_macros", version = "1.0.7", default-features = false }
-rattler_redaction = { version = "0.1.8", path = "../rattler_redaction", default-features = false }
+rattler_macros = { path = "../rattler_macros", version = "1.0.8", default-features = false }
+rattler_redaction = { version = "0.1.9", path = "../rattler_redaction", default-features = false }
 regex = { workspace = true }
 simd-json = { workspace = true, features = ["serde_impl"] }
 serde = { workspace = true, features = ["derive", "rc"] }

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.9](https://github.com/conda/rattler/compare/rattler_digest-v1.0.8...rattler_digest-v1.0.9) - 2025-04-03
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.0.8](https://github.com/conda/rattler/compare/rattler_digest-v1.0.7...rattler_digest-v1.0.8) - 2025-03-10
 
 ### Other

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "1.0.8"
+version = "1.0.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.3](https://github.com/conda/rattler/compare/rattler_index-v0.22.2...rattler_index-v0.22.3) - 2025-04-03
+
+### Added
+
+- add retry middleware to opendal operator ([#1207](https://github.com/conda/rattler/pull/1207))
+
+### Fixed
+
+- allow empty info key in repodata.json ([#1181](https://github.com/conda/rattler/pull/1181))
+- don't clone package bytes in rattler-index ([#1175](https://github.com/conda/rattler/pull/1175))
+
 ## [0.22.2](https://github.com/conda/rattler/compare/rattler_index-v0.22.1...rattler_index-v0.22.2) - 2025-03-18
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.22.2"
+version = "0.22.3"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."
@@ -44,10 +44,10 @@ opendal = { workspace = true, features = [
   "services-s3",
   "services-fs",
 ], default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.10", default-features = false }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.5" }
-rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false }
-rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.34", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.11", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.6" }
+rattler_digest = { path = "../rattler_digest", version = "1.0.9", default-features = false }
+rattler_package_streaming = { path = "../rattler_package_streaming", version = "0.22.35", default-features = false }
 reqwest = { workspace = true, default-features = false, features = [
   "http2",
   "macos-system-configuration",

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.49](https://github.com/conda/rattler/compare/rattler_lock-v0.22.48...rattler_lock-v0.22.49) - 2025-04-03
+
+### Other
+
+- add the remove_from_backup function and update the prefix ([#1155](https://github.com/conda/rattler/pull/1155))
+
 ## [0.22.48](https://github.com/conda/rattler/compare/rattler_lock-v0.22.47...rattler_lock-v0.22.48) - 2025-03-14
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.22.48"
+version = "0.22.49"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"
@@ -15,9 +15,9 @@ chrono = { workspace = true }
 fxhash = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.5", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false }
-file_url = { path = "../file_url", version = "0.2.3" }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.6", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.9", default-features = false }
+file_url = { path = "../file_url", version = "0.2.4" }
 pep508_rs = { workspace = true }
 pep440_rs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_macros/CHANGELOG.md
+++ b/crates/rattler_macros/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.8](https://github.com/conda/rattler/compare/rattler_macros-v1.0.7...rattler_macros-v1.0.8) - 2025-04-03
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.0.7](https://github.com/conda/rattler/compare/rattler_macros-v1.0.6...rattler_macros-v1.0.7) - 2025-03-10
 
 ### Other

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_macros"
-version = "1.0.7"
+version = "1.0.8"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate that provideds some procedural macros for the rattler project"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.5...rattler_menuinst-v0.2.6) - 2025-04-03
+
+### Fixed
+
+- install windows start menu shortcut ([#1198](https://github.com/conda/rattler/pull/1198))
+
+### Other
+
+- change default value of  menuinst windows `quicklaunch` to `false` ([#1196](https://github.com/conda/rattler/pull/1196))
+
 ## [0.2.5](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.4...rattler_menuinst-v0.2.5) - 2025-03-18
 
 ### Added

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"
@@ -15,8 +15,8 @@ dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tracing = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.5", default-features = false }
-rattler_shell = { path = "../rattler_shell", version = "0.22.24", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.6", default-features = false }
+rattler_shell = { path = "../rattler_shell", version = "0.22.25", default-features = false }
 thiserror = { workspace = true }
 unicode-normalization = { workspace = true }
 regex = { workspace = true }

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.11](https://github.com/conda/rattler/compare/rattler_networking-v0.22.10...rattler_networking-v0.22.11) - 2025-04-03
+
+### Other
+
+- add the remove_from_backup function and update the prefix ([#1155](https://github.com/conda/rattler/pull/1155))
+- fix js bindings ([#1203](https://github.com/conda/rattler/pull/1203))
+
 ## [0.22.10](https://github.com/conda/rattler/compare/rattler_networking-v0.22.9...rattler_networking-v0.22.10) - 2025-03-14
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.22.10"
+version = "0.22.11"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.35](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.34...rattler_package_streaming-v0.22.35) - 2025-04-03
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.34](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.33...rattler_package_streaming-v0.22.34) - 2025-03-14
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.34"
+version = "0.22.35"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"
@@ -16,10 +16,10 @@ chrono = { workspace = true }
 fs-err = { workspace = true }
 futures-util = { workspace = true }
 num_cpus = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.5", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false }
-rattler_networking = { path = "../rattler_networking", version = "0.22.10", default-features = false }
-rattler_redaction = { version = "0.1.8", path = "../rattler_redaction", features = [
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.6", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.9", default-features = false }
+rattler_networking = { path = "../rattler_networking", version = "0.22.11", default-features = false }
+rattler_redaction = { version = "0.1.9", path = "../rattler_redaction", features = [
   "reqwest",
   "reqwest-middleware",
 ], default-features = false }

--- a/crates/rattler_pty/CHANGELOG.md
+++ b/crates/rattler_pty/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/conda/rattler/compare/rattler_pty-v0.1.0...rattler_pty-v0.1.1) - 2025-04-03
+
+### Other
+
+- add the remove_from_backup function and update the prefix ([#1155](https://github.com/conda/rattler/pull/1155))
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_pty/Cargo.toml
+++ b/crates/rattler_pty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_pty"
-version = "0.1.0"
+version = "0.1.1"
 description = "A crate to create pty"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_redaction/CHANGELOG.md
+++ b/crates/rattler_redaction/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.8...rattler_redaction-v0.1.9) - 2025-04-03
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.8](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.7...rattler_redaction-v0.1.8) - 2025-03-04
 
 ### Other

--- a/crates/rattler_redaction/Cargo.toml
+++ b/crates/rattler_redaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_redaction"
-version = "0.1.8"
+version = "0.1.9"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Redact sensitive information from URLs (ie. conda tokens)"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.4](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.22.3...rattler_repodata_gateway-v0.22.4) - 2025-04-03
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.3](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.22.2...rattler_repodata_gateway-v0.22.3) - 2025-03-18
 
 ### Added

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.22.3"
+version = "0.22.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"
@@ -22,7 +22,7 @@ cache_control = { workspace = true }
 chrono = { workspace = true, features = ["std", "serde", "alloc", "clock"] }
 dashmap = { workspace = true }
 dirs = { workspace = true }
-file_url = { path = "../file_url", version = "0.2.3" }
+file_url = { path = "../file_url", version = "0.2.4" }
 futures = { workspace = true }
 hex = { workspace = true, features = ["serde"] }
 http = { workspace = true, optional = true }
@@ -34,9 +34,9 @@ json-patch = { workspace = true }
 self_cell = { workspace = true, optional = true }
 parking_lot = { workspace = true, optional = true }
 pin-project-lite = { workspace = true }
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.5", default-features = false, optional = true }
-rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false, features = ["tokio", "serde"] }
-rattler_networking = { path = "../rattler_networking", version = "0.22.10", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.6", default-features = false, optional = true }
+rattler_digest = { path = "../rattler_digest", version = "1.0.9", default-features = false, features = ["tokio", "serde"] }
+rattler_networking = { path = "../rattler_networking", version = "0.22.11", default-features = false }
 reqwest = { workspace = true, features = ["stream", "http2"] }
 reqwest-middleware = { workspace = true }
 rmp-serde = { workspace = true }
@@ -53,8 +53,8 @@ tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 zstd = { workspace = true }
 retry-policies = { workspace = true }
-rattler_cache = { version = "0.3.15", path = "../rattler_cache" }
-rattler_redaction = { version = "0.1.8", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
+rattler_cache = { version = "0.3.16", path = "../rattler_cache" }
+rattler_redaction = { version = "0.1.9", path = "../rattler_redaction", features = ["reqwest", "reqwest-middleware"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/rattler_sandbox/CHANGELOG.md
+++ b/crates/rattler_sandbox/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.5...rattler_sandbox-v0.1.6) - 2025-04-03
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.5](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.4...rattler_sandbox-v0.1.5) - 2025-03-10
 
 ### Other

--- a/crates/rattler_sandbox/Cargo.toml
+++ b/crates/rattler_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_sandbox"
-version = "0.1.5"
+version = "0.1.6"
 description = "A crate to run executables in a sandbox"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.25](https://github.com/conda/rattler/compare/rattler_shell-v0.22.24...rattler_shell-v0.22.25) - 2025-04-03
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.24](https://github.com/conda/rattler/compare/rattler_shell-v0.22.23...rattler_shell-v0.22.24) - 2025-03-14
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.22.24"
+version = "0.22.25"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"
@@ -15,7 +15,7 @@ enum_dispatch = { workspace = true }
 indexmap = { workspace = true }
 fs-err = { workspace = true }
 itertools = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.5", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.6", default-features = false }
 serde_json = { workspace = true, features = ["preserve_order"] }
 shlex = { workspace = true }
 sysinfo = { workspace = true , optional = true }

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.3](https://github.com/conda/rattler/compare/rattler_solve-v1.4.2...rattler_solve-v1.4.3) - 2025-04-03
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.4.2](https://github.com/conda/rattler/compare/rattler_solve-v1.4.1...rattler_solve-v1.4.2) - 2025-03-14
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.4.2"
+version = "1.4.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"
@@ -11,8 +11,8 @@ license.workspace = true
 readme.workspace = true
 
 [dependencies]
-rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.5", default-features = false }
-rattler_digest = { path = "../rattler_digest", version = "1.0.8", default-features = false }
+rattler_conda_types = { path = "../rattler_conda_types", version = "0.31.6", default-features = false }
+rattler_digest = { path = "../rattler_digest", version = "1.0.9", default-features = false }
 libc = { workspace = true, optional = true }
 chrono = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.9](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.8...rattler_virtual_packages-v2.0.9) - 2025-04-03
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [2.0.8](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.7...rattler_virtual_packages-v2.0.8) - 2025-03-14
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.8"
+version = "2.0.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"
@@ -14,7 +14,7 @@ readme.workspace = true
 libloading = { workspace = true }
 nom = { workspace = true }
 once_cell = { workspace = true }
-rattler_conda_types = { path="../rattler_conda_types", version = "0.31.5", default-features = false }
+rattler_conda_types = { path="../rattler_conda_types", version = "0.31.6", default-features = false }
 regex = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }


### PR DESCRIPTION



## 🤖 New release

* `file_url`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `rattler_digest`: 1.0.8 -> 1.0.9 (✓ API compatible changes)
* `rattler_macros`: 1.0.7 -> 1.0.8
* `rattler_redaction`: 0.1.8 -> 0.1.9 (✓ API compatible changes)
* `rattler_conda_types`: 0.31.5 -> 0.31.6 (✓ API compatible changes)
* `rattler_networking`: 0.22.10 -> 0.22.11 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.34 -> 0.22.35 (✓ API compatible changes)
* `rattler_cache`: 0.3.15 -> 0.3.16 (✓ API compatible changes)
* `rattler_shell`: 0.22.24 -> 0.22.25 (✓ API compatible changes)
* `rattler_menuinst`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `rattler`: 0.33.3 -> 0.34.0 (⚠ API breaking changes)
* `rattler_lock`: 0.22.48 -> 0.22.49 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.22.3 -> 0.22.4 (✓ API compatible changes)
* `rattler_solve`: 1.4.2 -> 1.4.3 (✓ API compatible changes)
* `rattler_virtual_packages`: 2.0.8 -> 2.0.9 (✓ API compatible changes)
* `rattler_index`: 0.22.2 -> 0.22.3 (✓ API compatible changes)
* `rattler_pty`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `rattler_sandbox`: 0.1.5 -> 0.1.6 (✓ API compatible changes)

### ⚠ `rattler` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/enum_variant_added.ron

Failed in:
  variant InstallerError:FailedToCreatePrefix in /tmp/.tmparbv7U/rattler/crates/rattler/src/install/installer/error.rs:57
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `file_url`

<blockquote>

## [0.2.4](https://github.com/conda/rattler/compare/file_url-v0.2.3...file_url-v0.2.4) - 2025-04-03

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_digest`

<blockquote>

## [1.0.9](https://github.com/conda/rattler/compare/rattler_digest-v1.0.8...rattler_digest-v1.0.9) - 2025-04-03

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_macros`

<blockquote>

## [1.0.8](https://github.com/conda/rattler/compare/rattler_macros-v1.0.7...rattler_macros-v1.0.8) - 2025-04-03

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_redaction`

<blockquote>

## [0.1.9](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.8...rattler_redaction-v0.1.9) - 2025-04-03

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_conda_types`

<blockquote>

## [0.31.6](https://github.com/conda/rattler/compare/rattler_conda_types-v0.31.5...rattler_conda_types-v0.31.6) - 2025-04-03

### Fixed

- allow empty info key in repodata.json ([#1181](https://github.com/conda/rattler/pull/1181))

### Other

- add the remove_from_backup function and update the prefix ([#1155](https://github.com/conda/rattler/pull/1155))
</blockquote>

## `rattler_networking`

<blockquote>

## [0.22.11](https://github.com/conda/rattler/compare/rattler_networking-v0.22.10...rattler_networking-v0.22.11) - 2025-04-03

### Other

- add the remove_from_backup function and update the prefix ([#1155](https://github.com/conda/rattler/pull/1155))
- fix js bindings ([#1203](https://github.com/conda/rattler/pull/1203))
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.35](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.34...rattler_package_streaming-v0.22.35) - 2025-04-03

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.16](https://github.com/conda/rattler/compare/rattler_cache-v0.3.15...rattler_cache-v0.3.16) - 2025-04-03

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_shell`

<blockquote>

## [0.22.25](https://github.com/conda/rattler/compare/rattler_shell-v0.22.24...rattler_shell-v0.22.25) - 2025-04-03

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.6](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.5...rattler_menuinst-v0.2.6) - 2025-04-03

### Fixed

- install windows start menu shortcut ([#1198](https://github.com/conda/rattler/pull/1198))

### Other

- change default value of  menuinst windows `quicklaunch` to `false` ([#1196](https://github.com/conda/rattler/pull/1196))
</blockquote>

## `rattler`

<blockquote>

## [0.34.0](https://github.com/conda/rattler/compare/rattler-v0.33.3...rattler-v0.34.0) - 2025-04-03

### Added

- Set link options in installer ([#1178](https://github.com/conda/rattler/pull/1178))

### Other

- add the remove_from_backup function and update the prefix ([#1155](https://github.com/conda/rattler/pull/1155))
</blockquote>

## `rattler_lock`

<blockquote>

## [0.22.49](https://github.com/conda/rattler/compare/rattler_lock-v0.22.48...rattler_lock-v0.22.49) - 2025-04-03

### Other

- add the remove_from_backup function and update the prefix ([#1155](https://github.com/conda/rattler/pull/1155))
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.22.4](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.22.3...rattler_repodata_gateway-v0.22.4) - 2025-04-03

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_solve`

<blockquote>

## [1.4.3](https://github.com/conda/rattler/compare/rattler_solve-v1.4.2...rattler_solve-v1.4.3) - 2025-04-03

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.9](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.8...rattler_virtual_packages-v2.0.9) - 2025-04-03

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_index`

<blockquote>

## [0.22.3](https://github.com/conda/rattler/compare/rattler_index-v0.22.2...rattler_index-v0.22.3) - 2025-04-03

### Added

- add retry middleware to opendal operator ([#1207](https://github.com/conda/rattler/pull/1207))

### Fixed

- allow empty info key in repodata.json ([#1181](https://github.com/conda/rattler/pull/1181))
- don't clone package bytes in rattler-index ([#1175](https://github.com/conda/rattler/pull/1175))
</blockquote>

## `rattler_pty`

<blockquote>

## [0.1.1](https://github.com/conda/rattler/compare/rattler_pty-v0.1.0...rattler_pty-v0.1.1) - 2025-04-03

### Other

- add the remove_from_backup function and update the prefix ([#1155](https://github.com/conda/rattler/pull/1155))
</blockquote>

## `rattler_sandbox`

<blockquote>

## [0.1.6](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.5...rattler_sandbox-v0.1.6) - 2025-04-03

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).