### PR TITLE
chore: Make lockfile pixi-0.57.0 compatible

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5304,7 +5304,7 @@ packages:
   - __glibc >=2.17
   license: BSD-3-Clause
   input:
-    hash: 74431efded7a33191f83e1b5a5029f244ccb9f6c000296f2770af01fdf2deabe
+    hash: 0350854ccf3b5175cbf31397030c6c1f173142a199c332ee5d86401b5d15c48f
     globs:
     - ../../Cargo.toml
     - ../Cargo.toml
@@ -5318,7 +5318,7 @@ packages:
   - __osx >=10.13
   license: BSD-3-Clause
   input:
-    hash: 74431efded7a33191f83e1b5a5029f244ccb9f6c000296f2770af01fdf2deabe
+    hash: 0350854ccf3b5175cbf31397030c6c1f173142a199c332ee5d86401b5d15c48f
     globs:
     - ../../Cargo.toml
     - ../Cargo.toml
@@ -5332,7 +5332,7 @@ packages:
   - __osx >=11.0
   license: BSD-3-Clause
   input:
-    hash: 74431efded7a33191f83e1b5a5029f244ccb9f6c000296f2770af01fdf2deabe
+    hash: 0350854ccf3b5175cbf31397030c6c1f173142a199c332ee5d86401b5d15c48f
     globs:
     - ../../Cargo.toml
     - ../Cargo.toml
@@ -5344,7 +5344,7 @@ packages:
   subdir: win-64
   license: BSD-3-Clause
   input:
-    hash: 74431efded7a33191f83e1b5a5029f244ccb9f6c000296f2770af01fdf2deabe
+    hash: 0350854ccf3b5175cbf31397030c6c1f173142a199c332ee5d86401b5d15c48f
     globs:
     - ../../Cargo.toml
     - ../Cargo.toml
@@ -5358,7 +5358,7 @@ packages:
   - __glibc >=2.17
   license: BSD-3-Clause
   input:
-    hash: d3bccdc7bbbc45ae757a774dc5fc7e09c3ddabbdc5edb8177dbf04f1db66f183
+    hash: 447fa34ece12dc6fe9055d4054a09252dba0d48d6b64af8fd9c69f78f4a50df5
     globs:
     - ../../Cargo.toml
     - ../Cargo.toml
@@ -5372,7 +5372,7 @@ packages:
   - __osx >=10.13
   license: BSD-3-Clause
   input:
-    hash: d3bccdc7bbbc45ae757a774dc5fc7e09c3ddabbdc5edb8177dbf04f1db66f183
+    hash: 447fa34ece12dc6fe9055d4054a09252dba0d48d6b64af8fd9c69f78f4a50df5
     globs:
     - ../../Cargo.toml
     - ../Cargo.toml
@@ -5386,7 +5386,7 @@ packages:
   - __osx >=11.0
   license: BSD-3-Clause
   input:
-    hash: d3bccdc7bbbc45ae757a774dc5fc7e09c3ddabbdc5edb8177dbf04f1db66f183
+    hash: 447fa34ece12dc6fe9055d4054a09252dba0d48d6b64af8fd9c69f78f4a50df5
     globs:
     - ../../Cargo.toml
     - ../Cargo.toml
@@ -5398,7 +5398,7 @@ packages:
   subdir: win-64
   license: BSD-3-Clause
   input:
-    hash: d3bccdc7bbbc45ae757a774dc5fc7e09c3ddabbdc5edb8177dbf04f1db66f183
+    hash: 447fa34ece12dc6fe9055d4054a09252dba0d48d6b64af8fd9c69f78f4a50df5
     globs:
     - ../../Cargo.toml
     - ../Cargo.toml


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->

pixi 0.57.0 results in the hash in the lockfile changing. otherwise setup-pixi with `pixi install --locked` will fail now (see failures on `main`: https://github.com/conda/rattler/commit/3e4e3d0bc021a536fab83a6149c3ba422383c232)