### PR TITLE
fix: validate symlink targets and parse features/license_family in MatchSpec

### DIFF
--- a/crates/rattler_cache/src/validation.rs
+++ b/crates/rattler_cache/src/validation.rs
@@ -79,6 +79,14 @@ pub enum PackageEntryValidationError {
     #[error("expected a symbolic link")]
     ExpectedSymlink,
 
+    /// The symlink target does not exist.
+    #[error("symlink target does not exist (broken symlink)")]
+    BrokenSymlink,
+
+    /// The symlink target resolves to a path outside the package directory.
+    #[error("symlink target escapes the package directory")]
+    SymlinkEscapesPackageDirectory,
+
     /// The file is not a directory.
     #[error("expected a directory")]
     ExpectedDirectory,
@@ -173,7 +181,7 @@ fn validate_package_entry(
     // Validate based on the type of path
     match entry.path_type {
         PathType::HardLink => validate_package_hard_link_entry(path, entry, mode),
-        PathType::SoftLink => validate_package_soft_link_entry(path, entry, mode),
+        PathType::SoftLink => validate_package_soft_link_entry(package_dir, path, entry, mode),
         PathType::Directory => validate_package_directory_entry(path, entry, mode),
     }
 }
@@ -244,10 +252,26 @@ fn validate_package_hard_link_entry(
 
     Ok(())
 }
+/// validates symlink targets even when the target does not exist on disk.
+fn normalize_path(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut result = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                result.pop();
+            }
+            c => result.push(c),
+        }
+    }
+    result
+}
 
 /// Determine whether the information in the [`PathsEntry`] matches the symbolic
 /// link at the specified path.
 fn validate_package_soft_link_entry(
+    package_dir: &Path,
     path: PathBuf,
     entry: &PathsEntry,
     _mode: ValidationMode,
@@ -258,11 +282,26 @@ fn validate_package_soft_link_entry(
         return Err(PackageEntryValidationError::ExpectedSymlink);
     }
 
-    // TODO: Validate symlink content. Dont validate the SHA256 hash of the file
-    // because since a symlink will most likely point to another file added as a
-    // hardlink by the package this is double work. Instead check that the
-    // symlink is correct e.g. `../a` points to the same file as `b/../../a` but
-    // they are different.
+    // Read the symlink target.
+    let target = std::fs::read_link(&path).map_err(PackageEntryValidationError::IoError)?;
+
+    // Resolve the target relative to the directory containing the symlink.
+    let parent = path.parent().unwrap_or(package_dir);
+    let resolved = if target.is_absolute() {
+        normalize_path(&target)
+    } else {
+        normalize_path(&parent.join(&target))
+    };
+
+    // The resolved target must stay within the package directory.
+    if !resolved.starts_with(package_dir) {
+        return Err(PackageEntryValidationError::SymlinkEscapesPackageDirectory);
+    }
+
+    // The target must actually exist (no dangling symlinks).
+    if !resolved.exists() {
+        return Err(PackageEntryValidationError::BrokenSymlink);
+    }
 
     Ok(())
 }
@@ -415,5 +454,92 @@ mod test {
             validate_package_directory(temp_dir.path(), ValidationMode::Full),
             Err(PackageValidationError::ReadIndexJsonError(_))
         );
