### PR TITLE
chore: bump py-rattler from 0.18.0 to 0.19.0

### DIFF
--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 license = "BSD-3-Clause"
 publish = false


### PR DESCRIPTION
Bumps the `py-rattler` version from 0.18.0 to 0.19.0. Notable changes are:

- https://github.com/conda/rattler/pull/1920
- https://github.com/conda/rattler/pull/1919
- https://github.com/conda/rattler/pull/1913
- https://github.com/conda/rattler/pull/1911
- https://github.com/conda/rattler/pull/1901
- https://github.com/conda/rattler/pull/1808
- https://github.com/conda/rattler/pull/1854
- https://github.com/conda/rattler/pull/1891
- https://github.com/conda/rattler/pull/1887