### PR TITLE
refactor: rename `loong64` to `loongarch64`

### DIFF
--- a/crates/rattler_conda_types/src/platform.rs
+++ b/crates/rattler_conda_types/src/platform.rs
@@ -24,7 +24,7 @@ pub enum Platform {
     LinuxAarch64,
     LinuxArmV6l,
     LinuxArmV7l,
-    LinuxLoong64,
+    LinuxLoongArch64,
     LinuxPpc64le,
     LinuxPpc64,
     LinuxPpc,
@@ -72,7 +72,7 @@ pub enum Arch {
     Arm64,
     ArmV6l,
     ArmV7l,
-    Loong64,
+    LoongArch64,
     Ppc64le,
     Ppc64,
     Ppc,
@@ -107,7 +107,7 @@ impl Platform {
             }
 
             #[cfg(target_arch = "loongarch64")]
-            return Platform::LinuxLoong64;
+            return Platform::LinuxLoongArch64;
 
             #[cfg(all(target_arch = "powerpc64", target_endian = "little"))]
             return Platform::LinuxPpc64le;
@@ -227,7 +227,7 @@ impl Platform {
                 | Platform::LinuxAarch64
                 | Platform::LinuxArmV6l
                 | Platform::LinuxArmV7l
-                | Platform::LinuxLoong64
+                | Platform::LinuxLoongArch64
                 | Platform::LinuxPpc64le
                 | Platform::LinuxPpc64
                 | Platform::LinuxPpc
@@ -251,7 +251,7 @@ impl Platform {
             | Platform::LinuxAarch64
             | Platform::LinuxArmV6l
             | Platform::LinuxArmV7l
-            | Platform::LinuxLoong64
+            | Platform::LinuxLoongArch64
             | Platform::LinuxPpc64le
             | Platform::LinuxPpc64
             | Platform::LinuxPpc
@@ -297,7 +297,7 @@ impl FromStr for Platform {
             "linux-aarch64" => Platform::LinuxAarch64,
             "linux-armv6l" => Platform::LinuxArmV6l,
             "linux-armv7l" => Platform::LinuxArmV7l,
-            "linux-loong64" => Platform::LinuxLoong64,
+            "linux-loongarch64" => Platform::LinuxLoongArch64,
             "linux-ppc64le" => Platform::LinuxPpc64le,
             "linux-ppc64" => Platform::LinuxPpc64,
             "linux-ppc" => Platform::LinuxPpc,
@@ -331,7 +331,7 @@ impl From<Platform> for &'static str {
             Platform::LinuxAarch64 => "linux-aarch64",
             Platform::LinuxArmV6l => "linux-armv6l",
             Platform::LinuxArmV7l => "linux-armv7l",
-            Platform::LinuxLoong64 => "linux-loong64",
+            Platform::LinuxLoongArch64 => "linux-loongarch64",
             Platform::LinuxPpc64le => "linux-ppc64le",
             Platform::LinuxPpc64 => "linux-ppc64",
             Platform::LinuxPpc => "linux-ppc",
@@ -362,7 +362,7 @@ impl Platform {
             Platform::Unknown | Platform::NoArch => None,
             Platform::LinuxArmV6l => Some(Arch::ArmV6l),
             Platform::LinuxArmV7l => Some(Arch::ArmV7l),
-            Platform::LinuxLoong64 => Some(Arch::Loong64),
+            Platform::LinuxLoongArch64 => Some(Arch::LoongArch64),
             Platform::LinuxPpc64le => Some(Arch::Ppc64le),
             Platform::LinuxPpc64 => Some(Arch::Ppc64),
             Platform::LinuxPpc => Some(Arch::Ppc),
@@ -439,7 +439,7 @@ impl FromStr for Arch {
             "arm64" => Arch::Arm64,
             "armv6l" => Arch::ArmV6l,
             "armv7l" => Arch::ArmV7l,
-            "loong64" => Arch::Loong64,
+            "loongarch64" => Arch::LoongArch64,
             "ppc64le" => Arch::Ppc64le,
             "ppc64" => Arch::Ppc64,
             "ppc" => Arch::Ppc,
@@ -466,7 +466,7 @@ impl From<Arch> for &'static str {
             Arch::Aarch64 => "aarch64",
             Arch::ArmV6l => "armv6l",
             Arch::ArmV7l => "armv7l",
-            Arch::Loong64 => "loong64",
+            Arch::LoongArch64 => "loongarch64",
             Arch::Ppc64le => "ppc64le",
             Arch::Ppc64 => "ppc64",
             Arch::Ppc => "ppc",
@@ -559,7 +559,7 @@ mod tests {
         assert_eq!(Platform::LinuxAarch64.arch(), Some(Arch::Aarch64));
         assert_eq!(Platform::LinuxArmV6l.arch(), Some(Arch::ArmV6l));
         assert_eq!(Platform::LinuxArmV7l.arch(), Some(Arch::ArmV7l));
-        assert_eq!(Platform::LinuxLoong64.arch(), Some(Arch::Loong64));
+        assert_eq!(Platform::LinuxLoongArch64.arch(), Some(Arch::LoongArch64));
         assert_eq!(Platform::LinuxPpc64le.arch(), Some(Arch::Ppc64le));
         assert_eq!(Platform::LinuxPpc64.arch(), Some(Arch::Ppc64));
         assert_eq!(Platform::LinuxPpc.arch(), Some(Arch::Ppc));

--- a/crates/rattler_virtual_packages/src/lib.rs
+++ b/crates/rattler_virtual_packages/src/lib.rs
@@ -682,7 +682,7 @@ impl Archspec {
             Platform::Win32 | Platform::Linux32 => "x86",
             Platform::Win64 | Platform::Osx64 | Platform::Linux64 => "x86_64",
             Platform::LinuxAarch64 | Platform::LinuxArmV6l | Platform::LinuxArmV7l => "aarch64",
-            Platform::LinuxLoong64 => "loong64",
+            Platform::LinuxLoongArch64 => "loongarch64",
             Platform::LinuxPpc64le => "ppc64le",
             Platform::LinuxPpc64 => "ppc64",
             Platform::LinuxPpc => "ppc",

--- a/js-rattler/Cargo.lock
+++ b/js-rattler/Cargo.lock
@@ -1776,7 +1776,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1807,7 +1807,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.42.3"
+version = "0.42.4"
 dependencies = [
  "ahash",
  "chrono",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "blake2",
  "digest",
@@ -1865,7 +1865,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "quote",
  "syn",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.28"
+version = "0.25.29"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.23.20"
+version = "0.23.21"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1996,7 +1996,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "4.1.1"
+version = "4.1.2"
 dependencies = [
  "chrono",
  "futures",

--- a/js-rattler/src/Platform.ts
+++ b/js-rattler/src/Platform.ts
@@ -11,7 +11,7 @@ export const platformNames = [
     "linux-aarch64",
     "linux-armv6l",
     "linux-armv7l",
-    "linux-loong64",
+    "linux-loongarch64",
     "linux-ppc64le",
     "linux-ppc64",
     "linux-ppc",
@@ -60,7 +60,7 @@ export const archNames = [
     "arm64",
     "armv6l",
     "armv7l",
-    "loong64",
+    "loongarch64",
     "ppc64le",
     "ppc64",
     "ppc",
@@ -111,8 +111,8 @@ export function platformArch(platform: Platform): Arch | null {
             return "armv6l";
         case "linux-armv7l":
             return "armv7l";
-        case "linux-loong64":
-            return "loong64";
+        case "linux-loongarch64":
+            return "loongarch64";
         case "linux-ppc64le":
             return "ppc64le";
         case "linux-ppc64":

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -3432,7 +3432,7 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path_resolver"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "ahash",
  "fs-err",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.39.6"
+version = "0.39.7"
 dependencies = [
  "anyhow",
  "console",
@@ -4070,7 +4070,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.42.3"
+version = "0.42.4"
 dependencies = [
  "ahash",
  "chrono",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "console",
  "fs-err",
@@ -4157,7 +4157,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "blake2",
  "digest",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.27.7"
+version = "0.27.8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4210,7 +4210,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.26.8"
+version = "0.26.9"
 dependencies = [
  "ahash",
  "chrono",
@@ -4234,7 +4234,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.0.11"
+version = "1.0.12"
 dependencies = [
  "quote",
  "syn",
@@ -4242,7 +4242,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.41"
+version = "0.2.42"
 dependencies = [
  "chrono",
  "configparser",
@@ -4271,7 +4271,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.25.28"
+version = "0.25.29"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.23.20"
+version = "0.23.21"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_pty"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "libc",
  "nix 0.30.1",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "reqwest",
  "reqwest-middleware",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.25.6"
+version = "0.25.7"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -4412,7 +4412,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4428,7 +4428,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.25.14"
+version = "0.25.15"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4446,7 +4446,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "4.1.1"
+version = "4.1.2"
 dependencies = [
  "chrono",
  "futures",
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.3.3"
+version = "2.3.4"
 dependencies = [
  "archspec",
  "libloading",

--- a/py-rattler/rattler/platform/arch.py
+++ b/py-rattler/rattler/platform/arch.py
@@ -10,6 +10,7 @@ ArchLiteral = Literal[
     "aarch64",
     "armv6l",
     "armv7l",
+    "loongarch64",
     "ppc64le",
     "ppc64",
     "s390x",

--- a/py-rattler/rattler/platform/platform.py
+++ b/py-rattler/rattler/platform/platform.py
@@ -13,7 +13,7 @@ PlatformLiteral = Literal[
     "linux-aarch64",
     "linux-armv6l",
     "linux-armv7l",
-    "linux-loong64",
+    "linux-loongarch64",
     "linux-ppc64le",
     "linux-ppc64",
     "linux-ppc",


### PR DESCRIPTION
Unfortunately we had to rename `loong64` to `loongarch64` because the latter is used by both mamba and conda.

Support was added in #1534 with an explicit note that `loong64` follows debian standards. Unfortunately, conda already went another way so to stay compatible we have to change this. 

@wszqkzqk This might affect you. Are you already using this in the wild? 
