### PR TITLE
feat: implement From<T> for PackageNameMatcher variants

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/package_name_matcher.rs
+++ b/crates/rattler_conda_types/src/match_spec/package_name_matcher.rs
@@ -62,6 +62,24 @@ impl PackageNameMatcher {
     }
 }
 
+impl From<PackageName> for PackageNameMatcher {
+    fn from(value: PackageName) -> Self {
+        PackageNameMatcher::Exact(value)
+    }
+}
+
+impl From<glob::Pattern> for PackageNameMatcher {
+    fn from(value: glob::Pattern) -> Self {
+        PackageNameMatcher::Glob(value)
+    }
+}
+
+impl From<regex::Regex> for PackageNameMatcher {
+    fn from(value: regex::Regex) -> Self {
+        PackageNameMatcher::Regex(value)
+    }
+}
+
 impl From<PackageNameMatcher> for Option<PackageName> {
     fn from(value: PackageNameMatcher) -> Self {
         match value {


### PR DESCRIPTION
Add `From` trait implementations for each `PackageNameMatcher` variant to allow easier construction:
- `From<PackageName>` for `Exact` variant
- `From<glob::Pattern>` for `Glob` variant
- `From<regex::Regex>` for `Regex` variant

This enables more ergonomic creation of `PackageNameMatcher` instances.
