### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4075,9 +4075,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.34.9"
+version = "0.34.10"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4621,7 +4621,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "chrono",
  "configparser",
@@ -4815,7 +4815,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.24.6"
+version = "0.24.7"
 dependencies = [
  "anyhow",
  "enum_dispatch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,7 +185,7 @@ zstd = { version = "0.13.3", default-features = false }
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
 file_url = { path = "crates/file_url", version = "=0.2.6", default-features = false }
 path_resolver = { path = "crates/path_resolver", version = "=0.1.2", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.34.9", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.34.10", default-features = false }
 rattler_cache = { path = "crates/rattler_cache", version = "=0.3.28", default-features = false }
 rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.37.0", default-features = false }
 rattler_config = { path = "crates/rattler_config", version = "=0.2.5", default-features = false }
@@ -194,14 +194,14 @@ rattler_index = { path = "crates/rattler_index", version = "=0.24.6", default-fe
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.3", default-features = false }
 rattler_lock = { path = "crates/rattler_lock", version = "=0.23.13", default-features = false }
 rattler_macros = { path = "crates/rattler_macros", version = "=1.0.11", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.19", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.20", default-features = false }
 rattler_networking = { path = "crates/rattler_networking", version = "=0.25.8", default-features = false }
 rattler_pty = { path = "crates/rattler_pty", version = "=0.2.6", default-features = false }
 rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.12", default-features = false }
 rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.47", default-features = false }
 rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.9", default-features = false }
 rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.10", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.24.6", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.24.7", default-features = false }
 rattler_solve = { path = "crates/rattler_solve", version = "=2.1.8", default-features = false }
 rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.1.1", default-features = false }
 

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.10](https://github.com/conda/rattler/compare/rattler-v0.34.9...rattler-v0.34.10) - 2025-07-24
+
+### Fixed
+
+- *(driver)* remove empty directories after unclobbering ([#1555](https://github.com/conda/rattler/pull/1555))
+
 ## [0.34.9](https://github.com/conda/rattler/compare/rattler-v0.34.8...rattler-v0.34.9) - 2025-07-23
 
 ### Other

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.34.9"
+version = "0.34.10"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.20](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.19...rattler_menuinst-v0.2.20) - 2025-07-24
+
+### Other
+
+- updated the following local packages: rattler_shell
+
 ## [0.2.19](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.18...rattler_menuinst-v0.2.19) - 2025-07-23
 
 ### Other

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.19"
+version = "0.2.20"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.7](https://github.com/conda/rattler/compare/rattler_shell-v0.24.6...rattler_shell-v0.24.7) - 2025-07-24
+
+### Fixed
+
+- allow variable expansion ([#1552](https://github.com/conda/rattler/pull/1552))
+
 ## [0.24.6](https://github.com/conda/rattler/compare/rattler_shell-v0.24.5...rattler_shell-v0.24.6) - 2025-07-23
 
 ### Other

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.24.6"
+version = "0.24.7"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"


### PR DESCRIPTION



## 🤖 New release

* `rattler_shell`: 0.24.6 -> 0.24.7 (✓ API compatible changes)
* `rattler`: 0.34.9 -> 0.34.10 (✓ API compatible changes)
* `rattler_menuinst`: 0.2.19 -> 0.2.20

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_shell`

<blockquote>

## [0.24.7](https://github.com/conda/rattler/compare/rattler_shell-v0.24.6...rattler_shell-v0.24.7) - 2025-07-24

### Fixed

- allow variable expansion ([#1552](https://github.com/conda/rattler/pull/1552))
</blockquote>

## `rattler`

<blockquote>

## [0.34.10](https://github.com/conda/rattler/compare/rattler-v0.34.9...rattler-v0.34.10) - 2025-07-24

### Fixed

- *(driver)* remove empty directories after unclobbering ([#1555](https://github.com/conda/rattler/pull/1555))
</blockquote>

## `rattler_menuinst`

<blockquote>

## [0.2.20](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.19...rattler_menuinst-v0.2.20) - 2025-07-24

### Other

- updated the following local packages: rattler_shell
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).