### PR TITLE
fix(cache): include subdir in CacheKey to prevent cross-platform cache collisions

### DIFF
--- a/crates/rattler_cache/src/package_cache/cache_key.rs
+++ b/crates/rattler_cache/src/package_cache/cache_key.rs
@@ -7,18 +7,30 @@ use std::{
 };
 
 /// Provides a unique identifier for packages in the cache.
-/// TODO: This could not be unique over multiple subdir. How to handle?
+///
+/// The key includes the package name, version, build string, and optionally the
+/// subdirectory (platform identifier, e.g. `linux-64`, `osx-arm64`). Including
+/// the subdir prevents cache collisions between packages with identical
+/// name/version/build coordinates from different platforms.
 #[derive(Debug, Hash, Clone, Eq, PartialEq)]
 pub struct CacheKey {
     pub(crate) name: String,
     pub(crate) version: String,
     pub(crate) build_string: String,
+    /// included in the cache directory name to avoid collisions across subdirectories.
+    pub(crate) subdir: Option<String>,
     pub(crate) sha256: Option<Sha256Hash>,
     pub(crate) md5: Option<Md5Hash>,
     pub(crate) origin_hash: Option<String>,
 }
 
 impl CacheKey {
+    /// Adds the subdirectory (platform identifier, e.g. `linux-64`) to the key.
+    pub fn with_subdir(mut self, subdir: impl Into<String>) -> Self {
+        self.subdir = Some(subdir.into());
+        self
+    }
+
     /// Adds a sha256 hash of the archive.
     pub fn with_sha256(mut self, sha256: Sha256Hash) -> Self {
         self.sha256 = Some(sha256);
@@ -76,6 +88,8 @@ impl From<CondaArchiveIdentifier> for CacheKey {
             name: pkg.identifier.name,
             version: pkg.identifier.version,
             build_string: pkg.identifier.build_string,
+            // Subdir is not available from the archive filename alone.
+            subdir: None,
             sha256: None,
             md5: None,
             origin_hash: None,
@@ -89,6 +103,10 @@ impl From<&PackageRecord> for CacheKey {
             name: record.name.as_normalized().to_string(),
             version: record.version.to_string(),
             build_string: record.build.clone(),
+            // Include the subdir so that packages with the same
+            // name/version/build from different platforms (e.g. linux-64 vs
+            // osx-arm64) do not collide in the cache.
+            subdir: Some(record.subdir.clone()),
             sha256: record.sha256,
             md5: record.md5,
             origin_hash: None,
@@ -104,7 +122,138 @@ impl Display for CacheKey {
                 "{}-{}-{}-{}",
                 &self.name, &self.version, &self.build_string, url_hash
             ),
-            None => write!(f, "{}-{}-{}", &self.name, &self.version, &self.build_string),
+            None => match &self.subdir {
+                // Include the subdir in the directory name so that packages
+                // from different platforms with identical name/version/build do
+                // not share the same cache entry.
+                Some(subdir) => write!(
+                    f,
+                    "{}-{}-{}-{}",
+                    &self.name, &self.version, &self.build_string, subdir
+                ),
+                None => write!(f, "{}-{}-{}", &self.name, &self.version, &self.build_string),
+            },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rattler_conda_types::{NoArchType, PackageName, VersionWithSource};
+    use std::collections::BTreeMap;
+    use std::str::FromStr;
+
+    fn make_record(name: &str, version: &str, build: &str, subdir: &str) -> PackageRecord {
+        PackageRecord {
+            name: PackageName::new_unchecked(name),
+            version: VersionWithSource::from_str(version).unwrap(),
+            build: build.to_string(),
+            build_number: 0,
+            subdir: subdir.to_string(),
+            arch: None,
+            platform: None,
+            depends: vec![],
+            constrains: vec![],
+            track_features: vec![],
+            features: None,
+            noarch: NoArchType::none(),
+            license: None,
+            license_family: None,
+            legacy_bz2_md5: None,
+            legacy_bz2_size: None,
+            md5: None,
+            sha256: None,
+            size: None,
+            timestamp: None,
+            purls: None,
+            run_exports: None,
+            python_site_packages_path: None,
+            experimental_extra_depends: BTreeMap::default(),
+        }
+    }
+
+    #[test]
+    fn test_display_no_subdir_no_hash() {
+        let key = CacheKey {
+            name: "zlib".to_string(),
+            version: "1.3.1".to_string(),
+            build_string: "hb9d3cd8_2".to_string(),
+            subdir: None,
+            sha256: None,
+            md5: None,
+            origin_hash: None,
+        };
+        assert_eq!(key.to_string(), "zlib-1.3.1-hb9d3cd8_2");
+    }
+
+    #[test]
+    fn test_display_with_subdir() {
+        let key = CacheKey {
+            name: "zlib".to_string(),
+            version: "1.3.1".to_string(),
+            build_string: "hb9d3cd8_2".to_string(),
+            subdir: Some("linux-64".to_string()),
+            sha256: None,
+            md5: None,
+            origin_hash: None,
+        };
+        assert_eq!(key.to_string(), "zlib-1.3.1-hb9d3cd8_2-linux-64");
+    }
+
+    #[test]
+    fn test_display_origin_hash_takes_precedence_over_subdir() {
+        let key = CacheKey {
+            name: "zlib".to_string(),
+            version: "1.3.1".to_string(),
+            build_string: "hb9d3cd8_2".to_string(),
+            subdir: Some("linux-64".to_string()),
+            sha256: None,
+            md5: None,
+            origin_hash: Some("abc123".to_string()),
+        };
+        // origin_hash wins — subdir is not appended separately
+        assert_eq!(key.to_string(), "zlib-1.3.1-hb9d3cd8_2-abc123");
+    }
+
+    #[test]
+    fn test_from_package_record_includes_subdir() {
+        let record = make_record("zlib", "1.3.1", "hb9d3cd8_2", "linux-64");
+        let key = CacheKey::from(&record);
+        assert_eq!(key.subdir, Some("linux-64".to_string()));
+        assert_eq!(key.to_string(), "zlib-1.3.1-hb9d3cd8_2-linux-64");
+    }
+
+    #[test]
+    fn test_cross_platform_keys_are_distinct() {
+        // Same name/version/build but different subdir must not collide.
+        let linux = make_record("mylib", "1.0.0", "h1234_0", "linux-64");
+        let osx = make_record("mylib", "1.0.0", "h1234_0", "osx-arm64");
+
+        let key_linux = CacheKey::from(&linux);
+        let key_osx = CacheKey::from(&osx);
+
+        assert_ne!(
+            key_linux.to_string(),
+            key_osx.to_string(),
+            "keys from different subdirs must produce different cache directory names"
+        );
+        assert_ne!(key_linux, key_osx);
+    }
+
+    #[test]
+    fn test_from_archive_identifier_has_no_subdir() {
+        let id = CondaArchiveIdentifier::try_from_filename("zlib-1.3.1-hb9d3cd8_2.conda").unwrap();
+        let key = CacheKey::from(id);
+        assert_eq!(key.subdir, None);
+        // Falls back to the subdir-less format for backward compatibility
+        assert_eq!(key.to_string(), "zlib-1.3.1-hb9d3cd8_2");
+    }
+
+    #[test]
+    fn test_with_subdir_builder() {
+        let id = CondaArchiveIdentifier::try_from_filename("zlib-1.3.1-hb9d3cd8_2.conda").unwrap();
+        let key = CacheKey::from(id).with_subdir("win-64");
+        assert_eq!(key.to_string(), "zlib-1.3.1-hb9d3cd8_2-win-64");
     }
 }

--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -68,6 +68,9 @@ pub struct BucketKey {
     name: String,
     version: String,
     build_string: String,
+    /// The platform subdirectory (e.g. `linux-64`), used to disambiguate
+    /// packages that share name/version/build across different platforms.
+    subdir: Option<String>,
     origin_hash: Option<String>,
 }
 
@@ -77,6 +80,7 @@ impl From<CacheKey> for BucketKey {
             name: key.name,
             version: key.version,
             build_string: key.build_string,
+            subdir: key.subdir,
             origin_hash: key.origin_hash,
         }
     }


### PR DESCRIPTION


### Description

Fixes the long-standing TODO in cache_key.rs about non-uniqueness of CacheKey across subdirectories.

 ### Problem

  CacheKey was keyed only on name + version + build_string. Two packages from different platforms
  (e.g. linux-64 and osx-arm64) with identical coordinates would hash to the same cache entry. The
  first one cached would be returned for both, silently installing the wrong architecture.

  ### Solution

  - Added subdir: Option<String> to CacheKey and BucketKey
  - From<&PackageRecord> now populates subdir from record.subdir
  - Display includes subdir in the directory name when no origin_hash is present:
    - Before: zlib-1.3.1-hb9d3cd8_2
    - After: zlib-1.3.1-hb9d3cd8_2-linux-64
  - When origin_hash is set (URL-based fetch), it takes precedence — the URL already encodes the
  subdir, so behavior is unchanged for that path
  - Added with_subdir() builder for keys created from CondaArchiveIdentifier (filename-only, no
  subdir info) where the caller knows the platform

Fixes #2166 

### How Has This Been Tested?

6 unit tests has been added to this properly

The critical test is test_cross_platform_keys_are_distinct — it directly exercises the bug scenario
 (two packages from linux-64 vs osx-arm64 with identical coordinates) and asserts they produce different cache directory names.

  To run just these tests:
  pixi run -- cargo nextest run -p rattler_cache cache_key::tests

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.


 ### Breaking change

  Cache directory names for PackageRecord-derived keys will include the subdir suffix. Existing
  cached entries without the suffix will be treated as misses and re-fetched. This is the correct and
   safe behavior.


<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
