### PR TITLE
feat: add `__cuda_arch` virtual package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5814,6 +5814,7 @@ dependencies = [
  "rattler_conda_types",
  "regex",
  "serde",
+ "temp-env",
  "thiserror 2.0.18",
  "tracing",
  "winver",

--- a/crates/rattler_virtual_packages/Cargo.toml
+++ b/crates/rattler_virtual_packages/Cargo.toml
@@ -26,3 +26,6 @@ plist = { workspace = true }
 
 [target.'cfg(target_os="windows")'.dependencies]
 winver = { workspace = true }
+
+[dev-dependencies]
+temp-env = { workspace = true }

--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -165,7 +165,7 @@ fn detect_cuda_info_via_libcuda() -> CudaInfo {
             return CudaInfo {
                 version: None,
                 arch_info: None,
-            }
+            };
         }
     };
 
@@ -177,7 +177,7 @@ fn detect_cuda_info_via_libcuda() -> CudaInfo {
                 return CudaInfo {
                     version: None,
                     arch_info: None,
-                }
+                };
             }
         };
 

--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -20,73 +20,10 @@ use once_cell::sync::OnceCell;
 use rattler_conda_types::Version;
 use std::process::Command;
 use std::{
-    ffi::CStr,
     mem::MaybeUninit,
     os::raw::{c_int, c_uint, c_ulong},
     str::FromStr,
 };
-
-/// Maximum length for device names in build strings to comply with CEP-26.
-const MAX_BUILD_STRING_LEN: usize = 64;
-
-/// Checks if a character is valid in a conda build string according to CEP-26.
-///
-/// Valid characters are: alphanumeric only (a-z, A-Z, 0-9).
-fn is_valid_build_string_char(c: char) -> bool {
-    c.is_ascii_alphanumeric()
-}
-
-/// Sanitizes a device name to comply with CEP-26 build string requirements.
-///
-/// This function:
-/// 1. Filters out any characters not allowed in build strings (keeps only alphanumeric)
-/// 2. Removes "NVIDIA" anywhere in the string (case-insensitive) to save space
-/// 3. Truncates to maximum 64 characters
-///
-/// Returns the sanitized device name.
-pub(crate) fn sanitize_device_name(name: &str) -> String {
-    // First, filter to keep only alphanumeric characters
-    let alphanumeric_only: String = name
-        .chars()
-        .filter(|c| is_valid_build_string_char(*c))
-        .collect();
-
-    // Remove "NVIDIA" anywhere in the string (case-insensitive)
-    let without_nvidia = remove_nvidia_ci(&alphanumeric_only);
-
-    // Truncate to maximum length
-    without_nvidia.chars().take(MAX_BUILD_STRING_LEN).collect()
-}
-
-/// Removes all case-insensitive occurrences of "NVIDIA" from a string.
-fn remove_nvidia_ci(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let mut chars = s.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        // Check if we're at the start of "NVIDIA" (case-insensitive)
-        if ch.eq_ignore_ascii_case(&'N') {
-            // Peek ahead to see if "VIDIA" follows
-            let upcoming: Vec<char> = chars.clone().take(5).collect();
-            if upcoming.len() == 5
-                && upcoming[0].eq_ignore_ascii_case(&'V')
-                && upcoming[1].eq_ignore_ascii_case(&'I')
-                && upcoming[2].eq_ignore_ascii_case(&'D')
-                && upcoming[3].eq_ignore_ascii_case(&'I')
-                && upcoming[4].eq_ignore_ascii_case(&'A')
-            {
-                // Skip the next 5 characters ("VIDIA")
-                for _ in 0..5 {
-                    chars.next();
-                }
-                continue;
-            }
-        }
-        result.push(ch);
-    }
-
-    result
-}
 
 /// Validates that a string is in the format "major.minor" where both parts are digits.
 ///
@@ -104,19 +41,20 @@ pub(crate) fn is_valid_cuda_version_format(s: &str) -> bool {
     }
 }
 
-/// Information about CUDA compute capability for a specific device.
+/// Information about CUDA compute capability.
 ///
 /// The compute capability (also called SM version) defines the set of features and
 /// instructions supported by a CUDA device. Higher compute capabilities generally
 /// support more features and newer instruction sets.
+///
+/// According to the CEP specification, this represents the minimum compute capability
+/// across all detected CUDA devices, formatted as `{major}.{minor}`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CudaArchInfo {
     /// Major version of the compute capability (e.g., 8 for compute capability 8.6)
     pub major: u32,
     /// Minor version of the compute capability (e.g., 6 for compute capability 8.6)
     pub minor: u32,
-    /// Human-readable name of the device (e.g., "NVIDIA `GeForce` RTX 3090")
-    pub device_name: String,
 }
 
 /// Combined CUDA information detected from the system.
@@ -294,9 +232,6 @@ fn detect_cuda_arch_from_library(cuda_library: &Library) -> Option<CudaArchInfo>
     const CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR: c_int = 75;
     const CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR: c_int = 76;
 
-    // Maximum device name length in CUDA
-    const MAX_DEVICE_NAME_LEN: usize = 256;
-
     // Get required function pointers from the library
     let cu_device_get_count: Symbol<'_, unsafe extern "C" fn(*mut c_int) -> c_ulong> =
         unsafe { cuda_library.get(b"cuDeviceGetCount\0") }.ok()?;
@@ -308,9 +243,6 @@ fn detect_cuda_arch_from_library(cuda_library: &Library) -> Option<CudaArchInfo>
         '_,
         unsafe extern "C" fn(*mut c_int, c_int, c_int) -> c_ulong,
     > = unsafe { cuda_library.get(b"cuDeviceGetAttribute\0") }.ok()?;
-
-    let cu_device_get_name: Symbol<'_, unsafe extern "C" fn(*mut u8, c_int, c_int) -> c_ulong> =
-        unsafe { cuda_library.get(b"cuDeviceGetName\0") }.ok()?;
 
     // Get the number of CUDA devices
     let mut device_count = MaybeUninit::uninit();
@@ -369,27 +301,10 @@ fn detect_cuda_arch_from_library(cuda_library: &Library) -> Option<CudaArchInfo>
         });
 
         if is_new_minimum {
-            // Get device name
-            let mut name_buffer = [0u8; MAX_DEVICE_NAME_LEN];
-            if unsafe {
-                cu_device_get_name(
-                    name_buffer.as_mut_ptr(),
-                    MAX_DEVICE_NAME_LEN as c_int,
-                    device,
-                )
-            } == 0
-            {
-                // Convert C string to Rust string and sanitize
-                if let Ok(cstr) = CStr::from_bytes_until_nul(&name_buffer) {
-                    if let Ok(device_name) = cstr.to_str() {
-                        min_arch = Some(CudaArchInfo {
-                            major: cc_major,
-                            minor: cc_minor,
-                            device_name: sanitize_device_name(device_name),
-                        });
-                    }
-                }
-            }
+            min_arch = Some(CudaArchInfo {
+                major: cc_major,
+                minor: cc_minor,
+            });
         }
     }
 
