### PR TITLE
fix: cache negative credential lookups in auth middleware

### DIFF
--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -140,6 +140,11 @@ impl AuthenticationStorage {
             }
         }
 
+        // Cache the negative result to avoid repeated backend lookups
+        // (especially important for keyring which uses D-Bus IPC on Linux).
+        let mut cache = self.cache.lock().unwrap();
+        cache.insert(host.to_string(), None);
+
         Ok(None)
     }
 


### PR DESCRIPTION
@ruben-arts was complaining that Pixi was really slow on a Jetson and had a suspicion that it might be related to the authentication storage.

Turns out we did not cache negative lookups.

Previously, AuthenticationStorage::get() only cached positive results. When no credentials were found for a host, every call went through all backends including the OS keyring. Combined with wildcard expansion in get_by_url(), this caused 3+ keyring lookups per HTTP request on hosts without stored credentials. On Linux, this is especially slow since the keyring crate uses D-Bus IPC to Secret Service.

