### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.34.0"
+version = "0.34.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4345,7 +4345,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "blake2",
  "digest",
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4398,7 +4398,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_libsolv_c"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "cc",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "chrono",
  "file_url",
@@ -4438,7 +4438,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "quote",
  "syn",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "configparser",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.39"
+version = "0.22.40"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4546,7 +4546,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "libc",
  "nix",
@@ -4555,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4629,7 +4629,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_sandbox"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "birdcage",
  "clap",
@@ -4640,7 +4640,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.13"
+version = "2.0.14"
 dependencies = [
  "archspec",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,25 +183,25 @@ zstd = { version = "0.13.3", default-features = false }
 
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
 file_url = { path = "crates/file_url", version = "=0.2.5", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.34.0", default-features = false }
-rattler_cache = { path = "crates/rattler_cache", version = "=0.3.20", default-features = false }
-rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.35.0", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.34.1", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.21", default-features = false }
+rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.35.1", default-features = false }
 rattler_config = { path = "crates/rattler_config", version = "=0.1.0", default-features = false }
-rattler_digest = { path = "crates/rattler_digest", version = "=1.1.2", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.23.0", default-features = false }
-rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.1", default-features = false }
-rattler_lock = { path = "crates/rattler_lock", version = "=0.23.5", default-features = false }
-rattler_macros = { path = "crates/rattler_macros", version = "=1.0.9", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.10", default-features = false }
-rattler_networking = { path = "crates/rattler_networking", version = "=0.25.0", default-features = false }
-rattler_pty = { path = "crates/rattler_pty", version = "=0.2.1", default-features = false }
-rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.10", default-features = false }
-rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.39", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.0", default-features = false }
-rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.8", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.23.2", default-features = false }
-rattler_solve = { path = "crates/rattler_solve", version = "=2.1.0", default-features = false }
-rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.13", default-features = false }
+rattler_digest = { path = "crates/rattler_digest", version = "=1.1.3", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.23.1", default-features = false }
+rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.2", default-features = false }
+rattler_lock = { path = "crates/rattler_lock", version = "=0.23.6", default-features = false }
+rattler_macros = { path = "crates/rattler_macros", version = "=1.0.10", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.11", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.25.1", default-features = false }
+rattler_pty = { path = "crates/rattler_pty", version = "=0.2.2", default-features = false }
+rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.11", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.40", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.1", default-features = false }
+rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.9", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.23.3", default-features = false }
+rattler_solve = { path = "crates/rattler_solve", version = "=2.1.1", default-features = false }
+rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.14", default-features = false }
 
 # This is also a rattler crate, but we only pin it to minor version
 simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.1](https://github.com/conda/rattler/compare/rattler-v0.34.0...rattler-v0.34.1) - 2025-06-23
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.34.0](https://github.com/conda/rattler/compare/rattler-v0.33.7...rattler-v0.34.0) - 2025-05-23
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.34.0"
+version = "0.34.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.21](https://github.com/conda/rattler/compare/rattler_cache-v0.3.20...rattler_cache-v0.3.21) - 2025-06-23
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.3.20](https://github.com/conda/rattler/compare/rattler_cache-v0.3.19...rattler_cache-v0.3.20) - 2025-05-23
 
 ### Fixed

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.20"
+version = "0.3.21"
 description = "A crate to manage the caching of data in rattler"
 categories = { workspace = true }
 homepage = { workspace = true }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.0...rattler_conda_types-v0.35.1) - 2025-06-23
+
+### Added
+
+- add `rattler_config` crate (derived from `pixi_config`) ([#1389](https://github.com/conda/rattler/pull/1389))
+
+### Fixed
+
+- fix code to use nom 8
+- parsing of `=0.*,>=0.4.1` ([#1384](https://github.com/conda/rattler/pull/1384))
+
+### Other
+
+- *(ci)* Update Rust crate nom to v8 ([#1404](https://github.com/conda/rattler/pull/1404))
+- Revert "fix code to use nom 8"
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.35.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.34.0...rattler_conda_types-v0.35.0) - 2025-05-23
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.35.0"
+version = "0.35.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_config/CHANGELOG.md
+++ b/crates/rattler_config/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_config-v0.1.0) - 2025-06-23
+
+### Added
+
+- add `rattler_config` crate (derived from `pixi_config`) ([#1389](https://github.com/conda/rattler/pull/1389))
+- better readme ([#118](https://github.com/conda/rattler/pull/118))
+- replace zulip with discord ([#116](https://github.com/conda/rattler/pull/116))
+- move all conda types to seperate crate
+
+### Fixed
+
+- added missing hyphen to relative url linking to what-is-conda section in README.md ([#1192](https://github.com/conda/rattler/pull/1192))
+- typos ([#849](https://github.com/conda/rattler/pull/849))
+- move more links to the conda org from conda-incubator ([#816](https://github.com/conda/rattler/pull/816))
+- use conda-incubator
+- add python docs badge
+- typo libsolve -> libsolv ([#164](https://github.com/conda/rattler/pull/164))
+- change urls from baszalmstra to mamba-org
+- build badge
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+- Fix badge style ([#1110](https://github.com/conda/rattler/pull/1110))
+- fix anchor link ([#1035](https://github.com/conda/rattler/pull/1035))
+- change links from conda-incubator to conda ([#813](https://github.com/conda/rattler/pull/813))
+- update banner ([#808](https://github.com/conda/rattler/pull/808))
+- update README.md
+- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
+- update installation gif
+- update banner image
+- address issue #282 ([#283](https://github.com/conda/rattler/pull/283))
+- Add an image to Readme ([#203](https://github.com/conda/rattler/pull/203))
+- Improve getting started with a micromamba environment. ([#163](https://github.com/conda/rattler/pull/163))
+- Misc/update readme ([#66](https://github.com/conda/rattler/pull/66))
+- update readme
+- layout the vision a little bit better
+- *(docs)* add build badge
+- matchspec parsing

--- a/crates/rattler_digest/CHANGELOG.md
+++ b/crates/rattler_digest/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.3](https://github.com/conda/rattler/compare/rattler_digest-v1.1.2...rattler_digest-v1.1.3) - 2025-06-23
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [1.1.2](https://github.com/conda/rattler/compare/rattler_digest-v1.1.1...rattler_digest-v1.1.2) - 2025-05-16
 
 ### Other

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_digest"
-version = "1.1.2"
+version = "1.1.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "An simple crate used by rattler crates to compute different hashes from different sources"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1](https://github.com/conda/rattler/compare/rattler_index-v0.23.0...rattler_index-v0.23.1) - 2025-06-23
+
+### Added
+
+- make rattler_networking system integration optional ([#1381](https://github.com/conda/rattler/pull/1381))
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.23.0](https://github.com/conda/rattler/compare/rattler_index-v0.22.7...rattler_index-v0.23.0) - 2025-05-23
 
 ### Added

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.23.0"
+version = "0.23.1"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_libsolv_c/CHANGELOG.md
+++ b/crates/rattler_libsolv_c/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.2.1...rattler_libsolv_c-v1.2.2) - 2025-06-23
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [1.2.1](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.2.0...rattler_libsolv_c-v1.2.1) - 2025-05-16
 
 ### Other

--- a/crates/rattler_libsolv_c/Cargo.toml
+++ b/crates/rattler_libsolv_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_libsolv_c"
-version = "1.2.1"
+version = "1.2.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Bindings for libsolv"

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.6](https://github.com/conda/rattler/compare/rattler_lock-v0.23.5...rattler_lock-v0.23.6) - 2025-06-23
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.23.5](https://github.com/conda/rattler/compare/rattler_lock-v0.23.4...rattler_lock-v0.23.5) - 2025-05-23
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.23.5"
+version = "0.23.6"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_macros/CHANGELOG.md
+++ b/crates/rattler_macros/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.10](https://github.com/conda/rattler/compare/rattler_macros-v1.0.9...rattler_macros-v1.0.10) - 2025-06-23
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [1.0.9](https://github.com/conda/rattler/compare/rattler_macros-v1.0.8...rattler_macros-v1.0.9) - 2025-05-16
 
 ### Other

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_macros"
-version = "1.0.9"
+version = "1.0.10"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate that provideds some procedural macros for the rattler project"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.11](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.10...rattler_menuinst-v0.2.11) - 2025-06-23
+
+### Fixed
+
+- use $PATH prepend behavior in `menuinst` activation ([#1376](https://github.com/conda/rattler/pull/1376))
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.2.10](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.9...rattler_menuinst-v0.2.10) - 2025-05-23
 
 ### Other

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.10"
+version = "0.2.11"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1](https://github.com/conda/rattler/compare/rattler_networking-v0.25.0...rattler_networking-v0.25.1) - 2025-06-23
+
+### Added
+
+- add `rattler_config` crate (derived from `pixi_config`) ([#1389](https://github.com/conda/rattler/pull/1389))
+- make rattler_networking system integration optional ([#1381](https://github.com/conda/rattler/pull/1381))
+
+### Fixed
+
+- reduce s3 into to trace ([#1395](https://github.com/conda/rattler/pull/1395))
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.25.0](https://github.com/conda/rattler/compare/rattler_networking-v0.24.0...rattler_networking-v0.25.0) - 2025-05-23
 
 ### Fixed

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.25.0"
+version = "0.25.1"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.40](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.39...rattler_package_streaming-v0.22.40) - 2025-06-23
+
+### Added
+
+- add `rattler_config` crate (derived from `pixi_config`) ([#1389](https://github.com/conda/rattler/pull/1389))
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.22.39](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.38...rattler_package_streaming-v0.22.39) - 2025-05-23
 
 ### Fixed

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.39"
+version = "0.22.40"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_pty/CHANGELOG.md
+++ b/crates/rattler_pty/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/conda/rattler/compare/rattler_pty-v0.2.1...rattler_pty-v0.2.2) - 2025-06-23
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.2.1](https://github.com/conda/rattler/compare/rattler_pty-v0.2.0...rattler_pty-v0.2.1) - 2025-05-16
 
 ### Other

--- a/crates/rattler_pty/Cargo.toml
+++ b/crates/rattler_pty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_pty"
-version = "0.2.1"
+version = "0.2.2"
 description = "A crate to create pty"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_redaction/CHANGELOG.md
+++ b/crates/rattler_redaction/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.10...rattler_redaction-v0.1.11) - 2025-06-23
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.1.10](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.9...rattler_redaction-v0.1.10) - 2025-04-10
 
 ### Other

--- a/crates/rattler_redaction/Cargo.toml
+++ b/crates/rattler_redaction/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_redaction"
-version = "0.1.10"
+version = "0.1.11"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Redact sensitive information from URLs (ie. conda tokens)"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.1](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.0...rattler_repodata_gateway-v0.23.1) - 2025-06-23
+
+### Fixed
+
+- end progress sharded repodata ([#1375](https://github.com/conda/rattler/pull/1375))
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.23.0](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.22.7...rattler_repodata_gateway-v0.23.0) - 2025-05-23
 
 ### Added

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.23.0"
+version = "0.23.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_sandbox/CHANGELOG.md
+++ b/crates/rattler_sandbox/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.8...rattler_sandbox-v0.1.9) - 2025-06-23
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.1.8](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.7...rattler_sandbox-v0.1.8) - 2025-05-16
 
 ### Other

--- a/crates/rattler_sandbox/Cargo.toml
+++ b/crates/rattler_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_sandbox"
-version = "0.1.8"
+version = "0.1.9"
 description = "A crate to run executables in a sandbox"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.3](https://github.com/conda/rattler/compare/rattler_shell-v0.23.2...rattler_shell-v0.23.3) - 2025-06-23
+
+### Fixed
+
+- quote values in bash activation with shlex ([#1392](https://github.com/conda/rattler/pull/1392))
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [0.23.2](https://github.com/conda/rattler/compare/rattler_shell-v0.23.1...rattler_shell-v0.23.2) - 2025-05-23
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.23.2"
+version = "0.23.3"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1](https://github.com/conda/rattler/compare/rattler_solve-v2.1.0...rattler_solve-v2.1.1) - 2025-06-23
+
+### Other
+
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [2.1.0](https://github.com/conda/rattler/compare/rattler_solve-v2.0.0...rattler_solve-v2.1.0) - 2025-05-23
 
 ### Added

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "2.1.0"
+version = "2.1.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.14](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.13...rattler_virtual_packages-v2.0.14) - 2025-06-23
+
+### Fixed
+
+- fix code to use nom 8
+
+### Other
+
+- *(ci)* Update Rust crate nom to v8 ([#1404](https://github.com/conda/rattler/pull/1404))
+- Revert "fix code to use nom 8"
+- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
+- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
+
 ## [2.0.13](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.12...rattler_virtual_packages-v2.0.13) - 2025-05-23
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.13"
+version = "2.0.14"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION



## 🤖 New release

* `rattler_digest`: 1.1.2 -> 1.1.3 (✓ API compatible changes)
* `rattler_macros`: 1.0.9 -> 1.0.10
* `rattler_redaction`: 0.1.10 -> 0.1.11 (✓ API compatible changes)
* `rattler_conda_types`: 0.35.0 -> 0.35.1 (✓ API compatible changes)
* `rattler_config`: 0.1.0
* `rattler_networking`: 0.25.0 -> 0.25.1 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.39 -> 0.22.40 (✓ API compatible changes)
* `rattler_cache`: 0.3.20 -> 0.3.21 (✓ API compatible changes)
* `rattler_pty`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `rattler_shell`: 0.23.2 -> 0.23.3 (✓ API compatible changes)
* `rattler_menuinst`: 0.2.10 -> 0.2.11 (✓ API compatible changes)
* `rattler`: 0.34.0 -> 0.34.1 (✓ API compatible changes)
* `rattler_libsolv_c`: 1.2.1 -> 1.2.2 (✓ API compatible changes)
* `rattler_solve`: 2.1.0 -> 2.1.1 (✓ API compatible changes)
* `rattler_lock`: 0.23.5 -> 0.23.6 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.23.0 -> 0.23.1 (✓ API compatible changes)
* `rattler_virtual_packages`: 2.0.13 -> 2.0.14 (✓ API compatible changes)
* `rattler_index`: 0.23.0 -> 0.23.1 (✓ API compatible changes)
* `rattler_sandbox`: 0.1.8 -> 0.1.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_digest`

<blockquote>

## [1.1.3](https://github.com/conda/rattler/compare/rattler_digest-v1.1.2...rattler_digest-v1.1.3) - 2025-06-23

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_macros`

<blockquote>

## [1.0.10](https://github.com/conda/rattler/compare/rattler_macros-v1.0.9...rattler_macros-v1.0.10) - 2025-06-23

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_redaction`

<blockquote>

## [0.1.11](https://github.com/conda/rattler/compare/rattler_redaction-v0.1.10...rattler_redaction-v0.1.11) - 2025-06-23

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_conda_types`

<blockquote>

## [0.35.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.0...rattler_conda_types-v0.35.1) - 2025-06-23

### Added

- add `rattler_config` crate (derived from `pixi_config`) ([#1389](https://github.com/conda/rattler/pull/1389))

### Fixed

- fix code to use nom 8
- parsing of `=0.*,>=0.4.1` ([#1384](https://github.com/conda/rattler/pull/1384))

### Other

- *(ci)* Update Rust crate nom to v8 ([#1404](https://github.com/conda/rattler/pull/1404))
- Revert "fix code to use nom 8"
- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_config`

<blockquote>

## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_config-v0.1.0) - 2025-06-23

### Added

- add `rattler_config` crate (derived from `pixi_config`) ([#1389](https://github.com/conda/rattler/pull/1389))
- better readme ([#118](https://github.com/conda/rattler/pull/118))
- replace zulip with discord ([#116](https://github.com/conda/rattler/pull/116))
- move all conda types to seperate crate

### Fixed

- added missing hyphen to relative url linking to what-is-conda section in README.md ([#1192](https://github.com/conda/rattler/pull/1192))
- typos ([#849](https://github.com/conda/rattler/pull/849))
- move more links to the conda org from conda-incubator ([#816](https://github.com/conda/rattler/pull/816))
- use conda-incubator
- add python docs badge
- typo libsolve -> libsolv ([#164](https://github.com/conda/rattler/pull/164))
- change urls from baszalmstra to mamba-org
- build badge

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
- Fix badge style ([#1110](https://github.com/conda/rattler/pull/1110))
- fix anchor link ([#1035](https://github.com/conda/rattler/pull/1035))
- change links from conda-incubator to conda ([#813](https://github.com/conda/rattler/pull/813))
- update banner ([#808](https://github.com/conda/rattler/pull/808))
- update README.md
- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
- update installation gif
- update banner image
- address issue #282 ([#283](https://github.com/conda/rattler/pull/283))
- Add an image to Readme ([#203](https://github.com/conda/rattler/pull/203))
- Improve getting started with a micromamba environment. ([#163](https://github.com/conda/rattler/pull/163))
- Misc/update readme ([#66](https://github.com/conda/rattler/pull/66))
- update readme
- layout the vision a little bit better
- *(docs)* add build badge
- matchspec parsing
</blockquote>

## `rattler_networking`

<blockquote>

## [0.25.1](https://github.com/conda/rattler/compare/rattler_networking-v0.25.0...rattler_networking-v0.25.1) - 2025-06-23

### Added

- add `rattler_config` crate (derived from `pixi_config`) ([#1389](https://github.com/conda/rattler/pull/1389))
- make rattler_networking system integration optional ([#1381](https://github.com/conda/rattler/pull/1381))

### Fixed

- reduce s3 into to trace ([#1395](https://github.com/conda/rattler/pull/1395))

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.40](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.39...rattler_package_streaming-v0.22.40) - 2025-06-23

### Added

- add `rattler_config` crate (derived from `pixi_config`) ([#1389](https://github.com/conda/rattler/pull/1389))

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.21](https://github.com/conda/rattler/compare/rattler_cache-v0.3.20...rattler_cache-v0.3.21) - 2025-06-23

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_pty`

<blockquote>

## [0.2.2](https://github.com/conda/rattler/compare/rattler_pty-v0.2.1...rattler_pty-v0.2.2) - 2025-06-23

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_shell`

<blockquote>

## [0.23.3](https://github.com/conda/rattler/compare/rattler_shell-v0.23.2...rattler_shell-v0.23.3) - 2025-06-23

### Fixed

- quote values in bash activation with shlex ([#1392](https://github.com/conda/rattler/pull/1392))

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.11](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.10...rattler_menuinst-v0.2.11) - 2025-06-23

### Fixed

- use $PATH prepend behavior in `menuinst` activation ([#1376](https://github.com/conda/rattler/pull/1376))

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler`

<blockquote>

## [0.34.1](https://github.com/conda/rattler/compare/rattler-v0.34.0...rattler-v0.34.1) - 2025-06-23

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_libsolv_c`

<blockquote>

## [1.2.2](https://github.com/conda/rattler/compare/rattler_libsolv_c-v1.2.1...rattler_libsolv_c-v1.2.2) - 2025-06-23

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_solve`

<blockquote>

## [2.1.1](https://github.com/conda/rattler/compare/rattler_solve-v2.1.0...rattler_solve-v2.1.1) - 2025-06-23

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_lock`

<blockquote>

## [0.23.6](https://github.com/conda/rattler/compare/rattler_lock-v0.23.5...rattler_lock-v0.23.6) - 2025-06-23

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.23.1](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.0...rattler_repodata_gateway-v0.23.1) - 2025-06-23

### Fixed

- end progress sharded repodata ([#1375](https://github.com/conda/rattler/pull/1375))

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.0.14](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.13...rattler_virtual_packages-v2.0.14) - 2025-06-23

### Fixed

- fix code to use nom 8

### Other

- *(ci)* Update Rust crate nom to v8 ([#1404](https://github.com/conda/rattler/pull/1404))
- Revert "fix code to use nom 8"
- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_index`

<blockquote>

## [0.23.1](https://github.com/conda/rattler/compare/rattler_index-v0.23.0...rattler_index-v0.23.1) - 2025-06-23

### Added

- make rattler_networking system integration optional ([#1381](https://github.com/conda/rattler/pull/1381))

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>

## `rattler_sandbox`

<blockquote>

## [0.1.9](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.8...rattler_sandbox-v0.1.9) - 2025-06-23

### Other

- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).