+    }
+
+    /// Unit tests for symlink validation that do not require downloading packages.
+    #[cfg(unix)]
+    mod symlink_validation {
+        use std::os::unix::fs::symlink;
+
+        use rattler_conda_types::package::{PathType, PathsEntry, PathsJson};
+
+        use crate::validation::{
+            validate_package_directory_from_paths, PackageEntryValidationError, ValidationMode,
+        };
+
+        fn make_paths_json(relative_path: &str) -> PathsJson {
+            PathsJson {
+                paths: vec![PathsEntry {
+                    relative_path: relative_path.into(),
+                    path_type: PathType::SoftLink,
+                    no_link: false,
+                    prefix_placeholder: None,
+                    sha256: None,
+                    size_in_bytes: None,
+                }],
+                paths_version: 1,
+            }
+        }
+
+        #[test]
+        fn test_valid_symlink_within_package() {
+            let dir = tempfile::tempdir().unwrap();
+            // Create a real file and a symlink pointing to it.
+            std::fs::write(dir.path().join("real_file"), b"data").unwrap();
+            symlink("real_file", dir.path().join("link")).unwrap();
+
+            let paths = make_paths_json("link");
+            assert!(validate_package_directory_from_paths(
+                dir.path(),
+                &paths,
+                ValidationMode::Full
+            )
+            .is_ok());
+        }
+
+        #[test]
+        fn test_broken_symlink_detected() {
+            let dir = tempfile::tempdir().unwrap();
+            // Symlink points to a non-existent target.
+            symlink("does_not_exist", dir.path().join("link")).unwrap();
+
+            let paths = make_paths_json("link");
+            assert_matches::assert_matches!(
+                validate_package_directory_from_paths(dir.path(), &paths, ValidationMode::Full),
+                Err((_, PackageEntryValidationError::BrokenSymlink))
+            );
+        }
+
+        #[test]
+        fn test_symlink_escaping_package_directory_detected() {
+            let dir = tempfile::tempdir().unwrap();
+            // Symlink target that walks above the package root via `..`.
+            symlink("../../outside", dir.path().join("link")).unwrap();
+
+            let paths = make_paths_json("link");
+            assert_matches::assert_matches!(
+                validate_package_directory_from_paths(dir.path(), &paths, ValidationMode::Full),
+                Err((
+                    _,
+                    PackageEntryValidationError::SymlinkEscapesPackageDirectory
+                ))
+            );
+        }
+
+        #[test]
+        fn test_symlink_absolute_escape_detected() {
+            let dir = tempfile::tempdir().unwrap();
+            // Absolute symlink target that is outside the package directory.
+            symlink("/etc/passwd", dir.path().join("link")).unwrap();
+
+            let paths = make_paths_json("link");
+            assert_matches::assert_matches!(
+                validate_package_directory_from_paths(dir.path(), &paths, ValidationMode::Full),
+                Err((
+                    _,
+                    PackageEntryValidationError::SymlinkEscapesPackageDirectory
+                ))
+            );
+        }
     }
 }

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -166,6 +166,10 @@ pub struct MatchSpec {
     pub url: Option<Url>,
     /// The license of the package
     pub license: Option<String>,
+    /// The license family of the package (e.g. `MIT`, `GPL`, `BSD`)
+    pub license_family: Option<String>,
+    /// The features of the package (deprecated conda field)
+    pub features: Option<String>,
     /// The condition under which this match spec applies.
     pub condition: Option<MatchSpecCondition>,
     /// The track features of the package
@@ -229,6 +233,14 @@ impl Display for MatchSpec {
             keys.push(format!("license=\"{license}\""));
         }
 
+        if let Some(license_family) = &self.license_family {
+            keys.push(format!("license_family=\"{license_family}\""));
+        }
+
+        if let Some(features) = &self.features {
+            keys.push(format!("features=\"{features}\""));
+        }
+
         if let Some(track_features) = &self.track_features {
             keys.push(format!(
                 "track_features=\"{}\"",
@@ -267,6 +279,8 @@ impl MatchSpec {
                 sha256: self.sha256,
                 url: self.url,
                 license: self.license,
+                license_family: self.license_family,
+                features: self.features,
                 condition: self.condition,
                 track_features: self.track_features,
             },
@@ -329,6 +343,10 @@ pub struct NamelessMatchSpec {
     pub url: Option<Url>,
     /// The license of the package
     pub license: Option<String>,
+    /// The license family of the package (e.g. `MIT`, `GPL`, `BSD`)
+    pub license_family: Option<String>,
+    /// The features of the package (deprecated conda field)
+    pub features: Option<String>,
     /// The condition under which this match spec applies.
     pub condition: Option<MatchSpecCondition>,
     /// The track features of the package
@@ -354,6 +372,14 @@ impl Display for NamelessMatchSpec {
 
         if let Some(sha256) = &self.sha256 {
             keys.push(format!("sha256=\"{sha256:x}\""));
+        }
+
+        if let Some(license_family) = &self.license_family {
+            keys.push(format!("license_family=\"{license_family}\""));
+        }
+
+        if let Some(features) = &self.features {
+            keys.push(format!("features=\"{features}\""));
         }
 
         if let Some(condition) = &self.condition {
@@ -384,6 +410,8 @@ impl From<MatchSpec> for NamelessMatchSpec {
             sha256: spec.sha256,
             url: spec.url,
             license: spec.license,
+            license_family: spec.license_family,
+            features: spec.features,
             condition: spec.condition,
             track_features: spec.track_features,
         }
@@ -407,6 +435,8 @@ impl MatchSpec {
             sha256: spec.sha256,
             url: spec.url,
             license: spec.license,
+            license_family: spec.license_family,
+            features: spec.features,
             condition: spec.condition,
             track_features: spec.track_features,
         }
@@ -482,6 +512,18 @@ impl Matches<PackageRecord> for NamelessMatchSpec {
             }
         }
 
+        if let Some(license_family) = self.license_family.as_ref() {
+            if Some(license_family) != other.license_family.as_ref() {
+                return false;
+            }
+        }
+
+        if let Some(features) = self.features.as_ref() {
+            if Some(features) != other.features.as_ref() {
+                return false;
+            }
+        }
+
         if let Some(track_features) = self.track_features.as_ref() {
             for feature in track_features {
                 if !other.track_features.contains(feature) {
@@ -533,6 +575,18 @@ impl Matches<PackageRecord> for MatchSpec {
 
         if let Some(license) = self.license.as_ref() {
             if Some(license) != other.license.as_ref() {
+                return false;
+            }
+        }
+
+        if let Some(license_family) = self.license_family.as_ref() {
+            if Some(license_family) != other.license_family.as_ref() {
+                return false;
+            }
+        }
+
+        if let Some(features) = self.features.as_ref() {
+            if Some(features) != other.features.as_ref() {
                 return false;
             }
         }

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -520,8 +520,8 @@ fn parse_bracket_vec_into_components(
                     return Err(ParseMatchSpecError::InvalidBracketKey("when".to_string()));
                 }
             }
-            // TODO: Still need to add `features` and `license_family`
-            // to the match spec.
+            "license_family" => match_spec.license_family = Some(value.to_string()),
+            "features" => match_spec.features = Some(value.to_string()),
             _ => Err(ParseMatchSpecError::InvalidBracketKey(key.to_owned()))?,
         }
     }
@@ -1611,6 +1611,65 @@ mod tests {
     }
 
     #[test]
+    fn test_parsing_license_family() {
+        let spec = MatchSpec::from_str("python[license_family=MIT]", Strict).unwrap();
+
+        assert_eq!(spec.name, "python".parse().unwrap());
+        assert_eq!(spec.license_family, Some("MIT".into()));
+
+        // Roundtrip: parse -> display -> parse
+        let display = spec.to_string();
+        let reparsed = MatchSpec::from_str(&display, Strict).unwrap();
+        assert_eq!(reparsed.license_family, Some("MIT".into()));
+    }
+
+    #[test]
+    fn test_parsing_features() {
+        let spec = MatchSpec::from_str("python[features=feature1]", Strict).unwrap();
+
+        assert_eq!(spec.name, "python".parse().unwrap());
+        assert_eq!(spec.features, Some("feature1".into()));
+
+        // Roundtrip: parse -> display -> parse
+        let display = spec.to_string();
+        let reparsed = MatchSpec::from_str(&display, Strict).unwrap();
+        assert_eq!(reparsed.features, Some("feature1".into()));
+    }
+
+    #[test]
+    fn test_features_and_license_family_matching() {
+        use crate::match_spec::Matches;
+        use crate::{PackageName, PackageRecord};
+        use std::str::FromStr;
+
+        use crate::Version;
+
+        let mut record = PackageRecord::new(
+            PackageName::from_str("python").unwrap(),
+            Version::from_str("3.10.0").unwrap(),
+            "py310".to_string(),
+        );
+        record.features = Some("feature1".to_string());
+        record.license_family = Some("MIT".to_string());
+
+        // license_family matches
+        let spec = MatchSpec::from_str("python[license_family=MIT]", Strict).unwrap();
+        assert!(spec.matches(&record));
+
+        // license_family does not match
+        let spec = MatchSpec::from_str("python[license_family=GPL]", Strict).unwrap();
+        assert!(!spec.matches(&record));
+
+        // features matches
+        let spec = MatchSpec::from_str("python[features=feature1]", Strict).unwrap();
+        assert!(spec.matches(&record));
+
+        // features does not match
+        let spec = MatchSpec::from_str("python[features=other_feature]", Strict).unwrap();
+        assert!(!spec.matches(&record));
+    }
+
+    #[test]
     fn test_parsing_track_features() {
         let cases = vec![
             "python[track_features=\"pypy debug\"]",  // Space
@@ -1714,6 +1773,8 @@ mod tests {
                 .unwrap(),
             ),
             license: Some("MIT".into()),
+            license_family: Some("MIT".into()),
+            features: Some("feature1".into()),
             condition: None,
             track_features: None,
         });

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__matchspec_to_string.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__matchspec_to_string.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
+assertion_line: 1725
 expression: vec_strings
 ---
 [
     "foo 1.0.*[build_number=\">6\"]",
-    "conda-forge/linux-64:foospace:foo 1.0.* py27_0*[md5=\"8b1a9953c4611296a827abf8c47804d7\", sha256=\"315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3\", build_number=\">=6\", fn=\"foo-1.0-py27_0.tar.bz2\", url=\"https://conda.anaconda.org/conda-forge/linux-64/foo-1.0-py27_0.tar.bz2\", license=\"MIT\"]",
+    "conda-forge/linux-64:foospace:foo 1.0.* py27_0*[md5=\"8b1a9953c4611296a827abf8c47804d7\", sha256=\"315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3\", build_number=\">=6\", fn=\"foo-1.0-py27_0.tar.bz2\", url=\"https://conda.anaconda.org/conda-forge/linux-64/foo-1.0-py27_0.tar.bz2\", license=\"MIT\", license_family=\"MIT\", features=\"feature1\"]",
 ]


### PR DESCRIPTION

### Description

  Fixes two independent correctness issues across rattler_cache and rattler_conda_types.

  ### Fix 1 — Symlink target validation (rattler_cache)

  validate_package_soft_link_entry previously contained a TODO and stopped after is_symlink(). This
  PR implements the actual validation:

  - Adds normalize_path to resolve . and .. components without canonicalize (so validation works on
  freshly extracted archives where targets may not exist yet on other code paths, but we still want
  to check containment)
  - Reads the symlink target via std::fs::read_link
  - Resolves the target relative to the symlink's parent directory
  - Returns SymlinkEscapesPackageDirectory if the resolved path does not start with package_dir
  - Returns BrokenSymlink if the resolved path does not exist
  - Adds 4 unit tests that run locally without downloading packages: valid relative symlink, broken
  symlink, relative escape (../../outside), absolute escape (/etc/passwd)

  ### Fix 2 — features and license_family in MatchSpec (rattler_conda_types)

  The bracket-key parser had a TODO for these two fields and was returning InvalidBracketKey. This
  PR:

  - Adds features: Option<String> and license_family: Option<String> to both MatchSpec and
  NamelessMatchSpec
  - Threads the fields through into_nameless, From<MatchSpec>, from_nameless, Display, and
  Matches<PackageRecord> for both structs
  - Adds parser branches for the "features" and "license_family" bracket keys
  - Adds 3 tests: parse license_family with roundtrip, parse features with roundtrip, matching both
  fields against a PackageRecord
  - Updates the test_matchspec_to_string insta snapshot to include the new fields

Fixes #2170 

### How Has This Been Tested?

  - cargo test -p rattler_cache symlink_validation — 4 new tests pass
  - cargo test -p rattler_conda_types match_spec — 100 tests pass (3 new)
  - cargo clippy -p rattler_cache -p rattler_conda_types — no new warnings
  - cargo fmt -p rattler_cache -p rattler_conda_types -- --check — clean


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
