### PR TITLE
feat(rattler_conda_types): use `fancy_regex` for matchers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4622,6 +4633,7 @@ dependencies = [
  "criterion",
  "dirs",
  "dunce",
+ "fancy-regex",
  "file_url",
  "fs-err",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ digest = "0.10.7"
 dirs = "6.0.0"
 dunce = "1.0.5"
 enum_dispatch = "0.3.13"
+fancy-regex = "0.14.0"
 fs-err = { version = "3.1.0" }
 fslock = "0.2.1"
 futures = "0.3.31"

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -32,6 +32,7 @@ rattler_digest = { workspace = true, default-features = false, features = [
 ] }
 rattler_macros = { workspace = true, default-features = false }
 rattler_redaction = { workspace = true, default-features = false }
+fancy-regex = { workspace = true }
 regex = { workspace = true }
 simd-json = { workspace = true, features = ["serde_impl"] }
 serde = { workspace = true, features = ["derive", "rc"] }


### PR DESCRIPTION
Replace the `regex` crate with `fancy_regex` for `StringMatcher` and `PackageNameMatcher`. This enables support for advanced regex features like lookahead and lookbehind assertions in package name and build string matching.