### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,7 +2263,7 @@ dependencies = [
  "google-cloud-gax",
  "http 1.3.1",
  "reqwest",
- "rustls 0.23.30",
+ "rustls 0.23.29",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -2655,7 +2655,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.30",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -3060,11 +3060,11 @@ dependencies = [
 
 [[package]]
 name = "known-folders"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d9a1740cc8b46e259a0eb787d79d855e79ff10b9855a5eba58868d5da7927c"
+checksum = "c644f4623d1c55eb60a9dac35e0858a59f982fb87db6ce34c872372b0a5b728f"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3124,7 +3124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -3135,13 +3135,13 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.16",
+ "redox_syscall 0.5.17",
 ]
 
 [[package]]
@@ -3761,7 +3761,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.16",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4173,7 +4173,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.30",
+ "rustls 0.23.29",
  "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
@@ -4193,7 +4193,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.30",
+ "rustls 0.23.29",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -4511,7 +4511,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.12",
- "toml 0.9.2",
+ "toml 0.9.3",
  "tracing",
  "url",
 ]
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.24.7"
+version = "0.24.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4863,7 +4863,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -4951,9 +4951,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -5124,7 +5124,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.30",
+ "rustls 0.23.29",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
@@ -5371,9 +5371,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.30"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069a8df149a16b1a12dcc31497c3396a173844be3cac4bd40c9e7671fef96671"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "log",
  "once_cell",
@@ -6379,7 +6379,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.30",
+ "rustls 0.23.29",
  "tokio",
 ]
 
@@ -6419,9 +6419,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "e06723639aaded957e5a80be250c1f82f274b9d23ebb4d94163668470623461c"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
@@ -6649,7 +6649,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.9.2",
+ "toml 0.9.3",
 ]
 
 [[package]]
@@ -7223,7 +7223,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -7259,10 +7259,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ rattler_cache = { path = "crates/rattler_cache", version = "=0.3.29", default-fe
 rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.37.0", default-features = false }
 rattler_config = { path = "crates/rattler_config", version = "=0.2.5", default-features = false }
 rattler_digest = { path = "crates/rattler_digest", version = "=1.1.5", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.24.7", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.24.8", default-features = false }
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.3", default-features = false }
 rattler_lock = { path = "crates/rattler_lock", version = "=0.23.13", default-features = false }
 rattler_macros = { path = "crates/rattler_macros", version = "=1.0.11", default-features = false }

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.8](https://github.com/conda/rattler/compare/rattler_index-v0.24.7...rattler_index-v0.24.8) - 2025-07-29
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.24.7](https://github.com/conda/rattler/compare/rattler_index-v0.24.6...rattler_index-v0.24.7) - 2025-07-28
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.24.7"
+version = "0.24.8"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_upload/CHANGELOG.md
+++ b/crates/rattler_upload/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/conda/rattler/compare/rattler_upload-v0.1.3...rattler_upload-v0.1.4) - 2025-07-29
+
+### Other
+
+- *(ci)* Update Rust crate opendal to 0.54.0 ([#1566](https://github.com/conda/rattler/pull/1566))
+
 ## [0.1.3](https://github.com/conda/rattler/compare/rattler_upload-v0.1.2...rattler_upload-v0.1.3) - 2025-07-28
 
 ### Other

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_upload"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>", "Magenta Qin <magenta2127@gmail.com>"]
 description = "A crate to Upload conda packages to various channels."


### PR DESCRIPTION



## 🤖 New release

* `rattler_index`: 0.24.7 -> 0.24.8 (✓ API compatible changes)
* `rattler_upload`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `rattler_index`

<blockquote>

## [0.24.8](https://github.com/conda/rattler/compare/rattler_index-v0.24.7...rattler_index-v0.24.8) - 2025-07-29

### Other

- update Cargo.toml dependencies
</blockquote>

## `rattler_upload`

<blockquote>

## [0.1.4](https://github.com/conda/rattler/compare/rattler_upload-v0.1.3...rattler_upload-v0.1.4) - 2025-07-29

### Other

- *(ci)* Update Rust crate opendal to 0.54.0 ([#1566](https://github.com/conda/rattler/pull/1566))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).