### PR TITLE
docs: fix quickstart solve_and_install.py example

### DIFF
--- a/py-rattler/examples/solve_and_install.py
+++ b/py-rattler/examples/solve_and_install.py
@@ -14,7 +14,7 @@ async def main() -> None:
         # Channels to use for solving
         channels=["conda-forge"],
         # The specs to solve for
-        specs=["python ~=3.12.0", "pip", "requests 2.31.0"],
+        specs=["python ~=3.12.0", "pip", "requests 2.31.0.*"],
         # Virtual packages define the specifications of the environment
         virtual_packages=VirtualPackage.detect(),
     )


### PR DESCRIPTION
using the template came up with the error:
```python
InvalidMatchSpecException: missing range specifier for '2.31.0'. Did you mean '==2.31.0' or '2.31.0.*'? 
```


