### PR TITLE
fix: add section to the llmstxt

### DIFF
--- a/py-rattler/mkdocs.yml
+++ b/py-rattler/mkdocs.yml
@@ -191,7 +191,7 @@ plugins:
       # Set debug to true to help troubleshoot social card generation issues
       debug: false
   - llmstxt:
-      enabled: !ENV [CI, true]
+      enabled: !ENV [CI, false]
       full_output: llms-full.txt
       sections:
         Home:


### PR DESCRIPTION
The llmstxt plugin failed during documentation deployment. This fixes that. 