### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.34.1"
+version = "0.34.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4364,7 +4364,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4447,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "chrono",
  "configparser",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4640,7 +4640,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "anyhow",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,23 +183,23 @@ zstd = { version = "0.13.3", default-features = false }
 
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
 file_url = { path = "crates/file_url", version = "=0.2.5", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.34.1", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.34.2", default-features = false }
 rattler_cache = { path = "crates/rattler_cache", version = "=0.3.21", default-features = false }
 rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.35.1", default-features = false }
 rattler_config = { path = "crates/rattler_config", version = "=0.1.0", default-features = false }
 rattler_digest = { path = "crates/rattler_digest", version = "=1.1.3", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.23.1", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.23.2", default-features = false }
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.2", default-features = false }
 rattler_lock = { path = "crates/rattler_lock", version = "=0.23.6", default-features = false }
 rattler_macros = { path = "crates/rattler_macros", version = "=1.0.10", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.11", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.12", default-features = false }
 rattler_networking = { path = "crates/rattler_networking", version = "=0.25.1", default-features = false }
 rattler_pty = { path = "crates/rattler_pty", version = "=0.2.2", default-features = false }
 rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.11", default-features = false }
 rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.40", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.1", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.2", default-features = false }
 rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.9", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.23.3", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.23.4", default-features = false }
 rattler_solve = { path = "crates/rattler_solve", version = "=2.1.1", default-features = false }
 rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.14", default-features = false }
 

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.2](https://github.com/conda/rattler/compare/rattler-v0.34.1...rattler-v0.34.2) - 2025-06-24
+
+### Other
+
+- updated the following local packages: rattler_shell, rattler_menuinst
+
 ## [0.34.1](https://github.com/conda/rattler/compare/rattler-v0.34.0...rattler-v0.34.1) - 2025-06-23
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.34.1"
+version = "0.34.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.2](https://github.com/conda/rattler/compare/rattler_index-v0.23.1...rattler_index-v0.23.2) - 2025-06-24
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.23.1](https://github.com/conda/rattler/compare/rattler_index-v0.23.0...rattler_index-v0.23.1) - 2025-06-23
 
 ### Added

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.23.1"
+version = "0.23.2"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.12](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.11...rattler_menuinst-v0.2.12) - 2025-06-24
+
+### Other
+
+- *(ci)* Update Rust crate windows to 0.61.0 ([#1462](https://github.com/conda/rattler/pull/1462))
+
 ## [0.2.11](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.10...rattler_menuinst-v0.2.11) - 2025-06-23
 
 ### Fixed

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.2](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.1...rattler_repodata_gateway-v0.23.2) - 2025-06-24
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.23.1](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.0...rattler_repodata_gateway-v0.23.1) - 2025-06-23
 
 ### Fixed

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.23.1"
+version = "0.23.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.4](https://github.com/conda/rattler/compare/rattler_shell-v0.23.3...rattler_shell-v0.23.4) - 2025-06-24
+
+### Fixed
+
+- simplify validate env vars ([#1465](https://github.com/conda/rattler/pull/1465))
+
 ## [0.23.3](https://github.com/conda/rattler/compare/rattler_shell-v0.23.2...rattler_shell-v0.23.3) - 2025-06-23
 
 ### Fixed

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.23.3"
+version = "0.23.4"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"


### PR DESCRIPTION



## 🤖 New release

* `rattler_shell`: 0.23.3 -> 0.23.4 (✓ API compatible changes)
* `rattler_menuinst`: 0.2.11 -> 0.2.12 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.23.1 -> 0.23.2 (✓ API compatible changes)
* `rattler_index`: 0.23.1 -> 0.23.2 (✓ API compatible changes)
* `rattler`: 0.34.1 -> 0.34.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_shell`

<blockquote>

## [0.23.4](https://github.com/conda/rattler/compare/rattler_shell-v0.23.3...rattler_shell-v0.23.4) - 2025-06-24

### Fixed

- simplify validate env vars ([#1465](https://github.com/conda/rattler/pull/1465))
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.12](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.11...rattler_menuinst-v0.2.12) - 2025-06-24

### Other

- *(ci)* Update Rust crate windows to 0.61.0 ([#1462](https://github.com/conda/rattler/pull/1462))
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.23.2](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.1...rattler_repodata_gateway-v0.23.2) - 2025-06-24

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_index`

<blockquote>

## [0.23.2](https://github.com/conda/rattler/compare/rattler_index-v0.23.1...rattler_index-v0.23.2) - 2025-06-24

### Other

- update Cargo.lock dependencies
</blockquote>

## `rattler`

<blockquote>

## [0.34.2](https://github.com/conda/rattler/compare/rattler-v0.34.1...rattler-v0.34.2) - 2025-06-24

### Other

- updated the following local packages: rattler_shell, rattler_menuinst
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).