### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,7 +4440,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.3.32"
+version = "0.3.33"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4647,7 +4647,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.24.12"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.11"
+version = "0.25.12"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -4798,7 +4798,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "assert_matches",
  "bzip2",
@@ -4850,7 +4850,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.24.2"
+version = "0.24.3"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4933,7 +4933,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_sandbox"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "birdcage",
  "clap",
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_upload"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -7839,9 +7839,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,26 +179,26 @@ zstd = { version = "0.13.3", default-features = false }
 coalesced_map = { path = "crates/coalesced_map", version = "=0.1.1", default-features = false }
 file_url = { path = "crates/file_url", version = "=0.2.6", default-features = false }
 path_resolver = { path = "crates/path_resolver", version = "=0.2.0", default-features = false }
-rattler = { path = "crates/rattler", version = "=0.37.0", default-features = false }
-rattler_cache = { path = "crates/rattler_cache", version = "=0.3.32", default-features = false }
+rattler = { path = "crates/rattler", version = "=0.37.1", default-features = false }
+rattler_cache = { path = "crates/rattler_cache", version = "=0.3.33", default-features = false }
 rattler_conda_types = { path = "crates/rattler_conda_types", version = "=0.39.1", default-features = false }
 rattler_config = { path = "crates/rattler_config", version = "=0.2.8", default-features = false }
 rattler_digest = { path = "crates/rattler_digest", version = "=1.1.5", default-features = false }
-rattler_index = { path = "crates/rattler_index", version = "=0.24.12", default-features = false }
+rattler_index = { path = "crates/rattler_index", version = "=0.25.0", default-features = false }
 rattler_libsolv_c = { path = "crates/rattler_libsolv_c", version = "=1.2.3", default-features = false }
 rattler_lock = { path = "crates/rattler_lock", version = "=0.24.0", default-features = false }
 rattler_macros = { path = "crates/rattler_macros", version = "=1.0.11", default-features = false }
 rattler_menuinst = { path = "crates/rattler_menuinst", version = "=0.2.24", default-features = false }
-rattler_networking = { path = "crates/rattler_networking", version = "=0.25.11", default-features = false }
-rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.23.2", default-features = false }
+rattler_networking = { path = "crates/rattler_networking", version = "=0.25.12", default-features = false }
+rattler_package_streaming = { path = "crates/rattler_package_streaming", version = "=0.23.3", default-features = false }
 rattler_pty = { path = "crates/rattler_pty", version = "=0.2.6", default-features = false }
 rattler_redaction = { path = "crates/rattler_redaction", version = "=0.1.12", default-features = false }
-rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.24.2", default-features = false }
-rattler_s3 = { path = "crates/rattler_s3", version = "=0.1.0", default-features = false }
-rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.10", default-features = false }
+rattler_repodata_gateway = { path = "crates/rattler_repodata_gateway", version = "=0.24.3", default-features = false }
+rattler_s3 = { path = "crates/rattler_s3", version = "=0.1.1", default-features = false }
+rattler_sandbox = { path = "crates/rattler_sandbox", version = "=0.1.11", default-features = false }
 rattler_shell = { path = "crates/rattler_shell", version = "=0.24.10", default-features = false }
 rattler_solve = { path = "crates/rattler_solve", version = "=3.0.2", default-features = false }
-rattler_upload = { path = "crates/rattler_upload", version = "=0.2.1", default-features = false }
+rattler_upload = { path = "crates/rattler_upload", version = "=0.3.0", default-features = false }
 rattler_virtual_packages = { path = "crates/rattler_virtual_packages", version = "=2.1.4", default-features = false }
 
 # This is also a rattler crate, but we only pin it to minor version

