### PR TITLE
fix: preserve entitlements when codesigning on macOS

### DIFF
--- a/crates/rattler/src/install/apple_codesign.rs
+++ b/crates/rattler/src/install/apple_codesign.rs
@@ -4,7 +4,7 @@ use super::LinkFileError;
 use std::path::Path;
 
 /// Controls the behavior of the [`super::link_package`] function when it encounters a binary that needs
-/// to be signed on macOS ARM64 (Apple Silicon).
+/// to be signed on macOS (both Intel and Apple Silicon).
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum AppleCodeSignBehavior {
     /// Do nothing (do not attempt to sign any binary)
@@ -16,8 +16,9 @@ pub enum AppleCodeSignBehavior {
     Fail,
 }
 
-/// Sign a binary using the `codesign` tool with an ad-hoc certificate on  macOS.
-/// This is required for binaries to run on Apple Silicon.
+/// Sign a binary using the `codesign` tool with an ad-hoc certificate on macOS.
+/// This is required for binaries to run on macOS when their signature has been invalidated
+/// by prefix replacement (modifying binary content). The function preserves existing entitlements.
 pub(crate) fn codesign(destination_path: &Path) -> Result<(), LinkFileError> {
     let status = std::process::Command::new("/usr/bin/codesign")
         .arg("--sign")
@@ -25,6 +26,8 @@ pub(crate) fn codesign(destination_path: &Path) -> Result<(), LinkFileError> {
         .arg("-")
         // replace any existing signature
         .arg("--force")
+        // preserve entitlements from the original binary
+        .arg("--preserve-metadata=entitlements")
         .arg(destination_path)
         .stdout(std::process::Stdio::null()) // Suppress stdout
         .stderr(std::process::Stdio::null()) // Suppress stderr

--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -228,9 +228,11 @@ pub fn link_file(
             .map_err(LinkFileError::FailedToUpdateDestinationFilePermissions)?;
 
         // (re)sign the binary if the file is executable or is a Mach-O binary (e.g., dylib)
+        // This is required for all macOS platforms because prefix replacement modifies the binary
+        // content, which invalidates existing signatures. We need to preserve entitlements.
         if (has_executable_permissions(&metadata.permissions())
             || file_type == Some(FileType::MachO))
-            && target_platform == Platform::OsxArm64
+            && target_platform.is_osx()
             && *file_mode == FileMode::Binary
         {
             // Did the binary actually change?

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -232,19 +232,20 @@ pub struct InstallOptions {
     /// [`InstallError::MissingPythonInfo`].
     pub python_info: Option<PythonInfo>,
 
-    /// For binaries on macOS ARM64 (Apple Silicon), binaries need to be signed
-    /// with an ad-hoc certificate to properly work. This field controls
-    /// whether or not to do that. Code signing is only executed when the
-    /// target platform is macOS ARM64. By default, codesigning will fail
-    /// the installation if it fails. This behavior can be changed by setting
+    /// For binaries on macOS (both Intel and Apple Silicon), binaries need to be signed
+    /// with an ad-hoc certificate to properly work when their signature has been invalidated
+    /// by prefix replacement (modifying binary content). This field controls whether or not to do that.
+    /// Code signing is executed when the target platform is macOS. By default, codesigning
+    /// will fail the installation if it fails. This behavior can be changed by setting
     /// this field to `AppleCodeSignBehavior::Ignore` or
     /// `AppleCodeSignBehavior::DoNothing`.
     ///
     /// To sign the binaries, the `/usr/bin/codesign` executable is called with
-    /// `--force` and `--sign -` arguments. The `--force` argument is used
-    /// to overwrite existing signatures, and the `--sign -` argument is
-    /// used to sign with an ad-hoc certificate. Ad-hoc signing does not use
-    /// an identity at all, and identifies exactly one instance of code.
+    /// `--force`, `--sign -`, and `--preserve-metadata=entitlements` arguments.
+    /// The `--force` argument is used to overwrite existing signatures, the `--sign -`
+    /// argument is used to sign with an ad-hoc certificate (which does not use an identity
+    /// at all), and `--preserve-metadata=entitlements` preserves the original entitlements
+    /// from the binary (required for programs that need specific permissions like virtualization).
     pub apple_codesign_behavior: AppleCodeSignBehavior,
 }
 


### PR DESCRIPTION
Fix: Preserve entitlements when codesigning on macOS

This fixes an issue on macOS where codesigning did not preserve entitlements, preventing programs requiring special permissions (such as virtualization tools) from running.

Key Changes:

1. Added the `--preserve-metadata=entitlements` parameter to the `codesign` command.

2. Expanded signing support to all macOS platforms (Intel and Apple Silicon).

3. Updated related documentation comments.

Root Cause:

- Hard links, copying, etc., invalidated existing signatures.

- The old implementation only re-signed on ARM64; signatures were invalidated on Intel Macs but not re-signed.

- The old implementation did not preserve entitlements, causing programs requiring special permissions to fail to run.

Fixed Effects:

- All macOS binaries can now be signed correctly.

- Existing entitlements (such as virtualization and network permissions) are preserved.

- Tools requiring special permissions, such as lima-vm, work correctly.

Fixes: https://github.com/prefix-dev/pixi/issues/4990