### PR TITLE
fix: topological sort looses nodes when they are in strongly connected graphs

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/topological_sort.rs
+++ b/crates/rattler_conda_types/src/repo_data/topological_sort.rs
@@ -1908,7 +1908,7 @@ mod tests {
     }
 
     /// Test case for disconnected cycle bug
-    /// See: https://github.com/prefix-dev/rattler-build/issues/1967
+    /// See: <https://github.com/prefix-dev/rattler-build/issues/1967>
     ///
     /// The bug occurs when:
     /// 1. There's a root package that doesn't connect to a cycle


### PR DESCRIPTION
During topological sorting, we apparently sometimes loose packages in cycles.

The fix is, after traversing from roots, we check for unvisited packages and add them as NEW roots.

In our test case, we installed: `python=3.10 airflow<3 dagster-airflow=1.12`

```mermaid
flowchart TB
    subgraph component1["Component 1: dagster-airflow cluster"]
        dagster-airflow["dagster-airflow<br/>(ROOT)"]
        dagster[dagster]
        dagster-pipes[dagster-pipes]
        dagster-shared[dagster-shared]
        other1["... other deps ..."]
        
        dagster-airflow --> dagster
        dagster --> dagster-pipes
        dagster --> dagster-shared
        dagster --> other1
    end

    subgraph component2["Component 2: airflow cluster (DISCONNECTED CYCLE)"]
        airflow[airflow]
        apache-airflow[apache-airflow]
        common-compat[apache-airflow-providers-common-compat]
        common-io[apache-airflow-providers-common-io]
        common-sql[apache-airflow-providers-common-sql]
        fab[apache-airflow-providers-fab]
        other-providers["... other providers ..."]
        
        apache-airflow --> airflow
        airflow --> common-compat
        airflow --> common-io
        airflow --> common-sql
        airflow --> fab
        airflow --> other-providers
        common-compat --> apache-airflow
        common-io --> apache-airflow
        common-sql --> apache-airflow
        fab --> apache-airflow
        other-providers --> apache-airflow
    end

    component1 ~~~ component2

    style component1 fill:#d4edda,stroke:#28a745
    style component2 fill:#f8d7da,stroke:#dc3545
    style dagster-airflow fill:#28a745,color:#fff
```

The cycle break removes: `airflow → apache-airflow-providers-common-compat`

```mermaid

flowchart TB
    subgraph visited["✅ VISITED (99 packages)"]
        dagster-airflow["dagster-airflow<br/>(ROOT)"]
        dagster[dagster]
        other1["... 97 other packages ..."]
        
        dagster-airflow --> dagster
        dagster --> other1
    end

    subgraph lost["❌ LOST! (143 packages)"]
        airflow[airflow]
        apache-airflow[apache-airflow]
        common-compat[apache-airflow-providers-common-compat]
        other-providers["... other providers ..."]
        
        apache-airflow -->|"still connected"| airflow
        airflow -.->|"BROKEN"| common-compat
        airflow --> other-providers
        common-compat --> apache-airflow
        other-providers --> apache-airflow
    end

    visited ~~~ lost

    style visited fill:#d4edda,stroke:#28a745
    style lost fill:#f8d7da,stroke:#dc3545
    style dagster-airflow fill:#28a745,color:#fff
```

The problem: Every node in the airflow cluster still has incoming edges from within the cluster, so none of them become a root. The entire cluster is unreachable from dagster-airflow!

## The fix

Add unvisited packages as new roots

```mermaid
flowchart TB
    subgraph pass1["Pass 1: From original roots"]
        dagster-airflow["dagster-airflow<br/>(ROOT)"]
        dagster[dagster]
        other1["... 97 packages ✅"]
        
        dagster-airflow --> dagster
        dagster --> other1
    end

    subgraph pass2["Pass 2: From unvisited packages (NEW ROOTS)"]
        airflow["airflow<br/>(NEW ROOT)"]
        apache-airflow[apache-airflow]
        providers["... 141 packages ✅"]
        
        airflow --> providers
        providers --> apache-airflow
        apache-airflow --> airflow
    end

    result["✅ All 242 packages included!"]

    pass1 --> result
    pass2 --> result

    style pass1 fill:#d4edda,stroke:#28a745
    style pass2 fill:#d4edda,stroke:#28a745
    style result fill:#28a745,color:#fff
    style dagster-airflow fill:#28a745,color:#fff
    style airflow fill:#007bff,color:#fff
```