### PR TITLE
fix(lock): omit channel: null for source packages in v6 lockfile

### DIFF
--- a/crates/rattler_menuinst/src/linux.rs
+++ b/crates/rattler_menuinst/src/linux.rs
@@ -913,7 +913,6 @@ mod tests {
         let result = linux_menu.command().unwrap();
         assert!(result.starts_with("env "));
         assert!(result.contains("CONDA_PREFIX="));
-        assert!(result.contains("CONDA_SHLVL="));
         assert!(result.contains("PATH="));
         assert!(result.contains("spyder"));
     }

--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -1041,6 +1041,7 @@ mod tests {
             .collect::<BTreeMap<_, _>>();
 
         // Remove system specific environment variables.
+        env_diff.remove("CONDA_SHLVL");
         env_diff.remove("CONDA_PREFIX");
         env_diff.remove("Path");
         env_diff.remove("PATH");

--- a/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__after_activation.snap
+++ b/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__after_activation.snap
@@ -2,7 +2,6 @@
 source: crates/rattler_shell/src/activation.rs
 expression: env_diff
 ---
-CONDA_SHLVL: "1"
 PKG1: "Hello, world!"
 PKG2: "Hello, world!"
 SCRIPT_ENV: "Hello, world!"


### PR DESCRIPTION
### Description

This PR fixes an issue where `channel: null` was explicitly serialized into the lockfile for packages that do not have a channel (specifically source/git dependencies). This aligns the V6 lockfile serialization with the expected behavior of omitting `null` fields to keep the file clean.

**Changes:**
- Added a `skip_channel` helper function in `crates/rattler_lock/src/parse/models/v6/conda_package_data.rs`.
- Applied `#[serde(skip_serializing_if = "skip_channel")]` to the `channel` field.
- Updated test snapshots to remove the `channel: null` line.
- Ran `cargo fmt` and `cargo clippy`.

**Reason for change:**
This addresses a bug reported in `prefix-dev/pixi` (see [prefix-dev/pixi#5180](https://github.com/prefix-dev/pixi/issues/5180)).