### PR TITLE
fix(menuinst): respect user-provided CFBundleIdentifier in macOS Info.plist

### DIFF
--- a/crates/rattler_menuinst/src/macos.rs
+++ b/crates/rattler_menuinst/src/macos.rs
@@ -444,9 +444,14 @@ impl MacOSMenu {
         // This one is _not_ part of the schema, so we just set it
         pl.insert("CFBundleExecutable".into(), Value::String(slugname.clone()));
 
+        let cf_bundle_identifier = resolve(
+            &self.item.cf_bundle_identifier,
+            &self.placeholders,
+            &format!("com.{slugname}"),
+        );
         pl.insert(
             "CFBundleIdentifier".into(),
-            Value::String(format!("com.{slugname}")),
+            Value::String(cf_bundle_identifier.clone()),
         );
         pl.insert("CFBundlePackageType".into(), Value::String("APPL".into()));
 
@@ -508,7 +513,7 @@ impl MacOSMenu {
             pl.insert("LSBackgroundOnly".into(), Value::Boolean(true));
             pl.insert(
                 "CFBundleIdentifier".into(),
-                Value::String(format!("com.{slugname}-appkit-launcher")),
+                Value::String(format!("{cf_bundle_identifier}-appkit-launcher")),
             );
         }
 

--- a/crates/rattler_menuinst/src/snapshots/rattler_menuinst__macos__tests__macos_menu_installation.snap
+++ b/crates/rattler_menuinst/src/snapshots/rattler_menuinst__macos__tests__macos_menu_installation.snap
@@ -13,7 +13,7 @@ expression: "fs::read_to_string(dirs.location.join(\"Contents/Info.plist\")).unw
 	<key>CFBundleExecutable</key>
 	<string>spyder-6-test-env</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.spyder-6-test-env</string>
+	<string>org.spyder-ide.Spyder-6-.prefix</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
The CFBundleIdentifier field was defined in the schema and could be specified in menu.json files, but the code always generated a default value using `com.{slugname}` instead of using the user-provided value.

This fix changes the behavior to:
1. Use the user-provided CFBundleIdentifier from menu.json if specified
2. Fall back to the default `com.{slugname}` format if not specified
3. For AppKit launcher bundles, append `-appkit-launcher` to the resolved identifier

Fixes #1886

<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
