### PR TITLE
fix: up license for `rattler-sandbox`

### DIFF
--- a/crates/rattler_sandbox/Cargo.toml
+++ b/crates/rattler_sandbox/Cargo.toml
@@ -5,7 +5,9 @@ description = "A crate to run executables in a sandbox"
 categories.workspace = true
 homepage.workspace = true
 repository.workspace = true
-license.workspace = true
+# Note: because `birdcage` is GPL-3.0-or-later, this crate must also be GPL-3.0-or-later
+# We might be able to change this in the future if we switch to a different sandboxing solution.
+license = "GPL-3.0-or-later"
 edition.workspace = true
 readme.workspace = true
 


### PR DESCRIPTION
Now we correctly follow birdcage's license (GPL-3.0-or-later) and also use it.