### PR TITLE
feat: Add index_url into Pypi packages

### DIFF
--- a/crates/rattler_lock/src/parse/deserialize.rs
+++ b/crates/rattler_lock/src/parse/deserialize.rs
@@ -92,6 +92,9 @@ pub struct PypiPackageDataRaw {
     /// Hashes of the file pointed to by `url`.
     pub hash: Option<PackageHashes>,
 
+    /// The index url used to retrieve this package.
+    pub index_url: Option<url::Url>,
+
     /// A list of (unparsed!) dependencies on other packages.
     pub requires_dist: Vec<String>,
 
@@ -112,6 +115,7 @@ impl From<PypiPackageData> for PypiPackageDataRaw {
             version: value.version.clone(),
             location: value.location.clone(),
             hash: value.hash.clone(),
+            index_url: value.index_url.clone(),
             requires_dist,
             requires_python: value.requires_python.clone(),
         }
@@ -380,6 +384,7 @@ fn convert_raw_pypi_package(
         name: raw_package.name,
         version: raw_package.version,
         location,
+        index_url: raw_package.index_url,
         hash: raw_package.hash,
         requires_dist,
         requires_python: raw_package.requires_python,

--- a/crates/rattler_lock/src/parse/models/v5/pypi_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v5/pypi_package_data.rs
@@ -31,6 +31,7 @@ impl<'a> From<PypiPackageDataModel<'a>> for PypiPackageDataRaw {
             version: Some(value.version.into_owned()),
             location: Verbatim::new(value.location),
             hash: value.hash.into_owned(),
+            index_url: None,
             requires_dist: value.requires_dist.into_owned(),
             requires_python: value.requires_python.into_owned(),
         }

--- a/crates/rattler_lock/src/parse/models/v6/pypi_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/pypi_package_data.rs
@@ -55,6 +55,7 @@ impl<'a> From<PypiPackageDataModel<'a>> for PypiPackageDataRaw {
             version: Some(value.version.into_owned()),
             location: value.location.into_owned(),
             hash: value.hash.into_owned(),
+            index_url: None,
             requires_dist: value.requires_dist.into_owned(),
             requires_python: value.requires_python.into_owned(),
         }

--- a/crates/rattler_lock/src/parse/models/v7/pypi_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/pypi_package_data.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, sync::LazyLock};
 
 use pep440_rs::VersionSpecifiers;
 use pep508_rs::{PackageName, VersionOrUrl};
@@ -36,6 +36,8 @@ pub(crate) struct PypiPackageDataModel<'a> {
     pub version: Option<Cow<'a, pep440_rs::Version>>,
     #[serde(default, skip_serializing_if = "Option::is_none", flatten)]
     pub hash: Cow<'a, Option<PackageHashes>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index_url: Option<Cow<'a, url::Url>>,
     #[serde(default, skip_serializing_if = "<[String]>::is_empty")]
     pub requires_dist: Cow<'a, [String]>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -44,16 +46,28 @@ pub(crate) struct PypiPackageDataModel<'a> {
 
 impl<'a> From<PypiPackageDataModel<'a>> for PypiPackageDataRaw {
     fn from(value: PypiPackageDataModel<'a>) -> Self {
+        let index_url = match value.location.inner() {
+            UrlOrPath::Url(_) => value
+                .index_url
+                .map(std::borrow::Cow::into_owned)
+                .or_else(|| Some((*PYPI_URL).clone())),
+            UrlOrPath::Path(_) => None,
+        };
+
         Self {
             name: value.name.into_owned(),
             version: value.version.map(std::borrow::Cow::into_owned),
             location: value.location.into_owned(),
             hash: value.hash.into_owned(),
+            index_url,
             requires_dist: value.requires_dist.into_owned(),
             requires_python: value.requires_python.into_owned(),
         }
     }
 }
+
+static PYPI_URL: LazyLock<url::Url> =
+    LazyLock::new(|| url::Url::parse("https://pypi.org/simple").expect("Valid, hard-coded URL"));
 
 impl<'a> From<&'a PypiPackageData> for PypiPackageDataModel<'a> {
     fn from(value: &'a PypiPackageData) -> Self {
@@ -62,11 +76,20 @@ impl<'a> From<&'a PypiPackageData> for PypiPackageDataModel<'a> {
             .iter()
             .map(requirement_to_string)
             .collect::<Vec<_>>();
+        let index_url = value.index_url.as_ref().and_then(|i| {
+            if *i == *PYPI_URL {
+                None
+            } else {
+                Some(Cow::Borrowed(i))
+            }
+        });
+
         Self {
             name: Cow::Borrowed(&value.name),
             version: value.version.as_ref().map(Cow::Borrowed),
             location: Cow::Borrowed(&value.location),
             hash: Cow::Borrowed(&value.hash),
+            index_url,
             requires_dist: requires_dist.into(),
             requires_python: Cow::Borrowed(&value.requires_python),
         }
@@ -118,4 +141,117 @@ fn requirement_to_string(req: &pep508_rs::Requirement) -> String {
         .unwrap_or_default();
 
     format!("{}{extras}{version_or_url}{marker}", req.name)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use pep508_rs::PackageName;
+
+    use typed_path::Utf8TypedPathBuf;
+
+    use crate::{parse::deserialize::PypiPackageDataRaw, UrlOrPath, Verbatim};
+
+    use super::{PypiPackageDataModel, PYPI_URL};
+
+    fn url_location(url: &str) -> Verbatim<UrlOrPath> {
+        Verbatim::new(UrlOrPath::Url(url::Url::parse(url).unwrap()))
+    }
+
+    fn path_location(path: &str) -> Verbatim<UrlOrPath> {
+        Verbatim::new(UrlOrPath::Path(Utf8TypedPathBuf::from(path)))
+    }
+
+    fn make_model(
+        location: Verbatim<UrlOrPath>,
+        index_url: Option<url::Url>,
+    ) -> PypiPackageDataModel<'static> {
+        PypiPackageDataModel {
+            location: Cow::Owned(location),
+            name: Cow::Owned("test-pkg".parse::<PackageName>().unwrap()),
+            version: None,
+            hash: Cow::Owned(None),
+            index_url: index_url.map(Cow::Owned),
+            requires_dist: Cow::Owned(vec![]),
+            requires_python: Cow::Owned(None),
+        }
+    }
+
+    #[test]
+    fn url_location_without_index_url_defaults_to_pypi() {
+        let model = make_model(
+            url_location("https://files.pythonhosted.org/pkg-1.0.whl"),
+            None,
+        );
+        let raw: PypiPackageDataRaw = model.into();
+        assert_eq!(raw.index_url.as_ref(), Some(&*PYPI_URL));
+    }
+
+    #[test]
+    fn url_location_with_custom_index_url_preserved() {
+        let custom = url::Url::parse("https://custom.index/simple").unwrap();
+        let model = make_model(
+            url_location("https://custom.index/packages/pkg-1.0.whl"),
+            Some(custom.clone()),
+        );
+        let raw: PypiPackageDataRaw = model.into();
+        assert_eq!(raw.index_url.as_ref(), Some(&custom));
+    }
+
+    #[test]
+    fn path_location_has_no_index_url() {
+        let model = make_model(path_location("./my-pkg"), None);
+        let raw: PypiPackageDataRaw = model.into();
+        assert!(raw.index_url.is_none());
+    }
+
+    #[test]
+    fn serialization_elides_default_pypi_url() {
+        let data = crate::PypiPackageData {
+            name: "test-pkg".parse().unwrap(),
+            version: None,
+            location: url_location("https://files.pythonhosted.org/pkg-1.0.whl"),
+            index_url: Some(PYPI_URL.clone()),
+            hash: None,
+            requires_dist: vec![],
+            requires_python: None,
+        };
+        let model = PypiPackageDataModel::from(&data);
+        assert!(
+            model.index_url.is_none(),
+            "default pypi.org URL should be elided"
+        );
+    }
+
+    #[test]
+    fn serialization_keeps_custom_index_url() {
+        let custom = url::Url::parse("https://custom.index/simple").unwrap();
+        let data = crate::PypiPackageData {
+            name: "test-pkg".parse().unwrap(),
+            version: None,
+            location: url_location("https://custom.index/packages/pkg-1.0.whl"),
+            index_url: Some(custom.clone()),
+            hash: None,
+            requires_dist: vec![],
+            requires_python: None,
+        };
+        let model = PypiPackageDataModel::from(&data);
+        assert_eq!(model.index_url.as_deref(), Some(&custom),);
+    }
+
+    #[test]
+    fn serialization_none_index_url_stays_none() {
+        let data = crate::PypiPackageData {
+            name: "test-pkg".parse().unwrap(),
+            version: None,
+            location: path_location("./my-pkg"),
+            index_url: None,
+            hash: None,
+            requires_dist: vec![],
+            requires_python: None,
+        };
+        let model = PypiPackageDataModel::from(&data);
+        assert!(model.index_url.is_none());
+    }
 }

--- a/crates/rattler_lock/src/parse/models/v7/source_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/source_package_data.rs
@@ -22,8 +22,8 @@ use crate::{
 /// This type is used for packages identified by the `- source:` key.
 /// Unlike `CondaPackageDataModel` (for binary packages), this type:
 /// - Always converts to `CondaPackageData::Source`
-/// - Does not include binary-specific fields (file_name, channel, hashes)
-/// - Includes source-specific fields (variants, package_build_source, sources)
+/// - Does not include binary-specific fields (`file_name`, `channel`, `hashes`)
+/// - Includes source-specific fields (`variants`, `package_build_source`, `sources`)
 /// - Uses `SourceIdentifier` format: `name[hash] @ location`
 ///
 /// The `source` field contains a unique identifier that includes:

--- a/crates/rattler_lock/src/parse/v3.rs
+++ b/crates/rattler_lock/src/parse/v3.rs
@@ -258,6 +258,7 @@ pub fn parse_v3_or_lower(
                         requires_python: pkg.requires_python,
                         location: Verbatim::new(UrlOrPath::Url(pkg.url)),
                         hash: pkg.hash,
+                        index_url: None,
                     })
                     .0;
                 EnvironmentPackageData::Pypi(deduplicated_index)

--- a/crates/rattler_lock/src/pypi.rs
+++ b/crates/rattler_lock/src/pypi.rs
@@ -18,6 +18,9 @@ pub struct PypiPackageData {
     /// The location of the package. This can be a URL or a path.
     pub location: Verbatim<UrlOrPath>,
 
+    /// The index this came from. Is `None` for source dependencies
+    pub index_url: Option<url::Url>,
+
     /// Hashes of the file pointed to by `url`.
     pub hash: Option<PackageHashes>,
 

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__pypi_custom_index.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__pypi_custom_index.yml.snap
@@ -1,0 +1,34 @@
+---
+source: crates/rattler_lock/src/lib.rs
+expression: conda_lock
+---
+version: 7
+platforms:
+  - name: linux-64
+environments:
+  default:
+    channels:
+      - url: "https://conda.anaconda.org/conda-forge/"
+    indexes:
+      - "https://my-custom-index.example.com/simple"
+    packages:
+      linux-64:
+        - pypi: "https://files.pythonhosted.org/packages/numpy-1.26.0-cp311-cp311-linux_x86_64.whl"
+        - pypi: "https://my-custom-index.example.com/packages/requests-2.31.0-py3-none-any.whl"
+        - pypi: "./local-pkg"
+packages:
+  - pypi: "./local-pkg"
+    name: local-pkg
+    version: 0.1.0
+    sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  - pypi: "https://files.pythonhosted.org/packages/numpy-1.26.0-cp311-cp311-linux_x86_64.whl"
+    name: numpy
+    version: 1.26.0
+    sha256: f93fc78fe8bf15afe2b8d6b6499f1c73953571c004b3135db0c83b9a5fd4e5e1
+    requires_python: ">=3.9"
+  - pypi: "https://my-custom-index.example.com/packages/requests-2.31.0-py3-none-any.whl"
+    name: requests
+    version: 2.31.0
+    sha256: 942c5a758f98d790eaed1a29cb6eefc7f0edf3fcb0fce8aea3fbd5951d1cae1b
+    index_url: "https://my-custom-index.example.com/simple"
+    requires_python: ">=3.7"

--- a/py-rattler/src/lock/mod.rs
+++ b/py-rattler/src/lock/mod.rs
@@ -214,6 +214,7 @@ impl PyLockFile {
                 location: Verbatim::<UrlOrPath>::from_str(&location)
                     .map_err(|e| PyRattlerError::LockFileError(e.to_string()))?,
                 hash: None,
+                index_url: None,
                 requires_dist: Vec::new(),
                 requires_python: None,
             };
@@ -835,6 +836,12 @@ impl PyPypiPackageData {
             return Some(hash.into());
         }
         None
+    }
+
+    /// The index this came from. Might be None if the default index was used.
+    #[getter]
+    pub fn index_url(&self) -> Option<String> {
+        self.inner.index_url.as_ref().map(|url| url.to_string())
     }
 
     /// A list of dependencies on other packages.

--- a/test-data/conda-lock/v7/pypi_custom_index.yml
+++ b/test-data/conda-lock/v7/pypi_custom_index.yml
@@ -1,0 +1,30 @@
+version: 7
+platforms:
+  - name: linux-64
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+      - https://my-custom-index.example.com/simple
+    packages:
+      linux-64:
+        - pypi: https://my-custom-index.example.com/packages/requests-2.31.0-py3-none-any.whl
+        - pypi: https://files.pythonhosted.org/packages/numpy-1.26.0-cp311-cp311-linux_x86_64.whl
+        - pypi: ./local-pkg
+packages:
+  - pypi: https://my-custom-index.example.com/packages/requests-2.31.0-py3-none-any.whl
+    name: requests
+    version: 2.31.0
+    index_url: https://my-custom-index.example.com/simple
+    sha256: 942c5a758f98d790eaed1a29cb6eefc7f0edf3fcb0fce8aea3fbd5951d1cae1b
+    requires_python: ">=3.7"
+  - pypi: https://files.pythonhosted.org/packages/numpy-1.26.0-cp311-cp311-linux_x86_64.whl
+    name: numpy
+    version: 1.26.0
+    sha256: f93fc78fe8bf15afe2b8d6b6499f1c73953571c004b3135db0c83b9a5fd4e5e1
+    requires_python: ">=3.9"
+  - pypi: ./local-pkg
+    name: local-pkg
+    version: 0.1.0
+    sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
### Description

Record any non-pypi index URL in python packages.

### How Has This Been Tested?

Mostly with test in Pixi, using https://github.com/hunger/pixi/tree/feature/lockfile-v7 This can nto go into pixi before the lockfile-v7 branch has not landed in rattler.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.