### PR TITLE
fix: Tune heavy py-rattler imports + lazy import networkx

### DIFF
--- a/py-rattler/rattler/repo_data/gateway.py
+++ b/py-rattler/rattler/repo_data/gateway.py
@@ -4,11 +4,12 @@ import os
 from dataclasses import dataclass
 from typing import Iterable, List, Optional
 
-from rattler.channel import Channel
-from rattler.match_spec import MatchSpec
-from rattler.networking import CacheAction, Client
+from rattler.channel.channel import Channel
+from rattler.match_spec.match_spec import MatchSpec
+from rattler.networking.client import Client
+from rattler.networking.fetch_repo_data import CacheAction
 from rattler.package.package_name import PackageName
-from rattler.platform import Platform, PlatformLiteral
+from rattler.platform.platform import Platform, PlatformLiteral
 from rattler.rattler import PyGateway, PyMatchSpec, PySourceConfig
 from rattler.repo_data.record import RepoDataRecord
 

--- a/py-rattler/rattler/repo_data/package_record.py
+++ b/py-rattler/rattler/repo_data/package_record.py
@@ -12,11 +12,6 @@ from rattler.rattler import PyRecord, ParsePlatformError
 
 if TYPE_CHECKING:
     import networkx as nx
-else:
-    try:
-        import networkx as nx
-    except ImportError:
-        nx = None
 
 
 class PackageRecord:
@@ -122,8 +117,10 @@ class PackageRecord:
 
         Note: Virtual packages (starting with `__`) are skipped.
         """
-        if nx is None:
-            raise ImportError("networkx is not installed")
+        try:
+            import networkx as nx
+        except ImportError:
+            raise ImportError("networkx is not installed") from None
 
         names_to_records = {record.name: record for record in records}
 

--- a/py-rattler/rattler/repo_data/record.py
+++ b/py-rattler/rattler/repo_data/record.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from rattler.rattler import PyRecord
-from rattler.repo_data import PackageRecord
+from rattler.repo_data.package_record import PackageRecord
 
 
 class RepoDataRecord(PackageRecord):

--- a/py-rattler/rattler/solver/solver.py
+++ b/py-rattler/rattler/solver/solver.py
@@ -3,14 +3,16 @@ from __future__ import annotations
 import datetime
 from typing import List, Literal, Optional, Sequence
 
-from rattler import Channel, Platform, SparseRepoData, VirtualPackage
-from rattler.channel import ChannelPriority
+from rattler.channel.channel import Channel
+from rattler.channel.channel_priority import ChannelPriority
 from rattler.match_spec.match_spec import MatchSpec
-from rattler.platform.platform import PlatformLiteral
+from rattler.platform.platform import Platform, PlatformLiteral
 from rattler.rattler import PyMatchSpec, PyPackageFormatSelection, py_solve, py_solve_with_sparse_repodata
 from rattler.repo_data.gateway import Gateway
 from rattler.repo_data.record import RepoDataRecord
+from rattler.repo_data.sparse import SparseRepoData
 from rattler.virtual_package.generic import GenericVirtualPackage
+from rattler.virtual_package.virtual_package import VirtualPackage
 
 SolveStrategy = Literal["highest", "lowest", "lowest-direct"]
 """Defines the strategy to use when multiple versions of a package are available during solving."""


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
Prevent some cascading imports where not needed (eg; from unnecessary top-level imports) + lazy-import networkx. This alone speeds up the worst offenders of import time for py-rattler significantly. Obviously for networkx you incur that if you use to_graph but only then.

For PackageRecord alone this this drops import time by 90% from networkx alone. Verified with an import profile + `tuna`.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
