### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.4"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3aaec682eb189e43c8a19c3dab2fe54590ad5f2cc2d26ab27608a20f2acf81c"
+checksum = "660f70d9d8af6876b4c9aa8dcb0dbaf0f89b04ee9a4455bea1b4ba03b15f26f6"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http 0.62.2",
@@ -701,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852b9226cb60b78ce9369022c0df678af1cac231c882d5da97a0c4e03be6e67"
+checksum = "38280ac228bc479f347fcfccf4bf4d22d68f3bb4629685cb591cabd856567bbc"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -2602,7 +2602,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2682,9 +2682,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2698,7 +2698,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2920,9 +2920,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -3774,7 +3774,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path_resolver"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "fs-err",
  "indexmap 2.10.0",
@@ -4174,7 +4174,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.29",
- "socket2",
+ "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -4211,7 +4211,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.34.8"
+version = "0.34.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.27"
+version = "0.3.28"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4451,7 +4451,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "console 0.16.0",
  "fs-err",
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.24.5"
+version = "0.24.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4584,7 +4584,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.12"
+version = "0.23.13"
 dependencies = [
  "chrono",
  "file_url",
@@ -4621,7 +4621,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "configparser",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.7"
+version = "0.25.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4686,7 +4686,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.46"
+version = "0.22.47"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4720,7 +4720,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -4738,7 +4738,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.23.8"
+version = "0.23.9"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.24.5"
+version = "0.24.6"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4837,7 +4837,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "2.1.7"
+version = "2.1.8"
 dependencies = [
  "chrono",
  "criterion",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "archspec",
  "libloading",
@@ -5933,6 +5933,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6327,7 +6337,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,26 +184,26 @@ zstd = { version = "0.13.3", default-features = false }
 
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
 file_url = { path = "crates/file_url", version = "=0.2.6", default-features = false }
-path_resolver = { path = "crates/path_resolver", version = "=0.1.1", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.34.8", default-features = false }
-rattler_cache = { path = "crates/rattler_cache", version = "=0.3.27", default-features = false }
-rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.36.0", default-features = false }
-rattler_config = { path = "crates/rattler_config", version = "=0.2.4", default-features = false }
+path_resolver = { path = "crates/path_resolver", version = "=0.1.2", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.34.9", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.28", default-features = false }
+rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.37.0", default-features = false }
+rattler_config = { path = "crates/rattler_config", version = "=0.2.5", default-features = false }
 rattler_digest = { path = "crates/rattler_digest", version = "=1.1.5", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.24.5", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.24.6", default-features = false }
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.3", default-features = false }
-rattler_lock = { path = "crates/rattler_lock", version = "=0.23.12", default-features = false }
+rattler_lock = { path = "crates/rattler_lock", version = "=0.23.13", default-features = false }
 rattler_macros = { path = "crates/rattler_macros", version = "=1.0.11", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.18", default-features = false }
-rattler_networking = { path = "crates/rattler_networking", version = "=0.25.7", default-features = false }
-rattler_pty = { path = "crates/rattler_pty", version = "=0.2.5", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.19", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.25.8", default-features = false }
+rattler_pty = { path = "crates/rattler_pty", version = "=0.2.6", default-features = false }
 rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.12", default-features = false }
-rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.46", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.8", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.47", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.9", default-features = false }
 rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.10", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.24.5", default-features = false }
-rattler_solve = { path = "crates/rattler_solve", version = "=2.1.7", default-features = false }
-rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.1.0", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.24.6", default-features = false }
+rattler_solve = { path = "crates/rattler_solve", version = "=2.1.8", default-features = false }
+rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.1.1", default-features = false }
 
 # This is also a rattler crate, but we only pin it to minor version
 simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/path_resolver/CHANGELOG.md
+++ b/crates/path_resolver/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/conda/rattler/compare/path_resolver-v0.1.1...path_resolver-v0.1.2) - 2025-07-23
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.1](https://github.com/conda/rattler/compare/path_resolver-v0.1.0...path_resolver-v0.1.1) - 2025-07-14
 
 ### Other

--- a/crates/path_resolver/Cargo.toml
+++ b/crates/path_resolver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "path_resolver"
-version = "0.1.1"
+version = "0.1.2"
 categories.workspace = true
 homepage.workspace = true
 repository.workspace = true

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.9](https://github.com/conda/rattler/compare/rattler-v0.34.8...rattler-v0.34.9) - 2025-07-23
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.34.8](https://github.com/conda/rattler/compare/rattler-v0.34.7...rattler-v0.34.8) - 2025-07-21
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.34.8"
+version = "0.34.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.28](https://github.com/conda/rattler/compare/rattler_cache-v0.3.27...rattler_cache-v0.3.28) - 2025-07-23
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.3.27](https://github.com/conda/rattler/compare/rattler_cache-v0.3.26...rattler_cache-v0.3.27) - 2025-07-21
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.27"
+version = "0.3.28"
 description = "A crate to manage the caching of data in rattler"
 categories = { workspace = true }
 homepage = { workspace = true }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.36.0...rattler_conda_types-v0.37.0) - 2025-07-23
