### PR TITLE
feat: add cross-platform detection and tests

### DIFF
--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -241,7 +241,7 @@ impl VirtualPackages {
     /// some reasonable defaults when cross-compiling.
     ///
     /// Overrides are always respected, even when cross-compiling to a different platform.
-    /// This matches the behavior of conda, where environment variables like CONDA_OVERRIDE_OSX
+    /// This matches the behavior of conda, where environment variables like `CONDA_OVERRIDE_OSX`
     /// are used even when targeting osx-* from a non-macOS machine.
     ///
     /// # Cross-compilation defaults
@@ -252,9 +252,9 @@ impl VirtualPackages {
     /// - **Windows** (`__win`): No version specified
     /// - **Linux** (`__linux`): Version 0
     /// - **OSX** (`__osx`): Version 0
-    /// - **LibC** (`__glibc`): glibc with version 0 (only for Linux platforms)
+    /// - **`LibC`** (`__glibc`): `glibc` with version 0 (only for Linux platforms)
     /// - **CUDA** (`__cuda`): Not included (None)
-    /// - **Archspec**: Platform-specific minimal architecture (e.g., x86_64 for osx-64)
+    /// - **Archspec**: Platform-specific minimal architecture (e.g., `x86_64` for `osx-64`)
     pub fn detect_for_platform(
         platform: Platform,
         overrides: &VirtualPackageOverrides,


### PR DESCRIPTION
This adds a new method for detecting virtual packages that takes an explicit `platform`. 

This is useful to get some sane defaults when cross-compiling (e.g. when the target-platform is `win-64` but we're on `linux-64`, we still want the `__win` package.