### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,9 +815,9 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
 dependencies = [
  "fastrand",
  "gloo-timers",
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "jobserver",
  "libc",
@@ -1194,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+checksum = "ed87a9d530bb41a67537289bafcac159cb3ee28460e0a4571123d2a778a6a882"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1215,9 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.41"
+version = "4.5.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+checksum = "64f4f3f3c77c94aff3c7e9aac9a2ca1974a5adf392a8bb751e827d6d127ab966"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2264,7 +2264,7 @@ dependencies = [
  "http 1.3.1",
  "reqwest",
  "rustc_version",
- "rustls 0.23.30",
+ "rustls 0.23.31",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -2656,7 +2656,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.30",
+ "rustls 0.23.31",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -3052,11 +3052,11 @@ dependencies = [
 
 [[package]]
 name = "known-folders"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d9a1740cc8b46e259a0eb787d79d855e79ff10b9855a5eba58868d5da7927c"
+checksum = "c644f4623d1c55eb60a9dac35e0858a59f982fb87db6ce34c872372b0a5b728f"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3116,7 +3116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -3127,13 +3127,13 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.16",
+ "redox_syscall 0.5.17",
 ]
 
 [[package]]
@@ -3753,7 +3753,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.16",
+ "redox_syscall 0.5.17",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -4167,7 +4167,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.30",
+ "rustls 0.23.31",
  "socket2 0.5.10",
  "thiserror 2.0.12",
  "tokio",
@@ -4187,7 +4187,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.30",
+ "rustls 0.23.31",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -4329,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.34.11"
+version = "0.34.12"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4407,7 +4407,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.29"
+version = "0.3.30"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4445,7 +4445,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "console 0.16.0",
  "fs-err",
@@ -4505,7 +4505,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.12",
- "toml 0.9.3",
+ "toml 0.9.4",
  "tracing",
  "url",
 ]
