### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -287,7 +287,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "tracing",
 ]
 
@@ -314,7 +314,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+checksum = "b68c2194a190e1efc999612792e25b1ab3abfefe4306494efaaabc25933c0cbe"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -393,15 +393,15 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.8"
+version = "1.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6c68419d8ba16d9a7463671593c54f81ba58cab466e9b759418da606dcc2e2"
+checksum = "b2090e664216c78e766b6bac10fe74d2f451c02441d43484cd76ac9a295075f7"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
  "aws-smithy-async",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.96.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e25d24de44b34dcdd5182ac4e4c6f07bcec2661c505acef94c0d293b65505fe"
+checksum = "029e89cae7e628553643aecb3a3f054a0a0912ff0fd1f5d6a0b4fda421dce64b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -428,7 +428,7 @@ dependencies = [
  "aws-smithy-async",
  "aws-smithy-checksums",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -452,14 +452,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.74.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a69de9c1b9272da2872af60c7402683e7f45c06267735b4332deacb203239b"
+checksum = "64bf26698dd6d238ef1486bdda46f22a589dc813368ba868dc3d94c8d27b56ba"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -474,14 +474,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.75.0"
+version = "1.77.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b161d836fac72bdd5ac1a4cd1cdc38ab888c7af26cfd95f661be4409505e63"
+checksum = "09cd07ed1edd939fae854a22054299ae3576500f4e0fadc560ca44f9c6ea1664"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
@@ -496,14 +496,14 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.76.0"
+version = "1.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb1cd79a3412751a341a28e2cd0d6fa4345241976da427b075a0c0cd5409f886"
+checksum = "37f7766d2344f56d10d12f3c32993da36d78217f32594fe4fb8e57a538c1cdea"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-json",
  "aws-smithy-query",
  "aws-smithy-runtime",
