### PR TITLE
chore(python): bump version from 0.17.0 to 0.18.0

### DIFF
--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 license = "BSD-3-Clause"
 publish = false


### PR DESCRIPTION
Bumps py-rattler bindings to 0.18.0. This includes:

- https://github.com/conda/rattler/pull/1867
- https://github.com/conda/rattler/pull/1868
- https://github.com/conda/rattler/pull/1880
- https://github.com/conda/rattler/pull/1881