### PR TITLE
chore: Remove dead struct

### DIFF
--- a/crates/rattler_menuinst/src/linux/mime_config.rs
+++ b/crates/rattler_menuinst/src/linux/mime_config.rs
@@ -1,12 +1,5 @@
 use configparser::ini::Ini;
 use std::path::{Path, PathBuf};
-use thiserror::Error;
-
-#[derive(Error, Debug)]
-pub enum MimeConfigError {
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-}
 
 #[derive(Debug)]
 pub struct MimeConfig {
@@ -165,7 +158,7 @@ mod tests {
     }
 
     #[test]
-    fn test_load_and_save() -> Result<(), MimeConfigError> {
+    fn test_load_and_save() -> std::io::Result<()> {
         let (mut config, file) = create_temp_config();
 
         config.register_mime_type("text/plain", "notepad.desktop");


### PR DESCRIPTION
Remove a dead struct that cargo keeps warning me about. It's already complaining about this in rattler v0.39.11, but let's do this properly and merge it via main.