### PR TITLE
chore: bump py-rattler from 0.19.0 to 0.20.0

### DIFF
--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 license = "BSD-3-Clause"
 publish = false


### PR DESCRIPTION
Bumps `py-rattler` from 0.19.0 to 0.20.0. Notable changes are:

- https://github.com/conda/rattler/pull/1922
- https://github.com/conda/rattler/pull/1923