### PR TITLE
perf: remove cache lock mutex

### DIFF
--- a/crates/rattler_cache/src/package_cache/cache_lock.rs
+++ b/crates/rattler_cache/src/package_cache/cache_lock.rs
@@ -257,12 +257,14 @@ impl CacheMetadataFile {
             )
         })?;
         let mut buf = [0; SHA256_LEN];
-        let _ = (&*self.file).seek(SeekFrom::Start(REVISION_LEN)).map_err(|e| {
-            PackageCacheLayerError::LockError(
-                "failed to seek to sha256 in cache lock".to_string(),
-                e,
-            )
-        })?;
+        let _ = (&*self.file)
+            .seek(SeekFrom::Start(REVISION_LEN))
+            .map_err(|e| {
+                PackageCacheLayerError::LockError(
+                    "failed to seek to sha256 in cache lock".to_string(),
+                    e,
+                )
+            })?;
         match (&*self.file).read_exact(&mut buf) {
             Ok(_) => {}
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {


### PR DESCRIPTION
This PR removes the `Mutex` from the `CacheRwLock`. It was not needed.

### AI Disclosure

Wrote it by hand