### PR TITLE
fix(driver): remove empty directories after unclobbering

### DIFF
--- a/crates/rattler/src/install/driver.rs
+++ b/crates/rattler/src/install/driver.rs
@@ -222,14 +222,14 @@ impl InstallDriver {
         let required_packages =
             PackageRecord::sort_topologically(prefix_records.iter().collect::<Vec<_>>());
 
+        let clobbered_paths = self
+            .clobber_registry()
+            .unclobber(&required_packages, target_prefix)?;
+
         self.remove_empty_directories(&transaction.operations, &prefix_records, target_prefix)
             .unwrap_or_else(|e| {
                 tracing::warn!("Failed to remove empty directories: {} (ignored)", e);
             });
-
-        let clobbered_paths = self
-            .clobber_registry()
-            .unclobber(&required_packages, target_prefix)?;
 
         let post_link_result = if self.execute_link_scripts {
             Some(self.run_post_link_scripts(transaction, &required_packages, target_prefix))


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Before it could leave empty directories in the `__clobbers__` directory, which could cause issues with unclobbering next time. This is also was aesthetically unpleasing.