### PR TITLE
chore: Remove Lockfile v5 serializing

### DIFF
--- a/crates/rattler_lock/src/parse/models/v5/pypi_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v5/pypi_package_data.rs
@@ -20,14 +20,8 @@ pub(crate) struct PypiPackageDataModel<'a> {
     pub requires_dist: Cow<'a, [Requirement]>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requires_python: Cow<'a, Option<VersionSpecifiers>>,
-    #[serde(default, skip_serializing_if = "should_skip_serializing_editable")]
+    #[serde(default)]
     pub editable: bool,
-}
-
-/// Used in `skip_serializing_if` to skip serializing the `editable` field if it
-/// is `false`.
-fn should_skip_serializing_editable(editable: &bool) -> bool {
-    !*editable
 }
 
 impl<'a> From<PypiPackageDataModel<'a>> for PypiPackageData {
@@ -39,20 +33,6 @@ impl<'a> From<PypiPackageDataModel<'a>> for PypiPackageData {
             hash: value.hash.into_owned(),
             requires_dist: value.requires_dist.into_owned(),
             requires_python: value.requires_python.into_owned(),
-            editable: value.editable,
-        }
-    }
-}
-
-impl<'a> From<&'a PypiPackageData> for PypiPackageDataModel<'a> {
-    fn from(value: &'a PypiPackageData) -> Self {
-        Self {
-            name: Cow::Borrowed(&value.name),
-            version: Cow::Borrowed(&value.version),
-            location: value.location.clone(),
-            hash: Cow::Borrowed(&value.hash),
-            requires_dist: Cow::Borrowed(&value.requires_dist),
-            requires_python: Cow::Borrowed(&value.requires_python),
             editable: value.editable,
         }
     }


### PR DESCRIPTION
We will never use that anymore, so remove it.