### PR TITLE
refactor: introduce legacy package data

### DIFF
--- a/crates/rattler_lock/src/parse/deserialize.rs
+++ b/crates/rattler_lock/src/parse/deserialize.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use indexmap::IndexSet;
-use itertools::Either;
 use pep440_rs::VersionSpecifiers;
 use pep508_rs::ExtraName;
 use rattler_conda_types::{PackageName, Platform, VersionWithSource};
@@ -18,7 +17,7 @@ use serde_yaml::Value;
 use crate::{
     file_format_version::FileFormatVersion,
     parse::{
-        models::{self, v6, v7},
+        models::{self, legacy::LegacyCondaPackageData, v6, v7},
         V5, V6, V7,
     },
     Channel, CondaPackageData, EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner,
@@ -33,6 +32,21 @@ struct DeserializableLockFile<P> {
     environments: BTreeMap<String, DeserializableEnvironment>,
     #[serde_as(as = "Vec<P>")]
     packages: Vec<PackageData>,
+    #[serde(skip)]
+    _data: PhantomData<P>,
+}
+
+/// Lock file struct for legacy (V4-V6) deserialization.
+///
+/// Uses `LegacyPackageData` instead of `PackageData` to preserve intermediate
+/// types needed for package disambiguation before converting to final types.
+#[serde_as]
+#[derive(Deserialize)]
+#[serde(bound(deserialize = "P: DeserializeAs<'de, LegacyPackageData>"))]
+struct DeserializableLockFileLegacy<P> {
+    environments: BTreeMap<String, DeserializableEnvironment>,
+    #[serde_as(as = "Vec<P>")]
+    packages: Vec<LegacyPackageData>,
     #[serde(skip)]
     _data: PhantomData<P>,
 }
@@ -84,6 +98,16 @@ enum PackageData {
     Pypi(PypiPackageDataRaw),
 }
 
+/// Package data enum used during legacy (V4-V6) deserialization.
+///
+/// This intermediate type preserves all fields needed for package disambiguation
+/// before converting to the final `CondaPackageData` type.
+#[allow(clippy::large_enum_variant)]
+enum LegacyPackageData {
+    Conda(LegacyCondaPackageData),
+    Pypi(PypiPackageDataRaw),
+}
+
 #[derive(Deserialize)]
 struct DeserializableEnvironment {
     channels: Vec<Channel>,
@@ -94,8 +118,8 @@ struct DeserializableEnvironment {
     packages: BTreeMap<Platform, Vec<DeserializablePackageSelector>>,
 }
 
-impl<'de> DeserializeAs<'de, PackageData> for V5 {
-    fn deserialize_as<D>(deserializer: D) -> Result<PackageData, D::Error>
+impl<'de> DeserializeAs<'de, LegacyPackageData> for V5 {
+    fn deserialize_as<D>(deserializer: D) -> Result<LegacyPackageData, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -108,14 +132,14 @@ impl<'de> DeserializeAs<'de, PackageData> for V5 {
         }
 
         Ok(match Inner::deserialize(deserializer)? {
-            Inner::Conda(c) => PackageData::Conda(c.into()),
-            Inner::Pypi(p) => PackageData::Pypi(p.into()),
+            Inner::Conda(c) => LegacyPackageData::Conda(c.into()),
+            Inner::Pypi(p) => LegacyPackageData::Pypi(p.into()),
         })
     }
 }
 
-impl<'de> DeserializeAs<'de, PackageData> for V6 {
-    fn deserialize_as<D>(deserializer: D) -> Result<PackageData, D::Error>
+impl<'de> DeserializeAs<'de, LegacyPackageData> for V6 {
+    fn deserialize_as<D>(deserializer: D) -> Result<LegacyPackageData, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -143,13 +167,13 @@ impl<'de> DeserializeAs<'de, PackageData> for V6 {
 
         let deserializer = serde_value::ValueDeserializer::<D::Error>::new(value);
         Ok(match discriminant {
-            Discriminant::Conda { .. } => PackageData::Conda(
+            Discriminant::Conda { .. } => LegacyPackageData::Conda(
                 v6::CondaPackageDataModel::deserialize(deserializer)?
                     .try_into()
                     .map_err(D::Error::custom)?,
             ),
             Discriminant::Pypi { .. } => {
-                PackageData::Pypi(v6::PypiPackageDataModel::deserialize(deserializer)?.into())
+                LegacyPackageData::Pypi(v6::PypiPackageDataModel::deserialize(deserializer)?.into())
             }
         })
     }
@@ -228,24 +252,24 @@ impl From<DeserializablePypiPackageEnvironmentData> for PypiPackageEnvironmentDa
     }
 }
 
-/// Parses a [`LockFile`] from a [`serde_yaml::Value`].
+/// Parses a [`LockFile`] from a [`serde_yaml::Value`] for V4/V5 format.
 pub fn parse_from_document_v5(
     document: Value,
     version: FileFormatVersion,
 ) -> Result<LockFile, ParseCondaLockError> {
-    let raw: DeserializableLockFile<V5> =
+    let raw: DeserializableLockFileLegacy<V5> =
         serde_yaml::from_value(document).map_err(ParseCondaLockError::ParseError)?;
-    parse_from_lock(version, raw, None)
+    parse_from_lock_legacy(version, raw, None)
 }
 
+/// Parses a [`LockFile`] from a [`serde_yaml::Value`] for V6 format.
 pub fn parse_from_document_v6(
     document: Value,
     base_dir: Option<&Path>,
 ) -> Result<LockFile, ParseCondaLockError> {
-    let raw: DeserializableLockFile<V6> =
-        serde_yaml::from_value::<DeserializableLockFile<V6>>(document)
-            .map_err(ParseCondaLockError::ParseError)?;
-    parse_from_lock(FileFormatVersion::V6, raw, base_dir)
+    let raw: DeserializableLockFileLegacy<V6> =
+        serde_yaml::from_value(document).map_err(ParseCondaLockError::ParseError)?;
+    parse_from_lock_legacy(FileFormatVersion::V6, raw, base_dir)
 }
 
 pub fn parse_from_document_v7(
@@ -293,6 +317,223 @@ fn convert_raw_pypi_package(
     })
 }
 
+/// Checks if a legacy conda package matches the given selector fields.
+fn legacy_package_matches_selector(
+    package: &LegacyCondaPackageData,
+    name: Option<&PackageName>,
+    version: Option<&VersionWithSource>,
+    build: Option<&str>,
+    subdir: Option<&str>,
+) -> bool {
+    let record = package.record();
+    name.is_none_or(|n| n == &record.name)
+        && version.is_none_or(|v| v == &record.version)
+        && build.is_none_or(|b| b == record.build)
+        && subdir.is_none_or(|s| s == record.subdir)
+}
+
+/// Resolves a conda package index for legacy lock file formats (V1-V6).
+///
+/// For V6, uses exact field matching (name, version, build, subdir).
+/// For V5 and earlier, matches by platform/subdir and merges duplicate packages
+/// that share the same URL to combine optional fields like purls and hashes.
+#[allow(clippy::too_many_arguments)]
+fn resolve_legacy_conda_package(
+    file_version: FileFormatVersion,
+    platform: Platform,
+    name: Option<&PackageName>,
+    version: Option<&VersionWithSource>,
+    build: Option<&str>,
+    subdir: Option<&str>,
+    candidate_indices: &[usize],
+    packages: &mut Vec<LegacyCondaPackageData>,
+) -> Option<usize> {
+    if file_version >= FileFormatVersion::V6 {
+        // V6+: Find the package that matches all selector fields exactly.
+        return candidate_indices
+            .iter()
+            .find(|&&idx| {
+                legacy_package_matches_selector(&packages[idx], name, version, build, subdir)
+            })
+            .copied();
+    }
+
+    // V5 and earlier: Match by platform subdir and merge duplicates.
+    // This handles a historical quirk where multiple packages could share
+    // the same URL but have different metadata.
+    let packages_for_platform: Vec<_> = candidate_indices
+        .iter()
+        .filter(|&&idx| packages[idx].record().subdir.as_str() == platform.as_str())
+        .copied()
+        .collect();
+
+    // Fall back to all candidates if none match the platform
+    let matching_indices = if packages_for_platform.is_empty() {
+        candidate_indices
+    } else {
+        &packages_for_platform
+    };
+
+    let mut iter = matching_indices.iter().copied();
+    let first_idx = iter.next()?;
+
+    // Merge all matching packages into one
+    let merged = iter.fold(
+        Cow::Borrowed(&packages[first_idx]),
+        |acc, next_idx| match acc.merge(&packages[next_idx]) {
+            Cow::Owned(merged) => Cow::Owned(merged),
+            Cow::Borrowed(_) => acc,
+        },
+    );
+
+    Some(match merged {
+        Cow::Borrowed(_) => first_idx,
+        Cow::Owned(merged_package) => {
+            packages.push(merged_package);
+            packages.len() - 1
+        }
+    })
+}
+
+/// Parses a legacy lock file (V4-V6) using `LegacyCondaPackageData` as the
+/// intermediate type, then converts to `CondaPackageData` at the end.
+///
+/// This separation allows `CondaPackageData` to evolve for newer versions (V7+)
+/// without breaking backward compatibility with older lock files.
+fn parse_from_lock_legacy<P>(
+    file_version: FileFormatVersion,
+    raw: DeserializableLockFileLegacy<P>,
+    base_dir: Option<&Path>,
+) -> Result<LockFile, ParseCondaLockError> {
+    // Split the packages into conda and pypi packages using legacy intermediate types.
+    let mut legacy_conda_packages: Vec<LegacyCondaPackageData> = Vec::new();
+    let mut pypi_packages = Vec::new();
+
+    for package in raw.packages {
+        match package {
+            LegacyPackageData::Conda(p) => legacy_conda_packages.push(p),
+            LegacyPackageData::Pypi(p) => {
+                pypi_packages.push(convert_raw_pypi_package(file_version, p, base_dir)?);
+            }
+        }
+    }
+
+    // Determine the indices of the packages by url
+    let mut conda_url_lookup: ahash::HashMap<UrlOrPath, Vec<_>> = ahash::HashMap::default();
+    for (idx, conda_package) in legacy_conda_packages.iter().enumerate() {
+        conda_url_lookup
+            .entry(conda_package.location().clone())
+            .or_default()
+            .push(idx);
+    }
+
+    let pypi_url_lookup = pypi_packages
+        .iter()
+        .enumerate()
+        .map(|(idx, p)| (&p.location, idx))
+        .collect::<ahash::HashMap<_, _>>();
+    let mut pypi_runtime_lookup = IndexSet::new();
+
+    let environments = raw
+        .environments
+        .into_iter()
+        .map(|(environment_name, env)| {
+            Ok((
+                environment_name.clone(),
+                EnvironmentData {
+                    channels: env.channels,
+                    indexes: env.indexes,
+                    options: env.options,
+                    packages: env
+                        .packages
+                        .into_iter()
+                        .map(|(platform, packages)| {
+                            let packages = packages
+                                .into_iter()
+                                .map(|p| {
+                                    Ok(match p {
+                                        DeserializablePackageSelector::Conda {
+                                            conda,
+                                            name,
+                                            version,
+                                            build,
+                                            subdir,
+                                        } => {
+                                            let candidate_indices = conda_url_lookup
+                                                .get(&conda)
+                                                .map_or(&[] as &[usize], Vec::as_slice);
+
+                                            let package_index = resolve_legacy_conda_package(
+                                                file_version,
+                                                platform,
+                                                name.as_ref(),
+                                                version.as_ref(),
+                                                build.as_deref(),
+                                                subdir.as_deref(),
+                                                candidate_indices,
+                                                &mut legacy_conda_packages,
+                                            );
+
+                                            EnvironmentPackageData::Conda(
+                                                package_index.ok_or_else(|| {
+                                                    ParseCondaLockError::MissingPackage(
+                                                        environment_name.clone(),
+                                                        platform,
+                                                        conda,
+                                                    )
+                                                })?,
+                                            )
+                                        }
+                                        DeserializablePackageSelector::Pypi { pypi, runtime } => {
+                                            EnvironmentPackageData::Pypi(
+                                                *pypi_url_lookup.get(&pypi).ok_or_else(|| {
+                                                    ParseCondaLockError::MissingPackage(
+                                                        environment_name.clone(),
+                                                        platform,
+                                                        pypi.inner().clone(),
+                                                    )
+                                                })?,
+                                                pypi_runtime_lookup.insert_full(runtime).0,
+                                            )
+                                        }
+                                    })
+                                })
+                                .collect::<Result<_, ParseCondaLockError>>()?;
+
+                            Ok((platform, packages))
+                        })
+                        .collect::<Result<_, ParseCondaLockError>>()?,
+                },
+            ))
+        })
+        .collect::<Result<BTreeMap<_, _>, ParseCondaLockError>>()?;
+
+    let (environment_lookup, environments) = environments
+        .into_iter()
+        .enumerate()
+        .map(|(idx, (name, env))| ((name, idx), env))
+        .unzip();
+
+    // Convert legacy conda packages to final CondaPackageData
+    let conda_packages: Vec<CondaPackageData> =
+        legacy_conda_packages.into_iter().map(Into::into).collect();
+
+    Ok(LockFile {
+        inner: Arc::new(LockFileInner {
+            version: file_version,
+            environments,
+            environment_lookup,
+            conda_packages,
+            pypi_packages,
+            pypi_environment_package_data: pypi_runtime_lookup
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        }),
+    })
+}
+
+/// Parses a V7+ lock file directly to `CondaPackageData`.
 fn parse_from_lock<P>(
     file_version: FileFormatVersion,
     raw: DeserializableLockFile<P>,
@@ -356,87 +597,22 @@ fn parse_from_lock<P>(
                                                 .get(&conda)
                                                 .map_or(&[] as &[usize], Vec::as_slice);
 
-                                            // Before V6 the package was selected by the first
-                                            // match. This is actually a bug because when parsing an
-                                            // older lock-file there can be more than one package
-                                            // with the same url. Instead, we should look at the
-                                            // subdir to disambiguate.
-                                            let package_index: Option<usize> = if file_version
-                                                < FileFormatVersion::V6
-                                            {
-                                                // Find the packages that match the subdir of
-                                                // this environment
-                                                let mut all_packages_with_subdir = all_packages
-                                                    .iter()
-                                                    .filter(|&idx| {
-                                                        let conda_package = &conda_packages[*idx];
-                                                        conda_package.record().subdir.as_str()
-                                                            == platform.as_str()
+                                            // V7+ uses exact field matching for disambiguation
+                                            let package_index = all_packages
+                                                .iter()
+                                                .find(|&idx| {
+                                                    let conda_package = &conda_packages[*idx];
+                                                    name.as_ref().is_none_or(|name| {
+                                                        name == &conda_package.record().name
+                                                    }) && version.as_ref().is_none_or(|version| {
+                                                        version == &conda_package.record().version
+                                                    }) && build.as_ref().is_none_or(|build| {
+                                                        build == &conda_package.record().build
+                                                    }) && subdir.as_ref().is_none_or(|subdir| {
+                                                        subdir == &conda_package.record().subdir
                                                     })
-                                                    .peekable();
-
-                                                // If there are no packages for the subdir, use all
-                                                // packages.
-                                                let mut matching_packages =
-                                                    if all_packages_with_subdir.peek().is_some() {
-                                                        Either::Left(all_packages_with_subdir)
-                                                    } else {
-                                                        Either::Right(all_packages.iter())
-                                                    };
-
-                                                // Merge all matching packages.
-                                                if let Some(&first_package_idx) =
-                                                    matching_packages.next()
-                                                {
-                                                    let merged_package = Cow::Borrowed(
-                                                        &conda_packages[first_package_idx],
-                                                    );
-                                                    let package = matching_packages.fold(
-                                                        merged_package,
-                                                        |acc, &next_package_idx| {
-                                                            if let Cow::Owned(merged) = acc.merge(
-                                                                &conda_packages[next_package_idx],
-                                                            ) {
-                                                                Cow::Owned(merged)
-                                                            } else {
-                                                                acc
-                                                            }
-                                                        },
-                                                    );
-                                                    Some(match package {
-                                                        Cow::Borrowed(_) => first_package_idx,
-                                                        Cow::Owned(package) => {
-                                                            conda_packages.push(package);
-                                                            conda_packages.len() - 1
-                                                        }
-                                                    })
-                                                } else {
-                                                    None
-                                                }
-                                            } else {
-                                                // Find the package that matches all the fields from
-                                                // the selector.
-                                                all_packages
-                                                    .iter()
-                                                    .find(|&idx| {
-                                                        let conda_package = &conda_packages[*idx];
-                                                        name.as_ref().is_none_or(|name| {
-                                                            name == &conda_package.record().name
-                                                        }) && version.as_ref().is_none_or(
-                                                            |version| {
-                                                                version
-                                                                    == &conda_package
-                                                                        .record()
-                                                                        .version
-                                                            },
-                                                        ) && build.as_ref().is_none_or(|build| {
-                                                            build == &conda_package.record().build
-                                                        }) && subdir.as_ref().is_none_or(|subdir| {
-                                                            subdir == &conda_package.record().subdir
-                                                        })
-                                                    })
-                                                    .copied()
-                                            };
+                                                })
+                                                .copied();
 
                                             EnvironmentPackageData::Conda(
                                                 package_index.ok_or_else(|| {

--- a/crates/rattler_lock/src/parse/models/legacy.rs
+++ b/crates/rattler_lock/src/parse/models/legacy.rs
@@ -1,0 +1,216 @@
+//! Intermediate types for legacy lock file deserialization (V1-V6).
+//!
+//! These types are used during lock file parsing for versions 1 through 6 to
+//! preserve all fields needed for package disambiguation. After environment
+//! resolution is complete, they are converted to the final `CondaPackageData`
+//! type.
+//!
+//! This intermediate layer allows `CondaPackageData` to evolve for newer
+//! versions (V7+) without breaking backward compatibility with older lock
+//! files.
+//!
+//! # Why merging exists
+//!
+//! In lock file versions before V6, multiple packages could share the same URL
+//! but differ in metadata (e.g., different subdirs for the same package). When
+//! resolving environment references, these packages needed to be merged to
+//! combine optional fields like `purls`, `run_exports`, and hashes that might
+//! only be present in one of the duplicates.
+//!
+//! V6 introduced disambiguating fields (name, version, build, subdir) in
+//! environment references, making exact matching possible. However, the merging
+//! logic is retained here for parsing older format versions.
+
+use std::{borrow::Cow, collections::BTreeMap};
+
+use rattler_conda_types::{ChannelUrl, PackageRecord};
+
+use crate::{
+    conda::{CondaBinaryData, CondaSourceData, PackageBuildSource, VariantValue},
+    source::SourceLocation,
+    CondaPackageData, UrlOrPath,
+};
+
+/// Intermediate representation of a conda package during legacy deserialization.
+///
+/// This type preserves all fields from legacy lock file formats (V1-V6) that
+/// are needed for package disambiguation (matching environment references to
+/// package data). After resolution, it is converted to `CondaPackageData`.
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub(crate) enum LegacyCondaPackageData {
+    /// A binary package.
+    Binary(LegacyCondaBinaryData),
+    /// A source package.
+    Source(LegacyCondaSourceData),
+}
+
+/// Intermediate binary package data for legacy deserialization.
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub(crate) struct LegacyCondaBinaryData {
+    /// The package record with all metadata.
+    pub package_record: PackageRecord,
+    /// The location of the package (URL or path).
+    pub location: UrlOrPath,
+    /// The filename of the package.
+    pub file_name: String,
+    /// The channel of the package.
+    pub channel: Option<ChannelUrl>,
+}
+
+/// Intermediate source package data for legacy deserialization.
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub(crate) struct LegacyCondaSourceData {
+    /// The package record with all metadata.
+    pub package_record: PackageRecord,
+    /// The location of the package (URL or path).
+    pub location: UrlOrPath,
+    /// Conda-build variants for disambiguation.
+    pub variants: BTreeMap<String, VariantValue>,
+    /// Package build source location.
+    pub package_build_source: Option<PackageBuildSource>,
+    /// Source locations for packages built from source.
+    pub sources: BTreeMap<String, SourceLocation>,
+}
+
+impl LegacyCondaPackageData {
+    /// Returns the location of the package.
+    pub fn location(&self) -> &UrlOrPath {
+        match self {
+            Self::Binary(data) => &data.location,
+            Self::Source(data) => &data.location,
+        }
+    }
+
+    /// Returns the package record.
+    pub fn record(&self) -> &PackageRecord {
+        match self {
+            Self::Binary(data) => &data.package_record,
+            Self::Source(data) => &data.package_record,
+        }
+    }
+
+    /// Performs best-effort merge of two packages with the same location.
+    ///
+    /// This is needed for lock file versions before V6, where multiple packages
+    /// could share the same URL but have different metadata. Optional fields
+    /// like `purls`, `run_exports`, `md5`, and `sha256` are merged from the
+    /// second package if they are missing in the first.
+    ///
+    /// For V6 and later, this method is typically not called because packages
+    /// are matched exactly using name/version/build/subdir fields.
+    pub fn merge(&self, other: &Self) -> Cow<'_, Self> {
+        match (self, other) {
+            (Self::Binary(left), Self::Binary(right)) => {
+                if left.location == right.location {
+                    if let Cow::Owned(merged) =
+                        merge_package_record(&left.package_record, &right.package_record)
+                    {
+                        return Cow::Owned(Self::Binary(LegacyCondaBinaryData {
+                            package_record: merged,
+                            location: left.location.clone(),
+                            file_name: left.file_name.clone(),
+                            channel: left.channel.clone(),
+                        }));
+                    }
+                }
+            }
+            (Self::Source(left), Self::Source(right)) => {
+                if left.location == right.location {
+                    let record_merge =
+                        merge_package_record(&left.package_record, &right.package_record);
+                    let build_source_merge = merge_package_build_source(
+                        &left.package_build_source,
+                        &right.package_build_source,
+                    );
+
+                    if matches!(record_merge, Cow::Owned(_))
+                        || matches!(build_source_merge, Cow::Owned(_))
+                    {
+                        return Cow::Owned(Self::Source(LegacyCondaSourceData {
+                            package_record: record_merge.into_owned(),
+                            location: left.location.clone(),
+                            variants: left.variants.clone(),
+                            package_build_source: build_source_merge.into_owned(),
+                            sources: left.sources.clone(),
+                        }));
+                    }
+                }
+            }
+            _ => {}
+        }
+        Cow::Borrowed(self)
+    }
+}
+
+/// Convert `LegacyCondaPackageData` to the final `CondaPackageData` type.
+///
+/// Currently this is a 1:1 conversion. When `CondaPackageData` is updated for
+/// V7 (e.g., source packages use hash instead of full `PackageRecord`), this
+/// conversion will compute the hash from the legacy data.
+impl From<LegacyCondaPackageData> for CondaPackageData {
+    fn from(value: LegacyCondaPackageData) -> Self {
+        match value {
+            LegacyCondaPackageData::Binary(data) => CondaPackageData::Binary(CondaBinaryData {
+                package_record: data.package_record,
+                location: data.location,
+                file_name: data.file_name,
+                channel: data.channel,
+            }),
+            LegacyCondaPackageData::Source(data) => CondaPackageData::Source(CondaSourceData {
+                package_record: data.package_record,
+                location: data.location,
+                variants: data.variants,
+                package_build_source: data.package_build_source,
+                sources: data.sources,
+            }),
+        }
+    }
+}
+
+/// Merge optional fields from `right` into `left` if they are missing.
+fn merge_package_record<'a>(
+    left: &'a PackageRecord,
+    right: &PackageRecord,
+) -> Cow<'a, PackageRecord> {
+    // Check which fields need to be merged
+    let needs_purls = left.purls.is_none() && right.purls.is_some();
+    let needs_run_exports = left.run_exports.is_none() && right.run_exports.is_some();
+    let needs_md5 = left.md5.is_none() && right.md5.is_some();
+    let needs_sha256 = left.sha256.is_none() && right.sha256.is_some();
+
+    // Return borrowed if no merging needed
+    if !needs_purls && !needs_run_exports && !needs_md5 && !needs_sha256 {
+        return Cow::Borrowed(left);
+    }
+
+    // Clone once and update only the fields that need merging
+    let mut merged = left.clone();
+    if needs_purls {
+        merged.purls.clone_from(&right.purls);
+    }
+    if needs_run_exports {
+        merged.run_exports.clone_from(&right.run_exports);
+    }
+    if needs_md5 {
+        merged.md5 = right.md5;
+    }
+    if needs_sha256 {
+        merged.sha256 = right.sha256;
+    }
+    Cow::Owned(merged)
+}
+
+/// Merge package build source, preferring the right value if left is None.
+fn merge_package_build_source<'a>(
+    left: &'a Option<PackageBuildSource>,
+    right: &Option<PackageBuildSource>,
+) -> Cow<'a, Option<PackageBuildSource>> {
+    if left == right {
+        Cow::Borrowed(left)
+    } else if let Some(right_source) = right {
+        // New data takes precedence
+        Cow::Owned(Some(right_source.clone()))
+    } else {
+        Cow::Borrowed(left)
+    }
+}

--- a/crates/rattler_lock/src/parse/models/mod.rs
+++ b/crates/rattler_lock/src/parse/models/mod.rs
@@ -1,5 +1,6 @@
 //! Contains serializable models of different data structures.
 
+pub(crate) mod legacy;
 pub mod v5;
 pub mod v6;
 pub mod v7;

--- a/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v5/conda_package_data.rs
@@ -9,9 +9,9 @@ use serde_with::serde_as;
 use url::Url;
 
 use crate::{
-    conda::CondaBinaryData,
+    parse::models::legacy::{LegacyCondaBinaryData, LegacyCondaPackageData},
     utils::derived_fields::{derive_arch_and_platform, derive_channel_from_location},
-    CondaPackageData, UrlOrPath,
+    UrlOrPath,
 };
 
 fn is_default<T: Default + Eq>(value: &T) -> bool {
@@ -92,7 +92,7 @@ pub(crate) struct CondaPackageDataModel<'a> {
     pub timestamp: Option<chrono::DateTime<chrono::Utc>>,
 }
 
-impl<'a> From<CondaPackageDataModel<'a>> for CondaPackageData {
+impl<'a> From<CondaPackageDataModel<'a>> for LegacyCondaPackageData {
     fn from(value: CondaPackageDataModel<'a>) -> Self {
         let location = UrlOrPath::Url(value.url.into_owned());
         let subdir = value.subdir.into_owned();
@@ -111,7 +111,7 @@ impl<'a> From<CondaPackageDataModel<'a>> for CondaPackageData {
                 )
             });
 
-        Self::Binary(CondaBinaryData {
+        Self::Binary(LegacyCondaBinaryData {
             package_record: PackageRecord {
                 build: value.build.into_owned(),
                 build_number: value.build_number,

--- a/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/conda_package_data.rs
@@ -12,12 +12,13 @@ use serde::Deserialize;
 use serde_with::serde_as;
 use url::Url;
 
+use super::super::legacy::{LegacyCondaBinaryData, LegacyCondaPackageData, LegacyCondaSourceData};
 use super::source_data::{PackageBuildSourceSerializer, SourceLocationSerializer};
 use crate::{
-    conda::{CondaBinaryData, CondaSourceData, PackageBuildSource, VariantValue},
+    conda::{PackageBuildSource, VariantValue},
     source::SourceLocation,
     utils::{derived_fields, derived_fields::LocationDerivedFields},
-    CondaPackageData, ConversionError, UrlOrPath,
+    ConversionError, UrlOrPath,
 };
 
 /// A helper struct that wraps all fields of a [`crate::CondaPackageData`] and
@@ -136,7 +137,7 @@ pub(crate) struct InputHash<'a> {
     pub globs: Cow<'a, [String]>,
 }
 
-impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaPackageData {
+impl<'a> TryFrom<CondaPackageDataModel<'a>> for LegacyCondaPackageData {
     type Error = ConversionError;
 
     fn try_from(value: CondaPackageDataModel<'a>) -> Result<Self, Self::Error> {
@@ -206,7 +207,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaPackageData {
             .file_name()
             .is_some_and(|name| ArchiveIdentifier::try_from_filename(name).is_some())
         {
-            Ok(CondaPackageData::Binary(CondaBinaryData {
+            Ok(LegacyCondaPackageData::Binary(LegacyCondaBinaryData {
                 location: value.location,
                 file_name: value
                     .file_name
@@ -228,7 +229,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaPackageData {
                 package_record,
             }))
         } else {
-            Ok(CondaPackageData::Source(CondaSourceData {
+            Ok(LegacyCondaPackageData::Source(LegacyCondaSourceData {
                 package_record,
                 location: value.location,
                 variants: value.variants.unwrap_or_default().into_owned(),


### PR DESCRIPTION
Introduces an intermediate `LegacyCondaPackageData` type for parsing lock file versions V1-V6, decoupling legacy parsing from the final `CondaPackageData` type. This prepares the codebase for V7 format changes where source packages will use a deterministic hash instead of a full `PackageRecord`.

Part of #1974