### PR TITLE
feat: Expose archspec in py-rattler

### DIFF
--- a/py-rattler/rattler/virtual_package/virtual_package.py
+++ b/py-rattler/rattler/virtual_package/virtual_package.py
@@ -79,7 +79,13 @@ class VirtualPackageOverrides:
         virtual_package_overrides._overrides = py_virtual_package_overrides
         return virtual_package_overrides
 
-    def __init__(self, osx: Override | None = None, libc: Override | None = None, cuda: Override | None = None) -> None:
+    def __init__(
+        self,
+        osx: Override | None = None,
+        libc: Override | None = None,
+        cuda: Override | None = None,
+        archspec: Override | None = None,
+    ) -> None:
         """
         Returns the default virtual package overrides. By default, none of the overrides are set.
         """
@@ -87,6 +93,7 @@ class VirtualPackageOverrides:
         self.osx = osx
         self.libc = libc
         self.cuda = cuda
+        self.archspec = archspec
 
     @classmethod
     def from_env(cls) -> VirtualPackageOverrides:
@@ -139,6 +146,21 @@ class VirtualPackageOverrides:
         Sets the CUDA override.
         """
         self._overrides.cuda = override._override if override else None
+
+    @property
+    def archspec(self) -> Override | None:
+        """
+        Returns the archspec override.
+        """
+        override = self._overrides.archspec
+        return Override._from_py_override(override) if override else None
+
+    @archspec.setter
+    def archspec(self, override: Override | None) -> None:
+        """
+        Sets the archspec override.
+        """
+        self._overrides.archspec = override._override if override else None
 
     def __str__(self) -> str:
         """

--- a/py-rattler/src/virtual_package.rs
+++ b/py-rattler/src/virtual_package.rs
@@ -117,6 +117,14 @@ impl PyVirtualPackageOverrides {
     pub fn set_libc(&mut self, value: Option<PyOverride>) {
         self.inner.libc = value.map(Into::into);
     }
+    #[getter]
+    pub fn get_archspec(&self) -> Option<PyOverride> {
+        self.inner.archspec.clone().map(Into::into)
+    }
+    #[setter]
+    pub fn set_archspec(&mut self, value: Option<PyOverride>) {
+        self.inner.archspec = value.map(Into::into);
+    }
 }
 
 #[pyclass]

--- a/py-rattler/tests/unit/test_override.py
+++ b/py-rattler/tests/unit/test_override.py
@@ -6,15 +6,18 @@ def test_overrides() -> None:
     assert overrides.osx is None
     assert overrides.libc is None
     assert overrides.cuda is None
+    assert overrides.archspec is None
 
     overrides = VirtualPackageOverrides.from_env()
     assert overrides.osx == Override.default_env_var()
     assert overrides.libc == Override.default_env_var()
     assert overrides.cuda == Override.default_env_var()
+    assert overrides.archspec == Override.default_env_var()
 
     overrides.osx = Override.string("123.45")
     overrides.libc = Override.string("123.457")
     overrides.cuda = Override.string("123.4578")
+    overrides.archspec = Override.string("m4")
 
     r = [i.into_generic() for i in VirtualPackage.detect(overrides)]
 
@@ -28,3 +31,7 @@ def test_overrides() -> None:
     find("__cuda", "123.4578")
     find("__libc", "123.4578", False)
     find("__osx", "123.45", False)
+
+    # archspec uses build_string rather than version
+    archspec_pkg = next(i for i in r if i.name == PackageName("__archspec"))
+    assert archspec_pkg.build_string == "m4"


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

Closes #1840. Forgot to actually submit a PR for this...

tl;dr this exposes archspec in py-rattler (for virtual package override use). Pretty straightforward.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
