### PR TITLE
chore: Remove `input` hash from Conda packages

### DIFF
--- a/crates/rattler_lock/src/conda.rs
+++ b/crates/rattler_lock/src/conda.rs
@@ -259,9 +259,6 @@ pub struct CondaSourceData {
     /// Package build source location for reproducible builds
     pub package_build_source: Option<PackageBuildSource>,
 
-    /// The input hash of the package
-    pub input: Option<InputHash>,
-
     /// Information about packages that should be built from source instead of binary.
     /// This maps from a normalized package name to location of the source.
     pub sources: BTreeMap<String, SourceLocation>,

--- a/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
@@ -14,7 +14,6 @@ use url::Url;
 
 use super::source_data::{PackageBuildSourceSerializer, SourceLocationSerializer};
 use crate::{
-    conda,
     conda::{CondaBinaryData, CondaSourceData, PackageBuildSource, VariantValue},
     source::SourceLocation,
     utils::{derived_fields, derived_fields::LocationDerivedFields},
@@ -234,10 +233,6 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaPackageData {
                 location: value.location,
                 variants: value.variants.unwrap_or_default().into_owned(),
                 package_build_source: value.package_build_source,
-                input: value.input.map(|input| conda::InputHash {
-                    hash: input.hash,
-                    globs: input.globs.into_owned(),
-                }),
                 sources: value.sources,
             }))
         }

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v6__derived-channel-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v6__derived-channel-lock.yml.snap
@@ -19,10 +19,6 @@ packages:
     subdir: noarch
     depends:
       - python
-    input:
-      hash: b67010bf5bc5608db89c0399e726852b07a7ef4fb26b3aa18171f1d0f6a19c89
-      globs:
-        - pixi.toml
   - conda: "https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda"
     sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
     md5: defd5d375853a2caff36a19d2d81a28e

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__derived-channel-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__derived-channel-lock.yml.snap
@@ -19,10 +19,6 @@ packages:
     subdir: noarch
     depends:
       - python
-    input:
-      hash: b67010bf5bc5608db89c0399e726852b07a7ef4fb26b3aa18171f1d0f6a19c89
-      globs:
-        - pixi.toml
   - conda: "https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda"
     sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
     md5: defd5d375853a2caff36a19d2d81a28e


### PR DESCRIPTION
Fixes: #1976 