### PR TITLE
feat: add ensure_channel_initialized for fs and s3 channels

### DIFF
--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -1310,7 +1310,7 @@ pub async fn ensure_channel_initialized_s3(
     channel: &Url,
     credentials: &ResolvedS3Credentials,
 ) -> anyhow::Result<()> {
-    let s3_config = s3_config(&credentials, &channel)?;
+    let s3_config = s3_config(credentials, channel)?;
 
     let op = Operator::new(s3_config.into_builder())?
         .layer(RetryLayer::new())


### PR DESCRIPTION
When publishing to an empty S3 bucket, it would be nice if we automatically initialize that bucket so that users can get going straight away.