### PR TITLE
chore: clean up installer

### DIFF
--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -692,6 +692,9 @@ async fn link_package(
 
     let (tx, rx) = tokio::sync::oneshot::channel();
 
+    // Since we use the `Prefix` type, the conda-meta folder is guaranteed to exist
+    let conda_meta_path = target_prefix.path().join("conda-meta");
+
     rayon::spawn_fifo(move || {
         let inner = move || {
             // Link the contents of the package into the prefix.
@@ -716,21 +719,7 @@ async fn link_package(
                 ..PrefixRecord::from_repodata_record(record.clone(), paths)
             };
 
-            let conda_meta_path = target_prefix.path().join("conda-meta");
-            std::fs::create_dir_all(&conda_meta_path).map_err(|e| {
-                InstallerError::IoError("failed to create conda-meta directory".to_string(), e)
-            })?;
-
-            let pkg_meta_path = format!(
-                "{}-{}-{}.json",
-                prefix_record
-                    .repodata_record
-                    .package_record
-                    .name
-                    .as_normalized(),
-                prefix_record.repodata_record.package_record.version,
-                prefix_record.repodata_record.package_record.build
-            );
+            let pkg_meta_path = prefix_record.file_name();
             prefix_record
                 .write_to_path(conda_meta_path.join(&pkg_meta_path), true)
                 .map_err(|e| {


### PR DESCRIPTION
We were using `create_dir_all` in every loop iteration, even though our new `Prefix` type should already ensure this for us.

Also we added a better way to get the filename from a prefix record, so using that! :)