### PR TITLE
refactor(py)!: rename exceptions to follow Error suffix convention

### DIFF
--- a/py-rattler/rattler/version/version.py
+++ b/py-rattler/rattler/version/version.py
@@ -140,7 +140,7 @@ class Version:
         >>>
         >>> Version("1.5").bump_segment(-5) # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
-        exceptions.VersionBumpException
+        exceptions.VersionBumpError
         >>> Version("1.5").bump_segment(5)
         Version("1.5.0.0.0.1")
         >>>
@@ -352,7 +352,7 @@ class Version:
         Version("2!1")
         >>> v.pop_segments(3) # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
-        exceptions.InvalidVersionException: new Version must have atleast 1 valid
+        exceptions.InvalidVersionError: new Version must have atleast 1 valid
         segment
         >>>
         ```

--- a/py-rattler/src/error.rs
+++ b/py-rattler/src/error.rs
@@ -108,93 +108,93 @@ impl From<PyRattlerError> for PyErr {
     fn from(value: PyRattlerError) -> Self {
         match value {
             PyRattlerError::InvalidVersion(err) => {
-                InvalidVersionException::new_err(pretty_print_error(&err))
+                InvalidVersionError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::InvalidVersionSpec(err) => {
-                InvalidVersionSpecException::new_err(pretty_print_error(&err))
+                InvalidVersionSpecError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::InvalidMatchSpec(err) => {
-                InvalidMatchSpecException::new_err(pretty_print_error(&err))
+                InvalidMatchSpecError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::InvalidPackageName(err) => {
-                InvalidPackageNameException::new_err(pretty_print_error(&err))
+                InvalidPackageNameError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::PackageNameMatcherParseError(err) => {
-                PackageNameMatcherParseException::new_err(pretty_print_error(&err))
+                PackageNameMatcherParseError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::InvalidUrl(err) => {
-                InvalidUrlException::new_err(pretty_print_error(&err))
+                InvalidUrlError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::InvalidChannel(err) => {
-                InvalidChannelException::new_err(pretty_print_error(&err))
+                InvalidChannelError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::ActivationError(err) => {
-                ActivationException::new_err(pretty_print_error(&err))
+                ActivationError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::ParsePlatformError(err) => {
-                ParsePlatformException::new_err(pretty_print_error(&err))
+                ParsePlatformError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::ParseArchError(err) => {
-                ParseArchException::new_err(pretty_print_error(&err))
+                ParseArchError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::FetchRepoDataError(err) => {
-                FetchRepoDataException::new_err(pretty_print_error(&err))
+                FetchRepoDataError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::CacheDirError(err) => {
-                CacheDirException::new_err(pretty_print_error(err.as_ref()))
+                CacheDirError::new_err(pretty_print_error(err.as_ref()))
             }
             PyRattlerError::DetectVirtualPackageError(err) => {
-                DetectVirtualPackageException::new_err(pretty_print_error(&err))
+                DetectVirtualPackageError::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::IoError(err) => IoException::new_err(pretty_print_error(&err)),
-            PyRattlerError::SolverError(err) => SolverException::new_err(pretty_print_error(&err)),
+            PyRattlerError::IoError(err) => IoError::new_err(pretty_print_error(&err)),
+            PyRattlerError::SolverError(err) => SolverError::new_err(pretty_print_error(&err)),
             PyRattlerError::TransactionError(err) => {
-                TransactionException::new_err(pretty_print_error(&err))
+                TransactionError::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::LinkError(err) => LinkException::new_err(err),
+            PyRattlerError::LinkError(err) => LinkError::new_err(err),
             PyRattlerError::ConvertSubdirError(err) => {
-                ConvertSubdirException::new_err(pretty_print_error(&err))
+                ConvertSubdirError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::VersionBumpError(err) => {
-                VersionBumpException::new_err(pretty_print_error(&err))
+                VersionBumpError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::VersionExtendError(err) => {
-                VersionExtendException::new_err(pretty_print_error(&err))
+                VersionExtendError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::ParseCondaLockError(err) => {
-                ParseCondaLockException::new_err(pretty_print_error(&err))
+                ParseCondaLockError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::ConversionError(err) => {
-                ConversionException::new_err(pretty_print_error(&err))
+                ConversionError::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::RequirementError(err) => RequirementException::new_err(err),
+            PyRattlerError::RequirementError(err) => RequirementError::new_err(err),
             PyRattlerError::EnvironmentCreationError(err) => {
-                EnvironmentCreationException::new_err(err)
+                EnvironmentCreationError::new_err(err)
             }
             PyRattlerError::ExtractError(err) => {
-                ExtractException::new_err(pretty_print_error(&err))
+                ExtractError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::GatewayError(err) => {
-                GatewayException::new_err(pretty_print_error(&err))
+                GatewayError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::InstallerError(err) => {
-                InstallerException::new_err(pretty_print_error(&err))
+                InstallerError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::ParseExplicitEnvironmentSpecError(err) => {
-                ParseExplicitEnvironmentSpecException::new_err(pretty_print_error(&err))
+                ParseExplicitEnvironmentSpecError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::ValidatePackageRecordsError(err) => {
-                ValidatePackageRecordsException::new_err(pretty_print_error(&err))
+                ValidatePackageRecordsError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::AuthenticationStorageError(err) => {
-                AuthenticationStorageException::new_err(pretty_print_error(&err))
+                AuthenticationStorageError::new_err(pretty_print_error(&err))
             }
-            PyRattlerError::ShellError(err) => ShellException::new_err(pretty_print_error(&err)),
+            PyRattlerError::ShellError(err) => ShellError::new_err(pretty_print_error(&err)),
             PyRattlerError::MatchSpecUrlError(err) => {
-                InvalidMatchSpecException::new_err(pretty_print_error(&err))
+                InvalidMatchSpecError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::InvalidHeaderNameError(err) => {
-                InvalidHeaderNameException::new_err(pretty_print_error(&err))
+                InvalidHeaderNameError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::InvalidHeaderValueError(err) => {
                 InvalidHeaderValueError::new_err(pretty_print_error(&err))
@@ -204,41 +204,41 @@ impl From<PyRattlerError> for PyErr {
     }
 }
 
-create_exception!(exceptions, InvalidVersionException, PyException);
-create_exception!(exceptions, InvalidVersionSpecException, PyException);
-create_exception!(exceptions, InvalidMatchSpecException, PyException);
-create_exception!(exceptions, InvalidPackageNameException, PyException);
-create_exception!(exceptions, PackageNameMatcherParseException, PyException);
-create_exception!(exceptions, InvalidUrlException, PyException);
-create_exception!(exceptions, InvalidChannelException, PyException);
-create_exception!(exceptions, ActivationException, PyException);
-create_exception!(exceptions, ParsePlatformException, PyException);
-create_exception!(exceptions, ParseArchException, PyException);
-create_exception!(exceptions, FetchRepoDataException, PyException);
-create_exception!(exceptions, CacheDirException, PyException);
-create_exception!(exceptions, DetectVirtualPackageException, PyException);
-create_exception!(exceptions, IoException, PyException);
-create_exception!(exceptions, SolverException, PyException);
-create_exception!(exceptions, TransactionException, PyException);
-create_exception!(exceptions, LinkException, PyException);
-create_exception!(exceptions, ConvertSubdirException, PyException);
-create_exception!(exceptions, VersionBumpException, PyException);
-create_exception!(exceptions, VersionExtendException, PyException);
-create_exception!(exceptions, ParseCondaLockException, PyException);
-create_exception!(exceptions, ConversionException, PyException);
-create_exception!(exceptions, RequirementException, PyException);
-create_exception!(exceptions, EnvironmentCreationException, PyException);
-create_exception!(exceptions, ExtractException, PyException);
-create_exception!(exceptions, ActivationScriptFormatException, PyException);
-create_exception!(exceptions, GatewayException, PyException);
-create_exception!(exceptions, InstallerException, PyException);
+create_exception!(exceptions, InvalidVersionError, PyException);
+create_exception!(exceptions, InvalidVersionSpecError, PyException);
+create_exception!(exceptions, InvalidMatchSpecError, PyException);
+create_exception!(exceptions, InvalidPackageNameError, PyException);
+create_exception!(exceptions, PackageNameMatcherParseError, PyException);
+create_exception!(exceptions, InvalidUrlError, PyException);
+create_exception!(exceptions, InvalidChannelError, PyException);
+create_exception!(exceptions, ActivationError, PyException);
+create_exception!(exceptions, ParsePlatformError, PyException);
+create_exception!(exceptions, ParseArchError, PyException);
+create_exception!(exceptions, FetchRepoDataError, PyException);
+create_exception!(exceptions, CacheDirError, PyException);
+create_exception!(exceptions, DetectVirtualPackageError, PyException);
+create_exception!(exceptions, IoError, PyException);
+create_exception!(exceptions, SolverError, PyException);
+create_exception!(exceptions, TransactionError, PyException);
+create_exception!(exceptions, LinkError, PyException);
+create_exception!(exceptions, ConvertSubdirError, PyException);
+create_exception!(exceptions, VersionBumpError, PyException);
+create_exception!(exceptions, VersionExtendError, PyException);
+create_exception!(exceptions, ParseCondaLockError, PyException);
+create_exception!(exceptions, ConversionError, PyException);
+create_exception!(exceptions, RequirementError, PyException);
+create_exception!(exceptions, EnvironmentCreationError, PyException);
+create_exception!(exceptions, ExtractError, PyException);
+create_exception!(exceptions, ActivationScriptFormatError, PyException);
+create_exception!(exceptions, GatewayError, PyException);
+create_exception!(exceptions, InstallerError, PyException);
 create_exception!(
     exceptions,
-    ParseExplicitEnvironmentSpecException,
+    ParseExplicitEnvironmentSpecError,
     PyException
 );
-create_exception!(exceptions, ValidatePackageRecordsException, PyException);
-create_exception!(exceptions, AuthenticationStorageException, PyException);
-create_exception!(exceptions, ShellException, PyException);
-create_exception!(exceptions, InvalidHeaderNameException, PyException);
+create_exception!(exceptions, ValidatePackageRecordsError, PyException);
+create_exception!(exceptions, AuthenticationStorageError, PyException);
+create_exception!(exceptions, ShellError, PyException);
+create_exception!(exceptions, InvalidHeaderNameError, PyException);
 create_exception!(exceptions, InvalidHeaderValueError, PyException);

--- a/py-rattler/src/lib.rs
+++ b/py-rattler/src/lib.rs
@@ -35,13 +35,13 @@ use std::ops::Deref;
 use about_json::PyAboutJson;
 use channel::{PyChannel, PyChannelConfig, PyChannelPriority};
 use error::{
-    ActivationException, CacheDirException, ConvertSubdirException, DetectVirtualPackageException,
-    EnvironmentCreationException, ExtractException, FetchRepoDataException,
-    InvalidChannelException, InvalidMatchSpecException, InvalidPackageNameException,
-    InvalidUrlException, InvalidVersionException, InvalidVersionSpecException, IoException,
-    LinkException, PackageNameMatcherParseException, ParseArchException, ParsePlatformException,
-    PyRattlerError, SolverException, TransactionException, ValidatePackageRecordsException,
-    VersionBumpException,
+    ActivationError, CacheDirError, ConvertSubdirError, DetectVirtualPackageError,
+    EnvironmentCreationError, ExtractError, FetchRepoDataError,
+    InvalidChannelError, InvalidMatchSpecError, InvalidPackageNameError,
+    InvalidUrlError, InvalidVersionError, InvalidVersionSpecError, IoError,
+    LinkError, PackageNameMatcherParseError, ParseArchError, ParsePlatformError,
+    PyRattlerError, SolverError, TransactionError, ValidatePackageRecordsError,
+    VersionBumpError,
 };
 use explicit_environment_spec::{PyExplicitEnvironmentEntry, PyExplicitEnvironmentSpec};
 use generic_virtual_package::PyGenericVirtualPackage;
@@ -83,7 +83,7 @@ use virtual_package::{PyOverride, PyVirtualPackage, PyVirtualPackageOverrides};
 #[cfg(feature = "pty")]
 use pty::{PyPtyProcess, PyPtyProcessOptions, PyPtySession};
 
-use crate::error::GatewayException;
+use crate::error::GatewayError;
 
 /// A struct to make it easy to wrap a type as a python type.
 #[repr(transparent)]
@@ -196,66 +196,66 @@ fn rattler<'py>(py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()> {
     // Exceptions
     m.add(
         "InvalidVersionError",
-        py.get_type::<InvalidVersionException>(),
+        py.get_type::<InvalidVersionError>(),
     )?;
     m.add(
         "InvalidVersionSpecError",
-        py.get_type::<InvalidVersionSpecException>(),
+        py.get_type::<InvalidVersionSpecError>(),
     )?;
     m.add(
         "InvalidMatchSpecError",
-        py.get_type::<InvalidMatchSpecException>(),
+        py.get_type::<InvalidMatchSpecError>(),
     )?;
     m.add(
         "PackageNameMatcherParseError",
-        py.get_type::<PackageNameMatcherParseException>(),
+        py.get_type::<PackageNameMatcherParseError>(),
     )?;
     m.add(
         "InvalidPackageNameError",
-        py.get_type::<InvalidPackageNameException>(),
+        py.get_type::<InvalidPackageNameError>(),
     )?;
-    m.add("InvalidUrlError", py.get_type::<InvalidUrlException>())?;
+    m.add("InvalidUrlError", py.get_type::<InvalidUrlError>())?;
     m.add(
         "InvalidChannelError",
-        py.get_type::<InvalidChannelException>(),
+        py.get_type::<InvalidChannelError>(),
     )?;
-    m.add("ActivationError", py.get_type::<ActivationException>())?;
+    m.add("ActivationError", py.get_type::<ActivationError>())?;
     m.add(
         "ParsePlatformError",
-        py.get_type::<ParsePlatformException>(),
+        py.get_type::<ParsePlatformError>(),
     )?;
-    m.add("ParseArchError", py.get_type::<ParseArchException>())?;
-    m.add("SolverError", py.get_type::<SolverException>())?;
-    m.add("TransactionError", py.get_type::<TransactionException>())?;
-    m.add("LinkError", py.get_type::<LinkException>())?;
-    m.add("IoError", py.get_type::<IoException>())?;
+    m.add("ParseArchError", py.get_type::<ParseArchError>())?;
+    m.add("SolverError", py.get_type::<SolverError>())?;
+    m.add("TransactionError", py.get_type::<TransactionError>())?;
+    m.add("LinkError", py.get_type::<LinkError>())?;
+    m.add("IoError", py.get_type::<IoError>())?;
     m.add(
         "DetectVirtualPackageError",
-        py.get_type::<DetectVirtualPackageException>(),
+        py.get_type::<DetectVirtualPackageError>(),
     )?;
-    m.add("CacheDirError", py.get_type::<CacheDirException>())?;
+    m.add("CacheDirError", py.get_type::<CacheDirError>())?;
     m.add(
         "FetchRepoDataError",
-        py.get_type::<FetchRepoDataException>(),
+        py.get_type::<FetchRepoDataError>(),
     )?;
     m.add(
         "ConvertSubdirError",
-        py.get_type::<ConvertSubdirException>(),
+        py.get_type::<ConvertSubdirError>(),
     )?;
-    m.add("VersionBumpError", py.get_type::<VersionBumpException>())?;
+    m.add("VersionBumpError", py.get_type::<VersionBumpError>())?;
 
     m.add(
         "EnvironmentCreationError",
-        py.get_type::<EnvironmentCreationException>(),
+        py.get_type::<EnvironmentCreationError>(),
     )?;
 
-    m.add("ExtractError", py.get_type::<ExtractException>())?;
+    m.add("ExtractError", py.get_type::<ExtractError>())?;
 
-    m.add("GatewayError", py.get_type::<GatewayException>())?;
+    m.add("GatewayError", py.get_type::<GatewayError>())?;
 
     m.add(
-        "ValidatePackageRecordsException",
-        py.get_type::<ValidatePackageRecordsException>(),
+        "ValidatePackageRecordsError",
+        py.get_type::<ValidatePackageRecordsError>(),
     )?;
 
     Ok(())


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description
This PR resolves an inconsistency where several exceptions were exported as `*Error` in Python but appeared with an `*Exception` suffix in tracebacks and documentation. This mismatch was causing confusion in the developer experience
<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->
 ## Changes made: 
 - Renamed all internal exception types from `*Exception` to `*Error` in `error.rs`
- Updated imports and registrations in `lib.rs` to use the new names
- Exception names now consistently use `*Error` suffix in both namespace and tracebacks


Related Issue: #1959 

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
