### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,25 +185,25 @@ zstd = { version = "0.13.3", default-features = false }
 # These are the all the crates defined in the workspace. We pin all of them together because they are always updated in tendem.
 file_url = { path = "crates/file_url", version = "=0.2.6", default-features = false }
 path_resolver = { path = "crates/path_resolver", version = "=0.1.2", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.34.11", default-features = false }
-rattler_cache = { path = "crates/rattler_cache", version = "=0.3.29", default-features = false }
-rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.37.0", default-features = false }
-rattler_config = { path = "crates/rattler_config", version = "=0.2.5", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.34.12", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.30", default-features = false }
+rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.37.1", default-features = false }
+rattler_config = { path = "crates/rattler_config", version = "=0.2.6", default-features = false }
 rattler_digest = { path = "crates/rattler_digest", version = "=1.1.5", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.24.7", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.24.8", default-features = false }
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.3", default-features = false }
-rattler_lock = { path = "crates/rattler_lock", version = "=0.23.13", default-features = false }
+rattler_lock = { path = "crates/rattler_lock", version = "=0.23.14", default-features = false }
 rattler_macros = { path = "crates/rattler_macros", version = "=1.0.11", default-features = false }
-rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.20", default-features = false }
-rattler_networking = { path = "crates/rattler_networking", version = "=0.25.8", default-features = false }
+rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.21", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.25.9", default-features = false }
 rattler_pty = { path = "crates/rattler_pty", version = "=0.2.6", default-features = false }
 rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.12", default-features = false }
-rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.22.48", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.10", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.23.0", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.23.11", default-features = false }
 rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.10", default-features = false }
