### PR TITLE
refactor: remove pypi `extras` from lock-file v7

### DIFF
--- a/crates/rattler_lock/src/pypi.rs
+++ b/crates/rattler_lock/src/pypi.rs
@@ -1,9 +1,8 @@
 use crate::{PackageHashes, UrlOrPath, Verbatim};
 use pep440_rs::VersionSpecifiers;
-use pep508_rs::{ExtraName, PackageName, Requirement};
+use pep508_rs::{PackageName, Requirement};
 use rattler_digest::{digest::Digest, Sha256};
 use std::cmp::Ordering;
-use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
 
@@ -27,14 +26,6 @@ pub struct PypiPackageData {
 
     /// The python version that this package requires.
     pub requires_python: Option<VersionSpecifiers>,
-}
-
-/// Additional runtime configuration of a package. Multiple environments/platforms might refer to
-/// the same pypi package but with different extras enabled.
-#[derive(Clone, Debug, Default)]
-pub struct PypiPackageEnvironmentData {
-    /// The extras enabled for the package. Note that the order doesn't matter here but it does matter for serialization.
-    pub extras: BTreeSet<ExtraName>,
 }
 
 impl PartialOrd for PypiPackageData {

--- a/py-rattler/rattler/lock/package.py
+++ b/py-rattler/rattler/lock/package.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from abc import ABC
-from typing import Optional, Set, List
+from typing import Optional, List
 
 from rattler import PackageRecord, Version, RepoDataRecord
 
@@ -211,27 +211,6 @@ class PypiLockedPackage(LockedPackage):
         ```
         """
         return self._package.pypi_requires_python
-
-    @property
-    def extras(self) -> Set[str]:
-        """
-        The extras enabled for the package.
-        Note that the order doesn't matter.
-
-        Examples
-        --------
-        ```python
-        >>> from rattler import LockFile
-        >>> lock_file = LockFile.from_path("../test-data/test.lock")
-        >>> env = lock_file.default_environment()
-        >>> pypi_packages = env.pypi_packages()
-        >>> env_data = pypi_packages["osx-arm64"][0]
-        >>> env_data.extras
-        set()
-        >>>
-        ```
-        """
-        return self._package.pypi_extras
 
     def satisfies(self, spec: str) -> bool:
         """

--- a/py-rattler/src/lib.rs
+++ b/py-rattler/src/lib.rs
@@ -50,7 +50,7 @@ use index_json::PyIndexJson;
 use installer::py_install;
 use lock::{
     PyEnvironment, PyLockChannel, PyLockFile, PyLockPlatform, PyLockedPackage, PyPackageHashes,
-    PyPypiPackageData, PyPypiPackageEnvironmentData,
+    PyPypiPackageData,
 };
 use match_spec::PyMatchSpec;
 use meta::get_rattler_version;
@@ -165,7 +165,6 @@ fn rattler<'py>(py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()> {
     m.add_class::<PyLockPlatform>()?;
     m.add_class::<PyLockedPackage>()?;
     m.add_class::<PyPypiPackageData>()?;
-    m.add_class::<PyPypiPackageEnvironmentData>()?;
     m.add_class::<PyPackageHashes>()?;
 
     m.add_class::<PyAboutJson>()?;


### PR DESCRIPTION
This PR removes `extras` stored in the lock file. 

The [previous PR](https://github.com/conda/rattler/pull/1993) was accidentally lost.

Fixes #1986 