### PR TITLE
feat(rattler_lock): add prerelease-mode support for PyPI dependencies

### DIFF
--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -102,7 +102,7 @@ pub use conda::{
 };
 pub use file_format_version::FileFormatVersion;
 pub use hash::PackageHashes;
-pub use options::SolveOptions;
+pub use options::{PypiPrereleaseMode, SolveOptions};
 pub use parse::ParseCondaLockError;
 pub use pypi::{PypiPackageData, PypiPackageEnvironmentData, PypiSourceTreeHashable};
 pub use pypi_indexes::{FindLinksUrlOrPath, PypiIndexes};
@@ -281,6 +281,13 @@ impl<'lock> Environment<'lock> {
     /// Starting with version `5` of the format this should not be optional.
     pub fn pypi_indexes(&self) -> Option<&PypiIndexes> {
         self.data().indexes.as_ref()
+    }
+
+    /// Returns the `PyPI` prerelease mode that was used to solve this environment.
+    ///
+    /// Returns `None` if no prerelease mode was explicitly set.
+    pub fn pypi_prerelease_mode(&self) -> Option<PypiPrereleaseMode> {
+        self.data().options.pypi_prerelease_mode
     }
 
     /// Returns the solver options that were used to create this environment.

--- a/crates/rattler_lock/src/options.rs
+++ b/crates/rattler_lock/src/options.rs
@@ -3,6 +3,28 @@
 // Reexport these fields.
 pub use rattler_solve::{ChannelPriority, SolveStrategy};
 
+/// The prerelease mode used to resolve `PyPI` dependencies.
+///
+/// This controls how the resolver handles pre-release versions of packages.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, Default,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum PypiPrereleaseMode {
+    /// Disallow all pre-release versions.
+    Disallow,
+    /// Allow all pre-release versions.
+    Allow,
+    /// Allow pre-release versions if necessary to satisfy the requirements.
+    IfNecessary,
+    /// Allow pre-release versions for packages explicitly requested.
+    Explicit,
+    /// Allow pre-release versions if necessary or explicitly requested.
+    /// This is the default mode.
+    #[default]
+    IfNecessaryOrExplicit,
+}
+
 /// Options that were used during the resolution of the packages stored in the
 /// lock-file. These options strongly influence the outcome of the solve and are
 /// therefore stored along with the locked packages.
@@ -20,4 +42,8 @@ pub struct SolveOptions {
     /// Packages after this date have been excluded from the lock file.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
+
+    /// The prerelease mode that was used to resolve `PyPI` dependencies.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pypi_prerelease_mode: Option<PypiPrereleaseMode>,
 }

--- a/crates/rattler_lock/src/snapshots/rattler_lock__builder__test__pypi_prerelease_mode.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__builder__test__pypi_prerelease_mode.snap
@@ -1,0 +1,16 @@
+---
+source: crates/rattler_lock/src/builder.rs
+expression: lock_file.render_to_string().unwrap()
+---
+version: 6
+environments:
+  default:
+    channels: []
+    options:
+      pypi-prerelease-mode: allow
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/example/linux-64/python-3.12.0-build.tar.bz2
+packages:
+- conda: https://prefix.dev/example/linux-64/python-3.12.0-build.tar.bz2
+  channel: null


### PR DESCRIPTION
## Summary

Add support for storing PyPI prerelease mode per environment in lock files. This enables tools like pixi to persist their prerelease configuration.

Related to: https://github.com/prefix-dev/pixi/pull/4984

## Changes

- Add `PypiPrereleaseMode` enum to `SolveOptions` with 5 variants:
  - `Disallow` - Disallow all pre-release versions
  - `Allow` - Allow all pre-release versions
  - `IfNecessary` - Allow pre-release versions if necessary to satisfy requirements
  - `Explicit` - Allow pre-release versions for packages explicitly requested
  - `IfNecessaryOrExplicit` - Default mode (allow if necessary or explicitly requested)
- Add optional `pypi_prerelease_mode` field to `SolveOptions` struct
- Add builder methods: `set_pypi_prerelease_mode()` and `with_pypi_prerelease_mode()`
- Add `Environment::pypi_prerelease_mode()` getter method
- Add tests for serialization roundtrip of all prerelease modes

## Lock File Format

The prerelease mode is stored at the environment level within the options section:

```yaml
version: 6
environments:
  default:
    channels: []
    options:
      pypi-prerelease-mode: allow
    packages:
      linux-64:
      - conda: https://...
```

## Backwards Compatibility

The implementation is fully backwards compatible:
- The `pypi_prerelease_mode` field is optional (`Option<PypiPrereleaseMode>`)
- Uses `skip_serializing_if = "Option::is_none"` so old lock files without this field will parse correctly
- Uses `default` attribute so missing field deserializes to `None`
- Existing roundtrip tests all pass, confirming no breaking changes