@@ -525,7 +525,7 @@ checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -558,11 +558,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.4"
+version = "0.63.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "244f00666380d35c1c76b90f7b88a11935d11b84076ac22a4c014ea0939627af"
+checksum = "5ab9472f7a8ec259ddb5681d2ef1cb1cf16c0411890063e67cdc7b62562cc496"
 dependencies = [
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.9"
+version = "0.60.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338a3642c399c0a5d157648426110e199ca7fd1c689cc395676b81aa563700c4"
+checksum = "604c7aec361252b8f1c871a7641d5e0ba3a7f5a586e51b66bc9510a5519594d9"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -609,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+checksum = "43c82ba4cab184ea61f6edaafc1072aad3c2a17dcf4c0fce19ac5694b90d8b5f"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -684,7 +684,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3aaec682eb189e43c8a19c3dab2fe54590ad5f2cc2d26ab27608a20f2acf81c"
 dependencies = [
  "aws-smithy-async",
- "aws-smithy-http 0.62.1",
+ "aws-smithy-http 0.62.2",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -2000,7 +2000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
  "fs-err",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "tokio",
  "windows-sys 0.59.0",
 ]
@@ -2242,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax"
-version = "0.23.0"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d88f66b6fccca3449ad9f0366ec3d1b74a004fa1100d98353a201dabc3203bd2"
+checksum = "5560b3cedeea7041862717175d98733ac81f7bedfdd0c7949bf06d761bf4094f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2262,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-rpc"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b4b7867ab6e94e56944116f2b1bdcdbac522eea794743a9884d84db7728470"
+checksum = "949f5858642f68efbd836a82400d04f2572e6d18a612c1144d0868832f40996e"
 dependencies = [
  "bytes",
  "google-cloud-wkt",
@@ -2275,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-wkt"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b1dbeb30ab8bde2423081b76f9c302d82fea1b99f8ca750f223d32065d3c6c"
+checksum = "8e2916ee3f086766d6989abd8a0b1c3910322af60d72352f6cdf5cb8eb951464"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4007,7 +4007,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4304,7 +4304,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.34.7"
+version = "0.34.8"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.26"
+version = "0.3.27"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.35.6"
+version = "0.36.0"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "console 0.15.11",
  "fs-err",
@@ -4506,7 +4506,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4553,7 +4553,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.11"
+version = "0.23.12"
 dependencies = [
  "chrono",
  "file_url",
@@ -4590,7 +4590,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "configparser",
@@ -4619,7 +4619,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4655,7 +4655,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.45"
+version = "0.22.46"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.23.7"
+version = "0.23.8"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4784,7 +4784,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.24.4"
+version = "0.24.5"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4806,7 +4806,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "2.1.6"
+version = "2.1.7"
 dependencies = [
  "chrono",
  "criterion",
@@ -4865,7 +4865,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.0.19"
+version = "2.1.0"
 dependencies = [
  "archspec",
  "libloading",
@@ -4966,7 +4966,7 @@ checksum = "78c81d000a2c524133cc00d2f92f019d399e57906c3b7119271a2495354fe895"
 dependencies = [
  "cfg-if",
  "libc",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows 0.61.3",
 ]
 
@@ -5315,15 +5315,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6125,7 +6125,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -6144,7 +6144,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -7002,7 +7002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "winsafe",
 ]
 
@@ -7435,7 +7435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix 1.0.8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,25 +185,25 @@ zstd = { version = "0.13.3", default-features = false }
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
 file_url = { path = "crates/file_url", version = "=0.2.5", default-features = false }
 path_resolver = { path = "crates/path_resolver", version = "=0.1.1", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.34.7", default-features = false }
-rattler_cache = { path = "crates/rattler_cache", version = "=0.3.26", default-features = false }
-rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.35.6", default-features = false }
-rattler_config = { path = "crates/rattler_config", version = "=0.2.3", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.34.8", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.27", default-features = false }
+rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.36.0", default-features = false }
+rattler_config = { path = "crates/rattler_config", version = "=0.2.4", default-features = false }
 rattler_digest = { path = "crates/rattler_digest", version = "=1.1.4", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.24.4", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.24.5", default-features = false }
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.3", default-features = false }
-rattler_lock = { path = "crates/rattler_lock", version = "=0.23.11", default-features = false }
+rattler_lock = { path = "crates/rattler_lock", version = "=0.23.12", default-features = false }
 rattler_macros = { path = "crates/rattler_macros", version = "=1.0.11", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.17", default-features = false }
-rattler_networking = { path = "crates/rattler_networking", version = "=0.25.6", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.18", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.25.7", default-features = false }
 rattler_pty = { path = "crates/rattler_pty", version = "=0.2.4", default-features = false }
 rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.12", default-features = false }
-rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.45", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.7", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.46", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.8", default-features = false }
 rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.10", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.24.4", default-features = false }
-rattler_solve = { path = "crates/rattler_solve", version = "=2.1.6", default-features = false }
-rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.0.19", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.24.5", default-features = false }
+rattler_solve = { path = "crates/rattler_solve", version = "=2.1.7", default-features = false }
+rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.1.0", default-features = false }
 
 # This is also a rattler crate, but we only pin it to minor version
 simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.8](https://github.com/conda/rattler/compare/rattler-v0.34.7...rattler-v0.34.8) - 2025-07-18
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.34.7](https://github.com/conda/rattler/compare/rattler-v0.34.6...rattler-v0.34.7) - 2025-07-14
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.34.7"
+version = "0.34.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.27](https://github.com/conda/rattler/compare/rattler_cache-v0.3.26...rattler_cache-v0.3.27) - 2025-07-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming
+
 ## [0.3.26](https://github.com/conda/rattler/compare/rattler_cache-v0.3.25...rattler_cache-v0.3.26) - 2025-07-14
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.26"
+version = "0.3.27"
 description = "A crate to manage the caching of data in rattler"
 categories = { workspace = true }
 homepage = { workspace = true }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.6...rattler_conda_types-v0.36.0) - 2025-07-18
+
+### Added
+
+- add support for loong64 platform to rattler ([#1534](https://github.com/conda/rattler/pull/1534))
+
 ## [0.35.6](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.5...rattler_conda_types-v0.35.6) - 2025-07-14
 
 ### Fixed

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.35.6"
+version = "0.36.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_config/CHANGELOG.md
+++ b/crates/rattler_config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/conda/rattler/compare/rattler_config-v0.2.3...rattler_config-v0.2.4) - 2025-07-18
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.3](https://github.com/conda/rattler/compare/rattler_config-v0.2.2...rattler_config-v0.2.3) - 2025-07-14
 
 ### Other

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_config"
-version = "0.2.3"
+version = "0.2.4"
 edition.workspace = true
 authors = []
 description = "A crate to configure rattler and derived tools."

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.5](https://github.com/conda/rattler/compare/rattler_index-v0.24.4...rattler_index-v0.24.5) - 2025-07-18
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.24.4](https://github.com/conda/rattler/compare/rattler_index-v0.24.3...rattler_index-v0.24.4) - 2025-07-14
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.24.4"
+version = "0.24.5"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.12](https://github.com/conda/rattler/compare/rattler_lock-v0.23.11...rattler_lock-v0.23.12) - 2025-07-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_solve
+
 ## [0.23.11](https://github.com/conda/rattler/compare/rattler_lock-v0.23.10...rattler_lock-v0.23.11) - 2025-07-14
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.23.11"
+version = "0.23.12"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.18](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.17...rattler_menuinst-v0.2.18) - 2025-07-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_shell
+
 ## [0.2.17](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.16...rattler_menuinst-v0.2.17) - 2025-07-14
 
 ### Other

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.17"
+version = "0.2.18"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.7](https://github.com/conda/rattler/compare/rattler_networking-v0.25.6...rattler_networking-v0.25.7) - 2025-07-18
+
+### Other
+
+- updated the following local packages: rattler_config
+
 ## [0.25.6](https://github.com/conda/rattler/compare/rattler_networking-v0.25.5...rattler_networking-v0.25.6) - 2025-07-14
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.25.6"
+version = "0.25.7"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.46](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.45...rattler_package_streaming-v0.22.46) - 2025-07-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking
+
 ## [0.22.45](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.44...rattler_package_streaming-v0.22.45) - 2025-07-14
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.45"
+version = "0.22.46"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.8](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.7...rattler_repodata_gateway-v0.23.8) - 2025-07-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_config, rattler_networking, rattler_cache
+
 ## [0.23.7](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.6...rattler_repodata_gateway-v0.23.7) - 2025-07-14
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.23.7"
+version = "0.23.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.5](https://github.com/conda/rattler/compare/rattler_shell-v0.24.4...rattler_shell-v0.24.5) - 2025-07-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.24.4](https://github.com/conda/rattler/compare/rattler_shell-v0.24.3...rattler_shell-v0.24.4) - 2025-07-14
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.24.4"
+version = "0.24.5"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.7](https://github.com/conda/rattler/compare/rattler_solve-v2.1.6...rattler_solve-v2.1.7) - 2025-07-18
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [2.1.6](https://github.com/conda/rattler/compare/rattler_solve-v2.1.5...rattler_solve-v2.1.6) - 2025-07-14
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "2.1.6"
+version = "2.1.7"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.19...rattler_virtual_packages-v2.1.0) - 2025-07-18
+
+### Added
+
+- add support for loong64 platform to rattler ([#1534](https://github.com/conda/rattler/pull/1534))
+
 ## [2.0.19](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.18...rattler_virtual_packages-v2.0.19) - 2025-07-14
 
 ### Other

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.0.19"
+version = "2.1.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION



## 🤖 New release

* `rattler_conda_types`: 0.35.6 -> 0.36.0 (⚠ API breaking changes)
* `rattler_config`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `rattler`: 0.34.7 -> 0.34.8 (✓ API compatible changes)
* `rattler_virtual_packages`: 2.0.19 -> 2.1.0 (✓ API compatible changes)
* `rattler_index`: 0.24.4 -> 0.24.5 (✓ API compatible changes)
* `rattler_upload`: 0.1.0
* `rattler_networking`: 0.25.6 -> 0.25.7
* `rattler_package_streaming`: 0.22.45 -> 0.22.46
* `rattler_cache`: 0.3.26 -> 0.3.27
* `rattler_shell`: 0.24.4 -> 0.24.5
* `rattler_menuinst`: 0.2.17 -> 0.2.18
* `rattler_solve`: 2.1.6 -> 2.1.7
* `rattler_lock`: 0.23.11 -> 0.23.12
* `rattler_repodata_gateway`: 0.23.7 -> 0.23.8

### ⚠ `rattler_conda_types` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Arch::Ppc64le 6 -> 7 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:68
  variant Arch::Ppc64 7 -> 8 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:69
  variant Arch::Ppc 8 -> 9 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:70
  variant Arch::S390X 9 -> 10 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:71
  variant Arch::Riscv32 10 -> 11 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:72
  variant Arch::Riscv64 11 -> 12 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:73
  variant Arch::Wasm32 12 -> 13 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:74
  variant Arch::Z 13 -> 14 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:75
  variant Arch::Ppc64le 6 -> 7 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:68
  variant Arch::Ppc64 7 -> 8 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:69
  variant Arch::Ppc 8 -> 9 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:70
  variant Arch::S390X 9 -> 10 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:71
  variant Arch::Riscv32 10 -> 11 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:72
  variant Arch::Riscv64 11 -> 12 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:73
  variant Arch::Wasm32 12 -> 13 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:74
  variant Arch::Z 13 -> 14 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:75
  variant Platform::LinuxPpc64le 7 -> 8 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:23
  variant Platform::LinuxPpc64 8 -> 9 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:24
  variant Platform::LinuxPpc 9 -> 10 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:25
  variant Platform::LinuxS390X 10 -> 11 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:26
  variant Platform::LinuxRiscv32 11 -> 12 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:27
  variant Platform::LinuxRiscv64 12 -> 13 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:28
  variant Platform::Osx64 13 -> 14 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:30
  variant Platform::OsxArm64 14 -> 15 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:31
  variant Platform::Win32 15 -> 16 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:33
  variant Platform::Win64 16 -> 17 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:34
  variant Platform::WinArm64 17 -> 18 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:35
  variant Platform::EmscriptenWasm32 18 -> 19 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:37
  variant Platform::WasiWasm32 19 -> 20 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:38
  variant Platform::ZosZ 20 -> 21 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:40
  variant Platform::LinuxPpc64le 7 -> 8 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:23
  variant Platform::LinuxPpc64 8 -> 9 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:24
  variant Platform::LinuxPpc 9 -> 10 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:25
  variant Platform::LinuxS390X 10 -> 11 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:26
  variant Platform::LinuxRiscv32 11 -> 12 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:27
  variant Platform::LinuxRiscv64 12 -> 13 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:28
  variant Platform::Osx64 13 -> 14 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:30
  variant Platform::OsxArm64 14 -> 15 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:31
  variant Platform::Win32 15 -> 16 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:33
  variant Platform::Win64 16 -> 17 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:34
  variant Platform::WinArm64 17 -> 18 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:35
  variant Platform::EmscriptenWasm32 18 -> 19 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:37
  variant Platform::WasiWasm32 19 -> 20 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:38
  variant Platform::ZosZ 20 -> 21 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:40

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant Platform:LinuxLoong64 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:22
  variant Platform:LinuxLoong64 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:22
  variant Arch:Loong64 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:67
  variant Arch:Loong64 in /tmp/.tmpOwTmRr/rattler/crates/rattler_conda_types/src/platform.rs:67
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_conda_types`

<blockquote>

## [0.36.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.6...rattler_conda_types-v0.36.0) - 2025-07-18

### Added

- add support for loong64 platform to rattler ([#1534](https://github.com/conda/rattler/pull/1534))
</blockquote>

## `rattler_config`

<blockquote>

## [0.2.4](https://github.com/conda/rattler/compare/rattler_config-v0.2.3...rattler_config-v0.2.4) - 2025-07-18

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler`

<blockquote>

## [0.34.8](https://github.com/conda/rattler/compare/rattler-v0.34.7...rattler-v0.34.8) - 2025-07-18

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.1.0](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.19...rattler_virtual_packages-v2.1.0) - 2025-07-18

### Added

- add support for loong64 platform to rattler ([#1534](https://github.com/conda/rattler/pull/1534))
</blockquote>

## `rattler_index`

<blockquote>

## [0.24.5](https://github.com/conda/rattler/compare/rattler_index-v0.24.4...rattler_index-v0.24.5) - 2025-07-18

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_upload`

<blockquote>

## [0.1.0](https://github.com/conda/rattler/releases/tag/rattler_upload-v0.1.0) - 2025-07-09

### Added

- better readme ([#118](https://github.com/conda/rattler/pull/118))
- replace zulip with discord ([#116](https://github.com/conda/rattler/pull/116))
- move all conda types to separate crate

### Fixed

- *(ci)* run pre-commit-run for all files ([#1481](https://github.com/conda/rattler/pull/1481))
- added missing hyphen to relative url linking to what-is-conda section in README.md ([#1192](https://github.com/conda/rattler/pull/1192))
- typos ([#849](https://github.com/conda/rattler/pull/849))
- move more links to the conda org from conda-incubator ([#816](https://github.com/conda/rattler/pull/816))
- use conda-incubator
- add python docs badge
- typo libsolve -> libsolv ([#164](https://github.com/conda/rattler/pull/164))
- change urls from baszalmstra to mamba-org
- build badge

### Other

- move upload from `rattler-build` to `rattler` ([#1386](https://github.com/conda/rattler/pull/1386))
- update npm name ([#1368](https://github.com/conda/rattler/pull/1368))
- update readme ([#1364](https://github.com/conda/rattler/pull/1364))
- Fix badge style ([#1110](https://github.com/conda/rattler/pull/1110))
- fix anchor link ([#1035](https://github.com/conda/rattler/pull/1035))
- change links from conda-incubator to conda ([#813](https://github.com/conda/rattler/pull/813))
- update banner ([#808](https://github.com/conda/rattler/pull/808))
- update README.md
- add pixi badge ([#563](https://github.com/conda/rattler/pull/563))
- update installation gif
- update banner image
- address issue #282 ([#283](https://github.com/conda/rattler/pull/283))
- Add an image to Readme ([#203](https://github.com/conda/rattler/pull/203))
- Improve getting started with a micromamba environment. ([#163](https://github.com/conda/rattler/pull/163))
- Misc/update readme ([#66](https://github.com/conda/rattler/pull/66))
- update readme
- layout the vision a little bit better
- *(docs)* add build badge
- matchspec parsing
</blockquote>

## `rattler_networking`

<blockquote>

## [0.25.7](https://github.com/conda/rattler/compare/rattler_networking-v0.25.6...rattler_networking-v0.25.7) - 2025-07-18

### Other

- updated the following local packages: rattler_config
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.46](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.45...rattler_package_streaming-v0.22.46) - 2025-07-18

### Other

- updated the following local packages: rattler_conda_types, rattler_networking
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.27](https://github.com/conda/rattler/compare/rattler_cache-v0.3.26...rattler_cache-v0.3.27) - 2025-07-18

### Other

- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming
</blockquote>

## `rattler_shell`

<blockquote>

## [0.24.5](https://github.com/conda/rattler/compare/rattler_shell-v0.24.4...rattler_shell-v0.24.5) - 2025-07-18

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.18](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.17...rattler_menuinst-v0.2.18) - 2025-07-18

### Other

- updated the following local packages: rattler_conda_types, rattler_shell
</blockquote>

## `rattler_solve`

<blockquote>

## [2.1.7](https://github.com/conda/rattler/compare/rattler_solve-v2.1.6...rattler_solve-v2.1.7) - 2025-07-18

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_lock`

<blockquote>

## [0.23.12](https://github.com/conda/rattler/compare/rattler_lock-v0.23.11...rattler_lock-v0.23.12) - 2025-07-18

### Other

- updated the following local packages: rattler_conda_types, rattler_solve
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.23.8](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.7...rattler_repodata_gateway-v0.23.8) - 2025-07-18

### Other

- updated the following local packages: rattler_conda_types, rattler_config, rattler_networking, rattler_cache
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).