### PR TITLE
fix: Set the modification time of any file we change

### DIFF
--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -56,7 +56,7 @@ use itertools::Itertools;
 pub use link::{link_file, LinkFileError, LinkMethod};
 pub use python::PythonInfo;
 use rattler_conda_types::{
-    package::{IndexJson, LinkJson, NoArchLinks, PackageFile, PathsEntry, PathsJson},
+    package::{AboutJson, IndexJson, LinkJson, NoArchLinks, PackageFile, PathsEntry, PathsJson},
     prefix::Prefix,
     prefix_record, Platform,
 };
@@ -259,6 +259,24 @@ struct LinkPath {
     clobber_path: Option<PathBuf>,
 }
 
+/// Find a timestamp to put on all files we modify. Use `info/about.json`, as a base. This
+/// file is always written after all the packaged data is already stored.
+///
+/// We add 1s to make sure our modification time is strictly bigger than any timestamp
+/// seen in the package data, even on systems that do not have nanosecond timestamps.
+///
+/// Fall back to `now()` if we can not detect a file time.
+fn modification_time(package_dir: &Path) -> filetime::FileTime {
+    if let Ok(info_metadata) = fs_err::symlink_metadata(package_dir.join(AboutJson::package_path()))
+    {
+        let info_time = filetime::FileTime::from_last_modification_time(&info_metadata);
+
+        filetime::FileTime::from_unix_time(info_time.unix_seconds() + 1, info_time.nanoseconds())
+    } else {
+        filetime::FileTime::now()
+    }
+}
+
 /// Given an extracted package archive (`package_dir`), installs its files to
 /// the `target_dir`.
 ///
@@ -286,6 +304,8 @@ pub async fn link_package(
     let paths_json = read_paths_json(package_dir, driver, options.paths_json);
     let index_json = read_index_json(package_dir, driver, options.index_json);
     let (paths_json, index_json) = tokio::try_join!(paths_json, index_json)?;
+
+    let modification_time = modification_time(package_dir);
 
     // Error out if this is a noarch python package but the python information is
     // missing.
@@ -421,6 +441,7 @@ pub async fn link_package(
                     allow_ref_links && !cloned_entry.no_link,
                     platform,
                     options.apple_codesign_behavior,
+                    modification_time,
                 )
             })
             .await
@@ -619,6 +640,7 @@ pub fn link_package_sync(
         },
         Ok,
     )?;
+    let modification_time = modification_time(package_dir);
 
     // Error out if this is a noarch python package but the python information is
     // missing.
@@ -843,6 +865,7 @@ pub fn link_package_sync(
                     allow_ref_links && !entry.no_link,
                     platform,
                     options.apple_codesign_behavior,
+                    modification_time,
                 );
 
                 let result = match link_result {

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -3973,7 +3973,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.39.13"
+version = "0.39.14"
 dependencies = [
  "anyhow",
  "console",
@@ -4017,7 +4017,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.43.3"
+version = "0.43.4"
 dependencies = [
  "ahash",
  "chrono",
@@ -4088,7 +4088,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "console",
  "fs-err",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.27.14"
+version = "0.27.15"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.26.14"
+version = "0.26.15"
 dependencies = [
  "ahash",
  "chrono",
@@ -4190,7 +4190,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.47"
+version = "0.2.48"
 dependencies = [
  "chrono",
  "configparser",
@@ -4219,7 +4219,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -4249,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -4303,7 +4303,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4399,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "4.2.4"
+version = "4.2.5"
 dependencies = [
  "chrono",
  "futures",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.3.9"
+version = "2.3.10"
 dependencies = [
  "archspec",
  "libloading",


### PR DESCRIPTION
### Description

This fixes pyc files not getting updated as we patch the py-file.

I choose a modification time which is bigger than the modification time, but that is the same for all files we change to keep the file tree more reproducible.

Fixes prefix-dev/rattler-build#2147

### How Has This Been Tested?

by trying it out :-)

### AI Disclosure

- [x] AI generated contents: Claude helped to write the tests.

AI Tool: Opus 4.6

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.