-rattler_shell = { path = "crates/rattler_shell", version = "=0.24.7", default-features = false }
-rattler_solve = { path = "crates/rattler_solve", version = "=2.1.8", default-features = false }
-rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.1.1", default-features = false }
+rattler_shell = { path = "crates/rattler_shell", version = "=0.24.8", default-features = false }
+rattler_solve = { path = "crates/rattler_solve", version = "=2.1.9", default-features = false }
+rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.1.2", default-features = false }
 
 # This is also a rattler crate, but we only pin it to minor version
 simple_spawn_blocking = { path = "crates/simple_spawn_blocking", version = "1.1", default-features = false }

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.34.12](https://github.com/conda/rattler/compare/rattler-v0.34.11...rattler-v0.34.12) - 2025-08-05
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_package_streaming, rattler_cache, rattler_shell, rattler_menuinst
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.34.11"
+version = "0.34.12"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -1,4 +1,23 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.30](https://github.com/conda/rattler/compare/rattler_cache-v0.3.29...rattler_cache-v0.3.30) - 2025-08-05
+
+### Added
+
+- Redact token in url when reporting a HashMismatch error ([#1579](https://github.com/conda/rattler/pull/1579))
+- Provide more details when hash mismatch occurs ([#1577](https://github.com/conda/rattler/pull/1577))
+
+### Fixed
+
+- improve hash mismatch warning to include package path ([#1573](https://github.com/conda/rattler/pull/1573))
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.29"
+version = "0.3.30"
 description = "A crate to manage the caching of data in rattler"
 categories = { workspace = true }
 homepage = { workspace = true }

--- a/crates/rattler_conda_types/CHANGELOG.md
+++ b/crates/rattler_conda_types/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.37.1](https://github.com/conda/rattler/compare/rattler_conda_types-v0.37.0...rattler_conda_types-v0.37.1) - 2025-08-05
+
+### Other
+
+- update Cargo.toml dependencies
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_conda_types"
-version = "0.37.0"
+version = "0.37.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for common types used within the Conda ecosystem"

--- a/crates/rattler_config/CHANGELOG.md
+++ b/crates/rattler_config/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/conda/rattler/compare/rattler_config-v0.2.5...rattler_config-v0.2.6) - 2025-08-05
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+
 ## [0.2.5](https://github.com/conda/rattler/compare/rattler_config-v0.2.4...rattler_config-v0.2.5) - 2025-07-23
 
 ### Other

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_config"
-version = "0.2.5"
+version = "0.2.6"
 edition.workspace = true
 authors = []
 description = "A crate to configure rattler and derived tools."

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.24.8](https://github.com/conda/rattler/compare/rattler_index-v0.24.7...rattler_index-v0.24.8) - 2025-08-05
+
+### Other
+
+- update Cargo.toml dependencies
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.24.7"
+version = "0.24.8"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_lock/CHANGELOG.md
+++ b/crates/rattler_lock/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.23.14](https://github.com/conda/rattler/compare/rattler_lock-v0.23.13...rattler_lock-v0.23.14) - 2025-08-05
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_solve
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.23.13"
+version = "0.23.14"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock"

--- a/crates/rattler_menuinst/CHANGELOG.md
+++ b/crates/rattler_menuinst/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.21](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.20...rattler_menuinst-v0.2.21) - 2025-08-05
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_shell
+
 ## [0.2.20](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.19...rattler_menuinst-v0.2.20) - 2025-07-24
 
 ### Other

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_menuinst"
-version = "0.2.20"
+version = "0.2.21"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Install menu entries for a Conda package"

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.25.9](https://github.com/conda/rattler/compare/rattler_networking-v0.25.8...rattler_networking-v0.25.9) - 2025-08-05
+
+### Other
+
+- update Cargo.toml dependencies
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.25.8"
+version = "0.25.9"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.23.0](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.22.48...rattler_package_streaming-v0.23.0) - 2025-08-05
+
+### Added
+
+- Provide more details when hash mismatch occurs ([#1577](https://github.com/conda/rattler/pull/1577))
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.22.48"
+version = "0.23.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.23.11](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.23.10...rattler_repodata_gateway-v0.23.11) - 2025-08-05
+
+### Other
+
+- updated the following local packages: rattler_conda_types, rattler_networking, rattler_cache, rattler_config
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.23.10"
+version = "0.23.11"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_shell/CHANGELOG.md
+++ b/crates/rattler_shell/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.24.8](https://github.com/conda/rattler/compare/rattler_shell-v0.24.7...rattler_shell-v0.24.8) - 2025-08-05
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_shell"
-version = "0.24.7"
+version = "0.24.8"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "A crate to help with activation and deactivation of a conda environment"

--- a/crates/rattler_solve/CHANGELOG.md
+++ b/crates/rattler_solve/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.1.9](https://github.com/conda/rattler/compare/rattler_solve-v2.1.8...rattler_solve-v2.1.9) - 2025-08-05
+
+### Other
+
+- `resolvo` bump ([#1576](https://github.com/conda/rattler/pull/1576))
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_solve"
-version = "2.1.8"
+version = "2.1.9"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to solve conda environments"

--- a/crates/rattler_upload/CHANGELOG.md
+++ b/crates/rattler_upload/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/conda/rattler/compare/rattler_upload-v0.1.3...rattler_upload-v0.1.4) - 2025-08-05
+
+### Other
+
+- *(ci)* Update Rust crate opendal to 0.54.0 ([#1566](https://github.com/conda/rattler/pull/1566))
+
 ## [0.1.3](https://github.com/conda/rattler/compare/rattler_upload-v0.1.2...rattler_upload-v0.1.3) - 2025-07-28
 
 ### Other

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_upload"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>", "Magenta Qin <magenta2127@gmail.com>"]
 description = "A crate to Upload conda packages to various channels."

--- a/crates/rattler_virtual_packages/CHANGELOG.md
+++ b/crates/rattler_virtual_packages/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.1.2](https://github.com/conda/rattler/compare/rattler_virtual_packages-v2.1.1...rattler_virtual_packages-v2.1.2) - 2025-08-05
+
+### Other
+
+- updated the following local packages: rattler_conda_types
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_virtual_packages"
-version = "2.1.1"
+version = "2.1.2"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Library to work with and detect Conda virtual packages"


### PR DESCRIPTION



## 🤖 New release

* `rattler_conda_types`: 0.37.0 -> 0.37.1 (✓ API compatible changes)
* `rattler_networking`: 0.25.8 -> 0.25.9 (✓ API compatible changes)
* `rattler_package_streaming`: 0.22.48 -> 0.23.0 (⚠ API breaking changes)
* `rattler_cache`: 0.3.29 -> 0.3.30 (✓ API compatible changes)
* `rattler_solve`: 2.1.8 -> 2.1.9 (✓ API compatible changes)
* `rattler_index`: 0.24.7 -> 0.24.8 (✓ API compatible changes)
* `rattler_upload`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `rattler_config`: 0.2.5 -> 0.2.6
* `rattler_shell`: 0.24.7 -> 0.24.8
* `rattler_menuinst`: 0.2.20 -> 0.2.21
* `rattler`: 0.34.11 -> 0.34.12
* `rattler_lock`: 0.23.13 -> 0.23.14
* `rattler_repodata_gateway`: 0.23.10 -> 0.23.11
* `rattler_virtual_packages`: 2.1.1 -> 2.1.2

### ⚠ `rattler_package_streaming` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ExtractResult.total_size in /tmp/.tmpSr2BPP/rattler/crates/rattler_package_streaming/src/lib.rs:100

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field url of variant ExtractError::HashMismatch in /tmp/.tmpSr2BPP/rattler/crates/rattler_package_streaming/src/lib.rs:35
  field destination of variant ExtractError::HashMismatch in /tmp/.tmpSr2BPP/rattler/crates/rattler_package_streaming/src/lib.rs:36
  field total_size of variant ExtractError::HashMismatch in /tmp/.tmpSr2BPP/rattler/crates/rattler_package_streaming/src/lib.rs:39
```

<details><summary><i><b>Changelog</b></i></summary><p>







## `rattler_upload`

<blockquote>

## [0.1.4](https://github.com/conda/rattler/compare/rattler_upload-v0.1.3...rattler_upload-v0.1.4) - 2025-08-05

### Other

- *(ci)* Update Rust crate opendal to 0.54.0 ([#1566](https://github.com/conda/rattler/pull/1566))
</blockquote>

## `rattler_config`

<blockquote>

## [0.2.6](https://github.com/conda/rattler/compare/rattler_config-v0.2.5...rattler_config-v0.2.6) - 2025-08-05

### Other

- updated the following local packages: rattler_conda_types
</blockquote>


## `rattler_menuinst`

<blockquote>

## [0.2.21](https://github.com/conda/rattler/compare/rattler_menuinst-v0.2.20...rattler_menuinst-v0.2.21) - 2025-08-05

### Other

- updated the following local packages: rattler_conda_types, rattler_shell
</blockquote>






</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).