### PR TITLE
fix(menuinst): activate menuinst per default

### DIFF
--- a/crates/rattler_menuinst/src/linux.rs
+++ b/crates/rattler_menuinst/src/linux.rs
@@ -285,7 +285,7 @@ impl LinuxMenu {
         let envs = self
             .command
             .activate
-            .unwrap_or(false)
+            .unwrap_or(true)
             .then(|| {
                 // create a bash activation script and emit it into the script
                 let activator =


### PR DESCRIPTION
According to the docs the original implementation also defaults to true
@lucascolley 

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->


<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
