### PR TITLE
fix: retry at least three times during install

### DIFF
--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -226,10 +226,8 @@ mod tests {
 
     #[test]
     fn test_should_retry_could_not_create_destination() {
-        let err = ExtractError::CouldNotCreateDestination(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            "could not create",
-        ));
+        let err =
+            ExtractError::CouldNotCreateDestination(std::io::Error::other("could not create"));
         assert!(err.should_retry());
     }
 


### PR DESCRIPTION
### Description

Changed the installation logic to retry at least three times in case of error `stream closed because of a broken pipe` 

Added a `should_retry` method that returns whether an Error should be retried or not.

All previous tests pass indicating no regression. 

Fixes #2054

### How Has This Been Tested?

Added several (16) unit test cases in `crates/rattler_package_streaming/src/lib.rs` for every case of pipe failure, all of which pass. These can probably be brought down based on actual test data, would love your input on that.

Also added 2 integration tests in `crates/rattler_cache/src/package_cache/mod.rs` for conda and bz2 packages, all of which pass.

Also my apologies, [f1a196d](https://github.com/conda/rattler/pull/2068/commits/f1a196d107dff97e29c892d7a0c9c2132388bb9b) pushed with the wrong commit message of a previous PR. Let me know if it needs rebasing and if I should squash all commits.

### AI Disclosure
  - [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Kimi K2.5

### Checklist:
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have added sufficient tests to cover my changes.