### PR TITLE
feat: add dependency override option to solver

### DIFF
--- a/crates/rattler_solve/benches/sorting_bench.rs
+++ b/crates/rattler_solve/benches/sorting_bench.rs
@@ -38,6 +38,7 @@ fn bench_sort(c: &mut Criterion, sparse_repo_data: &SparseRepoData, spec: &str) 
                     None,
                     None,
                     rattler_solve::SolveStrategy::Highest,
+                    Vec::new(),
                 )
                 .expect("failed to create dependency provider");
 

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -279,6 +279,9 @@ pub struct SolverTask<TAvailablePackagesIterator> {
 
     /// The solve strategy.
     pub strategy: SolveStrategy,
+
+    /// Dependency overrides that replace dependencies of matching packages.
+    pub dependency_overrides: Vec<(MatchSpec, MatchSpec)>,
 }
 
 impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
@@ -297,6 +300,7 @@ impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
             exclude_newer: None,
             min_age: None,
             strategy: SolveStrategy::default(),
+            dependency_overrides: Vec::new(),
         }
     }
 }

--- a/crates/rattler_solve/tests/backends/main.rs
+++ b/crates/rattler_solve/tests/backends/main.rs
@@ -714,6 +714,7 @@ mod libsolv_c {
                 exclude_newer: None,
                 min_age: None,
                 strategy: SolveStrategy::default(),
+                dependency_overrides: Vec::new(),
             })
             .unwrap()
             .records;
@@ -1000,6 +1001,26 @@ mod resolvo {
     fn test_lowest_version_direct_strategy() {
         crate::strategy_tests::solve_lowest_version_direct_strategy::<rattler_solve::resolvo::Solver>(
         );
+    }
+
+    #[test]
+    fn test_dependency_override_basic() {
+        crate::solver_case_tests::solve_dependency_override_basic::<rattler_solve::resolvo::Solver>(
+        );
+    }
+
+    #[test]
+    fn test_dependency_override_no_match() {
+        crate::solver_case_tests::solve_dependency_override_no_match::<
+            rattler_solve::resolvo::Solver,
+        >();
+    }
+
+    #[test]
+    fn test_dependency_override_multiple() {
+        crate::solver_case_tests::solve_dependency_override_multiple::<
+            rattler_solve::resolvo::Solver,
+        >();
     }
 }
 

--- a/crates/rattler_solve/tests/sorting.rs
+++ b/crates/rattler_solve/tests/sorting.rs
@@ -52,6 +52,7 @@ fn create_sorting_snapshot(package_name: &str, strategy: SolveStrategy) -> Strin
         None,
         None, // min_age
         strategy,
+        Vec::new(), // dependency_overrides
     )
     .expect("failed to create dependency provider");
 

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -168,6 +168,7 @@ pub fn py_solve<'a>(
                 exclude_newer,
                 min_age,
                 strategy: strategy.map_or_else(Default::default, |v| v.0),
+                dependency_overrides: Vec::new(),
             };
 
             Ok::<_, PyErr>(
@@ -274,6 +275,7 @@ pub fn py_solve_with_sparse_repodata<'py>(
                 exclude_newer,
                 min_age,
                 strategy: strategy.map_or_else(Default::default, |v| v.0),
+                dependency_overrides: Vec::new(),
             };
 
             Ok::<_, PyErr>(

--- a/tools/create-resolvo-snapshot/src/main.rs
+++ b/tools/create-resolvo-snapshot/src/main.rs
@@ -78,6 +78,7 @@ async fn main() {
         None,
         None,
         SolveStrategy::default(),
+        Vec::new(),
     )
     .unwrap();
 


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->
Added dependency_overrides field to SolverTask that lets you replace dependencies of specific packages during solve.
For example, to force jupyterlab 3.3.* to use python ==3.10:
`dependency_overrides: vec![("jupyterlab 3.3.*", "python ==3.10")]`
Fixes #586

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->
Added 3 tests covering basic override, no-match case, and multiple overrides. All tests pass.

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools:Claude

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
