### PR TITLE
fix: Improve package name matching for asterisk handling

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -571,17 +571,15 @@ fn strip_package_name(
 
     let rest = rest.trim();
 
-    // Handle asterisk as a wildcard (no package name)
-    if trimmed_package_name == "*" {
-        return Ok((None, rest));
-    }
-
     let package_name = match PackageNameMatcher::from_str(trimmed_package_name)
         .map_err(ParseMatchSpecError::InvalidPackageNameMatcher)?
     {
         PackageNameMatcher::Exact(name) => PackageNameMatcher::Exact(name),
         PackageNameMatcher::Glob(glob) => {
-            if exact_names_only {
+            // Allow the universal matcher "*" even when exact_names_only is true,
+            // since it semantically matches all packages (similar to having no name).
+            // Other glob patterns (like "foo*") are rejected when exact_names_only is set.
+            if exact_names_only && glob.as_str() != "*" {
                 return Err(
                     ParseMatchSpecError::OnlyExactPackageNameMatchersAllowedGlob(
                         glob.as_str().to_string(),


### PR DESCRIPTION
### Description

Previously, parsing a `MatchSpec` with `*` as the package name (e.g. `*[license=MIT]` or `* >=1.0`) would set `name = None`, making it a special case that needed to be handled separately everywhere the name was checked. This PR changes `*` to be parsed as a `PackageNameMatcher::Glob("*")` instead, which is semantically identical (matches all package names) but removes the special-casing.

**Changes:**
- **`parse.rs`**: Removed the early-return that converted `*` into `None`. Instead, `*` now flows through the normal `PackageNameMatcher::from_str` path and becomes `Glob("*")`. Added an exception so `*` is allowed even when `exact_names_only` is `true`, since it semantically matches all packages (similar to having no name). Other glob patterns like `foo*` are still rejected in strict mode.
- **`mod.rs` (tests)**: Updated `test_name_asterisk` to assert `name = Some(Glob("*"))` instead of `None`, and added a roundtrip test verifying that parsing and displaying `*` is stable.

This simplifies downstream code in the gateway and solver that previously needed to handle `name = None` as a separate branch — the `*` glob now naturally flows through the existing `Glob`/`Regex` pattern matching paths.

<img width="855" height="511" alt="image" src="https://github.com/user-attachments/assets/67cd84e6-ce4b-4545-b136-eb668e16a6ad" />


Fixes https://github.com/conda/rattler/issues/2039

### How Has This Been Tested?

```
$ pixi run -- cargo nextest run -p rattler_conda_types test_name_asterisk

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.42s
────────────
 Nextest run ID c66a3ba6-0e53-46e7-9e2b-e3f09031c615 with nextest profile: default
    Starting 1 test across 1 binary (409 tests skipped)
        PASS [   0.030s] rattler_conda_types match_spec::tests::test_name_asterisk
────────────
     Summary [   0.045s] 1 test run: 1 passed, 409 skipped
```

```
$ pixi run -- cargo nextest run -p rattler_conda_types

     Summary [   1.364s] 410 tests run: 410 passed, 0 skipped
```

```
$ pixi run -- cargo nextest run -p rattler_repodata_gateway

     Summary [   2.847s] 13 tests run: 13 passed, 0 skipped
```

```
$ ./target/debug/rattler search '*' --limit-packages 5 --limit 2 --sharded false

Searching for '*' on osx-arm64
Channels: https://conda.anaconda.org/conda-forge/
Found 603945 matching records in 12.922057959s

7zip (2 versions)
  26.00 h3feff0a_0 [osx-arm64] https://conda.anaconda.org/conda-forge/
  25.01 h49c215f_1 [osx-arm64] https://conda.anaconda.org/conda-forge/

_current_repodata_hack_gcc_linux_64_75 (1 version)
  0.0.1 0 [noarch] https://conda.anaconda.org/conda-forge/

_current_repodata_hack_gcc_linux_64_84 (1 version)
  0.0.1 0 [noarch] https://conda.anaconda.org/conda-forge/

_current_repodata_hack_gcc_linux_aarch64_75 (1 version)
  0.0.1 0 [noarch] https://conda.anaconda.org/conda-forge/

_current_repodata_hack_gcc_linux_aarch64_84 (1 version)
  0.0.1 0 [noarch] https://conda.anaconda.org/conda-forge/

... and 27602 more packages
```

```
$ ./target/debug/rattler search 'python*' --limit-packages 5 --limit 2 --sharded false

Searching for 'python*' on osx-arm64
Channels: https://conda.anaconda.org/conda-forge/
Found 12082 matching records in 7.458389292s

python (254 versions)
  3.14.3 h4c637c5_101_cp314 [osx-arm64] https://conda.anaconda.org/conda-forge/
  3.14.3 h4c637c5_100_cp314 [osx-arm64] https://conda.anaconda.org/conda-forge/
   ... and 252 more versions

python-a2a (1 version)
  0.5.10 pyhcf101f3_0 [noarch] https://conda.anaconda.org/conda-forge/

python-abi3 (30 versions)
  3.13 hdb156c7_2 [noarch] https://conda.anaconda.org/conda-forge/
  3.13 h9bebd56_2 [noarch] https://conda.anaconda.org/conda-forge/
   ... and 28 more versions

python-ace (3 versions)
  0.3.1 py312hd7f1de0_1 [osx-arm64] https://conda.anaconda.org/conda-forge/
  0.3.1 py310ha6c330b_1 [osx-arm64] https://conda.anaconda.org/conda-forge/
   ... and 1 more version

python-ags4 (11 versions)
  1.1.0 pyh332efcf_1 [noarch] https://conda.anaconda.org/conda-forge/
  1.1.0 pyhff2d567_0 [noarch] https://conda.anaconda.org/conda-forge/
   ... and 9 more versions

... and 324 more packages
```

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
  
Tools: GitHub Copilot (Claude)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
