### PR TITLE
fix: cache 404 response for sharded index

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/index.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/tokio/index.rs
@@ -28,7 +28,7 @@ use url::Url;
 
 const REPODATA_SHARDS_FILENAME: &str = "repodata_shards.msgpack.zst";
 
-/// Creates a SubdirNotFoundError for when sharded repodata is not available.
+/// Creates a `SubdirNotFoundError` for when sharded repodata is not available.
 fn create_subdir_not_found_error(channel_base_url: &Url) -> GatewayError {
     GatewayError::SubdirNotFoundError(Box::new(SubdirNotFoundError {
         channel: Channel::from_url(channel_base_url.clone()),


### PR DESCRIPTION
Fixes an issue with `CacheAction::ForceCacheOnly` for the sharded repodata index. If the sharded index was not found, we skipped caching any information. However, if the cache was forced this led to an error because no cache entry was found. With this PR we also cache if the sharded index was not present in the first place.