### PR TITLE
refactor: Make version optional when storing pypi packages

### DIFF
--- a/crates/rattler_lock/src/parse/deserialize.rs
+++ b/crates/rattler_lock/src/parse/deserialize.rs
@@ -84,7 +84,7 @@ pub struct PypiPackageDataRaw {
     pub name: pep508_rs::PackageName,
 
     /// The version of the package.
-    pub version: pep440_rs::Version,
+    pub version: Option<pep440_rs::Version>,
 
     /// The location of the package. This can be a URL or a path.
     pub location: Verbatim<UrlOrPath>,

--- a/crates/rattler_lock/src/parse/models/v5/pypi_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v5/pypi_package_data.rs
@@ -28,7 +28,7 @@ impl<'a> From<PypiPackageDataModel<'a>> for PypiPackageDataRaw {
     fn from(value: PypiPackageDataModel<'a>) -> Self {
         Self {
             name: value.name.into_owned(),
-            version: value.version.into_owned(),
+            version: Some(value.version.into_owned()),
             location: Verbatim::new(value.location),
             hash: value.hash.into_owned(),
             requires_dist: value.requires_dist.into_owned(),

--- a/crates/rattler_lock/src/parse/models/v6/pypi_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/pypi_package_data.rs
@@ -52,7 +52,7 @@ impl<'a> From<PypiPackageDataModel<'a>> for PypiPackageDataRaw {
     fn from(value: PypiPackageDataModel<'a>) -> Self {
         Self {
             name: value.name.into_owned(),
-            version: value.version.into_owned(),
+            version: Some(value.version.into_owned()),
             location: value.location.into_owned(),
             hash: value.hash.into_owned(),
             requires_dist: value.requires_dist.into_owned(),

--- a/crates/rattler_lock/src/parse/models/v7/pypi_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/pypi_package_data.rs
@@ -33,7 +33,7 @@ pub(crate) struct PypiPackageDataModel<'a> {
     #[serde(rename = "pypi")]
     pub location: Cow<'a, Verbatim<UrlOrPath>>,
     pub name: Cow<'a, PackageName>,
-    pub version: Cow<'a, pep440_rs::Version>,
+    pub version: Option<Cow<'a, pep440_rs::Version>>,
     #[serde(default, skip_serializing_if = "Option::is_none", flatten)]
     pub hash: Cow<'a, Option<PackageHashes>>,
     #[serde(default, skip_serializing_if = "<[String]>::is_empty")]
@@ -46,7 +46,7 @@ impl<'a> From<PypiPackageDataModel<'a>> for PypiPackageDataRaw {
     fn from(value: PypiPackageDataModel<'a>) -> Self {
         Self {
             name: value.name.into_owned(),
-            version: value.version.into_owned(),
+            version: value.version.map(std::borrow::Cow::into_owned),
             location: value.location.into_owned(),
             hash: value.hash.into_owned(),
             requires_dist: value.requires_dist.into_owned(),
@@ -64,7 +64,7 @@ impl<'a> From<&'a PypiPackageData> for PypiPackageDataModel<'a> {
             .collect::<Vec<_>>();
         Self {
             name: Cow::Borrowed(&value.name),
-            version: Cow::Borrowed(&value.version),
+            version: value.version.as_ref().map(Cow::Borrowed),
             location: Cow::Borrowed(&value.location),
             hash: Cow::Borrowed(&value.hash),
             requires_dist: requires_dist.into(),

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -253,7 +253,7 @@ pub fn parse_v3_or_lower(
                 let deduplicated_index = pypi_packages
                     .insert_full(PypiPackageData {
                         name: pep508_rs::PackageName::new(pkg.name)?,
-                        version: pkg.version,
+                        version: Some(pkg.version),
                         requires_dist: pkg.requires_dist,
                         requires_python: pkg.requires_python,
                         location: Verbatim::new(UrlOrPath::Url(pkg.url)),

--- a/crates/rattler_lock/src/pypi.rs
+++ b/crates/rattler_lock/src/pypi.rs
@@ -13,7 +13,7 @@ pub struct PypiPackageData {
     pub name: PackageName,
 
     /// The version of the package.
-    pub version: pep440_rs::Version,
+    pub version: Option<pep440_rs::Version>,
 
     /// The location of the package. This can be a URL or a path.
     pub location: Verbatim<UrlOrPath>,
@@ -57,13 +57,18 @@ impl PypiPackageData {
             None => {}
             Some(pep508_rs::VersionOrUrl::Url(_)) => return false,
             Some(pep508_rs::VersionOrUrl::VersionSpecifier(spec)) => {
-                if !spec.contains(&self.version) {
-                    return false;
-                }
+                return self.version.as_ref().is_none_or(|v| spec.contains(v))
             }
         }
 
         true
+    }
+
+    /// Return the the `version` as a `String` (or `<dynamic>` if the version is `None`)
+    pub fn version_string(&self) -> String {
+        self.version
+            .as_ref()
+            .map_or_else(|| "<dynamic>".to_string(), std::string::ToString::to_string)
     }
 }
 

--- a/py-rattler/src/lock/mod.rs
+++ b/py-rattler/src/lock/mod.rs
@@ -207,8 +207,10 @@ impl PyLockFile {
             let pkg_data = PypiPackageData {
                 name: pep508_rs::PackageName::from_str(&name)
                     .map_err(|e| PyRattlerError::LockFileError(e.to_string()))?,
-                version: pep440_rs::Version::from_str(&version)
-                    .map_err(|e| PyRattlerError::LockFileError(e.to_string()))?,
+                version: Some(
+                    pep440_rs::Version::from_str(&version)
+                        .map_err(|e| PyRattlerError::LockFileError(e.to_string()))?,
+                ),
                 location: Verbatim::<UrlOrPath>::from_str(&location)
                     .map_err(|e| PyRattlerError::LockFileError(e.to_string()))?,
                 hash: None,
@@ -706,7 +708,7 @@ impl PyLockedPackage {
 
     #[getter]
     pub fn pypi_version(&self) -> String {
-        self.as_pypi().version.to_string()
+        self.as_pypi().version_string()
     }
 
     // Hashes of the file pointed to by `url`.
@@ -817,7 +819,7 @@ impl PyPypiPackageData {
     /// The version of the package.
     #[getter]
     pub fn version(&self) -> String {
-        self.inner.version.clone().to_string()
+        self.inner.version_string()
     }
 
     /// The URL that points to where the artifact can be downloaded from.


### PR DESCRIPTION
The idea is to not store versions for pypi sources that have a dynamic version to avoid churn in the lock file.

### How Has This Been Tested?

I used the `feature/lockfile-v7` branch of the https://github.com/hunger/pixi repo to test this with.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests

The pixi branch referenced above has tests for this functionality.