### PR TITLE
refactor: remove pypi `extras` from lock-file v7

### DIFF
--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -4,7 +4,7 @@ use std::{collections::BTreeSet, ops::Not, str::FromStr, sync::Arc};
 
 use indexmap::IndexSet;
 use pep440_rs::VersionSpecifiers;
-use pep508_rs::{ExtraName, Requirement};
+use pep508_rs::Requirement;
 use rattler_conda_types::{
     NoArchType, PackageName, PackageRecord, PackageUrl, Platform, VersionWithSource,
 };
@@ -23,8 +23,7 @@ use crate::{
         LocationDerivedFields,
     },
     Channel, CondaPackageData, EnvironmentData, EnvironmentPackageData, LockFile, LockFileInner,
-    PackageHashes, PypiPackageData, PypiPackageEnvironmentData, SolveOptions, UrlOrPath, Verbatim,
-    DEFAULT_ENVIRONMENT_NAME,
+    PackageHashes, PypiPackageData, SolveOptions, UrlOrPath, Verbatim, DEFAULT_ENVIRONMENT_NAME,
 };
 
 #[derive(Deserialize)]
@@ -68,27 +67,11 @@ struct PypiLockedPackageV3 {
     #[serde_as(deserialize_as = "crate::utils::serde::Pep440MapOrVec")]
     pub requires_dist: Vec<Requirement>,
     pub requires_python: Option<VersionSpecifiers>,
-    #[serde(flatten)]
-    pub runtime: PypiPackageEnvironmentDataV3,
     pub url: Url,
     pub hash: Option<PackageHashes>,
     // These fields are not used by rattler-lock.
     // pub source: Option<Url>,
     // pub build: Option<String>,
-}
-
-#[derive(Clone, Debug, Deserialize, Hash, Eq, PartialEq)]
-pub struct PypiPackageEnvironmentDataV3 {
-    #[serde(default)]
-    pub extras: BTreeSet<ExtraName>,
-}
-
-impl From<PypiPackageEnvironmentDataV3> for PypiPackageEnvironmentData {
-    fn from(config: PypiPackageEnvironmentDataV3) -> Self {
-        Self {
-            extras: config.extras.into_iter().collect(),
-        }
-    }
 }
 
 #[serde_as]
@@ -138,7 +121,6 @@ pub fn parse_v3_or_lower(
     // per platform. There might be duplicates for noarch packages.
     let mut conda_packages = IndexSet::with_capacity(lock_file.package.len());
     let mut pypi_packages = IndexSet::with_capacity(lock_file.package.len());
-    let mut pypi_runtime_configs = IndexSet::with_capacity(lock_file.package.len());
     let mut per_platform: ahash::HashMap<Platform, IndexSet<EnvironmentPackageData>> =
         ahash::HashMap::default();
     for package in lock_file.package {
@@ -237,10 +219,7 @@ pub fn parse_v3_or_lower(
                         hash: pkg.hash,
                     })
                     .0;
-                EnvironmentPackageData::Pypi(
-                    deduplicated_index,
-                    pypi_runtime_configs.insert_full(pkg.runtime).0,
-                )
+                EnvironmentPackageData::Pypi(deduplicated_index)
             }
         };
 
@@ -266,10 +245,6 @@ pub fn parse_v3_or_lower(
                 .map(CondaPackageData::from)
                 .collect(),
             pypi_packages: pypi_packages.into_iter().collect(),
-            pypi_environment_package_data: pypi_runtime_configs
-                .into_iter()
-                .map(Into::into)
-                .collect(),
 
             environment_lookup: [(DEFAULT_ENVIRONMENT_NAME.to_string(), 0)]
                 .into_iter()

--- a/crates/rattler_lock/src/pypi.rs
+++ b/crates/rattler_lock/src/pypi.rs
@@ -1,9 +1,8 @@
 use crate::{PackageHashes, UrlOrPath, Verbatim};
 use pep440_rs::VersionSpecifiers;
-use pep508_rs::{ExtraName, PackageName, Requirement};
+use pep508_rs::{PackageName, Requirement};
 use rattler_digest::{digest::Digest, Sha256};
 use std::cmp::Ordering;
-use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
 
@@ -27,14 +26,6 @@ pub struct PypiPackageData {
 
     /// The python version that this package requires.
     pub requires_python: Option<VersionSpecifiers>,
-}
-
-/// Additional runtime configuration of a package. Multiple environments/platforms might refer to
-/// the same pypi package but with different extras enabled.
-#[derive(Clone, Debug, Default)]
-pub struct PypiPackageEnvironmentData {
-    /// The extras enabled for the package. Note that the order doesn't matter here but it does matter for serialization.
-    pub extras: BTreeSet<ExtraName>,
 }
 
 impl PartialOrd for PypiPackageData {

--- a/py-rattler/rattler/lock/package.py
+++ b/py-rattler/rattler/lock/package.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import ABC
-from typing import Optional, Set, List
+from typing import Optional, List
 
 from rattler import PackageRecord, Version, RepoDataRecord
 
@@ -207,27 +207,6 @@ class PypiLockedPackage(LockedPackage):
         ```
         """
         return self._package.pypi_requires_python
-
-    @property
-    def extras(self) -> Set[str]:
-        """
-        The extras enabled for the package.
-        Note that the order doesn't matter.
-
-        Examples
-        --------
-        ```python
-        >>> from rattler import LockFile, Platform
-        >>> lock_file = LockFile.from_path("../test-data/test.lock")
-        >>> env = lock_file.default_environment()
-        >>> pypi_packages = env.pypi_packages()
-        >>> env_data = pypi_packages[Platform("osx-arm64")][0]
-        >>> env_data.extras
-        set()
-        >>>
-        ```
-        """
-        return self._package.pypi_extras
 
     def satisfies(self, spec: str) -> bool:
         """

--- a/py-rattler/src/lib.rs
+++ b/py-rattler/src/lib.rs
@@ -50,7 +50,6 @@ use index_json::PyIndexJson;
 use installer::py_install;
 use lock::{
     PyEnvironment, PyLockChannel, PyLockFile, PyLockedPackage, PyPackageHashes, PyPypiPackageData,
-    PyPypiPackageEnvironmentData,
 };
 use match_spec::PyMatchSpec;
 use meta::get_rattler_version;
@@ -163,7 +162,6 @@ fn rattler<'py>(py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()> {
     m.add_class::<PyLockChannel>()?;
     m.add_class::<PyLockedPackage>()?;
     m.add_class::<PyPypiPackageData>()?;
-    m.add_class::<PyPypiPackageEnvironmentData>()?;
     m.add_class::<PyPackageHashes>()?;
 
     m.add_class::<PyAboutJson>()?;


### PR DESCRIPTION
This PR removes `extras` stored in the lock-file. 

Fixes #1986 