### PR TITLE
chore(python): bump version from 0.16.0 to 0.17.0

### DIFF
--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 license = "BSD-3-Clause"
 publish = false


### PR DESCRIPTION
Bumps py-rattler release from 0.16.0 to 0.17.0.

@jezdez 