### PR TITLE
fix: show shadowed channel in priority exclusions (#2091)

### DIFF
--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![deny(missing_docs)]
 
-#[cfg(feature = "libsolv_c")]
+#[cfg(feature = "libsolv_c")] 
 pub mod libsolv_c;
 #[cfg(feature = "resolvo")]
 pub mod resolvo;

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![deny(missing_docs)]
 
-#[cfg(feature = "libsolv_c")] 
+#[cfg(feature = "libsolv_c")]
 pub mod libsolv_c;
 #[cfg(feature = "resolvo")]
 pub mod resolvo;

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -505,7 +505,7 @@ impl<'a> CondaDependencyProvider<'a> {
                     if first_channel != &&record.channel {
                         let shadowed_by = match *first_channel {
                             Some(c) => c.clone(),
-                            //mathced to clippy suggestion to avoid cloning the string when its not necessary
+                            //matched to clippy suggestion to avoid cloning the string when its not necessary
                             None => "an unknown channel".to_string(),
                         };
 

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -504,7 +504,8 @@ impl<'a> CondaDependencyProvider<'a> {
 
                     if first_channel != &&record.channel {
                         let shadowed_by = match *first_channel {
-                            Some(c) => c.to_string(),
+                            Some(c) => c.clone(),
+                            //mathced to clippy suggestion to avoid cloning the string when its not necessary
                             None => "an unknown channel".to_string(),
                         };
 

--- a/crates/rattler_solve/tests/backends/main.rs
+++ b/crates/rattler_solve/tests/backends/main.rs
@@ -14,7 +14,7 @@ use rattler_solve::{
 use url::Url;
 
 mod conditional_tests;
-mod extras_tests;  
+mod extras_tests;
 mod helpers;
 mod min_age_tests;
 mod solver_case_tests;

--- a/crates/rattler_solve/tests/backends/main.rs
+++ b/crates/rattler_solve/tests/backends/main.rs
@@ -14,7 +14,7 @@ use rattler_solve::{
 use url::Url;
 
 mod conditional_tests;
-mod extras_tests;
+mod extras_tests;  
 mod helpers;
 mod min_age_tests;
 mod solver_case_tests;
@@ -1318,13 +1318,13 @@ fn channel_priority_strict() {
         ChannelPriority::Strict,
     );
 }
-
+//Solving PR "Error message should show channel priority exclusions#2091"
 #[test]
 #[should_panic(
     expected = "called `Result::unwrap()` on an `Err` value: Unsolvable([\"The following packages \
     are incompatible\\n└─ pytorch-cpu ==0.4.1 py36_cpu_1 cannot be installed because there are no \
     viable options:\\n   └─ pytorch-cpu 0.4.1 is excluded because due to strict channel priority \
-    not using this option from: 'https://conda.anaconda.org/pytorch/'\\n\"])"
+    not using this option from: 'https://conda.anaconda.org/pytorch/'. Shadowed by: 'https://conda.anaconda.org/conda-forge/'\\n\"])"
 )]
 fn channel_priority_strict_panic() {
     let repodata = vec![


### PR DESCRIPTION
- Updates the resolvo error message to explicitly show which higher-priority channel shadowed the excluded package,hope its resolving #2091.
- Fixes a compilation error in mod.rs (lines 572 & 615) by changing `as_ref()` to `as_exact()` for the new `PackageNameMatcher` enum.

### Description

**Summary & Motivation:**
Right now, if a build fails because of strict channel priority, the solver spits out a massive wall of excluded package versions. It tells you the channel that got excluded, but leaves you completely guessing as to *which* higher-priority channel actually caused the exclusion. 

To fix this and make debugging environments easier, I updated the `resolvo` error formatting to explicitly extract the winning channel and show it in the output.

**Example of the new output:**
`...due to strict channel priority not using this option from: 'https://conda.anaconda.org/pytorch/'. Shadowed by: 'https://conda.anaconda.org/conda-forge/'`

**(Side note: while working on this, `main` wasn't compiling for me locally because of a recent change to the `PackageNameMatcher` enum. I went ahead and patched `crates/rattler_solve/src/resolvo/mod.rs` on lines 572 & 615 by changing `.as_ref()` to `.as_exact()` so I could actually run the test suite).*

###Before and After

**Before:** 
main issue 

The following packages are incompatible
└─ pytorch-cpu ==0.4.1 py36_cpu_1 cannot be installed because there are no viable options:
   └─ pytorch-cpu 0.4.1 is excluded because due to strict channel priority not using this option from: '[https://conda.anaconda.org/pytorch/](https://conda.anaconda.org/pytorch/)'

**Other issues faced**
**Refractored package names in lines 572 and 615 in main.rs
error[E0599]: no method named `as_ref` found for enum `PackageNameMatcher` in the current scope
   --> crates/rattler_solve/src/resolvo/mod.rs:572:57
    |
572 |             if let Some(name) = rule.override_spec.name.as_ref() 

615 |         let dep_name = dep_spec.name.as_ref()?;
    |                                      ^^^^^^
    |

** submodules C dependency errors 
 1) process didn't exit successfully: `/Users/lalit/rattler/target/debug/build/rattler_libsolv_c-5980e79a4fd1da05/build-script-build` (exit status: 101)
  --- stdout

2)error: failed to run custom build command for `rattler_libsolv_c v1.3.1 (/Users/lalit/rattler/crates/rattler_libsolv_c)`
  process didn't exit successfully: `/Users/lalit/rattler/target/debug/build/rattler_libsolv_c-5980e79a4fd1da05/build-script-build` (exit status: 1)
  --- stderr
  Error: Bundled libsolv not found, please do `git submodule update --init` 

**After**

main issue
The following packages are incompatible
└─ pytorch-cpu ==0.4.1 py36_cpu_1 cannot be installed because there are no viable options:
   └─ pytorch-cpu 0.4.1 is excluded because due to strict channel priority not using this option from: '[https://conda.anaconda.org/pytorch/](https://conda.anaconda.org/pytorch/)'. Shadowed by: '[https://conda.anaconda.org/conda-forge/](https://conda.anaconda.org/conda-forge/)'

Other issues fixed:
Refactored package names in crates/rattler_solve/src/resolvo/mod.rs to fix broken compilation on main:
Changed .as_ref() to .as_exact() on lines 572 and 615 to correctly handle the new PackageNameMatcher enum.


Fixes #{2091}

### How Has This Been Tested?

- Updated the `channel_priority_strict_panic` test to specifically check for the new `. Shadowed by: '...'` string format.
- Ran the full `cargo test` suite locally (all tests passed successfully across `resolvo` and `libsolv_c`).

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure : none for the code but used  a bit of chatgpt for the PR proposal


### Checklist:
<!--- Remove the non relevant items. --->
- [x ] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all : org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
