### PR TITLE
refactor: replace async `conda` with `astral-async-zip`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral_async_zip"
+version = "0.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba"
+dependencies = [
+ "async-compression",
+ "crc32fast",
+ "futures-lite",
+ "pin-project",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +252,7 @@ checksum = "d10e4f991a553474232bc0a31799f6d24b034a84c0971d80d2e2f78b2e576e40"
 dependencies = [
  "compression-codecs",
  "compression-core",
+ "futures-io",
  "pin-project-lite",
  "tokio",
 ]
@@ -361,6 +377,16 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-spooled-tempfile"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9c58a1dbecfc23aa470d57e5aff60877ab1b459bf05e60e861dd18fcaa5f5"
+dependencies = [
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -4884,10 +4910,13 @@ version = "0.23.25"
 dependencies = [
  "assert_matches",
  "astral-tokio-tar",
+ "astral_async_zip",
  "async-compression",
+ "async-spooled-tempfile",
  "bzip2",
  "chrono",
  "fs-err",
+ "futures",
  "futures-util",
  "getrandom 0.2.17",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ async-fd-lock = "0.2.0"
 fs4 = "0.13.1"
 async-once-cell = "0.5.4"
 async-trait = "0.1.88"
+astral_async_zip = { version = "0.0.17", default-features = false }
 axum = { version = "0.8.4", default-features = false, features = [
   "tokio",
   "http1",

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -14,6 +14,7 @@ readme.workspace = true
 bzip2 = { workspace = true }
 chrono = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"], optional = true }
+futures = { workspace = true }
 futures-util = { workspace = true }
 rattler_conda_types = { workspace = true, default-features = false }
 rattler_digest = { workspace = true, default-features = false, features = ["tokio"] }
@@ -34,9 +35,11 @@ tokio-util = { workspace = true, features = ["io-util"] }
 tracing = { workspace = true }
 url = { workspace = true }
 zip = { workspace = true, features = ["deflate", "time"] }
+astral_async_zip = { workspace = true, features = ["deflate", "tokio", "tokio-fs"] }
 astral-tokio-tar = { workspace = true }
 async-compression = { workspace = true }
 zstd = { workspace = true, default-features = false }
+async-spooled-tempfile = { version = "0.1.0" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 num_cpus = { workspace = true }

--- a/crates/rattler_package_streaming/src/tokio/async_seek.rs
+++ b/crates/rattler_package_streaming/src/tokio/async_seek.rs
@@ -1,0 +1,69 @@
+//! Functions that enable extracting or streaming a Conda package for objects
+//! that implement the [`tokio::io::AsyncRead`] + [`tokio::io::AsyncSeek`] traits.
+
+use std::path::Path;
+
+use async_zip::base::read::seek::ZipFileReader;
+use tokio::io::{AsyncRead, AsyncSeek};
+use tokio_util::compat::{FuturesAsyncReadCompatExt, TokioAsyncReadCompatExt};
+
+use crate::ExtractError;
+
+use super::shared::{extract_tar_zst_entry, DEFAULT_BUF_SIZE};
+
+/// Extracts the contents of a `.conda` package archive using the seek-based API.
+/// This is more efficient than streaming when the entire file is available (e.g., from disk or memory).
+///
+/// This function only performs extraction and does NOT compute hashes or track size.
+/// Use this when you've already computed hashes separately or don't need them.
+pub async fn extract_conda(
+    reader: impl AsyncRead + AsyncSeek + Send + Unpin + 'static,
+    destination: &Path,
+) -> Result<(), ExtractError> {
+    // Ensure the destination directory exists
+    tokio::fs::create_dir_all(destination)
+        .await
+        .map_err(ExtractError::CouldNotCreateDestination)?;
+
+    // Clone destination for the async block
+    let destination = destination.to_owned();
+
+    // Convert to futures traits for async_zip (which uses futures traits)
+    let mut compat_reader = reader.compat();
+    let mut buf_reader =
+        futures::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, &mut compat_reader);
+
+    // Create a ZIP reader using the seek API
+    let mut zip_reader = ZipFileReader::new(&mut buf_reader)
+        .await
+        .map_err(|e| ExtractError::IoError(std::io::Error::other(e)))?;
+
+    // Process each ZIP entry
+    let num_entries = zip_reader.file().entries().len();
+    for index in 0..num_entries {
+        let entry = zip_reader.file().entries().get(index).ok_or_else(|| {
+            ExtractError::IoError(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "entry not found",
+            ))
+        })?;
+
+        let filename = entry.filename().as_str().map_err(|e| {
+            ExtractError::IoError(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+        })?;
+
+        // Only extract .tar.zst files
+        if filename.ends_with(".tar.zst") {
+            let entry_reader = zip_reader
+                .reader_with_entry(index)
+                .await
+                .map_err(|e| ExtractError::IoError(std::io::Error::other(e)))?;
+
+            // Convert from futures traits to tokio traits
+            let mut compat_entry = entry_reader.compat();
+            extract_tar_zst_entry(&mut compat_entry, &destination).await?;
+        }
+    }
+
+    Ok(())
+}

--- a/crates/rattler_package_streaming/src/tokio/mod.rs
+++ b/crates/rattler_package_streaming/src/tokio/mod.rs
@@ -1,4 +1,7 @@
 //! Functionality to stream and extract packages in an [`tokio`] async context.
 
+mod shared;
+
 pub mod async_read;
+pub mod async_seek;
 pub mod fs;

--- a/crates/rattler_package_streaming/src/tokio/shared.rs
+++ b/crates/rattler_package_streaming/src/tokio/shared.rs
@@ -1,0 +1,111 @@
+//! Shared functionality for async extraction operations.
+
+use std::path::Path;
+
+use async_compression::tokio::bufread::ZstdDecoder;
+use futures_util::stream::StreamExt;
+
+use crate::ExtractError;
+
+/// Buffer size for async I/O operations (128KB).
+pub(super) const DEFAULT_BUF_SIZE: usize = 128 * 1024;
+
+/// Unix permission bits for executable files (user, group, and other execute bits).
+#[cfg(unix)]
+const EXECUTABLE_MODE_BITS: u32 = 0o111;
+
+/// Unpacks a tar archive, preserving only the executable bit on Unix.
+pub(super) async fn unpack_tar_archive<R: tokio::io::AsyncRead + Unpin>(
+    mut archive: tokio_tar::Archive<R>,
+    destination: &Path,
+) -> Result<(), ExtractError> {
+    // Canonicalize the destination to ensure consistent path handling
+    let destination = tokio::fs::canonicalize(destination)
+        .await
+        .map_err(ExtractError::IoError)?;
+
+    let mut entries = archive.entries().map_err(ExtractError::IoError)?;
+
+    // Memoize filesystem calls to canonicalize paths
+    #[allow(clippy::default_trait_access)] // So we dont have to import rustc_hash
+    let mut memo = Default::default();
+
+    while let Some(entry) = entries.next().await {
+        let mut file = entry.map_err(ExtractError::IoError)?;
+
+        // On Windows, skip symlink entries as they require special privileges
+        if cfg!(windows) && file.header().entry_type().is_symlink() {
+            tracing::warn!(
+                "Skipping symlink in tar archive: {}",
+                file.path().map_err(ExtractError::IoError)?.display()
+            );
+            continue;
+        }
+
+        // Unpack the file into the destination directory
+        #[cfg_attr(not(unix), allow(unused_variables))]
+        let unpacked_path = file
+            .unpack_in_raw(&destination, &mut memo)
+            .await
+            .map_err(ExtractError::IoError)?;
+
+        // Preserve the executable bit on Unix systems
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+
+            let entry_type = file.header().entry_type();
+            if entry_type.is_file() || entry_type.is_hard_link() {
+                let mode = file.header().mode().map_err(ExtractError::IoError)?;
+                let has_any_executable_bit = mode & EXECUTABLE_MODE_BITS;
+
+                if has_any_executable_bit != 0 {
+                    if let Some(path) = unpacked_path {
+                        let metadata = tokio::fs::metadata(&path)
+                            .await
+                            .map_err(ExtractError::IoError)?;
+                        let permissions = metadata.permissions();
+
+                        // Only update if not already executable
+                        if permissions.mode() & EXECUTABLE_MODE_BITS != EXECUTABLE_MODE_BITS {
+                            tokio::fs::set_permissions(
+                                &path,
+                                std::fs::Permissions::from_mode(
+                                    permissions.mode() | EXECUTABLE_MODE_BITS,
+                                ),
+                            )
+                            .await
+                            .map_err(ExtractError::IoError)?;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Extracts a single tar.zst entry from a ZIP file
+pub(super) async fn extract_tar_zst_entry<R: tokio::io::AsyncRead + Unpin>(
+    mut reader: R,
+    destination: &Path,
+) -> Result<(), ExtractError> {
+    // Create a buffered reader for better performance
+    let buf_reader = tokio::io::BufReader::with_capacity(DEFAULT_BUF_SIZE, &mut reader);
+
+    // Decompress zstd asynchronously
+    let decoder = ZstdDecoder::new(buf_reader);
+
+    // Build archive with optimized settings
+    let archive = tokio_tar::ArchiveBuilder::new(decoder)
+        .set_preserve_mtime(true)
+        .set_preserve_permissions(false)
+        .set_unpack_xattrs(false)
+        .build();
+
+    // Unpack the tar archive
+    unpack_tar_archive(archive, destination).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
This PR replaces the spawn_blocking-based .conda extraction implementation with a fully async approach using astral-async-zip and async-compression. The new implementation eliminates the need for bridging between async and sync contexts, resulting in significant performance improvements for realistic package installation workloads.

This is build on top of #1808 and provides a similar performance gain in download and extraction speeds.