### PR TITLE
perf: add skip validation mode to minimize cache validation overhead

### DIFF
--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -595,7 +595,7 @@ where
 
             // Validate the package directory.
             let validation_result = tokio::task::spawn_blocking(move || {
-                validate_package_directory(&path_inner, ValidationMode::Fast)
+                validate_package_directory(&path_inner, ValidationMode::Skip)
             })
             .await;
 

--- a/crates/rattler_cache/src/validation.rs
+++ b/crates/rattler_cache/src/validation.rs
@@ -25,6 +25,11 @@ use rayon::prelude::IndexedParallelIterator;
 /// The mode in which the validation should be performed.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ValidationMode {
+    /// Only check if the package directory exists and contains a valid index.json.
+    /// Does not validate individual files or paths.json. This is the fastest validation
+    /// mode but provides minimal guarantees about package integrity.
+    Skip,
+
     /// Only check if the files exists. Do not check if the hashes match.
     Fast,
 
@@ -123,6 +128,12 @@ pub fn validate_package_directory(
         Err(e) => return Err(PackageValidationError::ReadPathsJsonError(e)),
         Ok(paths) => paths,
     };
+
+    // In Skip mode, only validate that index.json and paths.json exist and are readable.
+    // Skip all file validation checks.
+    if mode == ValidationMode::Skip {
+        return Ok((index_json, paths));
+    }
 
     // Validate all the entries
     validate_package_directory_from_paths(package_dir, &paths, mode)


### PR DESCRIPTION
 Changes:
  - Added `ValidationMode::Skip` enum variant
  - Updated `validate_package_directory` to only check `index.json` and `paths.json` exists in `Skip` mode
  - Changed package cache to use `Skip` instead of `Fast` validation.

Impact: Reducing loads of `stat` syscalls because the validation no longer checks if all files exist.

## AI Disclosure

Made by Claude Code