### PR TITLE
feat: add support for loong64 platform to rattler

### DIFF
--- a/crates/rattler_conda_types/src/platform.rs
+++ b/crates/rattler_conda_types/src/platform.rs
@@ -19,6 +19,7 @@ pub enum Platform {
     LinuxAarch64,
     LinuxArmV6l,
     LinuxArmV7l,
+    LinuxLoong64,
     LinuxPpc64le,
     LinuxPpc64,
     LinuxPpc,
@@ -63,6 +64,7 @@ pub enum Arch {
     Arm64,
     ArmV6l,
     ArmV7l,
+    Loong64,
     Ppc64le,
     Ppc64,
     Ppc,
@@ -96,6 +98,9 @@ impl Platform {
                 return Platform::LinuxArmV6l;
             }
 
+            #[cfg(target_arch = "loongarch64")]
+            return Platform::LinuxLoong64;
+
             #[cfg(all(target_arch = "powerpc64", target_endian = "little"))]
             return Platform::LinuxPpc64le;
 
@@ -123,7 +128,8 @@ impl Platform {
                 target_arch = "arm",
                 target_arch = "powerpc64",
                 target_arch = "powerpc",
-                target_arch = "s390x"
+                target_arch = "s390x",
+                target_arch = "loongarch64"
             )))]
             compile_error!("unsupported linux architecture");
         }
@@ -203,6 +209,7 @@ impl Platform {
                 | Platform::LinuxAarch64
                 | Platform::LinuxArmV6l
                 | Platform::LinuxArmV7l
+                | Platform::LinuxLoong64
                 | Platform::LinuxPpc64le
                 | Platform::LinuxPpc64
                 | Platform::LinuxPpc
@@ -226,6 +233,7 @@ impl Platform {
             | Platform::LinuxAarch64
             | Platform::LinuxArmV6l
             | Platform::LinuxArmV7l
+            | Platform::LinuxLoong64
             | Platform::LinuxPpc64le
             | Platform::LinuxPpc64
             | Platform::LinuxPpc
@@ -270,6 +278,7 @@ impl FromStr for Platform {
             "linux-aarch64" => Platform::LinuxAarch64,
             "linux-armv6l" => Platform::LinuxArmV6l,
             "linux-armv7l" => Platform::LinuxArmV7l,
+            "linux-loong64" => Platform::LinuxLoong64,
             "linux-ppc64le" => Platform::LinuxPpc64le,
             "linux-ppc64" => Platform::LinuxPpc64,
             "linux-ppc" => Platform::LinuxPpc,
@@ -302,6 +311,7 @@ impl From<Platform> for &'static str {
             Platform::LinuxAarch64 => "linux-aarch64",
             Platform::LinuxArmV6l => "linux-armv6l",
             Platform::LinuxArmV7l => "linux-armv7l",
+            Platform::LinuxLoong64 => "linux-loong64",
             Platform::LinuxPpc64le => "linux-ppc64le",
             Platform::LinuxPpc64 => "linux-ppc64",
             Platform::LinuxPpc => "linux-ppc",
@@ -330,6 +340,7 @@ impl Platform {
             Platform::Unknown | Platform::NoArch => None,
             Platform::LinuxArmV6l => Some(Arch::ArmV6l),
             Platform::LinuxArmV7l => Some(Arch::ArmV7l),
+            Platform::LinuxLoong64 => Some(Arch::Loong64),
             Platform::LinuxPpc64le => Some(Arch::Ppc64le),
             Platform::LinuxPpc64 => Some(Arch::Ppc64),
             Platform::LinuxPpc => Some(Arch::Ppc),
@@ -404,6 +415,7 @@ impl FromStr for Arch {
             "arm64" => Arch::Arm64,
             "armv6l" => Arch::ArmV6l,
             "armv7l" => Arch::ArmV7l,
+            "loong64" => Arch::Loong64,
             "ppc64le" => Arch::Ppc64le,
             "ppc64" => Arch::Ppc64,
             "ppc" => Arch::Ppc,
@@ -430,6 +442,7 @@ impl From<Arch> for &'static str {
             Arch::Aarch64 => "aarch64",
             Arch::ArmV6l => "armv6l",
             Arch::ArmV7l => "armv7l",
+            Arch::Loong64 => "loong64",
             Arch::Ppc64le => "ppc64le",
             Arch::Ppc64 => "ppc64",
             Arch::Ppc => "ppc",
@@ -518,6 +531,7 @@ mod tests {
         assert_eq!(Platform::LinuxAarch64.arch(), Some(Arch::Aarch64));
         assert_eq!(Platform::LinuxArmV6l.arch(), Some(Arch::ArmV6l));
         assert_eq!(Platform::LinuxArmV7l.arch(), Some(Arch::ArmV7l));
+        assert_eq!(Platform::LinuxLoong64.arch(), Some(Arch::Loong64));
         assert_eq!(Platform::LinuxPpc64le.arch(), Some(Arch::Ppc64le));
         assert_eq!(Platform::LinuxPpc64.arch(), Some(Arch::Ppc64));
         assert_eq!(Platform::LinuxPpc.arch(), Some(Arch::Ppc));

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -591,6 +591,7 @@ impl Archspec {
             Platform::Win32 | Platform::Linux32 => "x86",
             Platform::Win64 | Platform::Osx64 | Platform::Linux64 => "x86_64",
             Platform::LinuxAarch64 | Platform::LinuxArmV6l | Platform::LinuxArmV7l => "aarch64",
+            Platform::LinuxLoong64 => "loong64",
             Platform::LinuxPpc64le => "ppc64le",
             Platform::LinuxPpc64 => "ppc64",
             Platform::LinuxPpc => "ppc",


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->

[LoongArch](https://docs.kernel.org/arch/loongarch/introduction.html) is a new RISC ISA developed by loongson. There are already a lot of [community support and testing](https://www.phoronix.com/search/LoongArch) about it. This PR adds loong64 support to rattler.

PS. [debian names this architecture `loong64`](https://wiki.debian.org/Ports/loong64) so I followed this custom, but the gnu and rust toolchain still uses `loongarch64`. It's not a typo.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
