### PR TITLE
fix(upload): log GitHub trusted publishing context

### DIFF
--- a/crates/rattler_upload/src/utils/consts.rs
+++ b/crates/rattler_upload/src/utils/consts.rs
@@ -1,6 +1,11 @@
 /// A `recipe.yaml` file might be accompanied by a `variants.yaml` file from
 /// This env var is set to "true" when run inside a github actions runner
 pub const GITHUB_ACTIONS: &str = "GITHUB_ACTIONS";
+pub const GITHUB_REPOSITORY: &str = "GITHUB_REPOSITORY";
+pub const GITHUB_WORKFLOW_REF: &str = "GITHUB_WORKFLOW_REF";
+pub const GITHUB_WORKFLOW: &str = "GITHUB_WORKFLOW";
+pub const GITHUB_REF: &str = "GITHUB_REF";
+pub const GITHUB_ENVIRONMENT: &str = "GITHUB_ENVIRONMENT";
 
 /// This env var contains the oidc token url
 pub const ACTIONS_ID_TOKEN_REQUEST_URL: &str = "ACTIONS_ID_TOKEN_REQUEST_URL";


### PR DESCRIPTION
 ### Description

  Summary:
  - Log trusted publishing context derived from GitHub Actions env vars to make CI misconfiguration easier to debug.
  - Safe logging: OIDC request URL has query stripped, token value is never printed (only presence).

  Fixes #1909

  ### How Has This Been Tested?

  - `pixi run cargo-fmt`
  - `pixi run cargo-clippy`
  - `pixi run test` (failed locally due to OOM / paging file limits on Windows: os error 1455/1450)

  ### AI Disclosure

  - [x] This PR contains AI-generated content.
    - [x] I have tested any AI-generated content in my PR.
    - [x] I take responsibility for any AI-generated content in my PR.

  Tools: Codex 

  ### Checklist:

  - [x] I have performed a self-review of my own code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added sufficient tests to cover my changes.