### PR TITLE
refactor: replace `chrono` with `jiff`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5194,7 +5194,6 @@ version = "0.1.12"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
- "chrono",
  "clap",
  "clap_complete",
  "clap_complete_nushell",
@@ -5203,6 +5202,7 @@ dependencies = [
  "hex",
  "indicatif",
  "itertools 0.14.0",
+ "jiff",
  "miette",
  "once_cell",
  "rattler",
@@ -5268,7 +5268,6 @@ version = "0.46.4"
 dependencies = [
  "ahash",
  "assert_matches",
- "chrono",
  "core-foundation 0.10.1",
  "criterion",
  "dirs",
@@ -5282,6 +5281,7 @@ dependencies = [
  "indexmap 2.14.0",
  "insta",
  "itertools 0.14.0",
+ "jiff",
  "lazy-regex",
  "memmap2",
  "nom 8.0.0",
@@ -5390,6 +5390,7 @@ dependencies = [
  "hex",
  "indexmap 2.14.0",
  "indicatif",
+ "jiff",
  "opendal",
  "rattler_conda_types",
  "rattler_config",
@@ -5431,11 +5432,11 @@ name = "rattler_lock"
 version = "0.30.3"
 dependencies = [
  "ahash",
- "chrono",
  "file_url",
  "indexmap 2.14.0",
  "insta",
  "itertools 0.14.0",
+ "jiff",
  "pep440_rs",
  "pep508_rs",
  "rattler_conda_types",
@@ -5470,7 +5471,6 @@ dependencies = [
 name = "rattler_menuinst"
 version = "0.2.62"
 dependencies = [
- "chrono",
  "configparser",
  "dirs",
  "fs-err",
@@ -5551,7 +5551,6 @@ dependencies = [
  "async-spooled-tempfile",
  "axum",
  "bzip2",
- "chrono",
  "fs-err",
  "futures",
  "futures-util",
@@ -5560,6 +5559,7 @@ dependencies = [
  "hex",
  "http 1.4.0",
  "insta",
+ "jiff",
  "num_cpus",
  "rattler_conda_types",
  "rattler_digest",
@@ -5631,7 +5631,6 @@ dependencies = [
  "bytes",
  "cache_control",
  "cfg-if",
- "chrono",
  "coalesced_map",
  "criterion",
  "dashmap",
@@ -5650,6 +5649,7 @@ dependencies = [
  "indicatif",
  "insta",
  "itertools 0.14.0",
+ "jiff",
  "json-patch",
  "libc",
  "memmap2",
@@ -5740,13 +5740,12 @@ dependencies = [
 name = "rattler_solve"
 version = "7.1.1"
 dependencies = [
- "chrono",
  "criterion",
  "futures",
  "hex",
- "humantime",
  "insta",
  "itertools 0.14.0",
+ "jiff",
  "libc",
  "once_cell",
  "rattler_conda_types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5381,7 +5381,6 @@ dependencies = [
  "ahash",
  "anyhow",
  "bytes",
- "chrono",
  "clap",
  "clap-verbosity-flag",
  "console",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,6 @@ bytes = "1.10.1"
 bzip2 = "0.6.0"
 cache_control = "0.2.0"
 cfg-if = "1.0"
-chrono = { version = "0.4.41", default-features = false, features = [
-  "std",
-  "serde",
-  "alloc",
-] }
 jiff = { version = "0.2", default-features = false, features = ["std", "serde"] }
 clap = { version = "4.5.38", features = [
   "derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ chrono = { version = "0.4.41", default-features = false, features = [
   "serde",
   "alloc",
 ] }
+jiff = { version = "0.2", default-features = false, features = ["std", "serde"] }
 clap = { version = "4.5.38", features = [
   "derive",
   "color",

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -37,7 +37,7 @@ oauth = ["rattler/oauth"]
 
 [dependencies]
 anyhow = { workspace = true }
-chrono = { workspace = true }
+jiff = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 clap_complete = { workspace = true }
 clap_complete_nushell = { workspace = true }

--- a/crates/rattler-bin/src/exclude_newer.rs
+++ b/crates/rattler-bin/src/exclude_newer.rs
@@ -1,16 +1,16 @@
 //! Defines the `ExcludeNewer` type which is used to exclude packages based on
 //! their timestamp.
 
-use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use jiff::{civil::Date, tz::TimeZone, Timestamp};
 use std::fmt;
 use std::str::FromStr;
 
-/// A wrapper around a chrono `DateTime` that is used to exclude packages after a
+/// A wrapper around a jiff `Timestamp` that is used to exclude packages after a
 /// certain point in time.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct ExcludeNewer(pub DateTime<Utc>);
+pub struct ExcludeNewer(pub Timestamp);
 
-impl From<ExcludeNewer> for DateTime<Utc> {
+impl From<ExcludeNewer> for Timestamp {
     fn from(value: ExcludeNewer) -> Self {
         value.0
     }
@@ -23,32 +23,24 @@ impl From<ExcludeNewer> for rattler_solve::ExcludeNewer {
 }
 
 impl FromStr for ExcludeNewer {
-    type Err = chrono::ParseError;
+    type Err = jiff::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // First try to parse as an RFC 3339 timestamp
-        if let Ok(datetime) = DateTime::parse_from_rfc3339(s) {
-            return Ok(ExcludeNewer(datetime.with_timezone(&Utc)));
+        // Try parsing as full timestamp first
+        if let Ok(timestamp) = s.parse::<Timestamp>() {
+            return Ok(ExcludeNewer(timestamp));
         }
-
-        // Otherwise, try to parse as a date (YYYY-MM-DD)
-        // If we only have a date, we use the next day at midnight
-        // This ensures that packages from the entire day are included
-        let date = NaiveDate::parse_from_str(s, "%Y-%m-%d")?;
-        let next_day = date
-            .succ_opt()
-            .ok_or_else(|| NaiveDate::parse_from_str("invalid", "%Y-%m-%d").unwrap_err())?;
-        let datetime = Utc
-            .from_utc_datetime(&next_day.and_hms_opt(0, 0, 0).unwrap())
-            .with_timezone(&Utc);
-
-        Ok(ExcludeNewer(datetime))
+        // Fall back to date-only (use start of next day in UTC)
+        let date = s.parse::<Date>()?;
+        let next_day = date.tomorrow()?;
+        let timestamp = next_day.at(0, 0, 0, 0).to_zoned(TimeZone::UTC)?.timestamp();
+        Ok(ExcludeNewer(timestamp))
     }
 }
 
 impl fmt::Display for ExcludeNewer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0.to_rfc3339())
+        write!(f, "{}", self.0)
     }
 }
 
@@ -61,9 +53,7 @@ mod tests {
         let exclude_newer = ExcludeNewer::from_str("2006-12-02T02:07:43Z").unwrap();
         assert_eq!(
             exclude_newer.0,
-            DateTime::parse_from_rfc3339("2006-12-02T02:07:43Z")
-                .unwrap()
-                .with_timezone(&Utc)
+            "2006-12-02T02:07:43Z".parse::<Timestamp>().unwrap()
         );
     }
 
@@ -73,15 +63,13 @@ mod tests {
         let exclude_newer = ExcludeNewer::from_str("2006-12-02").unwrap();
         assert_eq!(
             exclude_newer.0,
-            DateTime::parse_from_rfc3339("2006-12-03T00:00:00Z")
-                .unwrap()
-                .with_timezone(&Utc)
+            "2006-12-03T00:00:00Z".parse::<Timestamp>().unwrap()
         );
     }
 
     #[test]
     fn test_display() {
         let exclude_newer = ExcludeNewer::from_str("2006-12-02T02:07:43Z").unwrap();
-        assert_eq!(exclude_newer.to_string(), "2006-12-02T02:07:43+00:00");
+        assert_eq!(exclude_newer.to_string(), "2006-12-02T02:07:43Z");
     }
 }

--- a/crates/rattler-bin/src/exclude_newer.rs
+++ b/crates/rattler-bin/src/exclude_newer.rs
@@ -1,7 +1,7 @@
 //! Defines the `ExcludeNewer` type which is used to exclude packages based on
 //! their timestamp.
 
-use jiff::{civil::Date, tz::TimeZone, Timestamp};
+use jiff::{Timestamp, civil::Date, tz::TimeZone};
 use std::fmt;
 use std::str::FromStr;
 

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 
 [dependencies]
 ahash = { workspace = true }
-chrono = { workspace = true }
+jiff = { workspace = true }
 file_url = { workspace = true }
 glob = { workspace = true }
 hex = { workspace = true }

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -1487,8 +1487,8 @@ mod test {
             r.build_number = build_number;
             r.subdir = subdir.to_string();
             r.timestamp = timestamp.map(|secs| {
-                crate::utils::TimestampMs::from_datetime_seconds(
-                    chrono::DateTime::from_timestamp(secs, 0).unwrap(),
+                crate::utils::TimestampMs::from_timestamp_seconds(
+                    jiff::Timestamp::from_second(secs).unwrap(),
                 )
             });
             r

--- a/crates/rattler_conda_types/src/repo_data/sharded.rs
+++ b/crates/rattler_conda_types/src/repo_data/sharded.rs
@@ -3,8 +3,8 @@
 use crate::PackageRecord;
 use crate::package::DistArchiveIdentifier;
 use crate::repo_data::{ChannelRelations, ExperimentalV3Packages, RepodataRevisionInfo};
-use jiff::Timestamp;
 use indexmap::IndexMap;
+use jiff::Timestamp;
 use rattler_digest::{Sha256, Sha256Hash, serde::SerializableHash};
 use serde::{Deserialize, Serialize};
 

--- a/crates/rattler_conda_types/src/repo_data/sharded.rs
+++ b/crates/rattler_conda_types/src/repo_data/sharded.rs
@@ -3,7 +3,7 @@
 use crate::PackageRecord;
 use crate::package::DistArchiveIdentifier;
 use crate::repo_data::{ChannelRelations, ExperimentalV3Packages, RepodataRevisionInfo};
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use indexmap::IndexMap;
 use rattler_digest::{Sha256, Sha256Hash, serde::SerializableHash};
 use serde::{Deserialize, Serialize};
@@ -43,7 +43,7 @@ pub struct ShardedSubdirInfo {
 
     /// The date at which this entry was created.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub created_at: Option<DateTime<Utc>>,
+    pub created_at: Option<Timestamp>,
 
     /// Repodata revisions available through this sharded index.
     ///

--- a/crates/rattler_conda_types/src/utils/serde.rs
+++ b/crates/rattler_conda_types/src/utils/serde.rs
@@ -104,46 +104,41 @@ impl<'de> DeserializeAs<'de, String> for MultiLineString {
 /// in seconds or milliseconds format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TimestampMs {
-    datetime: chrono::DateTime<chrono::Utc>,
+    timestamp: jiff::Timestamp,
     /// Whether the original timestamp was in milliseconds (true) or seconds (false)
     is_millis: bool,
 }
 
 impl TimestampMs {
-    /// Create a new `TimestampMs` from a `DateTime` with millisecond precision
-    pub fn from_datetime_millis(datetime: chrono::DateTime<chrono::Utc>) -> Self {
+    /// Create a new `TimestampMs` from a `Timestamp` with millisecond precision
+    pub fn from_timestamp_millis(timestamp: jiff::Timestamp) -> Self {
         Self {
-            datetime,
+            timestamp,
             is_millis: true,
         }
     }
 
-    /// Create a new `TimestampMs` from a `DateTime` with second precision
-    pub fn from_datetime_seconds(datetime: chrono::DateTime<chrono::Utc>) -> Self {
+    /// Create a new `TimestampMs` from a `Timestamp` with second precision
+    pub fn from_timestamp_seconds(timestamp: jiff::Timestamp) -> Self {
         Self {
-            datetime,
+            timestamp,
             is_millis: false,
         }
     }
 
-    /// Get the inner `DateTime`
-    pub fn datetime(&self) -> &chrono::DateTime<chrono::Utc> {
-        &self.datetime
-    }
-
-    /// Convert to the inner `DateTime`
-    pub fn into_datetime(self) -> chrono::DateTime<chrono::Utc> {
-        self.datetime
+    /// Get the inner `Timestamp`
+    pub fn jiff_timestamp(&self) -> jiff::Timestamp {
+        self.timestamp
     }
 
     /// Get the timestamp as seconds since Unix epoch
     pub fn timestamp(&self) -> i64 {
-        self.datetime.timestamp()
+        self.timestamp.as_second()
     }
 
     /// Get the timestamp as milliseconds since Unix epoch
     pub fn timestamp_millis(&self) -> i64 {
-        self.datetime.timestamp_millis()
+        self.timestamp.as_millisecond()
     }
 }
 
@@ -155,33 +150,33 @@ impl PartialOrd for TimestampMs {
 
 impl Ord for TimestampMs {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.datetime.cmp(&other.datetime)
+        self.timestamp.cmp(&other.timestamp)
     }
 }
 
-// Allow comparison with DateTime<Utc>
-impl PartialEq<chrono::DateTime<chrono::Utc>> for TimestampMs {
-    fn eq(&self, other: &chrono::DateTime<chrono::Utc>) -> bool {
-        self.datetime == *other
+// Allow comparison with jiff::Timestamp
+impl PartialEq<jiff::Timestamp> for TimestampMs {
+    fn eq(&self, other: &jiff::Timestamp) -> bool {
+        self.timestamp == *other
     }
 }
 
-impl PartialOrd<chrono::DateTime<chrono::Utc>> for TimestampMs {
-    fn partial_cmp(&self, other: &chrono::DateTime<chrono::Utc>) -> Option<std::cmp::Ordering> {
-        self.datetime.partial_cmp(other)
+impl PartialOrd<jiff::Timestamp> for TimestampMs {
+    fn partial_cmp(&self, other: &jiff::Timestamp) -> Option<std::cmp::Ordering> {
+        self.timestamp.partial_cmp(other)
     }
 }
 
-impl From<chrono::DateTime<chrono::Utc>> for TimestampMs {
-    fn from(datetime: chrono::DateTime<chrono::Utc>) -> Self {
+impl From<jiff::Timestamp> for TimestampMs {
+    fn from(timestamp: jiff::Timestamp) -> Self {
         // Default to millisecond precision for compatibility
-        Self::from_datetime_millis(datetime)
+        Self::from_timestamp_millis(timestamp)
     }
 }
 
-impl From<TimestampMs> for chrono::DateTime<chrono::Utc> {
+impl From<TimestampMs> for jiff::Timestamp {
     fn from(ts: TimestampMs) -> Self {
-        ts.datetime
+        ts.timestamp
     }
 }
 
@@ -193,22 +188,20 @@ impl<'de> Deserialize<'de> for TimestampMs {
         let timestamp = i64::deserialize(deserializer)?;
 
         // Determine if this is milliseconds or seconds based on magnitude
-        let (datetime, is_millis) = if timestamp > 253_402_300_799 {
+        let (ts, is_millis) = if timestamp > 253_402_300_799 {
             // This is milliseconds (year 9999 in seconds is 253402300799)
-            let microseconds = timestamp * 1_000;
-            let dt = chrono::DateTime::from_timestamp_micros(microseconds)
-                .ok_or_else(|| D::Error::custom("got invalid timestamp, timestamp out of range"))?;
-            (dt, true)
+            let ts = jiff::Timestamp::from_millisecond(timestamp)
+                .map_err(|_| D::Error::custom("got invalid timestamp, timestamp out of range"))?;
+            (ts, true)
         } else {
             // This is seconds
-            let microseconds = timestamp * 1_000_000;
-            let dt = chrono::DateTime::from_timestamp_micros(microseconds)
-                .ok_or_else(|| D::Error::custom("got invalid timestamp, timestamp out of range"))?;
-            (dt, false)
+            let ts = jiff::Timestamp::from_second(timestamp)
+                .map_err(|_| D::Error::custom("got invalid timestamp, timestamp out of range"))?;
+            (ts, false)
         };
 
         Ok(Self {
-            datetime,
+            timestamp: ts,
             is_millis,
         })
     }
@@ -221,9 +214,9 @@ impl Serialize for TimestampMs {
     {
         // Preserve the original format
         let timestamp = if self.is_millis {
-            self.datetime.timestamp_millis()
+            self.timestamp.as_millisecond()
         } else {
-            self.datetime.timestamp()
+            self.timestamp.as_second()
         };
 
         timestamp.serialize(serializer)

--- a/crates/rattler_conda_types/src/utils/serde.rs
+++ b/crates/rattler_conda_types/src/utils/serde.rs
@@ -364,30 +364,34 @@ mod tests {
     }
 
     #[test]
-    fn test_timestamp_ms_from_datetime() {
-        let datetime = chrono::DateTime::from_timestamp(1640000000, 0).unwrap();
+    fn test_timestamp_ms_from_timestamp() {
+        let timestamp = jiff::Timestamp::from_second(1640000000).unwrap();
 
-        // Test creating from datetime with milliseconds
-        let ts_millis = TimestampMs::from_datetime_millis(datetime);
-        assert!(ts_millis.is_millis);
-        assert_eq!(ts_millis.datetime(), &datetime);
+        // Test creating from timestamp with milliseconds precision marker
+        let ts_millis = TimestampMs::from_timestamp_millis(timestamp);
+        assert_eq!(ts_millis.jiff_timestamp(), timestamp);
+        // Serializes as milliseconds
+        let json = serde_json::to_string(&ts_millis).unwrap();
+        assert_eq!(json, "1640000000000");
 
-        // Test creating from datetime with seconds
-        let ts_seconds = TimestampMs::from_datetime_seconds(datetime);
-        assert!(!ts_seconds.is_millis);
-        assert_eq!(ts_seconds.datetime(), &datetime);
+        // Test creating from timestamp with seconds precision marker
+        let ts_seconds = TimestampMs::from_timestamp_seconds(timestamp);
+        assert_eq!(ts_seconds.jiff_timestamp(), timestamp);
+        // Serializes as seconds
+        let json = serde_json::to_string(&ts_seconds).unwrap();
+        assert_eq!(json, "1640000000");
     }
 
     #[test]
     fn test_timestamp_ms_conversion() {
-        let datetime = chrono::DateTime::from_timestamp(1640000000, 0).unwrap();
+        let timestamp = jiff::Timestamp::from_second(1640000000).unwrap();
 
         // Test From trait
-        let ts: TimestampMs = datetime.into();
-        assert!(ts.is_millis); // Default is milliseconds
+        let ts: TimestampMs = timestamp.into();
+        assert_eq!(ts.jiff_timestamp(), timestamp);
 
         // Test Into trait
-        let converted: chrono::DateTime<chrono::Utc> = ts.into();
-        assert_eq!(converted, datetime);
+        let converted: jiff::Timestamp = ts.into();
+        assert_eq!(converted, timestamp);
     }
 }

--- a/crates/rattler_conda_types/src/utils/serde.rs
+++ b/crates/rattler_conda_types/src/utils/serde.rs
@@ -190,13 +190,15 @@ impl<'de> Deserialize<'de> for TimestampMs {
         // Determine if this is milliseconds or seconds based on magnitude
         let (ts, is_millis) = if timestamp > 253_402_300_799 {
             // This is milliseconds (year 9999 in seconds is 253402300799)
-            let ts = jiff::Timestamp::from_millisecond(timestamp)
-                .map_err(|_| D::Error::custom("got invalid timestamp, timestamp out of range"))?;
+            let ts = jiff::Timestamp::from_millisecond(timestamp).map_err(|_err| {
+                D::Error::custom("got invalid timestamp, timestamp out of range")
+            })?;
             (ts, true)
         } else {
             // This is seconds
-            let ts = jiff::Timestamp::from_second(timestamp)
-                .map_err(|_| D::Error::custom("got invalid timestamp, timestamp out of range"))?;
+            let ts = jiff::Timestamp::from_second(timestamp).map_err(|_err| {
+                D::Error::custom("got invalid timestamp, timestamp out of range")
+            })?;
             (ts, false)
         };
 

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -38,7 +38,8 @@ ahash = { workspace = true }
 anyhow = { workspace = true }
 bytes = { workspace = true }
 indexmap = { workspace = true }
-chrono = { workspace = true, features = ["clock"] }
+jiff = { workspace = true }
+chrono = { workspace = true }  # needed for opendal compatibility
 clap = { workspace = true, features = ["derive", "env"] }
 clap-verbosity-flag = { workspace = true, features = ["tracing"] }
 console = { workspace = true }

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -39,7 +39,6 @@ anyhow = { workspace = true }
 bytes = { workspace = true }
 indexmap = { workspace = true }
 jiff = { workspace = true }
-chrono = { workspace = true }  # needed for opendal compatibility
 clap = { workspace = true, features = ["derive", "env"] }
 clap-verbosity-flag = { workspace = true, features = ["tracing"] }
 console = { workspace = true }

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -1266,7 +1266,7 @@ pub async fn write_repodata(
                 subdir: subdir.to_string(),
                 base_url: sharded_base_url,
                 shards_base_url: "./shards/".into(),
-                created_at: Some(chrono::Utc::now()),
+                created_at: Some(jiff::Timestamp::now()),
                 repodata_revisions: sharded_repodata_revisions,
                 channel_relations: sharded_channel_relations,
             },

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -12,7 +12,7 @@ readme.workspace = true
 
 [dependencies]
 ahash = { workspace = true }
-chrono = { workspace = true }
+jiff = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
 rattler_conda_types = { workspace = true, default-features = false }

--- a/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
@@ -91,7 +91,7 @@ pub(crate) struct CondaPackageDataModel<'a> {
 
     #[serde(default)]
     #[serde_as(as = "Option<crate::utils::serde::Timestamp>")]
-    pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    pub timestamp: Option<jiff::Timestamp>,
 }
 
 fn find_build_and_build_number(

--- a/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
@@ -115,7 +115,7 @@ pub(crate) struct CondaPackageDataModel<'a> {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde_as(as = "Option<crate::utils::serde::Timestamp>")]
-    pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    pub timestamp: Option<jiff::Timestamp>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub input: Option<InputHash<'a>>,

--- a/crates/rattler_lock/src/parse/models/v7/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/conda_package_data.rs
@@ -7,7 +7,6 @@ use rattler_conda_types::{
     BuildNumber, ChannelUrl, Flag, NoArchType, PackageName, PackageRecord, PackageUrl,
     VersionWithSource,
     package::{DistArchiveIdentifier, RunExportsJson},
-    utils::TimestampMs,
 };
 use rattler_digest::{Md5Hash, Sha256Hash, serde::SerializableHash};
 use serde::{Deserialize, Serialize};
@@ -126,7 +125,7 @@ pub(crate) struct CondaPackageDataModel<'a> {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde_as(as = "Option<crate::utils::serde::Timestamp>")]
-    pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    pub timestamp: Option<jiff::Timestamp>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub python_site_packages_path: Cow<'a, Option<String>>,
@@ -286,7 +285,7 @@ impl<'a> From<&'a CondaBinaryData> for CondaPackageDataModel<'a> {
             sha256: package_record.sha256,
             size: Cow::Borrowed(&package_record.size),
             legacy_bz2_size: Cow::Borrowed(&package_record.legacy_bz2_size),
-            timestamp: package_record.timestamp.map(TimestampMs::into_datetime),
+            timestamp: package_record.timestamp.map(|ts| ts.jiff_timestamp()),
             features: Cow::Borrowed(&package_record.features),
             flags: Cow::Borrowed(&package_record.flags),
             track_features: Cow::Borrowed(&package_record.track_features),

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -103,7 +103,7 @@ pub struct CondaLockedPackageV3 {
     pub python_site_packages_path: Option<String>,
     pub size: Option<u64>,
     #[serde_as(as = "Option<crate::utils::serde::Timestamp>")]
-    pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    pub timestamp: Option<jiff::Timestamp>,
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub purls: BTreeSet<PackageUrl>,
 }

--- a/crates/rattler_lock/src/utils/serde/timestamp.rs
+++ b/crates/rattler_lock/src/utils/serde/timestamp.rs
@@ -1,43 +1,42 @@
-use chrono::{DateTime, Utc};
+use jiff::Timestamp as JiffTimestamp;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
 
 /// Converts a raw integer timestamp (seconds or milliseconds) to a
-/// `DateTime<Utc>`. Values larger than the year-9999 boundary in seconds
+/// `jiff::Timestamp`. Values larger than the year-9999 boundary in seconds
 /// are treated as milliseconds; smaller values are treated as seconds.
-pub(crate) fn millis_to_datetime(timestamp: i64) -> Option<DateTime<Utc>> {
-    let microseconds = if timestamp > 253_402_300_799 {
-        timestamp * 1_000
+pub(crate) fn millis_to_timestamp(timestamp: i64) -> Option<JiffTimestamp> {
+    if timestamp > 253_402_300_799 {
+        JiffTimestamp::from_millisecond(timestamp).ok()
     } else {
-        timestamp * 1_000_000
-    };
-    DateTime::from_timestamp_micros(microseconds)
+        JiffTimestamp::from_second(timestamp).ok()
+    }
 }
 
-/// Converts a `DateTime<Utc>` to milliseconds since the Unix epoch.
-pub(crate) fn datetime_to_millis(dt: &DateTime<Utc>) -> i64 {
-    dt.timestamp_millis()
+/// Converts a `jiff::Timestamp` to milliseconds since the Unix epoch.
+pub(crate) fn timestamp_to_millis(ts: &JiffTimestamp) -> i64 {
+    ts.as_millisecond()
 }
 
 pub(crate) struct Timestamp;
 
-impl<'de> DeserializeAs<'de, chrono::DateTime<chrono::Utc>> for Timestamp {
-    fn deserialize_as<D>(deserializer: D) -> Result<chrono::DateTime<chrono::Utc>, D::Error>
+impl<'de> DeserializeAs<'de, JiffTimestamp> for Timestamp {
+    fn deserialize_as<D>(deserializer: D) -> Result<JiffTimestamp, D::Error>
     where
         D: Deserializer<'de>,
     {
         let timestamp = i64::deserialize(deserializer)?;
-        millis_to_datetime(timestamp)
+        millis_to_timestamp(timestamp)
             .ok_or_else(|| D::Error::custom("got invalid timestamp, timestamp out of range"))
     }
 }
 
-impl SerializeAs<chrono::DateTime<chrono::Utc>> for Timestamp {
-    fn serialize_as<S>(source: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+impl SerializeAs<JiffTimestamp> for Timestamp {
+    fn serialize_as<S>(source: &JiffTimestamp, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        datetime_to_millis(source).serialize(serializer)
+        timestamp_to_millis(source).serialize(serializer)
     }
 }

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -23,7 +23,6 @@ regex = { workspace = true }
 tempfile = { workspace = true }
 fs-err = { workspace = true }
 which = { workspace = true }
-chrono = { workspace = true, features = ["clock"] }
 once_cell = { workspace = true }
 indexmap = { workspace = true }
 

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -12,7 +12,7 @@ readme.workspace = true
 
 [dependencies]
 bzip2 = { workspace = true }
-chrono = { workspace = true }
+jiff = { workspace = true }
 http = { workspace = true, optional = true }
 fs-err = { workspace = true, features = ["tokio"], optional = true }
 futures = { workspace = true }

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -21,7 +21,7 @@ async-trait = { workspace = true, optional = true }
 blake2 = { workspace = true }
 bytes = { workspace = true }
 cache_control = { workspace = true }
-chrono = { workspace = true, features = ["std", "serde", "alloc", "clock"] }
+jiff = { workspace = true }
 dashmap = { workspace = true }
 dirs = { workspace = true }
 file_url = { workspace = true }

--- a/crates/rattler_repodata_gateway/src/fetch/cache/mod.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/cache/mod.rs
@@ -76,13 +76,17 @@ impl FromStr for RepoDataState {
 pub struct Expiring<T> {
     pub value: T,
 
-    // #[serde(with = "chrono::serde::ts_seconds")]
-    pub last_checked: chrono::DateTime<chrono::Utc>,
+    pub last_checked: jiff::Timestamp,
 }
 
 impl<T> Expiring<T> {
-    pub fn value(&self, expiration: chrono::Duration) -> Option<&T> {
-        if chrono::Utc::now().signed_duration_since(self.last_checked) >= expiration {
+    pub fn value(&self, expiration: jiff::Span) -> Option<&T> {
+        let now = jiff::Timestamp::now();
+        let expires_at = match self.last_checked.checked_add(expiration) {
+            Ok(t) => t,
+            Err(_) => return None,
+        };
+        if now >= expires_at {
             None
         } else {
             Some(&self.value)

--- a/crates/rattler_repodata_gateway/src/fetch/with_cache.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/with_cache.rs
@@ -361,7 +361,7 @@ pub async fn fetch_repo_data(
                 Ok(response) if response.status() == StatusCode::NOT_FOUND => {
                     let unavailable = Some(Expiring {
                         value: false,
-                        last_checked: chrono::Utc::now(),
+                        last_checked: jiff::Timestamp::now(),
                     });
                     match content_encoding {
                         Encoding::Zst => variant_availability.has_zst = unavailable,
@@ -626,7 +626,7 @@ pub async fn check_variant_availability(
 ) -> VariantAvailability {
     // Determine from the cache which variant are available. This is currently
     // cached for a maximum of 14 days.
-    let expiration_duration = chrono::TimeDelta::try_days(14).expect("14 days is a valid duration");
+    let expiration_duration = jiff::Span::new().days(14);
     let has_zst = if options.zstd_enabled {
         cache_state
             .and_then(|state| state.has_zst.as_ref())
@@ -656,7 +656,7 @@ pub async fn check_variant_availability(
         None => async {
             Some(Expiring {
                 value: check_valid_download_target(&zst_repodata_url, client).await,
-                last_checked: chrono::Utc::now(),
+                last_checked: jiff::Timestamp::now(),
             })
         }
         .right_future(),
@@ -680,7 +680,7 @@ pub async fn check_variant_availability(
                 }
                 None => Some(Expiring {
                     value: check_valid_download_target(&bz2_repodata_url, client).await,
-                    last_checked: chrono::Utc::now(),
+                    last_checked: jiff::Timestamp::now(),
                 }),
             }
         }

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -214,7 +214,7 @@ mod tests {
                     subdir: "linux-64".to_string(),
                     base_url: "./".to_string(),
                     shards_base_url: "./shards/".to_string(),
-                    created_at: Some(chrono::Utc::now()),
+                    created_at: Some(jiff::Timestamp::now()),
                     repodata_revisions: Vec::new(),
                     channel_relations: None,
                 },

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -15,8 +15,7 @@ rattler_conda_types = { workspace = true, default-features = false }
 rattler_digest = { workspace = true, default-features = false }
 hex = { workspace = true }
 libc = { workspace = true, optional = true }
-chrono = { workspace = true, features = ["clock"] }
-humantime = { workspace = true }
+jiff = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 itertools = { workspace = true }
@@ -29,6 +28,7 @@ serde = { workspace = true, optional = true }
 [dev-dependencies]
 criterion = { workspace = true }
 insta = { workspace = true, features = ["yaml"] }
+jiff = { workspace = true }
 once_cell = { workspace = true }
 rattler_repodata_gateway = { path = "../rattler_repodata_gateway", default-features = false, features = [
     "sparse",

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -236,8 +236,10 @@ impl ExcludeNewer {
         package: PackageName,
         duration: std::time::Duration,
     ) -> Self {
-        self.package_cutoffs
-            .insert(package, Self::cutoff_from_duration(duration, Timestamp::now()));
+        self.package_cutoffs.insert(
+            package,
+            Self::cutoff_from_duration(duration, Timestamp::now()),
+        );
         self
     }
 
@@ -281,11 +283,7 @@ impl ExcludeNewer {
     }
 
     /// Sets the absolute cutoff override for a specific channel.
-    pub fn with_channel_cutoff(
-        mut self,
-        channel: impl Into<String>,
-        cutoff: Timestamp,
-    ) -> Self {
+    pub fn with_channel_cutoff(mut self, channel: impl Into<String>, cutoff: Timestamp) -> Self {
         self.channel_cutoffs.insert(channel.into(), cutoff);
         self
     }
@@ -304,11 +302,7 @@ impl ExcludeNewer {
     }
 
     /// Computes the cutoff time for the given package and channel.
-    pub fn cutoff_for_package(
-        &self,
-        package: &PackageName,
-        channel: Option<&str>,
-    ) -> Timestamp {
+    pub fn cutoff_for_package(&self, package: &PackageName, channel: Option<&str>) -> Timestamp {
         self.package_cutoffs
             .get(package)
             .copied()

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -16,7 +16,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use rattler_conda_types::{
     GenericVirtualPackage, MatchSpec, PackageName, RepoDataRecord, SolverResult, utils::TimestampMs,
 };
@@ -175,31 +175,31 @@ impl CancellationToken {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExcludeNewer {
     /// The default cutoff date. Packages uploaded after this date are excluded.
-    cutoff: DateTime<Utc>,
+    cutoff: Timestamp,
 
     /// Channel-specific cutoff dates that override [`Self::cutoff`] for
     /// records from matching channels.
     ///
     /// The key is matched against [`RepoDataRecord::channel`] exactly.
-    channel_cutoffs: HashMap<String, DateTime<Utc>>,
+    channel_cutoffs: HashMap<String, Timestamp>,
 
     /// Package-specific cutoff dates that override both [`Self::cutoff`] and
     /// [`Self::channel_cutoffs`] for matching package names.
-    package_cutoffs: HashMap<PackageName, DateTime<Utc>>,
+    package_cutoffs: HashMap<PackageName, Timestamp>,
 
     /// Whether to include packages that don't have a timestamp.
     include_unknown_timestamp: bool,
 }
 
 impl ExcludeNewer {
-    fn cutoff_from_duration(duration: std::time::Duration, now: DateTime<Utc>) -> DateTime<Utc> {
-        let duration =
-            chrono::Duration::from_std(duration).expect("exclude_newer duration is too large");
-        now - duration
+    fn cutoff_from_duration(duration: std::time::Duration, now: Timestamp) -> Timestamp {
+        let span = jiff::Span::try_from(duration).expect("exclude_newer duration is too large");
+        now.checked_sub(span)
+            .expect("exclude_newer duration subtraction overflowed")
     }
 
     /// Creates a new configuration from an absolute cutoff date.
-    pub fn from_datetime(cutoff: DateTime<Utc>) -> Self {
+    pub fn from_datetime(cutoff: Timestamp) -> Self {
         Self {
             cutoff,
             channel_cutoffs: HashMap::new(),
@@ -210,12 +210,12 @@ impl ExcludeNewer {
 
     /// Creates a new configuration from a relative duration.
     pub fn from_duration(duration: std::time::Duration) -> Self {
-        Self::from_duration_with_now(duration, Utc::now())
+        Self::from_duration_with_now(duration, Timestamp::now())
     }
 
     /// Creates a new configuration from a relative duration and explicit
     /// reference time.
-    pub fn from_duration_with_now(duration: std::time::Duration, now: DateTime<Utc>) -> Self {
+    pub fn from_duration_with_now(duration: std::time::Duration, now: Timestamp) -> Self {
         Self {
             cutoff: Self::cutoff_from_duration(duration, now),
             channel_cutoffs: HashMap::new(),
@@ -225,7 +225,7 @@ impl ExcludeNewer {
     }
 
     /// Sets the absolute cutoff override for a specific package.
-    pub fn with_package_cutoff(mut self, package: PackageName, cutoff: DateTime<Utc>) -> Self {
+    pub fn with_package_cutoff(mut self, package: PackageName, cutoff: Timestamp) -> Self {
         self.package_cutoffs.insert(package, cutoff);
         self
     }
@@ -237,7 +237,7 @@ impl ExcludeNewer {
         duration: std::time::Duration,
     ) -> Self {
         self.package_cutoffs
-            .insert(package, Self::cutoff_from_duration(duration, Utc::now()));
+            .insert(package, Self::cutoff_from_duration(duration, Timestamp::now()));
         self
     }
 
@@ -247,7 +247,7 @@ impl ExcludeNewer {
         mut self,
         package: PackageName,
         duration: std::time::Duration,
-        now: DateTime<Utc>,
+        now: Timestamp,
     ) -> Self {
         self.package_cutoffs
             .insert(package, Self::cutoff_from_duration(duration, now));
@@ -262,7 +262,7 @@ impl ExcludeNewer {
     ) -> Self {
         self.channel_cutoffs.insert(
             channel.into(),
-            Self::cutoff_from_duration(duration, Utc::now()),
+            Self::cutoff_from_duration(duration, Timestamp::now()),
         );
         self
     }
@@ -273,7 +273,7 @@ impl ExcludeNewer {
         mut self,
         channel: impl Into<String>,
         duration: std::time::Duration,
-        now: DateTime<Utc>,
+        now: Timestamp,
     ) -> Self {
         self.channel_cutoffs
             .insert(channel.into(), Self::cutoff_from_duration(duration, now));
@@ -284,7 +284,7 @@ impl ExcludeNewer {
     pub fn with_channel_cutoff(
         mut self,
         channel: impl Into<String>,
-        cutoff: DateTime<Utc>,
+        cutoff: Timestamp,
     ) -> Self {
         self.channel_cutoffs.insert(channel.into(), cutoff);
         self
@@ -308,7 +308,7 @@ impl ExcludeNewer {
         &self,
         package: &PackageName,
         channel: Option<&str>,
-    ) -> DateTime<Utc> {
+    ) -> Timestamp {
         self.package_cutoffs
             .get(package)
             .copied()
@@ -330,8 +330,8 @@ impl ExcludeNewer {
     }
 }
 
-impl From<DateTime<Utc>> for ExcludeNewer {
-    fn from(value: DateTime<Utc>) -> Self {
+impl From<Timestamp> for ExcludeNewer {
+    fn from(value: Timestamp) -> Self {
         Self::from_datetime(value)
     }
 }

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -11,7 +11,6 @@ use std::{
 use conda_sorting::SolvableSorter;
 use itertools::Itertools;
 use rattler_conda_types::MatchSpecCondition;
-use jiff::Timestamp;
 use rattler_conda_types::{
     GenericVirtualPackage, MatchSpec, Matches, NamelessMatchSpec, PackageName, PackageNameMatcher,
     ParseMatchSpecError, ParseMatchSpecOptions, RepoDataRecord, RepodataRevision, SolverResult,
@@ -193,10 +192,9 @@ impl SolverPackageRecord<'_> {
 
     fn timestamp(&self) -> Option<jiff::Timestamp> {
         match self {
-            SolverPackageRecord::Record(rec) => rec
-                .package_record
-                .timestamp
-                .map(|ts| ts.jiff_timestamp()),
+            SolverPackageRecord::Record(rec) => {
+                rec.package_record.timestamp.map(|ts| ts.jiff_timestamp())
+            }
             SolverPackageRecord::Extra { .. } | SolverPackageRecord::VirtualPackage(..) => None,
         }
     }

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -11,11 +11,11 @@ use std::{
 use conda_sorting::SolvableSorter;
 use itertools::Itertools;
 use rattler_conda_types::MatchSpecCondition;
+use jiff::Timestamp;
 use rattler_conda_types::{
     GenericVirtualPackage, MatchSpec, Matches, NamelessMatchSpec, PackageName, PackageNameMatcher,
     ParseMatchSpecError, ParseMatchSpecOptions, RepoDataRecord, RepodataRevision, SolverResult,
     package::{ArchiveIdentifier, DistArchiveType},
-    utils::TimestampMs,
 };
 use resolvo::{
     Candidates, Condition, ConditionId, ConditionalRequirement, Dependencies, DependencyProvider,
@@ -191,13 +191,12 @@ impl SolverPackageRecord<'_> {
         }
     }
 
-    fn timestamp(&self) -> Option<&chrono::DateTime<chrono::Utc>> {
+    fn timestamp(&self) -> Option<jiff::Timestamp> {
         match self {
             SolverPackageRecord::Record(rec) => rec
                 .package_record
                 .timestamp
-                .as_ref()
-                .map(TimestampMs::datetime),
+                .map(|ts| ts.jiff_timestamp()),
             SolverPackageRecord::Extra { .. } | SolverPackageRecord::VirtualPackage(..) => None,
         }
     }

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -41,9 +41,15 @@ fn exclude_newer_reason(
 ) -> Option<String> {
     let cutoff = config.cutoff_for_package(package, channel);
     match timestamp {
-        Some(timestamp) if *timestamp > cutoff => Some(format!(
-            "the package is uploaded after the cutoff date of {cutoff}"
-        )),
+        Some(timestamp) if *timestamp > cutoff => {
+            // Display in user's local timezone for better readability
+            let display_time = cutoff
+                .to_zoned(jiff::tz::TimeZone::system())
+                .strftime("%Y-%m-%d %H:%M:%S");
+            Some(format!(
+                "the package is uploaded after the cutoff date of {display_time}"
+            ))
+        }
         None if !config.include_unknown_timestamp() => Some("the package has no timestamp".into()),
         _ => None,
     }

--- a/crates/rattler_solve/tests/backends/helpers/package_builder.rs
+++ b/crates/rattler_solve/tests/backends/helpers/package_builder.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use rattler_conda_types::{
     Flag, NoArchType, PackageRecord, RepoDataRecord, Version,
     package::{ArchiveIdentifier, CondaArchiveType, DistArchiveIdentifier, DistArchiveType},
@@ -138,8 +138,8 @@ impl PackageBuilder {
     }
 
     pub fn timestamp(mut self, timestamp: &str) -> Self {
-        let dt: DateTime<Utc> = timestamp.parse().expect("invalid timestamp format");
-        self.record.package_record.timestamp = Some(dt.into());
+        let ts: Timestamp = timestamp.parse().expect("invalid timestamp format");
+        self.record.package_record.timestamp = Some(ts.into());
         self
     }
 

--- a/crates/rattler_solve/tests/backends/main.rs
+++ b/crates/rattler_solve/tests/backends/main.rs
@@ -281,8 +281,8 @@ fn read_conda_forge_sparse_repo_data() -> &'static SparseRepoData {
 }
 macro_rules! solver_backend_tests {
     ($T:path) => {
-        use chrono::{DateTime, Utc};
         use itertools::Itertools;
+        use jiff::Timestamp;
 
         #[test]
         fn test_solve_quetz() {
@@ -853,7 +853,7 @@ mod resolvo {
 
     #[test]
     fn test_exclude_newer_error() {
-        let date = "2021-12-12T12:12:12Z".parse::<DateTime<Utc>>().unwrap();
+        let date = "2021-12-12T12:12:12Z".parse::<Timestamp>().unwrap();
 
         let result = solve::<rattler_solve::resolvo::Solver>(
             &[dummy_channel_json_path()],

--- a/crates/rattler_solve/tests/backends/min_age_tests.rs
+++ b/crates/rattler_solve/tests/backends/min_age_tests.rs
@@ -4,12 +4,12 @@
 //! packages that have been published too recently, helping reduce the risk
 //! of installing compromised packages.
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use rattler_solve::{ExcludeNewer, SolverImpl};
 
 use crate::helpers::{PackageBuilder, SolverCase};
 
-fn fixed_now() -> DateTime<Utc> {
+fn fixed_now() -> Timestamp {
     "2026-03-24T00:00:00Z"
         .parse()
         .expect("invalid fixed test timestamp")

--- a/crates/rattler_solve/tests/backends/snapshots/backends__backends__resolvo__exclude_newer_error.snap
+++ b/crates/rattler_solve/tests/backends/snapshots/backends__backends__resolvo__exclude_newer_error.snap
@@ -4,4 +4,4 @@ expression: result.unwrap_err()
 ---
 Cannot solve the request because of: The following packages are incompatible
 └─ foo >=4 cannot be installed because there are no viable options:
-   └─ foo 4.0.2 is excluded because the package is uploaded after the cutoff date of 2021-12-12 12:12:12 UTC
+   └─ foo 4.0.2 is excluded because the package is uploaded after the cutoff date of 2021-12-12T12:12:12Z

--- a/crates/rattler_solve/tests/backends/snapshots/backends__backends__resolvo__exclude_newer_error.snap
+++ b/crates/rattler_solve/tests/backends/snapshots/backends__backends__resolvo__exclude_newer_error.snap
@@ -4,4 +4,4 @@ expression: result.unwrap_err()
 ---
 Cannot solve the request because of: The following packages are incompatible
 └─ foo >=4 cannot be installed because there are no viable options:
-   └─ foo 4.0.2 is excluded because the package is uploaded after the cutoff date of 2021-12-12T12:12:12Z
+   └─ foo 4.0.2 is excluded because the package is uploaded after the cutoff date of 2021-12-12 12:12:12

--- a/crates/rattler_solve/tests/backends/snapshots/backends__resolvo__exclude_newer_error.snap
+++ b/crates/rattler_solve/tests/backends/snapshots/backends__resolvo__exclude_newer_error.snap
@@ -4,4 +4,4 @@ expression: result.unwrap_err()
 ---
 Cannot solve the request because of: The following packages are incompatible
 └─ foo >=4 cannot be installed because there are no viable options:
-   └─ foo 4.0.2 is excluded because the package is uploaded after the cutoff date of 2021-12-12 12:12:12 UTC
+   └─ foo 4.0.2 is excluded because the package is uploaded after the cutoff date of 2021-12-12T12:12:12Z

--- a/crates/rattler_solve/tests/backends/snapshots/backends__resolvo__exclude_newer_error.snap
+++ b/crates/rattler_solve/tests/backends/snapshots/backends__resolvo__exclude_newer_error.snap
@@ -4,4 +4,4 @@ expression: result.unwrap_err()
 ---
 Cannot solve the request because of: The following packages are incompatible
 └─ foo >=4 cannot be installed because there are no viable options:
-   └─ foo 4.0.2 is excluded because the package is uploaded after the cutoff date of 2021-12-12T12:12:12Z
+   └─ foo 4.0.2 is excluded because the package is uploaded after the cutoff date of 2021-12-12 12:12:12

--- a/js-rattler/Cargo.toml
+++ b/js-rattler/Cargo.toml
@@ -42,7 +42,8 @@ rattler_solve = { path = "../crates/rattler_solve", default-features = false, fe
 
 url = "2.5.4"
 
-chrono = { version = "0.4.40", features = ["wasmbind"] }
+jiff = { version = "0.2", features = ["js"] }
+js-sys = "0.3"
 reqwest = { version = "0.13.3", default-features = false, features = ["default-tls"] }
 reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.5.1", default-features = false }
 

--- a/js-rattler/crate/package_record.rs
+++ b/js-rattler/crate/package_record.rs
@@ -449,7 +449,7 @@ macro_rules! impl_package_record {
             pub fn timestamp(&self) -> Option<js_sys::Date> {
                 AsRef::<PackageRecord>::as_ref(self)
                     .timestamp
-                    .map(|ts| ts.into_datetime().into())
+                    .map(|ts| js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ts.jiff_timestamp().as_millisecond() as f64)))
             }
 
             #[wasm_bindgen::prelude::wasm_bindgen(setter)]
@@ -458,9 +458,8 @@ macro_rules! impl_package_record {
                 #[wasm_bindgen::prelude::wasm_bindgen(unchecked_param_type = "Date | undefined")]
                 timestamp: Option<js_sys::Date>,
             ) {
-                AsMut::<PackageRecord>::as_mut(self).timestamp = timestamp.map(|date| {
-                    let datetime: chrono::DateTime<chrono::Utc> = date.into();
-                    datetime.into()
+                AsMut::<PackageRecord>::as_mut(self).timestamp = timestamp.and_then(|date| {
+                    jiff::Timestamp::from_millisecond(date.get_time() as i64).ok().map(|ts| ts.into())
                 });
             }
 

--- a/js-rattler/crate/package_record.rs
+++ b/js-rattler/crate/package_record.rs
@@ -447,9 +447,11 @@ macro_rules! impl_package_record {
                 unchecked_return_type = "Date | undefined"
             )]
             pub fn timestamp(&self) -> Option<js_sys::Date> {
-                AsRef::<PackageRecord>::as_ref(self)
-                    .timestamp
-                    .map(|ts| js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(ts.jiff_timestamp().as_millisecond() as f64)))
+                AsRef::<PackageRecord>::as_ref(self).timestamp.map(|ts| {
+                    js_sys::Date::new(&wasm_bindgen::JsValue::from_f64(
+                        ts.jiff_timestamp().as_millisecond() as f64,
+                    ))
+                })
             }
 
             #[wasm_bindgen::prelude::wasm_bindgen(setter)]
@@ -459,7 +461,9 @@ macro_rules! impl_package_record {
                 timestamp: Option<js_sys::Date>,
             ) {
                 AsMut::<PackageRecord>::as_mut(self).timestamp = timestamp.and_then(|date| {
-                    jiff::Timestamp::from_millisecond(date.get_time() as i64).ok().map(|ts| ts.into())
+                    jiff::Timestamp::from_millisecond(date.get_time() as i64)
+                        .ok()
+                        .map(|ts| ts.into())
                 });
             }
 

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -25,7 +25,7 @@ pty = ["rattler_pty", "nix"]
 
 [dependencies]
 anyhow = "1.0.97"
-chrono = { version = "0.4" }
+jiff = { version = "0.2" }
 futures = "0.3.31"
 parking_lot = { version = "0.12.3", features = ["arc_lock", "send_guard"] }
 
@@ -59,7 +59,7 @@ pyo3 = { version = "0.25.1", features = [
     "abi3-py38",
     "extension-module",
     "multiple-pymethods",
-    "chrono",
+    "jiff-02",
 ] }
 pyo3-async-runtimes = { version = "0.25.0", features = ["tokio-runtime"] }
 pythonize = "0.25.0"

--- a/py-rattler/src/index_json.rs
+++ b/py-rattler/src/index_json.rs
@@ -257,9 +257,9 @@ impl PyIndexJson {
     #[setter]
     pub fn set_timestamp(&mut self, timestamp: Option<i64>) -> PyResult<()> {
         if let Some(ts) = timestamp {
-            self.inner.timestamp = Some(TimestampMs::from_datetime_millis(
-                chrono::DateTime::from_timestamp_millis(ts)
-                    .ok_or_else(|| PyValueError::new_err("Invalid timestamp"))?,
+            self.inner.timestamp = Some(TimestampMs::from_timestamp_millis(
+                jiff::Timestamp::from_millisecond(ts)
+                    .map_err(|_| PyValueError::new_err("Invalid timestamp"))?,
             ));
         } else {
             self.inner.timestamp = None;

--- a/py-rattler/src/record.rs
+++ b/py-rattler/src/record.rs
@@ -609,9 +609,9 @@ impl PyRecord {
     #[setter]
     pub fn set_timestamp(&mut self, timestamp: Option<i64>) -> PyResult<()> {
         if let Some(ts) = timestamp {
-            self.as_package_record_mut().timestamp = Some(TimestampMs::from_datetime_millis(
-                chrono::DateTime::from_timestamp_millis(ts)
-                    .ok_or_else(|| PyValueError::new_err("Invalid timestamp"))?,
+            self.as_package_record_mut().timestamp = Some(TimestampMs::from_timestamp_millis(
+                jiff::Timestamp::from_millisecond(ts)
+                    .map_err(|_| PyValueError::new_err("Invalid timestamp"))?,
             ));
         } else {
             self.as_package_record_mut().timestamp = None;

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use chrono::DateTime;
+use jiff::Timestamp;
 use pyo3::{
     Bound, FromPyObject, PyAny, PyErr, PyResult, Python, exceptions::PyValueError,
     pybacked::PyBackedStr, pyfunction, types::PyAnyMethods,
@@ -46,7 +46,7 @@ fn parse_exclude_newer(
     exclude_newer_duration_seconds: Option<u64>,
 ) -> PyResult<Option<ExcludeNewer>> {
     match (
-        exclude_newer_timestamp_ms.and_then(DateTime::from_timestamp_millis),
+        exclude_newer_timestamp_ms.and_then(|ts| Timestamp::from_millisecond(ts).ok()),
         exclude_newer_duration_seconds,
     ) {
         (Some(_), Some(_)) => Err(PyValueError::new_err(


### PR DESCRIPTION
Migrate from `chrono` to `jiff` which seems to be taking over.

~The current `opendal` version still depends on `chrono`~