### PR TITLE
chore(ci): add merge gatekeeper

### DIFF
--- a/.github/workflows/merge-gatekeeper.yml
+++ b/.github/workflows/merge-gatekeeper.yml
@@ -1,0 +1,22 @@
+# This workflow uses Merge Gatekeeper to ensure that pull requests to the main
+# branch meet certain criteria before they can be merged. It checks for
+# required status checks and ensures that the pull request is not a draft.
+---
+name: Merge Gatekeeper
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  merge-gatekeeper:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      statuses: read
+    steps:
+      - name: Run Merge Gatekeeper
+        uses: upsidr/merge-gatekeeper@09af7a82c1666d0e64d2bd8c01797a0bcfd3bb5d # v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We have a number of workflows that only apply to certain directories. We also have required status checks which only allow merging if certain workflows have succeeded. However, if you have filters in there then that doesnt work. With this new workflow we can fix this.