### PR TITLE
chore: Do not persist pypi-prerelease-mode

### DIFF
--- a/crates/rattler_lock/src/builder.rs
+++ b/crates/rattler_lock/src/builder.rs
@@ -421,7 +421,7 @@ impl LockFileBuilder {
     ) -> &mut Self {
         self.environment_data(environment)
             .options
-            .pypi_prerelease_mode = Some(prerelease_mode);
+            .pypi_prerelease_mode = prerelease_mode;
         self
     }
 
@@ -627,7 +627,7 @@ mod test {
 
         // Verify the prerelease mode is set correctly
         let env = lock_file.environment("default").unwrap();
-        assert_eq!(env.pypi_prerelease_mode(), Some(PypiPrereleaseMode::Allow));
+        assert_eq!(env.pypi_prerelease_mode(), PypiPrereleaseMode::Allow);
 
         // Verify it serializes correctly
         insta::assert_snapshot!(lock_file.render_to_string().unwrap());
@@ -692,7 +692,7 @@ mod test {
                     .environment("default")
                     .unwrap()
                     .pypi_prerelease_mode(),
-                Some(mode)
+                mode
             );
         }
     }

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -325,7 +325,7 @@ impl<'lock> Environment<'lock> {
     /// Returns the `PyPI` prerelease mode that was used to solve this environment.
     ///
     /// Returns `None` if no prerelease mode was explicitly set.
-    pub fn pypi_prerelease_mode(&self) -> Option<PypiPrereleaseMode> {
+    pub fn pypi_prerelease_mode(&self) -> PypiPrereleaseMode {
         self.data().options.pypi_prerelease_mode
     }
 

--- a/crates/rattler_lock/src/options.rs
+++ b/crates/rattler_lock/src/options.rs
@@ -44,6 +44,6 @@ pub struct SolveOptions {
     pub exclude_newer: Option<chrono::DateTime<chrono::Utc>>,
 
     /// The prerelease mode that was used to resolve `PyPI` dependencies.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub pypi_prerelease_mode: Option<PypiPrereleaseMode>,
+    #[serde(default, skip_serializing_if = "crate::utils::serde::is_default")]
+    pub pypi_prerelease_mode: PypiPrereleaseMode,
 }

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__invalid_platform.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__invalid_platform.yml.snap
@@ -1,5 +1,0 @@
----
-source: crates/rattler_lock/src/lib.rs
-expression: error_message
----
-No such file or directory (os error 2)


### PR DESCRIPTION
... if it is the default value anyway.

Also get rid of the Option, as I see no reason to have it: Even with it we are not able to destinquish between "default value explicitly set" and "default value just defaulted in", considering that we write the default value pretty much always.

Related-to: prefix-dev/pixi:#5130