+
+### Fixed
+
+- indexing `extra-depends` ([#1546](https://github.com/conda/rattler/pull/1546))
+
 ## [0.36.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.35.6...rattler_conda_types-v0.36.0) - 2025-07-21
 
 ### Added

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.36.0"
+version = "0.37.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_config/CHANGELOG.md
+++ b/crates/rattler_config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/conda/rattler/compare/rattler_config-v0.2.4...rattler_config-v0.2.5) - 2025-07-23
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.4](https://github.com/conda/rattler/compare/rattler_config-v0.2.3...rattler_config-v0.2.4) - 2025-07-21
 
 ### Other

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_config"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 authors = []
 description = "A crate to configure rattler and derived tools."

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.6](https://github.com/conda/rattler/compare/rattler_index-v0.24.5...rattler_index-v0.24.6) - 2025-07-23
+
+### Fixed
+
+- indexing `extra-depends` ([#1546](https://github.com/conda/rattler/pull/1546))
+
 ## [0.24.5](https://github.com/conda/rattler/compare/rattler_index-v0.24.4...rattler_index-v0.24.5) - 2025-07-21
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.24.5"
+version = "0.24.6"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.13](https://github.com/conda/rattler/compare/rattler_lock-v0.23.12...rattler_lock-v0.23.13) - 2025-07-23
+
+### Fixed
+
+- indexing `extra-depends` ([#1546](https://github.com/conda/rattler/pull/1546))
+
 ## [0.23.12](https://github.com/conda/rattler/compare/rattler_lock-v0.23.11...rattler_lock-v0.23.12) - 2025-07-21
 
 ### Other

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.23.12"
+version = "0.23.13"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.19](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.18...rattler_menuinst-v0.2.19) - 2025-07-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_shell
+
 ## [0.2.18](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.17...rattler_menuinst-v0.2.18) - 2025-07-21
 
 ### Other

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.18"
+version = "0.2.19"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.8](https://github.com/conda/rattler/compare/rattler_networking-v0.25.7...rattler_networking-v0.25.8) - 2025-07-23
+
+### Other
+
+- updated the following local packages: rattler_config
+
 ## [0.25.7](https://github.com/conda/rattler/compare/rattler_networking-v0.25.6...rattler_networking-v0.25.7) - 2025-07-21
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.25.7"
+version = "0.25.8"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.47](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.46...rattler_package_streaming-v0.22.47) - 2025-07-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking
+
 ## [0.22.46](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.45...rattler_package_streaming-v0.22.46) - 2025-07-21
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.46"
+version = "0.22.47"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_pty/CHANGELOG.md
+++ b/crates/rattler_pty/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/conda/rattler/compare/rattler_pty-v0.2.5...rattler_pty-v0.2.6) - 2025-07-23
+
+### Other
+
+- *(rattler_pty)* fix `needless_continue` lint ([#1547](https://github.com/conda/rattler/pull/1547))
+
 ## [0.2.5](https://github.com/conda/rattler/compare/rattler_pty-v0.2.4...rattler_pty-v0.2.5) - 2025-07-21
 
 ### Other

--- a/crates/rattler_pty/Cargo.toml
+++ b/crates/rattler_pty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_pty"
-version = "0.2.5"
+version = "0.2.6"
 description = "A crate to create pty"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.9](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.8...rattler_repodata_gateway-v0.23.9) - 2025-07-23
+
+### Fixed
+
+- indexing `extra-depends` ([#1546](https://github.com/conda/rattler/pull/1546))
+- use channel `subdir` instead of the one from the record ([#1543](https://github.com/conda/rattler/pull/1543))
+
 ## [0.23.8](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.7...rattler_repodata_gateway-v0.23.8) - 2025-07-21
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.23.8"
+version = "0.23.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.6](https://github.com/conda/rattler/compare/rattler_shell-v0.24.5...rattler_shell-v0.24.6) - 2025-07-23
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.24.5](https://github.com/conda/rattler/compare/rattler_shell-v0.24.4...rattler_shell-v0.24.5) - 2025-07-21
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.24.5"
+version = "0.24.6"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.8](https://github.com/conda/rattler/compare/rattler_solve-v2.1.7...rattler_solve-v2.1.8) - 2025-07-23
+
+### Fixed
+
+- indexing `extra-depends` ([#1546](https://github.com/conda/rattler/pull/1546))
+
 ## [2.1.7](https://github.com/conda/rattler/compare/rattler_solve-v2.1.6...rattler_solve-v2.1.7) - 2025-07-21
 
 ### Other

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "2.1.7"
+version = "2.1.8"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"

--- a/crates/rattler_upload/CHANGELOG.md
+++ b/crates/rattler_upload/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/conda/rattler/compare/rattler_upload-v0.1.1...rattler_upload-v0.1.2) - 2025-07-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_config, rattler_solve, rattler_networking, rattler_package_streaming
+
 ## [0.1.1](https://github.com/conda/rattler/compare/rattler_upload-v0.1.0...rattler_upload-v0.1.1) - 2025-07-21
 
 ### Other

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_upload"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>", "Magenta Qin <magenta2127@gmail.com>"]
 description = "A crate to Upload conda packages to various channels."

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.1.0...rattler_virtual_packages-v2.1.1) - 2025-07-23
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [2.1.0](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.0.19...rattler_virtual_packages-v2.1.0) - 2025-07-21
 
 ### Added

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.1.0"
+version = "2.1.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION



## 🤖 New release

* `path_resolver`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `rattler_conda_types`: 0.36.0 -> 0.37.0 (⚠ API breaking changes)
* `rattler_config`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `rattler_cache`: 0.3.27 -> 0.3.28 (✓ API compatible changes)
* `rattler_pty`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `rattler_shell`: 0.24.5 -> 0.24.6 (✓ API compatible changes)
* `rattler`: 0.34.8 -> 0.34.9 (✓ API compatible changes)
* `rattler_solve`: 2.1.7 -> 2.1.8 (✓ API compatible changes)
* `rattler_lock`: 0.23.12 -> 0.23.13 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.23.8 -> 0.23.9 (✓ API compatible changes)
* `rattler_index`: 0.24.5 -> 0.24.6 (✓ API compatible changes)
* `rattler_networking`: 0.25.7 -> 0.25.8
* `rattler_package_streaming`: 0.22.46 -> 0.22.47
* `rattler_menuinst`: 0.2.18 -> 0.2.19
* `rattler_virtual_packages`: 2.1.0 -> 2.1.1
* `rattler_upload`: 0.1.1 -> 0.1.2

### ⚠ `rattler_conda_types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field PackageRecord.experimental_extra_depends in /tmp/.tmpQ1RHzq/rattler/crates/rattler_conda_types/src/repo_data/mod.rs:125
  field IndexJson.experimental_extra_depends in /tmp/.tmpQ1RHzq/rattler/crates/rattler_conda_types/src/package/index.rs:45

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field extra_depends of struct PackageRecord, previously in file /tmp/.tmpEb2ktM/rattler_conda_types/src/repo_data/mod.rs:124
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `path_resolver`

<blockquote>

## [0.1.2](https://github.com/conda/rattler/compare/path_resolver-v0.1.1...path_resolver-v0.1.2) - 2025-07-23

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_conda_types`

<blockquote>

## [0.37.0](https://github.com/conda/rattler/compare/rattler_conda_types-v0.36.0...rattler_conda_types-v0.37.0) - 2025-07-23

### Fixed

- indexing `extra-depends` ([#1546](https://github.com/conda/rattler/pull/1546))
</blockquote>

## `rattler_config`

<blockquote>

## [0.2.5](https://github.com/conda/rattler/compare/rattler_config-v0.2.4...rattler_config-v0.2.5) - 2025-07-23

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_cache`

<blockquote>

## [0.3.28](https://github.com/conda/rattler/compare/rattler_cache-v0.3.27...rattler_cache-v0.3.28) - 2025-07-23

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_pty`

<blockquote>

## [0.2.6](https://github.com/conda/rattler/compare/rattler_pty-v0.2.5...rattler_pty-v0.2.6) - 2025-07-23

### Other

- *(rattler_pty)* fix `needless_continue` lint ([#1547](https://github.com/conda/rattler/pull/1547))
</blockquote>

## `rattler_shell`

<blockquote>

## [0.24.6](https://github.com/conda/rattler/compare/rattler_shell-v0.24.5...rattler_shell-v0.24.6) - 2025-07-23

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler`

<blockquote>

## [0.34.9](https://github.com/conda/rattler/compare/rattler-v0.34.8...rattler-v0.34.9) - 2025-07-23

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_solve`

<blockquote>

## [2.1.8](https://github.com/conda/rattler/compare/rattler_solve-v2.1.7...rattler_solve-v2.1.8) - 2025-07-23

### Fixed

- indexing `extra-depends` ([#1546](https://github.com/conda/rattler/pull/1546))
</blockquote>

## `rattler_lock`

<blockquote>

## [0.23.13](https://github.com/conda/rattler/compare/rattler_lock-v0.23.12...rattler_lock-v0.23.13) - 2025-07-23

### Fixed

- indexing `extra-depends` ([#1546](https://github.com/conda/rattler/pull/1546))
</blockquote>

## `rattler_repodata_gateway`

<blockquote>

## [0.23.9](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.8...rattler_repodata_gateway-v0.23.9) - 2025-07-23

### Fixed

- indexing `extra-depends` ([#1546](https://github.com/conda/rattler/pull/1546))
- use channel `subdir` instead of the one from the record ([#1543](https://github.com/conda/rattler/pull/1543))
</blockquote>

## `rattler_index`

<blockquote>

## [0.24.6](https://github.com/conda/rattler/compare/rattler_index-v0.24.5...rattler_index-v0.24.6) - 2025-07-23

### Fixed

- indexing `extra-depends` ([#1546](https://github.com/conda/rattler/pull/1546))
</blockquote>

## `rattler_networking`

<blockquote>

## [0.25.8](https://github.com/conda/rattler/compare/rattler_networking-v0.25.7...rattler_networking-v0.25.8) - 2025-07-23

### Other

- updated the following local packages: rattler_config
</blockquote>

## `rattler_package_streaming`

<blockquote>

## [0.22.47](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.46...rattler_package_streaming-v0.22.47) - 2025-07-23

### Other

- updated the following local packages: rattler_conda_types, rattler_networking
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.19](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.18...rattler_menuinst-v0.2.19) - 2025-07-23

### Other

- updated the following local packages: rattler_conda_types, rattler_shell
</blockquote>

## `rattler_virtual_packages`

<blockquote>

## [2.1.1](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.1.0...rattler_virtual_packages-v2.1.1) - 2025-07-23

### Other

- updated the following local packages: rattler_conda_types
</blockquote>

## `rattler_upload`

<blockquote>

## [0.1.2](https://github.com/conda/rattler/compare/rattler_upload-v0.1.1...rattler_upload-v0.1.2) - 2025-07-23

### Other

- updated the following local packages: rattler_conda_types, rattler_config, rattler_solve, rattler_networking, rattler_package_streaming
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).