--- a/crates/rattler/CHANGELOG.md
+++ b/crates/rattler/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.1](https://github.com/conda/rattler/compare/rattler-v0.37.0...rattler-v0.37.1) - 2025-09-04
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.37.0](https://github.com/conda/rattler/compare/rattler-v0.36.1...rattler-v0.37.0) - 2025-09-04
 
 ### Fixed

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler"
-version = "0.37.0"
+version = "0.37.1"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust library to install conda environments"

--- a/crates/rattler_cache/CHANGELOG.md
+++ b/crates/rattler_cache/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.33](https://github.com/conda/rattler/compare/rattler_cache-v0.3.32...rattler_cache-v0.3.33) - 2025-09-04
+
+### Other
+
+- updated the following local packages: rattler_networking, rattler_package_streaming
+
 ## [0.3.32](https://github.com/conda/rattler/compare/rattler_cache-v0.3.31...rattler_cache-v0.3.32) - 2025-09-02
 
 ### Other

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_cache"
-version = "0.3.32"
+version = "0.3.33"
 description = "A crate to manage the caching of data in rattler"
 categories = { workspace = true }
 homepage = { workspace = true }

--- a/crates/rattler_index/CHANGELOG.md
+++ b/crates/rattler_index/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/conda/rattler/compare/rattler_index-v0.24.12...rattler_index-v0.25.0) - 2025-09-04
+
+### Added
+
+- derive default credentials from aws sdk ([#1629](https://github.com/conda/rattler/pull/1629))
+
 ## [0.24.12](https://github.com/conda/rattler/compare/rattler_index-v0.24.11...rattler_index-v0.24.12) - 2025-09-02
 
 ### Other

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_index"
-version = "0.24.12"
+version = "0.25.0"
 edition.workspace = true
 authors = []
 description = "A crate to index conda channels and create a repodata.json file."

--- a/crates/rattler_networking/CHANGELOG.md
+++ b/crates/rattler_networking/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.12](https://github.com/conda/rattler/compare/rattler_networking-v0.25.11...rattler_networking-v0.25.12) - 2025-09-04
+
+### Added
+
+- derive default credentials from aws sdk ([#1629](https://github.com/conda/rattler/pull/1629))
+
 ## [0.25.11](https://github.com/conda/rattler/compare/rattler_networking-v0.25.10...rattler_networking-v0.25.11) - 2025-09-02
 
 ### Other

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_networking"
-version = "0.25.11"
+version = "0.25.12"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>"]
 description = "Authenticated requests in the conda ecosystem"

--- a/crates/rattler_package_streaming/CHANGELOG.md
+++ b/crates/rattler_package_streaming/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.3](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.23.2...rattler_package_streaming-v0.23.3) - 2025-09-04
+
+### Other
+
+- updated the following local packages: rattler_networking
+
 ## [0.23.2](https://github.com/conda/rattler/compare/rattler_package_streaming-v0.23.1...rattler_package_streaming-v0.23.2) - 2025-09-02
 
 ### Other

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_package_streaming"
-version = "0.23.2"
+version = "0.23.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Extract and stream of Conda package archives"

--- a/crates/rattler_repodata_gateway/CHANGELOG.md
+++ b/crates/rattler_repodata_gateway/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.3](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.24.2...rattler_repodata_gateway-v0.24.3) - 2025-09-04
+
+### Added
+
+- derive default credentials from aws sdk ([#1629](https://github.com/conda/rattler/pull/1629))
+
 ## [0.24.2](https://github.com/conda/rattler/compare/rattler_repodata_gateway-v0.24.1...rattler_repodata_gateway-v0.24.2) - 2025-09-02
 
 ### Other

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_repodata_gateway"
-version = "0.24.2"
+version = "0.24.3"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "A crate to interact with Conda repodata"

--- a/crates/rattler_s3/CHANGELOG.md
+++ b/crates/rattler_s3/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/conda/rattler/compare/rattler_s3-v0.1.0...rattler_s3-v0.1.1) - 2025-09-04
+
+### Other
+
+- updated the following local packages: rattler_networking

--- a/crates/rattler_s3/Cargo.toml
+++ b/crates/rattler_s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_s3"
-version = "0.1.0"
+version = "0.1.1"
 description = "A crate to streamline interaction with S3 storage for rattler"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_sandbox/CHANGELOG.md
+++ b/crates/rattler_sandbox/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.11](https://github.com/conda/rattler/compare/rattler_sandbox-v0.1.10...rattler_sandbox-v0.1.11) - 2025-09-04
+
+### Other
+
+- update Cargo.toml dependencies
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/crates/rattler_sandbox/Cargo.toml
+++ b/crates/rattler_sandbox/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_sandbox"
-version = "0.1.10"
+version = "0.1.11"
 description = "A crate to run executables in a sandbox"
 categories.workspace = true
 homepage.workspace = true

--- a/crates/rattler_upload/CHANGELOG.md
+++ b/crates/rattler_upload/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/conda/rattler/compare/rattler_upload-v0.2.1...rattler_upload-v0.3.0) - 2025-09-04
+
+### Added
+
+- derive default credentials from aws sdk ([#1629](https://github.com/conda/rattler/pull/1629))
+
 ## [0.2.1](https://github.com/conda/rattler/compare/rattler_upload-v0.2.0...rattler_upload-v0.2.1) - 2025-09-02
 
 ### Other

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_upload"
-version = "0.2.1"
+version = "0.3.0"
 edition.workspace = true
 authors = ["Wolf Vollprecht <w.vollprecht@gmail.com>", "Magenta Qin <magenta2127@gmail.com>"]
 description = "A crate to Upload conda packages to various channels."


### PR DESCRIPTION



## 🤖 New release

* `rattler_networking`: 0.25.11 -> 0.25.12 (✓ API compatible changes)
* `rattler`: 0.37.0 -> 0.37.1 (✓ API compatible changes)
* `rattler_repodata_gateway`: 0.24.2 -> 0.24.3 (✓ API compatible changes)
* `rattler_upload`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `rattler_index`: 0.24.12 -> 0.25.0 (⚠ API breaking changes)
* `rattler_sandbox`: 0.1.10 -> 0.1.11 (✓ API compatible changes)
* `rattler_package_streaming`: 0.23.2 -> 0.23.3
* `rattler_cache`: 0.3.32 -> 0.3.33
* `rattler_s3`: 0.1.0 -> 0.1.1

### ⚠ `rattler_upload` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field S3Opts.credentials in /tmp/.tmpT3NP9b/rattler/crates/rattler_upload/src/upload/opt.rs:435
  field S3Opts.force in /tmp/.tmpT3NP9b/rattler/crates/rattler_upload/src/upload/opt.rs:439

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_parameter_count_changed.ron

Failed in:
  rattler_upload::upload::upload_package_to_s3 now takes 5 parameters instead of 9, in /tmp/.tmpT3NP9b/rattler/crates/rattler_upload/src/upload/s3.rs:13

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field endpoint_url of struct S3Opts, previously in file /tmp/.tmpr94ilx/rattler_upload/src/upload/opt.rs:435
  field region of struct S3Opts, previously in file /tmp/.tmpr94ilx/rattler_upload/src/upload/opt.rs:439
  field force_path_style of struct S3Opts, previously in file /tmp/.tmpr94ilx/rattler_upload/src/upload/opt.rs:443
  field access_key_id of struct S3Opts, previously in file /tmp/.tmpr94ilx/rattler_upload/src/upload/opt.rs:447
  field secret_access_key of struct S3Opts, previously in file /tmp/.tmpr94ilx/rattler_upload/src/upload/opt.rs:451
  field session_token of struct S3Opts, previously in file /tmp/.tmpr94ilx/rattler_upload/src/upload/opt.rs:455
```

### ⚠ `rattler_index` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field IndexS3Config.credentials in /tmp/.tmpT3NP9b/rattler/crates/rattler_index/src/lib.rs:614

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field region of struct IndexS3Config, previously in file /tmp/.tmpr94ilx/rattler_index/src/lib.rs:598
  field endpoint_url of struct IndexS3Config, previously in file /tmp/.tmpr94ilx/rattler_index/src/lib.rs:600
  field force_path_style of struct IndexS3Config, previously in file /tmp/.tmpr94ilx/rattler_index/src/lib.rs:602
  field access_key_id of struct IndexS3Config, previously in file /tmp/.tmpr94ilx/rattler_index/src/lib.rs:605
  field secret_access_key of struct IndexS3Config, previously in file /tmp/.tmpr94ilx/rattler_index/src/lib.rs:608
  field session_token of struct IndexS3Config, previously in file /tmp/.tmpr94ilx/rattler_index/src/lib.rs:611
```

<details><summary><i><b>Changelog</b></i></summary><p>




## `rattler_upload`

<blockquote>

## [0.3.0](https://github.com/conda/rattler/compare/rattler_upload-v0.2.1...rattler_upload-v0.3.0) - 2025-09-04

### Added

- derive default credentials from aws sdk ([#1629](https://github.com/conda/rattler/pull/1629))
</blockquote>





## `rattler_s3`

<blockquote>

## [0.1.1](https://github.com/conda/rattler/compare/rattler_s3-v0.1.0...rattler_s3-v0.1.1) - 2025-09-04

### Other

- updated the following local packages: rattler_networking
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).