### PR TITLE
feat: expose crate features on docs.rs

### DIFF
--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -17,6 +17,9 @@ rustls-tls = ['reqwest/rustls-tls', 'rattler_package_streaming/rustls-tls', 'rat
 cli-tools = ['dep:clap', 'reqwest/blocking']
 indicatif = ['dep:indicatif', 'dep:console']
 
+[package.metadata.docs.rs]
+features = ["cli-tools", "indicatif"]
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, optional = true }

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -15,6 +15,9 @@ default = ["rayon"]
 experimental_extras = ["experimental_conditionals"]
 experimental_conditionals = []
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 ahash = { workspace = true }
 chrono = { workspace = true }

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -14,6 +14,9 @@ readme.workspace = true
 edit = []
 default = ["edit"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 console = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -27,6 +27,9 @@ generic-array = { workspace = true, optional = true }
 tokio = ["dep:tokio"]
 serde = ["dep:serde", "generic-array/serde"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dev-dependencies]
 rstest = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -18,6 +18,9 @@ gcs = ["google-cloud-auth"]
 s3 = ["aws-config", "aws-sdk-s3", "aws-smithy-http-client"]
 system-integration = ["keyring", "netrc-rs", "dirs"]
 
+[package.metadata.docs.rs]
+features = ["gcs", "s3"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-once-cell = { workspace = true }

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -47,6 +47,9 @@ native-tls = ["rattler_networking/native-tls", "rattler_redaction/native-tls"]
 rustls-tls = ["rattler_networking/rustls-tls", "rattler_redaction/rustls-tls"]
 reqwest = ["dep:reqwest-middleware", "dep:reqwest"]
 
+[package.metadata.docs.rs]
+features = ["reqwest"]
+
 [dev-dependencies]
 assert_matches = { workspace = true }
 tokio = { workspace = true, features = ["rt", "macros", "rt-multi-thread"] }

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -13,6 +13,9 @@ readme.workspace = true
 [features]
 s3 = ["rattler_networking/s3", "rattler_s3"]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 rattler_conda_types = { workspace = true, default-features = false }
 rattler_digest = { workspace = true, default-features = false }


### PR DESCRIPTION
Add `[package.metadata.docs.rs]` configuration to ensure important features are properly documented on docs.rs. Only non-default features are explicitly listed, as docs.rs builds with default features automatically.