### PR TITLE
feat: Add a __str__ method to PackageName

### DIFF
--- a/py-rattler/rattler/package/package_name.py
+++ b/py-rattler/rattler/package/package_name.py
@@ -188,6 +188,20 @@ class PackageName:
 
         return self._name != other._name
 
+    def __str__(self) -> str:
+        """
+        Returns the source representation of the package name as a string.
+
+        Examples
+        --------
+        ```python
+        >>> str(PackageName("test-xyz"))
+        'test-xyz'
+        >>>
+        ```
+        """
+        return self.source
+
     def __repr__(self) -> str:
         """
         Returns a representation of the PackageName.


### PR DESCRIPTION
### Description

This makes it so using a PackageName as a string gives you what you'd expect, `'py-rattler'` rather than `'PackageName("py-rattler")'`

### How Has This Been Tested?

```
from rattler import PackageName

p = PackageName("numpy")
print(repr(p))  # PackageName("numpy")
print(str(p))   # PackageName("numpy")  <-- should be "numpy"
```

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.

I don't think tests are really necessary for this but happy to add if you'd like.