### PR TITLE
fix: rename solver argument from lib-solv to libsolv

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -85,6 +85,7 @@ pub enum SolveStrategy {
 pub enum Solver {
     #[default]
     Resolvo,
+    #[value(name = "libsolv")]
     LibSolv,
 }
 


### PR DESCRIPTION
Ensures that `rattler create --solver` accepts `libsolv` instead of `lib-solve`.