@@ -4531,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.24.7"
+version = "0.24.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.23.13"
+version = "0.23.14"
 dependencies = [
  "chrono",
  "file_url",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "chrono",
  "configparser",
@@ -4644,7 +4644,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.8"
+version = "0.25.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4680,7 +4680,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.22.48"
+version = "0.22.49"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.23.10"
+version = "0.23.11"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.24.7"
+version = "0.24.8"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "2.1.8"
+version = "2.1.9"
 dependencies = [
  "chrono",
  "criterion",
@@ -4857,7 +4857,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -4890,7 +4890,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "archspec",
  "libloading",
@@ -4945,18 +4945,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.16"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7251471db004e509f4e75a62cca9435365b5ec7bcdff530d612ac7c87c44a792"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -5118,7 +5118,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.30",
+ "rustls 0.23.31",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
@@ -5365,9 +5365,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.30"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069a8df149a16b1a12dcc31497c3396a173844be3cac4bd40c9e7671fef96671"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
@@ -5666,9 +5666,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.141"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
@@ -6318,9 +6318,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6373,7 +6373,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.30",
+ "rustls 0.23.31",
  "tokio",
 ]
 
@@ -6413,9 +6413,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06723639aaded957e5a80be250c1f82f274b9d23ebb4d94163668470623461c"
+checksum = "41ae868b5a0f67631c14589f7e250c1ea2c574ee5ba21c6c8dd4b1485705a5a1"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
@@ -6632,9 +6632,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.106"
+version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65af40ad689f2527aebbd37a0a816aea88ff5f774ceabe99de5be02f2f91dae2"
+checksum = "32e257d7246e7a9fd015fb0b28b330a8d4142151a33f03e6a497754f4b1f6a8e"
 dependencies = [
  "dissimilar",
  "glob",
@@ -6643,7 +6643,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.9.3",
+ "toml 0.9.4",
 ]
 
 [[package]]
@@ -7217,7 +7217,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -7253,10 +7253,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,25 +185,25 @@ zstd = { version = "0.13.3", default-features = false }
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
 file_url = { path = "crates/file_url", version = "=0.2.6", default-features = false }
 path_resolver = { path = "crates/path_resolver", version = "=0.1.2", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.34.11", default-features = false }
-rattler_cache = { path = "crates/rattler_cache", version = "=0.3.29", default-features = false }
-rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.37.0", default-features = false }
-rattler_config = { path = "crates/rattler_config", version = "=0.2.5", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.34.12", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.30", default-features = false }
+rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.37.1", default-features = false }
+rattler_config = { path = "crates/rattler_config", version = "=0.2.6", default-features = false }
 rattler_digest = { path = "crates/rattler_digest", version = "=1.1.5", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.24.7", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.24.8", default-features = false }
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.3", default-features = false }
-rattler_lock = { path = "crates/rattler_lock", version = "=0.23.13", default-features = false }
+rattler_lock = { path = "crates/rattler_lock", version = "=0.23.14", default-features = false }
 rattler_macros = { path = "crates/rattler_macros", version = "=1.0.11", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.20", default-features = false }
-rattler_networking = { path = "crates/rattler_networking", version = "=0.25.8", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.21", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.25.9", default-features = false }
 rattler_pty = { path = "crates/rattler_pty", version = "=0.2.6", default-features = false }
 rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.12", default-features = false }
-rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.48", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.10", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.49", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.11", default-features = false }
 rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.10", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.24.7", default-features = false }
-rattler_solve = { path = "crates/rattler_solve", version = "=2.1.8", default-features = false }
-rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.1.1", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.24.8", default-features = false }
+rattler_solve = { path = "crates/rattler_solve", version = "=2.1.9", default-features = false }
+rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.1.2", default-features = false }
 
 # This is also a rattler crate, but we only pin it to minor version
 simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.34.12](https://github.com/conda/rattler/compare/rattler-v0.34.11...rattler-v0.34.12) - 2025-08-01
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_cache, rattler_package_streaming, rattler_shell, rattler_menuinst
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.34.11"
+version = "0.34.12"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.30](https://github.com/conda/rattler/compare/rattler_cache-v0.3.29...rattler_cache-v0.3.30) - 2025-08-01
+
+### Fixed
+
+- improve hash mismatch warning to include package path ([#1573](https://github.com/conda/rattler/pull/1573))
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.29"
+version = "0.3.30"
 description = "A crate to manage the caching of data in rattler"
 categories = { workspace = true }
 homepage = { workspace = true }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.37.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.37.0...rattler_conda_types-v0.37.1) - 2025-08-01
+
+### Other
+
+- update Cargo.toml dependencies
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.37.0"
+version = "0.37.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_config/CHANGELOG.md
+++ b/crates/rattler_config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/conda/rattler/compare/rattler_config-v0.2.5...rattler_config-v0.2.6) - 2025-08-01
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.2.5](https://github.com/conda/rattler/compare/rattler_config-v0.2.4...rattler_config-v0.2.5) - 2025-07-23
 
 ### Other

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_config"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 authors = []
 description = "A crate to configure rattler and derived tools."

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.24.8](https://github.com/conda/rattler/compare/rattler_index-v0.24.7...rattler_index-v0.24.8) - 2025-08-01
+
+### Other
+
+- update Cargo.toml dependencies
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.24.7"
+version = "0.24.8"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.23.14](https://github.com/conda/rattler/compare/rattler_lock-v0.23.13...rattler_lock-v0.23.14) - 2025-08-01
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_solve
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.23.13"
+version = "0.23.14"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.21](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.20...rattler_menuinst-v0.2.21) - 2025-08-01
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_shell
+
 ## [0.2.20](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.19...rattler_menuinst-v0.2.20) - 2025-07-24
 
 ### Other

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.20"
+version = "0.2.21"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.25.9](https://github.com/conda/rattler/compare/rattler_networking-v0.25.8...rattler_networking-v0.25.9) - 2025-08-01
+
+### Other
+
+- update Cargo.toml dependencies
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.25.8"
+version = "0.25.9"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.22.49](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.48...rattler_package_streaming-v0.22.49) - 2025-08-01
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.48"
+version = "0.22.49"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.23.11](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.10...rattler_repodata_gateway-v0.23.11) - 2025-08-01
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_cache, rattler_config
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.23.10"
+version = "0.23.11"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.24.8](https://github.com/conda/rattler/compare/rattler_shell-v0.24.7...rattler_shell-v0.24.8) - 2025-08-01
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.24.7"
+version = "0.24.8"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.1.9](https://github.com/conda/rattler/compare/rattler_solve-v2.1.8...rattler_solve-v2.1.9) - 2025-08-01
+
+### Other
+
+- `resolvo` bump ([#1576](https://github.com/conda/rattler/pull/1576))
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "2.1.8"
+version = "2.1.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"

--- a/crates/rattler_upload/CHANGELOG.md
+++ b/crates/rattler_upload/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/conda/rattler/compare/rattler_upload-v0.1.3...rattler_upload-v0.1.4) - 2025-08-01
+
+### Other
+
+- *(ci)* Update Rust crate opendal to 0.54.0 ([#1566](https://github.com/conda/rattler/pull/1566))
+
 ## [0.1.3](https://github.com/conda/rattler/compare/rattler_upload-v0.1.2...rattler_upload-v0.1.3) - 2025-07-28
 
 ### Other

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_upload"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>", "Magenta Qin <magenta2127@gmail.com>"]
 description = "A crate to Upload conda packages to various channels."

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.1.2](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.1.1...rattler_virtual_packages-v2.1.2) - 2025-08-01
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.1.1"
+version = "2.1.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION



## 🤖 New release

* `rattler_conda_types`: 0.37.0 -> 0.37.1 (✓ API compatible changes)
* `rattler_networking`: 0.25.8 -> 0.25.9 (✓ API compatible changes)
* `rattler_cache`: 0.3.29 -> 0.3.30 (✓ API compatible changes)
* `rattler_solve`: 2.1.8 -> 2.1.9 (✓ API compatible changes)
* `rattler_index`: 0.24.7 -> 0.24.8 (✓ API compatible changes)
* `rattler_upload`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `rattler_config`: 0.2.5 -> 0.2.6
* `rattler_package_streaming`: 0.22.48 -> 0.22.49
* `rattler_shell`: 0.24.7 -> 0.24.8
* `rattler_menuinst`: 0.2.20 -> 0.2.21
* `rattler`: 0.34.11 -> 0.34.12
* `rattler_lock`: 0.23.13 -> 0.23.14
* `rattler_repodata_gateway`: 0.23.10 -> 0.23.11
* `rattler_virtual_packages`: 2.1.1 -> 2.1.2

<details><summary><i><b>Changelog</b></i></summary><p>






## `rattler_upload`

<blockquote>

## [0.1.4](https://github.com/conda/rattler/compare/rattler_upload-v0.1.3...rattler_upload-v0.1.4) - 2025-08-01

### Other

- *(ci)* Update Rust crate opendal to 0.54.0 ([#1566](https://github.com/conda/rattler/pull/1566))
</blockquote>

## `rattler_config`

<blockquote>

## [0.2.6](https://github.com/conda/rattler/compare/rattler_config-v0.2.5...rattler_config-v0.2.6) - 2025-08-01

### Other

- updated the following local packages: rattler_conda_types
</blockquote>



## `rattler_menuinst`

<blockquote>

## [0.2.21](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.20...rattler_menuinst-v0.2.21) - 2025-08-01

### Other

- updated the following local packages: rattler_conda_types, rattler_shell
</blockquote>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).