### PR TITLE
feat: enable credentials-login for aws new login functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ checksum = "a0149602eeaf915158e14029ba0c78dedb8c08d554b024d54c8f239aab46511d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-signin",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
@@ -372,15 +373,20 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
+ "base64-simd",
  "bytes",
  "fastrand",
  "hex",
  "http 1.4.0",
+ "p256 0.13.2",
+ "rand 0.8.5",
  "ring",
+ "sha2",
  "time",
  "tokio",
  "tracing",
  "url",
+ "uuid",
  "zeroize",
 ]
 
@@ -453,6 +459,28 @@ dependencies = [
  "sha2",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "aws-sdk-signin"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539a464c46384f614b887611bf958ec5a9fb3bf6e3ee966f18fd0b040ced9996"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -6745,9 +6773,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "8eb41cbdb933e23b7929f47bb577710643157d7602ef3a2ebd3902b13ac5eda6"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -6756,9 +6784,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6767,9 +6795,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -6788,9 +6816,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "bee4bf13715d00789f2a099fd05d127c012bddc5c6628f2c8968374c1820c01d"
 dependencies = [
  "matchers",
  "nu-ansi-term",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,10 @@ generic-array = "=0.14.7"
 getrandom = { version = "0.3.3", default-features = false }
 glob = "0.3.2"
 google-cloud-auth = { version = "1.0.0", default-features = false }
-aws-config = { version = "1.8.7", default-features = false }
-aws-sdk-s3 = { version = "1.107.0", default-features = false }
+aws-config = { version = "1.8.11", default-features = false }
+aws-sdk-s3 = { version = "1.115.0", default-features = false }
 aws-smithy-http-client = { version = "1.1.2", default-features = false }
-aws-credential-types = { version = "1.2.5", default-features = false }
+aws-credential-types = { version = "1.2.10", default-features = false }
 hex = "0.4.3"
 hex-literal = "1.0.0"
 http = "1.3"

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -32,6 +32,7 @@ google-cloud-auth = { workspace = true, optional = true }
 aws-config = { workspace = true, optional = true, features = [
     "rt-tokio",
     "sso",
+    "credentials-login",
     "credentials-process",
 ] }
 aws-sdk-s3 = { workspace = true, optional = true, features = [

--- a/crates/rattler_networking/src/authentication_storage/backends/netrc.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/netrc.rs
@@ -23,7 +23,7 @@ pub enum NetRcStorageError {
     IOError(#[from] std::io::Error),
 
     /// An error occurred when parsing the netrc file
-    #[error("could not parse .netc file: {0}")]
+    #[error("could not parse .netrc file: {0}")]
     ParseError(netrc_rs::Error),
 
     /// Something is not supported

--- a/crates/rattler_s3/Cargo.toml
+++ b/crates/rattler_s3/Cargo.toml
@@ -15,7 +15,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 
-aws-config = { workspace = true, features = ["sso", "credentials-process", "rt-tokio"] }
+aws-config = { workspace = true, features = ["sso", "credentials-process", "rt-tokio", "credentials-login"] }
 aws-sdk-s3 = { workspace = true, features = ["rt-tokio"] }
 aws-smithy-http-client = { workspace = true, features = ["rustls-ring"] }
 aws-credential-types = { workspace = true }


### PR DESCRIPTION
This enables support for the new credential scheme coming from 

```
aws login
```

Which stores credentials as `login_session = arn:aws:iam::XXX...` and a JSON file under `~/.aws/login` (as far as I can tell).