### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "file_url"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "itertools 0.14.0",
  "percent-encoding",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.33.6"
+version = "0.33.7"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4225,7 +4225,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4263,7 +4263,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4311,7 +4311,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "blake2",
  "digest",
@@ -4330,7 +4330,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4358,7 +4358,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_libsolv_c"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -4370,7 +4370,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "chrono",
  "file_url",
@@ -4398,7 +4398,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "quote",
  "syn",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "chrono",
  "configparser",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4471,7 +4471,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.37"
+version = "0.22.38"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4505,7 +4505,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "libc",
  "nix",
@@ -4523,7 +4523,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.22.6"
+version = "0.22.7"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4587,7 +4587,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_sandbox"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "birdcage",
  "clap",
@@ -4598,7 +4598,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4620,7 +4620,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "1.4.6"
+version = "2.0.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -4646,7 +4646,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.11"
+version = "2.0.12"
 dependencies = [
  "archspec",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,25 +179,25 @@ zip = { version = "3.0.0", default-features = false }
 zstd = { version = "0.13.3", default-features = false }
 
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
-file_url = { path = "crates/file_url", version = "=0.2.4", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.33.6", default-features = false }
-rattler_cache = { path = "crates/rattler_cache", version = "=0.3.18", default-features = false }
-rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.33.0", default-features = false }
-rattler_digest = { path = "crates/rattler_digest", version = "=1.1.1", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.22.6", default-features = false }
-rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.0", default-features = false }
-rattler_lock = { path = "crates/rattler_lock", version = "=0.23.3", default-features = false }
-rattler_macros = { path = "crates/rattler_macros", version = "=1.0.8", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.8", default-features = false }
-rattler_networking = { path = "crates/rattler_networking", version = "=0.23.0", default-features = false }
-rattler_pty = { path = "crates/rattler_pty", version = "=0.2.0", default-features = false }
+file_url = { path = "crates/file_url", version = "=0.2.5", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.33.7", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.19", default-features = false }
+rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.34.0", default-features = false }
+rattler_digest = { path = "crates/rattler_digest", version = "=1.1.2", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.22.7", default-features = false }
+rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.1", default-features = false }
+rattler_lock = { path = "crates/rattler_lock", version = "=0.23.4", default-features = false }
+rattler_macros = { path = "crates/rattler_macros", version = "=1.0.9", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.9", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.24.0", default-features = false }
+rattler_pty = { path = "crates/rattler_pty", version = "=0.2.1", default-features = false }
 rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.10", default-features = false }
-rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.37", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.22.6", default-features = false }
-rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.7", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.23.0", default-features = false }
-rattler_solve = { path = "crates/rattler_solve", version = "=1.4.6", default-features = false }
-rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.11", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.38", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.22.7", default-features = false }
+rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.8", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.23.1", default-features = false }
+rattler_solve = { path = "crates/rattler_solve", version = "=2.0.0", default-features = false }
+rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.12", default-features = false }
 
 # This is also a rattler crate, but we only pin it to minor version
 simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/file_url/CHANGELOG.md
+++ b/crates/file_url/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/conda/rattler/compare/file_url-v0.2.4...file_url-v0.2.5) - 2025-05-16
+
+### Other
+
+- update dependencies ([#1126](https://github.com/conda/rattler/pull/1126))
+
 ## [0.2.4](https://github.com/conda/rattler/compare/file_url-v0.2.3...file_url-v0.2.4) - 2025-04-04
 
 ### Other

--- a/crates/file_url/Cargo.toml
+++ b/crates/file_url/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file_url"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Helper functions to work with file:// urls"

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.7](https://github.com/conda/rattler/compare/rattler-v0.33.6...rattler-v0.33.7) - 2025-05-16
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.33.6](https://github.com/conda/rattler/compare/rattler-v0.33.5...rattler-v0.33.6) - 2025-05-03
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.33.6"
+version = "0.33.7"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.19](https://github.com/conda/rattler/compare/rattler_cache-v0.3.18...rattler_cache-v0.3.19) - 2025-05-16
+
+### Other
+
+- Bump zip to 3.0.0 ([#1310](https://github.com/conda/rattler/pull/1310))
+
 ## [0.3.18](https://github.com/conda/rattler/compare/rattler_cache-v0.3.17...rattler_cache-v0.3.18) - 2025-05-03
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.18"
+version = "0.3.19"
 description = "A crate to manage the caching of data in rattler"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.33.0...rattler_conda_types-v0.34.0) - 2025-05-16
+
+### Added
+
+- add purls to `IndexJson` ([#1303](https://github.com/conda/rattler/pull/1303))
+
+### Fixed
+
+- skip serializing if purls are None ([#1306](https://github.com/conda/rattler/pull/1306))
+
+### Other
+
+- Bump zip to 3.0.0 ([#1310](https://github.com/conda/rattler/pull/1310))
+
 ## [0.33.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.32.0...rattler_conda_types-v0.33.0) - 2025-05-03
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.33.0"
+version = "0.34.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2](https://github.com/conda/rattler/compare/rattler_digest-v1.1.1...rattler_digest-v1.1.2) - 2025-05-16
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.1.1](https://github.com/conda/rattler/compare/rattler_digest-v1.1.0...rattler_digest-v1.1.1) - 2025-04-10
 
 ### Fixed

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "1.1.1"
+version = "1.1.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.7](https://github.com/conda/rattler/compare/rattler_index-v0.22.6...rattler_index-v0.22.7) - 2025-05-16
+
+### Added
+
+- add purls to `IndexJson` ([#1303](https://github.com/conda/rattler/pull/1303))
+
 ## [0.22.6](https://github.com/conda/rattler/compare/rattler_index-v0.22.5...rattler_index-v0.22.6) - 2025-05-03
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.22.6"
+version = "0.22.7"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_libsolv_c/CHANGELOG.md
+++ b/crates/rattler_libsolv_c/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.2.0...rattler_libsolv_c-v1.2.1) - 2025-05-16
+
+### Other
+
+- update dependencies ([#1126](https://github.com/conda/rattler/pull/1126))
+
 ## [1.1.3](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.1.2...rattler_libsolv_c-v1.1.3) - 2025-03-10
 
 ### Other

--- a/crates/rattler_libsolv_c/Cargo.toml
+++ b/crates/rattler_libsolv_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_libsolv_c"
-version = "1.2.0"
+version = "1.2.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Bindings for libsolv"

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.4](https://github.com/conda/rattler/compare/rattler_lock-v0.23.3...rattler_lock-v0.23.4) - 2025-05-16
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.23.3](https://github.com/conda/rattler/compare/rattler_lock-v0.23.2...rattler_lock-v0.23.3) - 2025-05-03
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.23.3"
+version = "0.23.4"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_macros/CHANGELOG.md
+++ b/crates/rattler_macros/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.9](https://github.com/conda/rattler/compare/rattler_macros-v1.0.8...rattler_macros-v1.0.9) - 2025-05-16
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.0.8](https://github.com/conda/rattler/compare/rattler_macros-v1.0.7...rattler_macros-v1.0.8) - 2025-04-04
 
 ### Other

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_macros"
-version = "1.0.8"
+version = "1.0.9"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate that provideds some procedural macros for the rattler project"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.9](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.8...rattler_menuinst-v0.2.9) - 2025-05-16
+
+### Other
+
+- update dependencies ([#1126](https://github.com/conda/rattler/pull/1126))
+- Bump zip to 3.0.0 ([#1310](https://github.com/conda/rattler/pull/1310))
+
 ## [0.2.8](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.7...rattler_menuinst-v0.2.8) - 2025-05-03
 
 ### Fixed

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/conda/rattler/compare/rattler_networking-v0.23.0...rattler_networking-v0.24.0) - 2025-05-16
+
+### Other
+
+- update dependencies of js-rattler and py-rattler as well ([#1317](https://github.com/conda/rattler/pull/1317))
+- update GCS authentication ([#1314](https://github.com/conda/rattler/pull/1314))
+
 ## [0.23.0](https://github.com/conda/rattler/compare/rattler_networking-v0.22.12...rattler_networking-v0.23.0) - 2025-05-03
 
 ### Added

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.23.0"
+version = "0.24.0"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.38](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.37...rattler_package_streaming-v0.22.38) - 2025-05-16
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.22.37](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.36...rattler_package_streaming-v0.22.37) - 2025-05-03
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.37"
+version = "0.22.38"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_pty/CHANGELOG.md
+++ b/crates/rattler_pty/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/conda/rattler/compare/rattler_pty-v0.2.0...rattler_pty-v0.2.1) - 2025-05-16
+
+### Other
+
+- update dependencies ([#1126](https://github.com/conda/rattler/pull/1126))
+
 ## [0.2.0](https://github.com/conda/rattler/compare/rattler_pty-v0.1.1...rattler_pty-v0.2.0) - 2025-04-10
 
 ### Added

--- a/crates/rattler_pty/Cargo.toml
+++ b/crates/rattler_pty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_pty"
-version = "0.2.0"
+version = "0.2.1"
 description = "A crate to create pty"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.7](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.22.6...rattler_repodata_gateway-v0.22.7) - 2025-05-16
+
+### Other
+
+- Bump zip to 3.0.0 ([#1310](https://github.com/conda/rattler/pull/1310))
+
 ## [0.22.6](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.22.5...rattler_repodata_gateway-v0.22.6) - 2025-05-03
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.22.6"
+version = "0.22.7"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_sandbox/CHANGELOG.md
+++ b/crates/rattler_sandbox/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.7...rattler_sandbox-v0.1.8) - 2025-05-16
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.7](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.6...rattler_sandbox-v0.1.7) - 2025-04-10
 
 ### Other

--- a/crates/rattler_sandbox/Cargo.toml
+++ b/crates/rattler_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_sandbox"
-version = "0.1.7"
+version = "0.1.8"
 description = "A crate to run executables in a sandbox"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1](https://github.com/conda/rattler/compare/rattler_shell-v0.23.0...rattler_shell-v0.23.1) - 2025-05-16
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.23.0](https://github.com/conda/rattler/compare/rattler_shell-v0.22.26...rattler_shell-v0.23.0) - 2025-05-03
 
 ### Fixed

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.23.0"
+version = "0.23.1"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/conda/rattler/compare/rattler_solve-v1.4.6...rattler_solve-v2.0.0) - 2025-05-16
+
+### Added
+
+- allows enabling of resolvo diagnostics ([#1296](https://github.com/conda/rattler/pull/1296))
+
 ## [1.4.6](https://github.com/conda/rattler/compare/rattler_solve-v1.4.5...rattler_solve-v1.4.6) - 2025-05-03
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "1.4.6"
+version = "2.0.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.12](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.11...rattler_virtual_packages-v2.0.12) - 2025-05-16
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [2.0.11](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.10...rattler_virtual_packages-v2.0.11) - 2025-05-03
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.11"
+version = "2.0.12"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION



## 🤖 New release

* `file_url`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `rattler_digest`: 1.1.1 -> 1.1.2 (✓ API compatible changes)
* `rattler_macros`: 1.0.8 -> 1.0.9
* `rattler_conda_types`: 0.33.0 -> 0.34.0 (⚠ API breaking changes)
* `rattler_networking`: 0.23.0 -> 0.24.0 (⚠ API breaking changes)
* `rattler_package_streaming`: 0.22.37 -> 0.22.38 (✓ API compatible changes)
* `rattler_cache`: 0.3.18 -> 0.3.19 (✓ API compatible changes)
* `rattler_pty`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `rattler_shell`: 0.23.0 -> 0.23.1 (✓ API compatible changes)
* `rattler_menuinst`: 0.2.8 -> 0.2.9 (✓ API compatible changes)
* `rattler`: 0.33.6 -> 0.33.7 (✓ API compatible changes)
* `rattler_libsolv_c`: 1.2.0 -> 1.2.1 (✓ API compatible changes)
* `rattler_solve`: 1.4.6 -> 2.0.0 (⚠ API breaking changes)
* `rattler_lock`: 0.23.3 -> 0.23.4 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.22.6 -> 0.22.7 (✓ API compatible changes)
* `rattler_virtual_packages`: 2.0.11 -> 2.0.12 (✓ API compatible changes)
* `rattler_index`: 0.22.6 -> 0.22.7 (✓ API compatible changes)
* `rattler_sandbox`: 0.1.7 -> 0.1.8 (✓ API compatible changes)

### ⚠ `rattler_conda_types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field IndexJson.purls in /tmp/.tmprmlseF/rattler/crates/rattler_conda_types/src/package/index.rs:64
```

### ⚠ `rattler_networking` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/feature_missing.ron

Failed in:
  feature google-cloud-token in the package's Cargo.toml
```

### ⚠ `rattler_solve` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/feature_missing.ron

Failed in:
  feature libc in the package's Cargo.toml
  feature rattler_libsolv_c in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `file_url`

<blockquote>

## [0.2.5](https://github.com/conda/rattler/compare/file_url-v0.2.4...file_url-v0.2.5) - 2025-05-16

### Other

- update dependencies ([#1126](https://github.com/conda/rattler/pull/1126))
</blockquote>

## `rattler_digest`

<blockquote>

## [1.1.2](https://github.com/conda/rattler/compare/rattler_digest-v1.1.1...rattler_digest-v1.1.2) - 2025-05-16

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_macros`

<blockquote>

## [1.0.9](https://github.com/conda/rattler/compare/rattler_macros-v1.0.8...rattler_macros-v1.0.9) - 2025-05-16

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_conda_types`

<blockquote>

## [0.34.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.33.0...rattler_conda_types-v0.34.0) - 2025-05-16

### Added

- add purls to `IndexJson` ([#1303](https://github.com/conda/rattler/pull/1303))

### Fixed

- skip serializing if purls are None ([#1306](https://github.com/conda/rattler/pull/1306))

### Other

- Bump zip to 3.0.0 ([#1310](https://github.com/conda/rattler/pull/1310))
</blockquote>

## `rattler_networking`

<blockquote>

## [0.24.0](https://github.com/conda/rattler/compare/rattler_networking-v0.23.0...rattler_networking-v0.24.0) - 2025-05-16

### Other

- update dependencies of js-rattler and py-rattler as well ([#1317](https://github.com/conda/rattler/pull/1317))
- update GCS authentication ([#1314](https://github.com/conda/rattler/pull/1314))
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.38](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.37...rattler_package_streaming-v0.22.38) - 2025-05-16

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.19](https://github.com/conda/rattler/compare/rattler_cache-v0.3.18...rattler_cache-v0.3.19) - 2025-05-16

### Other

- Bump zip to 3.0.0 ([#1310](https://github.com/conda/rattler/pull/1310))
</blockquote>

## `rattler_pty`

<blockquote>

## [0.2.1](https://github.com/conda/rattler/compare/rattler_pty-v0.2.0...rattler_pty-v0.2.1) - 2025-05-16

### Other

- update dependencies ([#1126](https://github.com/conda/rattler/pull/1126))
</blockquote>

## `rattler_shell`

<blockquote>

## [0.23.1](https://github.com/conda/rattler/compare/rattler_shell-v0.23.0...rattler_shell-v0.23.1) - 2025-05-16

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.9](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.8...rattler_menuinst-v0.2.9) - 2025-05-16

### Other

- update dependencies ([#1126](https://github.com/conda/rattler/pull/1126))
- Bump zip to 3.0.0 ([#1310](https://github.com/conda/rattler/pull/1310))
</blockquote>

## `rattler`

<blockquote>

## [0.33.7](https://github.com/conda/rattler/compare/rattler-v0.33.6...rattler-v0.33.7) - 2025-05-16

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_libsolv_c`

<blockquote>

## [1.2.1](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.2.0...rattler_libsolv_c-v1.2.1) - 2025-05-16

### Other

- update dependencies ([#1126](https://github.com/conda/rattler/pull/1126))
</blockquote>

## `rattler_solve`

<blockquote>

## [2.0.0](https://github.com/conda/rattler/compare/rattler_solve-v1.4.6...rattler_solve-v2.0.0) - 2025-05-16

### Added

- allows enabling of resolvo diagnostics ([#1296](https://github.com/conda/rattler/pull/1296))
</blockquote>

## `rattler_lock`

<blockquote>

## [0.23.4](https://github.com/conda/rattler/compare/rattler_lock-v0.23.3...rattler_lock-v0.23.4) - 2025-05-16

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.22.7](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.22.6...rattler_repodata_gateway-v0.22.7) - 2025-05-16

### Other

- Bump zip to 3.0.0 ([#1310](https://github.com/conda/rattler/pull/1310))
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.12](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.11...rattler_virtual_packages-v2.0.12) - 2025-05-16

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_index`

<blockquote>

## [0.22.7](https://github.com/conda/rattler/compare/rattler_index-v0.22.6...rattler_index-v0.22.7) - 2025-05-16

### Added

- add purls to `IndexJson` ([#1303](https://github.com/conda/rattler/pull/1303))
</blockquote>

## `rattler_sandbox`

<blockquote>

## [0.1.8](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.7...rattler_sandbox-v0.1.8) - 2025-05-16

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).