### PR TITLE
feat: move repodata fetch logic to tools crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4807,6 +4807,7 @@ dependencies = [
  "similar-asserts",
  "tempfile",
  "thiserror 2.0.17",
+ "tools",
  "tracing",
  "url",
 ]
@@ -6341,6 +6342,7 @@ dependencies = [
  "clap",
  "difference",
  "dirs",
+ "fs-err",
  "fslock",
  "rattler_digest",
  "reqwest",

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -290,22 +290,28 @@ mod test {
     use url::Url;
 
     use crate::{
-        fetch::CacheAction,
-        gateway::Gateway,
-        utils::{simple_channel_server::SimpleChannelServer, test::fetch_repo_data},
+        fetch::CacheAction, gateway::Gateway, utils::simple_channel_server::SimpleChannelServer,
         DownloadReporter, GatewayError, JLAPReporter, RepoData, Reporter, SourceConfig,
         SubdirSelection,
     };
 
     async fn local_conda_forge() -> Channel {
-        tokio::try_join!(fetch_repo_data("noarch"), fetch_repo_data("linux-64")).unwrap();
+        tokio::try_join!(
+            tools::fetch_test_conda_forge_repodata_async("noarch"),
+            tools::fetch_test_conda_forge_repodata_async("linux-64")
+        )
+        .unwrap();
         Channel::from_directory(
             &Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/channels/conda-forge"),
         )
     }
 
     async fn remote_conda_forge() -> SimpleChannelServer {
-        tokio::try_join!(fetch_repo_data("noarch"), fetch_repo_data("linux-64")).unwrap();
+        tokio::try_join!(
+            tools::fetch_test_conda_forge_repodata_async("noarch"),
+            tools::fetch_test_conda_forge_repodata_async("linux-64")
+        )
+        .unwrap();
         SimpleChannelServer::new(
             Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/channels/conda-forge"),
         )

--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -749,10 +749,7 @@ impl<'de> TryFrom<&'de str> for PackageFilename<'de> {
 
 #[cfg(test)]
 mod test {
-    use std::{
-        collections::HashSet,
-        path::{Path, PathBuf},
-    };
+    use std::{collections::HashSet, path::PathBuf};
 
     use bytes::Bytes;
     use fs_err as fs;
@@ -765,14 +762,17 @@ mod test {
     use super::{
         load_repo_data_recursively, PackageFilename, PackageFormatSelection, SparseRepoData,
     };
-    use crate::utils::test::fetch_repo_data;
 
     fn test_dir() -> PathBuf {
-        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data")
+        tools::test_data_dir()
     }
 
     async fn default_repo_data() -> Vec<(Channel, &'static str, PathBuf)> {
-        tokio::try_join!(fetch_repo_data("linux-64"), fetch_repo_data("noarch")).unwrap();
+        tokio::try_join!(
+            tools::fetch_test_conda_forge_repodata_async("linux-64"),
+            tools::fetch_test_conda_forge_repodata_async("noarch")
+        )
+        .unwrap();
 
         let channel_config = ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap());
         vec![
@@ -832,7 +832,11 @@ mod test {
         package_names: impl IntoIterator<Item = impl AsRef<str>>,
         variant_consolidation: PackageFormatSelection,
     ) -> Vec<Vec<RepoDataRecord>> {
-        tokio::try_join!(fetch_repo_data("noarch"), fetch_repo_data("linux-64")).unwrap();
+        tokio::try_join!(
+            tools::fetch_test_conda_forge_repodata_async("noarch"),
+            tools::fetch_test_conda_forge_repodata_async("linux-64")
+        )
+        .unwrap();
 
         //"linux-sha=20021d1dff9941ccf189f27404e296c54bc37fc4600c7027b366c03fc0bfa89e"
         //"noarch-sha=05e0c4ce7be29f36949c33cce782f21aecfbdd41f9e3423839670fb38fc5d691"
@@ -960,7 +964,11 @@ mod test {
 
     #[tokio::test]
     async fn load_complete_records() {
-        tokio::try_join!(fetch_repo_data("noarch"), fetch_repo_data("linux-64")).unwrap();
+        tokio::try_join!(
+            tools::fetch_test_conda_forge_repodata_async("noarch"),
+            tools::fetch_test_conda_forge_repodata_async("linux-64")
+        )
+        .unwrap();
 
         let mut records = Vec::new();
         for path in [

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -35,6 +35,7 @@ rstest = { workspace = true }
 serde_json = { workspace = true }
 similar-asserts = { workspace = true }
 url = { workspace = true }
+tools = { path = "../tools" }
 
 [features]
 default = ["resolvo"]

--- a/crates/rattler_solve/tests/backends.rs
+++ b/crates/rattler_solve/tests/backends.rs
@@ -14,22 +14,6 @@ fn channel_config() -> ChannelConfig {
     ChannelConfig::default_with_root_dir(std::env::current_dir().unwrap())
 }
 
-fn conda_json_path() -> String {
-    format!(
-        "{}/{}",
-        env!("CARGO_MANIFEST_DIR"),
-        "../../test-data/channels/conda-forge/linux-64/repodata.json"
-    )
-}
-
-fn conda_json_path_noarch() -> String {
-    format!(
-        "{}/{}",
-        env!("CARGO_MANIFEST_DIR"),
-        "../../test-data/channels/conda-forge/noarch/repodata.json"
-    )
-}
-
 fn pytorch_json_path() -> String {
     format!(
         "{}/{}",
@@ -175,12 +159,14 @@ fn solve_real_world<T: SolverImpl + Default>(specs: Vec<&str>) -> Vec<String> {
 
 fn read_real_world_repo_data() -> &'static Vec<SparseRepoData> {
     static REPO_DATA: Lazy<Vec<SparseRepoData>> = Lazy::new(|| {
-        let json_file = conda_json_path();
-        let json_file_noarch = conda_json_path_noarch();
+        let json_file = tools::fetch_test_conda_forge_repodata("linux-64")
+            .expect("Failed to fetch linux-64 repodata");
+        let json_file_noarch = tools::fetch_test_conda_forge_repodata("noarch")
+            .expect("Failed to fetch noarch repodata");
 
         vec![
-            read_sparse_repodata(&json_file),
-            read_sparse_repodata(&json_file_noarch),
+            read_sparse_repodata(json_file.to_str().unwrap()),
+            read_sparse_repodata(json_file_noarch.to_str().unwrap()),
         ]
     });
 
@@ -204,11 +190,13 @@ fn read_pytorch_sparse_repo_data() -> &'static SparseRepoData {
 
 fn read_conda_forge_sparse_repo_data() -> &'static SparseRepoData {
     static REPO_DATA: Lazy<SparseRepoData> = Lazy::new(|| {
-        let conda_forge = conda_json_path();
+        let conda_forge = tools::fetch_test_conda_forge_repodata("linux-64")
+            .expect("Failed to fetch linux-64 repodata");
+
         SparseRepoData::from_file(
             Channel::from_str("conda-forge", &channel_config()).unwrap(),
             "conda-forge".to_string(),
-            conda_forge,
+            conda_forge.to_str().unwrap(),
             None,
         )
         .unwrap()

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = { workspace = true, default-features = false, features = [
 ] }
 tempfile = { workspace = true }
 tokio = { workspace = true }
+fs-err = { workspace = true, features = ["tokio"] }
 
 [package.metadata.release]
 # Dont publish the binary

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod libsolv_bindings;
 mod test_files;
 
-pub use test_files::{download_and_cache_file, download_and_cache_file_async};
+pub use test_files::{
+    download_and_cache_file, download_and_cache_file_async, fetch_test_conda_forge_repodata,
+    fetch_test_conda_forge_repodata_async, test_data_dir,
+};
 
 use std::{
     fs,


### PR DESCRIPTION
Move the logic for fetching test repodata files from `rattler-test.pixi.run` from `rattler_repodata_gateway` to the `tools` crate, making it available for use in other crates' tests.

The implementation provides both blocking and async variants that download conda-forge repodata on-demand with file locking for thread-safety.

The logic is also used in rattler_solve.

This centralizes the repodata fetching logic and eliminates code duplication across multiple crates.

## AI Disclosure 

Written by Claude Code web