@@ -645,10 +560,7 @@ mod test {
         let info = cuda_info();
         println!("CUDA Info: {info:?}");
         if let Some(ref arch) = info.arch_info {
-            println!(
-                "  Device: {} (compute {}.{})",
-                arch.device_name, arch.major, arch.minor
-            );
+            println!("  Compute capability: {}.{}", arch.major, arch.minor);
         }
     }
 
@@ -683,112 +595,5 @@ mod test {
         assert!(!is_valid_cuda_version_format("eight.six"));
         assert!(!is_valid_cuda_version_format("8-6"));
         assert!(!is_valid_cuda_version_format("8_6"));
-    }
-
-    #[test]
-    fn test_is_valid_build_string_char() {
-        // Valid characters - alphanumeric only
-        assert!(is_valid_build_string_char('a'));
-        assert!(is_valid_build_string_char('Z'));
-        assert!(is_valid_build_string_char('0'));
-        assert!(is_valid_build_string_char('9'));
-
-        // Invalid characters - everything else
-        assert!(!is_valid_build_string_char(' '));
-        assert!(!is_valid_build_string_char('-'));
-        assert!(!is_valid_build_string_char('/'));
-        assert!(!is_valid_build_string_char('!'));
-        assert!(!is_valid_build_string_char('@'));
-        assert!(!is_valid_build_string_char('#'));
-        assert!(!is_valid_build_string_char('_'));
-        assert!(!is_valid_build_string_char('.'));
-        assert!(!is_valid_build_string_char('+'));
-    }
-
-    #[test]
-    fn test_remove_nvidia_ci() {
-        // Remove NVIDIA at the start
-        assert_eq!(remove_nvidia_ci("NVIDIAGeForce"), "GeForce");
-        assert_eq!(remove_nvidia_ci("nvidiaRTX"), "RTX");
-
-        // Remove NVIDIA in the middle
-        assert_eq!(remove_nvidia_ci("GeForceNVIDIARTX"), "GeForceRTX");
-        assert_eq!(remove_nvidia_ci("TestNVIDIAGPU"), "TestGPU");
-
-        // Remove NVIDIA at the end
-        assert_eq!(remove_nvidia_ci("TeslaNVIDIA"), "Tesla");
-        assert_eq!(remove_nvidia_ci("GPUnvidia"), "GPU");
-
-        // Multiple occurrences
-        assert_eq!(remove_nvidia_ci("NVIDIATestNVIDIA"), "Test");
-        assert_eq!(remove_nvidia_ci("nvidianvidianvidia"), "");
-
-        // Case variations
-        assert_eq!(remove_nvidia_ci("NvIdIaTest"), "Test");
-        assert_eq!(remove_nvidia_ci("TestNVidia"), "Test");
-
-        // No NVIDIA
-        assert_eq!(remove_nvidia_ci("AMDRadeon"), "AMDRadeon");
-        assert_eq!(remove_nvidia_ci("Intel"), "Intel");
-
-        // Edge cases
-        assert_eq!(remove_nvidia_ci(""), "");
-        assert_eq!(remove_nvidia_ci("NVIDIA"), "");
-        assert_eq!(remove_nvidia_ci("nvidia"), "");
-
-        // Partial matches should not be removed
-        assert_eq!(remove_nvidia_ci("NVID"), "NVID");
-        assert_eq!(remove_nvidia_ci("NVIDI"), "NVIDI");
-        assert_eq!(remove_nvidia_ci("VIDIA"), "VIDIA");
-    }
-
-    #[test]
-    fn test_sanitize_device_name() {
-        // Valid name with NVIDIA prefix - alphanumeric only, NVIDIA removed
-        assert_eq!(
-            sanitize_device_name("NVIDIA GeForce RTX 3090"),
-            "GeForceRTX3090"
-        );
-
-        // Different NVIDIA case variations
-        assert_eq!(sanitize_device_name("nvidia GeForce"), "GeForce");
-        assert_eq!(sanitize_device_name("Nvidia Tesla"), "Tesla");
-        assert_eq!(sanitize_device_name("NVIDIA RTX"), "RTX");
-
-        // NVIDIA appearing in the middle or end (not just prefix)
-        assert_eq!(sanitize_device_name("GeForce NVIDIA RTX"), "GeForceRTX");
-        assert_eq!(sanitize_device_name("Tesla NVIDIA"), "Tesla");
-        assert_eq!(sanitize_device_name("nVidia Test nvidia GPU"), "TestGPU");
-
-        // No NVIDIA prefix
-        assert_eq!(
-            sanitize_device_name("AMD Radeon RX 6800"),
-            "AMDRadeonRX6800"
-        );
-        assert_eq!(sanitize_device_name("Tesla V100"), "TeslaV100");
-
-        // Special characters and spaces - only alphanumeric allowed
-        assert_eq!(
-            sanitize_device_name("Device-Name_Test.1+2"),
-            "DeviceNameTest12"
-        );
-        assert_eq!(sanitize_device_name("Test @ Device #1!"), "TestDevice1");
-
-        // Length truncation (64 char limit)
-        let long_name = "A".repeat(100);
-        assert_eq!(sanitize_device_name(&long_name).len(), 64);
-
-        let long_with_nvidia = format!("NVIDIA {}", "A".repeat(100));
-        assert_eq!(sanitize_device_name(&long_with_nvidia).len(), 64);
-
-        // Edge cases
-        assert_eq!(sanitize_device_name(""), "");
-        assert_eq!(sanitize_device_name("NVIDIA"), "");
-        assert_eq!(sanitize_device_name("nvidia "), "");
-        assert_eq!(sanitize_device_name("   "), "");
-        assert_eq!(sanitize_device_name("!@#$%"), "");
-
-        // Only alphanumeric chars allowed now
-        assert_eq!(sanitize_device_name("ABC_123.test+v2"), "ABC123testv2");
     }
 }

--- a/crates/rattler_virtual_packages/src/cuda.rs
+++ b/crates/rattler_virtual_packages/src/cuda.rs
@@ -7,8 +7,8 @@
 //! The CUDA driver version represents the maximum CUDA version supported by the installed
 //! NVIDIA drivers. This is detected via:
 //!
