### PR TITLE
feat(py-rattler): allow passing PyPI packages to Environment constructor

### DIFF
--- a/py-rattler/rattler/lock/environment.py
+++ b/py-rattler/rattler/lock/environment.py
@@ -18,10 +18,14 @@ class Environment:
     _env: PyEnvironment
 
     def __init__(
-        self, name: str, requirements: Dict[Platform, List[RepoDataRecord]], channels: List[Union[Channel, LockChannel]]
+        self,
+        name: str,
+        requirements: Dict[Platform, List[RepoDataRecord]],
+        channels: List[Union[Channel, LockChannel]],
+        pypi_packages: Optional[Dict[Platform, List[PypiLockedPackage]]] = None,
     ) -> None:
         """
-        Create a new environment.
+        Create a new environment with Conda and optionally PyPI requirements.
         """
         # Convert LockChannel to Channel for compatibility
         py_channels = []
@@ -31,6 +35,12 @@ class Environment:
             else:
                 py_channels.append(channel._channel)
 
+        py_pypi = None
+        if pypi_packages is not None:
+            py_pypi = {
+                platform._inner: [pkg._package for pkg in packages] for (platform, packages) in pypi_packages.items()
+            }
+
         self._env = PyEnvironment(
             name=name,
             # TODO: move this logic to rust
@@ -38,6 +48,7 @@ class Environment:
                 platform._inner: [record._record for record in records] for (platform, records) in requirements.items()
             },
             channels=py_channels,
+            pypi_packages=py_pypi,
         )
 
     def platforms(self) -> List[Platform]:

--- a/py-rattler/tests/unit/test_lock_environment.py
+++ b/py-rattler/tests/unit/test_lock_environment.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+from rattler import Channel, Environment, Platform, LockFile
+
+
+def test_environment_with_pypi_packages() -> None:
+    """
+    Verifies that the Environment constructor accepts pypi_packages,
+    resolving issue #1387.
+    """
+    # 1. Arrange: Load a real lockfile that contains PyPI packages
+    # FIX: Wrap the string in Path() to satisfy mypy
+    lock_path = Path("../test-data/test.lock")
+    lock_file = LockFile.from_path(lock_path)
+
+    source_env = lock_file.default_environment()
+
+    # FIX: Assert is not None so mypy knows it is safe to use
+    assert source_env is not None, "Default environment not found in lockfile"
+
+    # 2. Extract a valid PypiLockedPackage from the existing lockfile
+    pypi_packages = source_env.pypi_packages()
+    assert len(pypi_packages) > 0, "Test lockfile does not contain PyPI packages"
+
+    # 3. Act: Create a new environment using the extracted PyPI package
+    try:
+        new_env = Environment(
+            name="test-env-with-pypi",
+            requirements={},
+            channels=[Channel("conda-forge")],
+            pypi_packages=pypi_packages,
+        )
+    except TypeError as e:
+        assert False, f"Environment constructor failed to accept pypi_packages: {e}"
+
+    # 4. Assert: Check if the PyPI packages were actually added to the new environment
+    pypi_in_new_env = new_env.pypi_packages_for_platform(Platform("osx-arm64"))
+    assert pypi_in_new_env is not None
+    assert len(pypi_in_new_env) > 0
+
+    # Verify that at least one package name matches to prove success
+    original_names = {pkg.name for pkg in pypi_packages[Platform("osx-arm64")]}
+    new_names = {pkg.name for pkg in pypi_in_new_env}
+    assert original_names == new_names


### PR DESCRIPTION
### Description
The aim of this PR is to update the Environment constructor in both the Rust backend (PyEnvironment) and the Python wrapper to accept an optional pypi_packages argument, allowing users to include PyPI records when programmatically creating an environment, bringing the constructor into parity with the library's ability to read PyPI packages from existing lockfiles.
<img width="1497" height="281" alt="image" src="https://github.com/user-attachments/assets/b81cd497-7ed0-4aa3-978b-ffd0d11b172f" />

 Fix #1387

### How Has This Been Tested?

I created a new test suite in tests/unit/test_lock_environment.py. The test verifies the fix by loading a real lockfile containing PyPI packages and passing them into a newly constructed Environment instance. Have also verified that the new constructor should be backward compatible by creating environments without the pypi_packages argument.
All checks passed via pixi run type-check and pixi run test.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: GPT is used for analyzing the RUST components used (eg:``mod.rs``).

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added one test to cover my changes (tests/unit/test_lock_environment.py)
