### PR TITLE
fix: Ignore CONDA_SHLVL in tests

### DIFF
--- a/crates/rattler_menuinst/src/linux.rs
+++ b/crates/rattler_menuinst/src/linux.rs
@@ -913,7 +913,6 @@ mod tests {
         let result = linux_menu.command().unwrap();
         assert!(result.starts_with("env "));
         assert!(result.contains("CONDA_PREFIX="));
-        assert!(result.contains("CONDA_SHLVL="));
         assert!(result.contains("PATH="));
         assert!(result.contains("spyder"));
     }

--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -1041,6 +1041,7 @@ mod tests {
             .collect::<BTreeMap<_, _>>();
 
         // Remove system specific environment variables.
+        env_diff.remove("CONDA_SHLVL");
         env_diff.remove("CONDA_PREFIX");
         env_diff.remove("Path");
         env_diff.remove("PATH");

--- a/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__after_activation.snap
+++ b/crates/rattler_shell/src/snapshots/rattler_shell__activation__tests__after_activation.snap
@@ -2,7 +2,6 @@
 source: crates/rattler_shell/src/activation.rs
 expression: env_diff
 ---
-CONDA_SHLVL: "1"
 PKG1: "Hello, world!"
 PKG2: "Hello, world!"
 SCRIPT_ENV: "Hello, world!"


### PR DESCRIPTION
The tests run scripts assuming an empty environment in the real shell environment. So if CONDA_SHLVL is set already, it may result in the variable getting removed from the output, which triggers the tests to fail.