-//! * CUDA driver library (libcuda) - Standard method
-//! * nvidia-smi command - Fallback on musl systems where dynamic library loading is not supported
+//! * CUDA driver library (libcuda): Standard method
+//! * nvidia-smi command: Fallback on musl systems where dynamic library loading is not supported
 //!
 //! ## CUDA Compute Capability (`__cuda_arch`)
 //!

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -233,14 +233,22 @@ impl VirtualPackages {
     /// Detect the virtual packages of the current system with the given
     /// overrides.
     pub fn detect(overrides: &VirtualPackageOverrides) -> Result<Self, DetectVirtualPackageError> {
+        let cuda = Cuda::detect(overrides.cuda.as_ref())?;
+        let mut cuda_arch = CudaArch::detect(overrides.cuda_arch.as_ref())?;
+
+        // Enforce CEP requirement: __cuda_arch must be absent when __cuda is absent
+        if cuda.is_none() {
+            cuda_arch = None;
+        }
+
         Ok(Self {
             win: Windows::detect(overrides.win.as_ref())?,
             unix: Platform::current().is_unix(),
             linux: Linux::detect(overrides.linux.as_ref())?,
             osx: Osx::detect(overrides.osx.as_ref())?,
             libc: LibC::detect(overrides.libc.as_ref())?,
-            cuda: Cuda::detect(overrides.cuda.as_ref())?,
-            cuda_arch: CudaArch::detect(overrides.cuda_arch.as_ref())?,
+            cuda,
+            cuda_arch,
             archspec: Archspec::detect(overrides.archspec.as_ref())?,
         })
     }
@@ -652,23 +660,16 @@ impl CudaArch {
 
 impl EnvOverride for CudaArch {
     fn parse_version(env_var_value: &str) -> Result<Self, ParseVersionError> {
-        // Parse format: "major.minor" (e.g., "8.6")
-        // Per CEP specification, only the version is needed
-
-        // Validate version format: must be "major.minor" where both are digits
+        // CEP requires exactly "major.minor" format where both are digits
         if !cuda::is_valid_cuda_version_format(env_var_value) {
-            tracing::warn!(
-                "Invalid CUDA compute capability format '{}'. Expected format: 'major.minor' (e.g., '8.6'). \
-                 The default capability of '0.0' will be used instead.",
-                env_var_value
-            );
-            return Ok(Self {
-                version: Version::from_str("0.0")?,
+            // Invalid format - return a ParseVersionError
+            // We use an empty string to generate a proper error
+            return Version::from_str("").map(|_| Self {
+                version: Version::major(0),
             });
         }
 
         let version = Version::from_str(env_var_value)?;
-
         Ok(Self { version })
     }
 
@@ -1152,15 +1153,10 @@ mod test {
         let cuda_arch = CudaArch::parse_version("9.0").unwrap();
         assert_eq!(cuda_arch.version, Version::from_str("9.0").unwrap());
 
-        // Test invalid version format (falls back to 0.0)
-        let cuda_arch = CudaArch::parse_version("invalid").unwrap();
-        assert_eq!(cuda_arch.version, Version::from_str("0.0").unwrap());
-
-        let cuda_arch = CudaArch::parse_version("8").unwrap();
-        assert_eq!(cuda_arch.version, Version::from_str("0.0").unwrap());
-
-        let cuda_arch = CudaArch::parse_version("8.6.1").unwrap();
-        assert_eq!(cuda_arch.version, Version::from_str("0.0").unwrap());
+        // Test invalid version format (should return error)
+        assert!(CudaArch::parse_version("invalid").is_err());
+        assert!(CudaArch::parse_version("8").is_err());
+        assert!(CudaArch::parse_version("8.6.1").is_err());
 
         // Test override via environment variable
         let env_var_name = format!("{}_{}", CudaArch::DEFAULT_ENV_NAME, "test123");
@@ -1170,5 +1166,75 @@ mod test {
         let cuda_arch = result.unwrap();
         assert_eq!(cuda_arch.version, Version::from_str("7.5").unwrap());
         env::remove_var(&env_var_name);
+    }
+
+    #[test]
+    fn test_cuda_arch_coupling() {
+        // Test that cuda_arch is absent when cuda is absent (CEP requirement)
+        // Even with cuda_arch override, it should be None if cuda is None
+
+        // Case 1: Both not present - cuda_arch should be None
+        let overrides = VirtualPackageOverrides::default();
+        let packages = VirtualPackages::detect(&overrides).unwrap();
+        // If cuda is None, cuda_arch must also be None
+        if packages.cuda.is_none() {
+            assert!(
+                packages.cuda_arch.is_none(),
+                "cuda_arch should be None when cuda is None"
+            );
+        }
+
+        // Case 2: cuda_arch override with no cuda - cuda_arch should be None
+        let cuda_arch_override = Override::String("8.6".to_string());
+        let overrides = VirtualPackageOverrides {
+            cuda: None, // No cuda
+            cuda_arch: Some(cuda_arch_override),
+            ..Default::default()
+        };
+        let packages = VirtualPackages::detect(&overrides).unwrap();
+        if packages.cuda.is_none() {
+            assert!(
+                packages.cuda_arch.is_none(),
+                "cuda_arch should be None when cuda is None, even with override"
+            );
+        }
+
+        // Case 3: Both have overrides - cuda_arch should be present
+        let cuda_override = Override::String("12.0".to_string());
+        let cuda_arch_override = Override::String("8.6".to_string());
+        let overrides = VirtualPackageOverrides {
+            cuda: Some(cuda_override),
+            cuda_arch: Some(cuda_arch_override),
+            ..Default::default()
+        };
+        let packages = VirtualPackages::detect(&overrides).unwrap();
+        assert!(
+            packages.cuda.is_some(),
+            "cuda should be present with override"
+        );
+        assert!(
+            packages.cuda_arch.is_some(),
+            "cuda_arch should be present when cuda is present"
+        );
+        let cuda_arch = packages.cuda_arch.unwrap();
+        assert_eq!(cuda_arch.version, Version::from_str("8.6").unwrap());
+
+        // Case 4: Empty string cuda override (disables cuda) - cuda_arch should be None
+        let cuda_override = Override::String("".to_string());
+        let cuda_arch_override = Override::String("8.6".to_string());
+        let overrides = VirtualPackageOverrides {
+            cuda: Some(cuda_override),
+            cuda_arch: Some(cuda_arch_override),
+            ..Default::default()
+        };
+        let packages = VirtualPackages::detect(&overrides).unwrap();
+        assert!(
+            packages.cuda.is_none(),
+            "cuda should be None with empty string override"
+        );
+        assert!(
+            packages.cuda_arch.is_none(),
+            "cuda_arch should be None when cuda is disabled via empty string"
+        );
     }
 }

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -616,6 +616,15 @@ impl From<Cuda> for VirtualPackage {
 /// across all detected CUDA devices on the system. The compute capability determines
 /// which instruction sets and features are available on a GPU.
 ///
+/// ## CEP Specification
+///
+/// According to the official CEP specification:
+///
+/// * The version is formatted as `{major}.{minor}` (e.g., 8.6, 9.0)
+/// * Represents the **minimum** compute capability across all detected devices
+/// * Subarchitecture letters (e.g., 'a', 'f') are excluded
+/// * The build string is always `"0"` (fixed value per CEP standard)
+///
 /// ## Rationale
 ///
 /// CUDA compute capability is critical for package compatibility because:
@@ -625,6 +634,12 @@ impl From<Cuda> for VirtualPackage {
 ///   capability or higher
 /// * The minimum capability ensures packages work on all GPUs in a multi-GPU system
 ///
+/// ## Why Device Names Are Excluded
+///
+/// The CEP explicitly rejects including device product names in the build string
+/// because doing so would encourage problematic dependency constraints based on
+/// specific GPU models rather than compute capability.
+///
 /// ## Use Cases
 ///
 /// The `__cuda_arch` virtual package enables:
@@ -632,11 +647,6 @@ impl From<Cuda> for VirtualPackage {
 /// * **Hardware-specific constraints**: Packages can specify minimum compute capability requirements
 /// * **Multi-variant builds**: Build different optimized variants for different architectures
 /// * **Forward compatibility**: Properly configured packages can run on newer GPUs
-///
-/// ## Build String
-///
-/// The build string contains the device name (e.g., "NVIDIA `GeForce` RTX 3090") to help
-/// users identify which GPU determined the minimum compute capability.
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize)]
 pub struct CudaArch {
     /// The compute capability version (e.g., 8.6 for RTX 3090).
@@ -644,12 +654,6 @@ pub struct CudaArch {
     /// This is formatted as `{major}.{minor}` and represents the minimum
     /// compute capability across all detected CUDA devices.
     pub version: Version,
-
-    /// The name of the device that has the minimum compute capability.
-    ///
-    /// This is used as the build string to help identify which GPU
-    /// determined the virtual package version.
-    pub device_name: String,
 }
 
 impl CudaArch {
@@ -664,58 +668,30 @@ impl CudaArch {
         cuda::cuda_arch().map(|arch_info| Self {
             version: Version::from_str(&format!("{}.{}", arch_info.major, arch_info.minor))
                 .unwrap_or_else(|_| Version::major(u64::from(arch_info.major))),
-            device_name: arch_info.device_name,
         })
     }
 }
 
 impl EnvOverride for CudaArch {
     fn parse_version(env_var_value: &str) -> Result<Self, ParseVersionError> {
-        // Parse format: "version" or "version=build"
-        // e.g., "8.6" or "8.6=NVIDIA GeForce RTX 3090"
-        let (version_str, device_name_input) = env_var_value
-            .split_once('=')
-            .map_or((env_var_value, None), |(v, b)| (v, Some(b)));
+        // Parse format: "major.minor" (e.g., "8.6")
+        // Per CEP specification, only the version is needed
 
         // Validate version format: must be "major.minor" where both are digits
-        if !cuda::is_valid_cuda_version_format(version_str) {
+        if !cuda::is_valid_cuda_version_format(env_var_value) {
             tracing::warn!(
                 "Invalid CUDA compute capability format '{}'. Expected format: 'major.minor' (e.g., '8.6'). \
-                 The default capability of '0.0=None' will be used instead.",
-                version_str
+                 The default capability of '0.0' will be used instead.",
+                env_var_value
             );
             return Ok(Self {
                 version: Version::from_str("0.0")?,
-                device_name: "None".to_string(),
             });
         }
 
-        let version = Version::from_str(version_str)?;
+        let version = Version::from_str(env_var_value)?;
 
-        // Validate and sanitize device name if provided
-        let device_name = if let Some(name) = device_name_input {
-            let sanitized = cuda::sanitize_device_name(name);
-            if sanitized.is_empty() || sanitized != name {
-                tracing::warn!(
-                    "Invalid device name '{}' contains characters not allowed in build strings. \
-                     Sanitized to '{}'.",
-                    name,
-                    sanitized
-                );
-            }
-            if sanitized.is_empty() {
-                "override".to_string()
-            } else {
-                sanitized
-            }
-        } else {
-            "override".to_string()
-        };
-
-        Ok(Self {
-            version,
-            device_name,
-        })
+        Ok(Self { version })
     }
 
     fn detect_from_host() -> Result<Option<Self>, DetectVirtualPackageError> {
@@ -730,9 +706,8 @@ impl From<CudaArch> for GenericVirtualPackage {
         GenericVirtualPackage {
             name: PackageName::new_unchecked("__cuda_arch"),
             version: cuda_arch.version,
-            // Use the device name as the build string to help identify which GPU
-            // determined the minimum compute capability
-            build_string: cuda_arch.device_name,
+            // Build string is always "0" per CEP specification
+            build_string: "0".into(),
         }
     }
 }
@@ -1189,47 +1164,33 @@ mod test {
 
     #[test]
     fn test_parse_cuda_arch() {
-        // Test parsing version only
+        // Test parsing valid version format
         let cuda_arch = CudaArch::parse_version("8.6").unwrap();
         assert_eq!(cuda_arch.version, Version::from_str("8.6").unwrap());
-        assert_eq!(cuda_arch.device_name, "override");
 
-        // Test parsing version with build string (sanitized)
-        let cuda_arch = CudaArch::parse_version("8.6=NVIDIA GeForce RTX 3090").unwrap();
-        assert_eq!(cuda_arch.version, Version::from_str("8.6").unwrap());
-        assert_eq!(cuda_arch.device_name, "GeForceRTX3090");
-
-        // Test with device name that needs sanitization (hyphen filtered out)
-        let cuda_arch = CudaArch::parse_version("7.5=Tesla V100-SXM2").unwrap();
+        let cuda_arch = CudaArch::parse_version("7.5").unwrap();
         assert_eq!(cuda_arch.version, Version::from_str("7.5").unwrap());
-        assert_eq!(cuda_arch.device_name, "TeslaV100SXM2");
 
-        // Test invalid version format (falls back to 0.0=None)
+        let cuda_arch = CudaArch::parse_version("9.0").unwrap();
+        assert_eq!(cuda_arch.version, Version::from_str("9.0").unwrap());
+
+        // Test invalid version format (falls back to 0.0)
         let cuda_arch = CudaArch::parse_version("invalid").unwrap();
         assert_eq!(cuda_arch.version, Version::from_str("0.0").unwrap());
-        assert_eq!(cuda_arch.device_name, "None");
 
         let cuda_arch = CudaArch::parse_version("8").unwrap();
         assert_eq!(cuda_arch.version, Version::from_str("0.0").unwrap());
-        assert_eq!(cuda_arch.device_name, "None");
 
         let cuda_arch = CudaArch::parse_version("8.6.1").unwrap();
         assert_eq!(cuda_arch.version, Version::from_str("0.0").unwrap());
-        assert_eq!(cuda_arch.device_name, "None");
-
-        // Test device name with all invalid chars (falls back to "override")
-        let cuda_arch = CudaArch::parse_version("8.6=!!!").unwrap();
-        assert_eq!(cuda_arch.version, Version::from_str("8.6").unwrap());
-        assert_eq!(cuda_arch.device_name, "override");
 
         // Test override via environment variable
         let env_var_name = format!("{}_{}", CudaArch::DEFAULT_ENV_NAME, "test123");
-        env::set_var(&env_var_name, "7.5=Tesla V100");
+        env::set_var(&env_var_name, "7.5");
         let result = CudaArch::detect(Some(&Override::EnvVar(env_var_name.clone()))).unwrap();
         assert!(result.is_some());
         let cuda_arch = result.unwrap();
         assert_eq!(cuda_arch.version, Version::from_str("7.5").unwrap());
-        assert_eq!(cuda_arch.device_name, "TeslaV100");
         env::remove_var(&env_var_name);
     }
 }

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -1184,12 +1184,12 @@ mod test {
 
         // Test override via environment variable
         let env_var_name = format!("{}_{}", CudaArch::DEFAULT_ENV_NAME, "test123");
-        env::set_var(&env_var_name, "7.5");
-        let result = CudaArch::detect(Some(&Override::EnvVar(env_var_name.clone()))).unwrap();
-        assert!(result.is_some());
-        let cuda_arch = result.unwrap();
-        assert_eq!(cuda_arch.version, Version::from_str("7.5").unwrap());
-        env::remove_var(&env_var_name);
+        temp_env::with_var(&env_var_name, Some("7.5"), || {
+            let result = CudaArch::detect(Some(&Override::EnvVar(env_var_name.clone()))).unwrap();
+            assert!(result.is_some());
+            let cuda_arch = result.unwrap();
+            assert_eq!(cuda_arch.version, Version::from_str("7.5").unwrap());
+        });
     }
 
     #[test]

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -51,7 +51,8 @@ use archspec::cpu::Microarchitecture;
 use libc::DetectLibCError;
 use linux::ParseLinuxVersionError;
 use rattler_conda_types::{
-    GenericVirtualPackage, PackageName, ParseVersionError, Platform, Version,
+    GenericVirtualPackage, PackageName, ParseVersionError, ParseVersionErrorKind, Platform,
+    Version,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -662,11 +663,10 @@ impl EnvOverride for CudaArch {
     fn parse_version(env_var_value: &str) -> Result<Self, ParseVersionError> {
         // CEP requires exactly "major.minor" format where both are digits
         if !cuda::is_valid_cuda_version_format(env_var_value) {
-            // Invalid format - return a ParseVersionError
-            // We use an empty string to generate a proper error
-            return Version::from_str("").map(|_| Self {
-                version: Version::major(0),
-            });
+            return Err(ParseVersionError::new(
+                env_var_value,
+                ParseVersionErrorKind::ExpectedComponent,
+            ));
         }
 
         let version = Version::from_str(env_var_value)?;

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -51,8 +51,7 @@ use archspec::cpu::Microarchitecture;
 use libc::DetectLibCError;
 use linux::ParseLinuxVersionError;
 use rattler_conda_types::{
-    GenericVirtualPackage, PackageName, ParseVersionError, ParseVersionErrorKind, Platform,
-    Version,
+    GenericVirtualPackage, PackageName, ParseVersionError, ParseVersionErrorKind, Platform, Version,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -618,7 +618,7 @@ impl From<Cuda> for VirtualPackage {
 ///
 /// ## Format
 ///
-/// * Version: `{major}.{minor}` (e.g., 8.6, 9.0) - minimum across all devices
+/// * Version: `{major}.{minor}` (e.g., 8.6, 9.0), representing minimum across all devices
 /// * Build string: always `"0"` per CEP specification
 /// * Subarchitecture letters excluded (e.g., 'a', 'f')
 ///

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -51,11 +51,30 @@ use archspec::cpu::Microarchitecture;
 use libc::DetectLibCError;
 use linux::ParseLinuxVersionError;
 use rattler_conda_types::{
-    GenericVirtualPackage, PackageName, ParseVersionError, ParseVersionErrorKind, Platform, Version,
+    GenericVirtualPackage, PackageName, ParseVersionError, Platform, Version,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::osx::ParseOsxVersionError;
+
+/// An error that occurred during parsing of a virtual package override value.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum ParseVirtualPackageOverrideError {
+    /// The version string could not be parsed
+    #[error(transparent)]
+    ParseVersion(#[from] ParseVersionError),
+
+    /// The override value failed custom validation with a specific message
+    #[error("{0}")]
+    ValidationError(String),
+}
+
+impl ParseVirtualPackageOverrideError {
+    /// Create a validation error with a custom message
+    pub fn validation_error(message: impl Into<String>) -> Self {
+        Self::ValidationError(message.into())
+    }
+}
 
 /// Configure the overrides used in in this crate.
 #[derive(Clone, Debug, PartialEq, Default)]
@@ -73,7 +92,7 @@ pub enum Override {
 /// Use as `Cuda::detect(override)`
 pub trait EnvOverride: Sized {
     /// Parse `env_var_value`
-    fn parse_version(value: &str) -> Result<Self, ParseVersionError>;
+    fn parse_version(value: &str) -> Result<Self, ParseVirtualPackageOverrideError>;
 
     /// Helper to convert the output of `parse_version` and handling empty
     /// strings.
@@ -405,6 +424,9 @@ pub enum DetectVirtualPackageError {
 
     #[error(transparent)]
     VersionParseError(#[from] ParseVersionError),
+
+    #[error(transparent)]
+    ParseOverride(#[from] ParseVirtualPackageOverrideError),
 }
 /// Configure the overrides used in this crate.
 ///
@@ -496,8 +518,8 @@ impl From<Version> for Linux {
 impl EnvOverride for Linux {
     const DEFAULT_ENV_NAME: &'static str = "CONDA_OVERRIDE_LINUX";
 
-    fn parse_version(env_var_value: &str) -> Result<Self, ParseVersionError> {
-        Version::from_str(env_var_value).map(Self::from)
+    fn parse_version(env_var_value: &str) -> Result<Self, ParseVirtualPackageOverrideError> {
+        Ok(Self::from(Version::from_str(env_var_value)?))
     }
 
     fn detect_from_host() -> Result<Option<Self>, DetectVirtualPackageError> {
@@ -554,10 +576,10 @@ impl From<LibC> for VirtualPackage {
 impl EnvOverride for LibC {
     const DEFAULT_ENV_NAME: &'static str = "CONDA_OVERRIDE_GLIBC";
 
-    fn parse_version(env_var_value: &str) -> Result<Self, ParseVersionError> {
-        Version::from_str(env_var_value).map(|version| Self {
+    fn parse_version(env_var_value: &str) -> Result<Self, ParseVirtualPackageOverrideError> {
+        Ok(Self {
             family: "glibc".into(),
-            version,
+            version: Version::from_str(env_var_value)?,
         })
     }
 
@@ -593,8 +615,10 @@ impl From<Version> for Cuda {
 }
 
 impl EnvOverride for Cuda {
-    fn parse_version(env_var_value: &str) -> Result<Self, ParseVersionError> {
-        Version::from_str(env_var_value).map(|version| Self { version })
+    fn parse_version(env_var_value: &str) -> Result<Self, ParseVirtualPackageOverrideError> {
+        Ok(Self {
+            version: Version::from_str(env_var_value)?,
+        })
     }
     fn detect_from_host() -> Result<Option<Self>, DetectVirtualPackageError> {
         Ok(Self::current())
@@ -659,13 +683,12 @@ impl CudaArch {
 }
 
 impl EnvOverride for CudaArch {
-    fn parse_version(env_var_value: &str) -> Result<Self, ParseVersionError> {
+    fn parse_version(env_var_value: &str) -> Result<Self, ParseVirtualPackageOverrideError> {
         // CEP requires exactly "major.minor" format where both are digits
         if !cuda::is_valid_cuda_version_format(env_var_value) {
-            return Err(ParseVersionError::new(
-                env_var_value,
-                ParseVersionErrorKind::ExpectedComponent,
-            ));
+            return Err(ParseVirtualPackageOverrideError::validation_error(format!(
+                "invalid CUDA compute capability format '{env_var_value}': expected 'major.minor' where both are digits (e.g., '8.6')"
+            )));
         }
 
         let version = Version::from_str(env_var_value)?;
@@ -837,7 +860,7 @@ impl From<Archspec> for VirtualPackage {
 }
 
 impl EnvOverride for Archspec {
-    fn parse_version(value: &str) -> Result<Self, ParseVersionError> {
+    fn parse_version(value: &str) -> Result<Self, ParseVirtualPackageOverrideError> {
         if value == "0" {
             Ok(Archspec::Unknown)
         } else {
@@ -892,8 +915,10 @@ impl From<Version> for Osx {
 }
 
 impl EnvOverride for Osx {
-    fn parse_version(env_var_value: &str) -> Result<Self, ParseVersionError> {
-        Version::from_str(env_var_value).map(|version| Self { version })
+    fn parse_version(env_var_value: &str) -> Result<Self, ParseVirtualPackageOverrideError> {
+        Ok(Self {
+            version: Version::from_str(env_var_value)?,
+        })
     }
     fn detect_from_host() -> Result<Option<Self>, DetectVirtualPackageError> {
         Ok(Self::current()?)
@@ -948,9 +973,9 @@ impl From<Version> for Windows {
 }
 
 impl EnvOverride for Windows {
-    fn parse_version(env_var_value: &str) -> Result<Self, ParseVersionError> {
-        Version::from_str(env_var_value).map(|version| Self {
-            version: Some(version),
+    fn parse_version(env_var_value: &str) -> Result<Self, ParseVirtualPackageOverrideError> {
+        Ok(Self {
+            version: Some(Version::from_str(env_var_value)?),
         })
     }
     fn detect_from_host() -> Result<Option<Self>, DetectVirtualPackageError> {

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -612,47 +612,25 @@ impl From<Cuda> for VirtualPackage {
 
 /// CUDA compute capability virtual package description.
 ///
-/// This virtual package represents the minimum CUDA compute capability (SM version)
-/// across all detected CUDA devices on the system. The compute capability determines
-/// which instruction sets and features are available on a GPU.
+/// Represents the minimum CUDA compute capability (SM version) across all detected
+/// devices. The compute capability determines which instruction sets and features
+/// are available on a GPU.
 ///
-/// ## CEP Specification
+/// ## Format
 ///
-/// According to the official CEP specification:
+/// * Version: `{major}.{minor}` (e.g., 8.6, 9.0) - minimum across all devices
+/// * Build string: always `"0"` per CEP specification
+/// * Subarchitecture letters excluded (e.g., 'a', 'f')
 ///
-/// * The version is formatted as `{major}.{minor}` (e.g., 8.6, 9.0)
-/// * Represents the **minimum** compute capability across all detected devices
-/// * Subarchitecture letters (e.g., 'a', 'f') are excluded
-/// * The build string is always `"0"` (fixed value per CEP standard)
-///
-/// ## Rationale
-///
-/// CUDA compute capability is critical for package compatibility because:
-///
-/// * Different GPU models support different compute capabilities (e.g., 5.0, 7.0, 8.0, 9.0)
-/// * Packages compiled for a specific compute capability only run on GPUs with that
-///   capability or higher
-/// * The minimum capability ensures packages work on all GPUs in a multi-GPU system
-///
-/// ## Why Device Names Are Excluded
-///
-/// The CEP explicitly rejects including device product names in the build string
-/// because doing so would encourage problematic dependency constraints based on
-/// specific GPU models rather than compute capability.
-///
-/// ## Use Cases
-///
-/// The `__cuda_arch` virtual package enables:
-///
-/// * **Hardware-specific constraints**: Packages can specify minimum compute capability requirements
-/// * **Multi-variant builds**: Build different optimized variants for different architectures
-/// * **Forward compatibility**: Properly configured packages can run on newer GPUs
+/// Packages compiled for a specific compute capability require that capability or
+/// higher to run. Using the minimum ensures compatibility with all GPUs in multi-GPU
+/// systems.
 #[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize)]
 pub struct CudaArch {
-    /// The compute capability version (e.g., 8.6 for RTX 3090).
+    /// The compute capability version (e.g., 8.6).
     ///
-    /// This is formatted as `{major}.{minor}` and represents the minimum
-    /// compute capability across all detected CUDA devices.
+    /// Formatted as `{major}.{minor}`, represents the minimum compute capability
+    /// across all detected CUDA devices.
     pub version: Version,
 }
 

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -162,6 +162,9 @@ pub enum VirtualPackage {
     /// Available `Cuda` version
     Cuda(Cuda),
 
+    /// Available CUDA compute capability
+    CudaArch(CudaArch),
+
     /// The CPU architecture
     Archspec(Archspec),
 }
@@ -187,6 +190,9 @@ pub struct VirtualPackages {
     /// Available `Cuda` version
     pub cuda: Option<Cuda>,
 
+    /// Available CUDA compute capability
+    pub cuda_arch: Option<CudaArch>,
+
     /// The CPU architecture
     pub archspec: Option<Archspec>,
 }
@@ -201,6 +207,7 @@ impl VirtualPackages {
             osx,
             libc,
             cuda,
+            cuda_arch,
             archspec,
         } = self;
 
@@ -211,6 +218,7 @@ impl VirtualPackages {
             osx.map(VirtualPackage::Osx),
             libc.map(VirtualPackage::LibC),
             cuda.map(VirtualPackage::Cuda),
+            cuda_arch.map(VirtualPackage::CudaArch),
             archspec.map(VirtualPackage::Archspec),
         ]
         .into_iter()
@@ -232,6 +240,7 @@ impl VirtualPackages {
             osx: Osx::detect(overrides.osx.as_ref())?,
             libc: LibC::detect(overrides.libc.as_ref())?,
             cuda: Cuda::detect(overrides.cuda.as_ref())?,
+            cuda_arch: CudaArch::detect(overrides.cuda_arch.as_ref())?,
             archspec: Archspec::detect(overrides.archspec.as_ref())?,
         })
     }
@@ -322,6 +331,7 @@ impl VirtualPackages {
                 osx,
                 libc,
                 cuda: virtual_packages.cuda,
+                cuda_arch: virtual_packages.cuda_arch,
                 archspec,
             })
         }
@@ -341,6 +351,7 @@ impl From<VirtualPackage> for GenericVirtualPackage {
             VirtualPackage::Osx(osx) => osx.into(),
             VirtualPackage::LibC(libc) => libc.into(),
             VirtualPackage::Cuda(cuda) => cuda.into(),
+            VirtualPackage::CudaArch(cuda_arch) => cuda_arch.into(),
             VirtualPackage::Archspec(spec) => spec.into(),
         }
     }
@@ -406,6 +417,8 @@ pub struct VirtualPackageOverrides {
     pub libc: Option<Override>,
     /// The override for the cuda virtual package
     pub cuda: Option<Override>,
+    /// The override for the `cuda_arch` virtual package
+    pub cuda_arch: Option<Override>,
     /// The override for the archspec virtual package
     pub archspec: Option<Override>,
 }
@@ -420,6 +433,7 @@ impl VirtualPackageOverrides {
             linux: Some(ov.clone()),
             libc: Some(ov.clone()),
             cuda: Some(ov.clone()),
+            cuda_arch: Some(ov.clone()),
             archspec: Some(ov),
         }
     }
@@ -593,6 +607,139 @@ impl From<Cuda> for GenericVirtualPackage {
 impl From<Cuda> for VirtualPackage {
     fn from(cuda: Cuda) -> Self {
         VirtualPackage::Cuda(cuda)
+    }
+}
+
+/// CUDA compute capability virtual package description.
+///
+/// This virtual package represents the minimum CUDA compute capability (SM version)
+/// across all detected CUDA devices on the system. The compute capability determines
+/// which instruction sets and features are available on a GPU.
+///
+/// ## Rationale
+///
+/// CUDA compute capability is critical for package compatibility because:
+///
+/// * Different GPU models support different compute capabilities (e.g., 5.0, 7.0, 8.0, 9.0)
+/// * Packages compiled for a specific compute capability only run on GPUs with that
+///   capability or higher
+/// * The minimum capability ensures packages work on all GPUs in a multi-GPU system
+///
+/// ## Use Cases
+///
+/// The `__cuda_arch` virtual package enables:
+///
+/// * **Hardware-specific constraints**: Packages can specify minimum compute capability requirements
+/// * **Multi-variant builds**: Build different optimized variants for different architectures
+/// * **Forward compatibility**: Properly configured packages can run on newer GPUs
+///
+/// ## Build String
+///
+/// The build string contains the device name (e.g., "NVIDIA `GeForce` RTX 3090") to help
+/// users identify which GPU determined the minimum compute capability.
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Deserialize)]
+pub struct CudaArch {
+    /// The compute capability version (e.g., 8.6 for RTX 3090).
+    ///
+    /// This is formatted as `{major}.{minor}` and represents the minimum
+    /// compute capability across all detected CUDA devices.
+    pub version: Version,
+
+    /// The name of the device that has the minimum compute capability.
+    ///
+    /// This is used as the build string to help identify which GPU
+    /// determined the virtual package version.
+    pub device_name: String,
+}
+
+impl CudaArch {
+    /// Returns the minimum CUDA compute capability available on the current platform.
+    ///
+    /// Returns `None` if:
+    /// * No CUDA drivers are installed
+    /// * No CUDA devices are detected
+    /// * Device enumeration fails
+    /// * The system is using musl libc (dynamic library loading not supported)
+    pub fn current() -> Option<Self> {
+        cuda::cuda_arch().map(|arch_info| Self {
+            version: Version::from_str(&format!("{}.{}", arch_info.major, arch_info.minor))
+                .unwrap_or_else(|_| Version::major(u64::from(arch_info.major))),
+            device_name: arch_info.device_name,
+        })
+    }
+}
+
+impl EnvOverride for CudaArch {
+    fn parse_version(env_var_value: &str) -> Result<Self, ParseVersionError> {
+        // Parse format: "version" or "version=build"
+        // e.g., "8.6" or "8.6=NVIDIA GeForce RTX 3090"
+        let (version_str, device_name_input) = env_var_value
+            .split_once('=')
+            .map_or((env_var_value, None), |(v, b)| (v, Some(b)));
+
+        // Validate version format: must be "major.minor" where both are digits
+        if !cuda::is_valid_cuda_version_format(version_str) {
+            tracing::warn!(
+                "Invalid CUDA compute capability format '{}'. Expected format: 'major.minor' (e.g., '8.6'). \
+                 The default capability of '0.0=None' will be used instead.",
+                version_str
+            );
+            return Ok(Self {
+                version: Version::from_str("0.0")?,
+                device_name: "None".to_string(),
+            });
+        }
+
+        let version = Version::from_str(version_str)?;
+
+        // Validate and sanitize device name if provided
+        let device_name = if let Some(name) = device_name_input {
+            let sanitized = cuda::sanitize_device_name(name);
+            if sanitized.is_empty() || sanitized != name {
+                tracing::warn!(
+                    "Invalid device name '{}' contains characters not allowed in build strings. \
+                     Sanitized to '{}'.",
+                    name,
+                    sanitized
+                );
+            }
+            if sanitized.is_empty() {
+                "override".to_string()
+            } else {
+                sanitized
+            }
+        } else {
+            "override".to_string()
+        };
+
+        Ok(Self {
+            version,
+            device_name,
+        })
+    }
+
+    fn detect_from_host() -> Result<Option<Self>, DetectVirtualPackageError> {
+        Ok(Self::current())
+    }
+
+    const DEFAULT_ENV_NAME: &'static str = "CONDA_OVERRIDE_CUDA_ARCH";
+}
+
+impl From<CudaArch> for GenericVirtualPackage {
+    fn from(cuda_arch: CudaArch) -> Self {
+        GenericVirtualPackage {
+            name: PackageName::new_unchecked("__cuda_arch"),
+            version: cuda_arch.version,
+            // Use the device name as the build string to help identify which GPU
+            // determined the minimum compute capability
+            build_string: cuda_arch.device_name,
+        }
+    }
+}
+
+impl From<CudaArch> for VirtualPackage {
+    fn from(cuda_arch: CudaArch) -> Self {
+        VirtualPackage::CudaArch(cuda_arch)
     }
 }
 
@@ -1011,5 +1158,78 @@ mod test {
         assert!(win_names.contains(&"__win".to_string()));
         assert!(!win_names.contains(&"__unix".to_string()));
         assert!(win_names.contains(&"__archspec".to_string()));
+    }
+
+    #[test]
+    fn test_is_valid_cuda_version_format() {
+        // Valid formats
+        assert!(cuda::is_valid_cuda_version_format("8.6"));
+        assert!(cuda::is_valid_cuda_version_format("7.5"));
+        assert!(cuda::is_valid_cuda_version_format("10.2"));
+        assert!(cuda::is_valid_cuda_version_format("0.0"));
+        assert!(cuda::is_valid_cuda_version_format("12.0"));
+
+        // Invalid formats - not major.minor
+        assert!(!cuda::is_valid_cuda_version_format("8"));
+        assert!(!cuda::is_valid_cuda_version_format("8.6.1"));
+        assert!(!cuda::is_valid_cuda_version_format("8.6.1.0"));
+        assert!(!cuda::is_valid_cuda_version_format(""));
+        assert!(!cuda::is_valid_cuda_version_format(".6"));
+        assert!(!cuda::is_valid_cuda_version_format("8."));
+        assert!(!cuda::is_valid_cuda_version_format("."));
+
+        // Invalid formats - non-digit characters
+        assert!(!cuda::is_valid_cuda_version_format("8.6a"));
+        assert!(!cuda::is_valid_cuda_version_format("a.6"));
+        assert!(!cuda::is_valid_cuda_version_format("8.b"));
+        assert!(!cuda::is_valid_cuda_version_format("eight.six"));
+        assert!(!cuda::is_valid_cuda_version_format("8-6"));
+        assert!(!cuda::is_valid_cuda_version_format("8_6"));
+    }
+
+    #[test]
+    fn test_parse_cuda_arch() {
+        // Test parsing version only
+        let cuda_arch = CudaArch::parse_version("8.6").unwrap();
+        assert_eq!(cuda_arch.version, Version::from_str("8.6").unwrap());
+        assert_eq!(cuda_arch.device_name, "override");
+
+        // Test parsing version with build string (sanitized)
+        let cuda_arch = CudaArch::parse_version("8.6=NVIDIA GeForce RTX 3090").unwrap();
+        assert_eq!(cuda_arch.version, Version::from_str("8.6").unwrap());
+        assert_eq!(cuda_arch.device_name, "GeForceRTX3090");
+
+        // Test with device name that needs sanitization (hyphen filtered out)
+        let cuda_arch = CudaArch::parse_version("7.5=Tesla V100-SXM2").unwrap();
+        assert_eq!(cuda_arch.version, Version::from_str("7.5").unwrap());
+        assert_eq!(cuda_arch.device_name, "TeslaV100SXM2");
+
+        // Test invalid version format (falls back to 0.0=None)
+        let cuda_arch = CudaArch::parse_version("invalid").unwrap();
+        assert_eq!(cuda_arch.version, Version::from_str("0.0").unwrap());
+        assert_eq!(cuda_arch.device_name, "None");
+
+        let cuda_arch = CudaArch::parse_version("8").unwrap();
+        assert_eq!(cuda_arch.version, Version::from_str("0.0").unwrap());
+        assert_eq!(cuda_arch.device_name, "None");
+
+        let cuda_arch = CudaArch::parse_version("8.6.1").unwrap();
+        assert_eq!(cuda_arch.version, Version::from_str("0.0").unwrap());
+        assert_eq!(cuda_arch.device_name, "None");
+
+        // Test device name with all invalid chars (falls back to "override")
+        let cuda_arch = CudaArch::parse_version("8.6=!!!").unwrap();
+        assert_eq!(cuda_arch.version, Version::from_str("8.6").unwrap());
+        assert_eq!(cuda_arch.device_name, "override");
+
+        // Test override via environment variable
+        let env_var_name = format!("{}_{}", CudaArch::DEFAULT_ENV_NAME, "test123");
+        env::set_var(&env_var_name, "7.5=Tesla V100");
+        let result = CudaArch::detect(Some(&Override::EnvVar(env_var_name.clone()))).unwrap();
+        assert!(result.is_some());
+        let cuda_arch = result.unwrap();
+        assert_eq!(cuda_arch.version, Version::from_str("7.5").unwrap());
+        assert_eq!(cuda_arch.device_name, "TeslaV100");
+        env::remove_var(&env_var_name);
     }
 }

--- a/py-rattler/src/virtual_package.rs
+++ b/py-rattler/src/virtual_package.rs
@@ -110,6 +110,14 @@ impl PyVirtualPackageOverrides {
         self.inner.cuda = value.map(Into::into);
     }
     #[getter]
+    pub fn get_cuda_arch(&self) -> Option<PyOverride> {
+        self.inner.cuda_arch.clone().map(Into::into)
+    }
+    #[setter]
+    pub fn set_cuda_arch(&mut self, value: Option<PyOverride>) {
+        self.inner.cuda_arch = value.map(Into::into);
+    }
+    #[getter]
     pub fn get_libc(&self) -> Option<PyOverride> {
         self.inner.libc.clone().map(Into::into)
     }


### PR DESCRIPTION
This PR implements the `__cuda_arch` virtual package based on the [nvidia-virtual-packages](https://github.com/conda-incubator/nvidia-virtual-packages) reference implementation. The package detects the **minimum CUDA compute capability** (SM version) across all CUDA devices on the system, enabling hardware-specific package constraints and multi-variant builds.

@carterbox I wanted to get a head start with this to also make it available in rattler-build so we can experiment with this more easily. 

### AI Disclosure

Written by Claude Sonnet 4.5, edited and reviewed by me.