### PR TITLE
feat: warn on stale zst shards repodata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,6 +5042,7 @@ dependencies = [
  "tools",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
  "url",
  "zstd",
 ]

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -78,3 +78,4 @@ retry-policies = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 tools = { path = "../tools", default-features = false }
+tracing-test = { workspace = true, features = ["no-env-filter"] }

--- a/crates/rattler_index/tests/integration/mod.rs
+++ b/crates/rattler_index/tests/integration/mod.rs
@@ -3,3 +3,4 @@ mod basic_indexing;
 mod cache_tests;
 mod concurrent_indexing;
 pub mod etag_memory_backend;
+mod stale_output_tests;

--- a/crates/rattler_index/tests/integration/stale_output_tests.rs
+++ b/crates/rattler_index/tests/integration/stale_output_tests.rs
@@ -1,0 +1,132 @@
+use rattler_conda_types::Platform;
+use rattler_index::{index_fs, IndexFsConfig};
+
+/// When both zst and shards were previously enabled then both disabled,
+/// the stale files must still exist on disk (they are not cleaned up).
+/// Stale-file warnings must be emitted.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_stale_files_persist_when_outputs_disabled() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    // First run: generate both zst and shards files.
+    index_fs(IndexFsConfig {
+        channel: temp_dir.path().into(),
+        target_platform: Some(Platform::NoArch),
+        repodata_patch: None,
+        write_zst: true,
+        write_shards: true,
+        force: true,
+        max_parallel: 10,
+        multi_progress: None,
+    })
+    .await
+    .unwrap();
+
+    let zst_path = temp_dir.path().join("noarch/repodata.json.zst");
+    let shards_path = temp_dir.path().join("noarch/repodata_shards.msgpack.zst");
+    assert!(zst_path.exists());
+    assert!(shards_path.exists());
+
+    // Second run: both disabled, stale files should still exist.
+    index_fs(IndexFsConfig {
+        channel: temp_dir.path().into(),
+        target_platform: Some(Platform::NoArch),
+        repodata_patch: None,
+        write_zst: false,
+        write_shards: false,
+        force: false,
+        max_parallel: 10,
+        multi_progress: None,
+    })
+    .await
+    .unwrap();
+
+    // Stale files are not cleaned up by the indexer.
+    assert!(zst_path.exists());
+    assert!(shards_path.exists());
+
+    // Stale-file warnings must have been logged.
+    assert!(logs_contain(
+        "Found stale file 'noarch/repodata.json.zst' but zst output is disabled"
+    ));
+    assert!(logs_contain(
+        "Found stale file 'noarch/repodata_shards.msgpack.zst' but sharded repodata output is disabled"
+    ));
+}
+
+/// No stale files exist when both outputs are disabled from the start.
+/// No stale-file warnings should be emitted.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_no_stale_files_on_clean_start() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    index_fs(IndexFsConfig {
+        channel: temp_dir.path().into(),
+        target_platform: Some(Platform::NoArch),
+        repodata_patch: None,
+        write_zst: false,
+        write_shards: false,
+        force: true,
+        max_parallel: 10,
+        multi_progress: None,
+    })
+    .await
+    .unwrap();
+
+    assert!(!temp_dir.path().join("noarch/repodata.json.zst").exists());
+    assert!(!temp_dir
+        .path()
+        .join("noarch/repodata_shards.msgpack.zst")
+        .exists());
+
+    // No stale files means no warnings.
+    assert!(!logs_contain("Found stale file"));
+}
+
+/// Output files are kept up to date when both outputs remain enabled across runs.
+/// No stale-file warnings should be emitted since outputs stay enabled.
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn test_outputs_updated_when_enabled() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    index_fs(IndexFsConfig {
+        channel: temp_dir.path().into(),
+        target_platform: Some(Platform::NoArch),
+        repodata_patch: None,
+        write_zst: true,
+        write_shards: true,
+        force: true,
+        max_parallel: 10,
+        multi_progress: None,
+    })
+    .await
+    .unwrap();
+
+    let zst_path = temp_dir.path().join("noarch/repodata.json.zst");
+    let shards_path = temp_dir.path().join("noarch/repodata_shards.msgpack.zst");
+    assert!(zst_path.exists());
+    assert!(shards_path.exists());
+
+    index_fs(IndexFsConfig {
+        channel: temp_dir.path().into(),
+        target_platform: Some(Platform::NoArch),
+        repodata_patch: None,
+        write_zst: true,
+        write_shards: true,
+        force: false,
+        max_parallel: 10,
+        multi_progress: None,
+    })
+    .await
+    .unwrap();
+
+    // Files still exist and were updated (not stale).
+    assert!(zst_path.exists());
+    assert!(shards_path.exists());
+
+    // No stale-file warnings since both outputs remained enabled.
+    assert!(!logs_contain("Found stale file"));
+}


### PR DESCRIPTION
### Description

In this PR, we warn when stale `repodata.json.zst` or `repodata_shards.msgpack.zst` files exist, but their outputs are disabled, preventing clients from silently consuming outdated package metadata. It also adds integration tests to verify that it has the intended behavior changes and to ensure no regressions.

Closes https://github.com/conda/rattler/issues/1856.

### Rattler Index Demo Update

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/bc0e88aa-7592-4339-a659-87ac81cc5011" /> | <video src="https://github.com/user-attachments/assets/815a5be9-5207-4f67-b39c-daca9538db43" /> |

### How Has This Been Tested?

With integration tests in place in `tests/integration/stale_output_tests.rs.`

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {Claude Code}

I used Claude Code to learn and explore relevant parts of rattler codebase. I also used it to write boilerpalate rust test code

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->