### PR TITLE
fix(cache): isolate package cache by platform

### DIFF
--- a/crates/rattler_cache/src/package_cache/cache_key.rs
+++ b/crates/rattler_cache/src/package_cache/cache_key.rs
@@ -3,7 +3,7 @@ use rattler_conda_types::PackageRecord;
 use rattler_digest::{compute_bytes_digest, compute_url_digest, Md5Hash, Sha256, Sha256Hash};
 use std::{
     fmt::{Display, Formatter},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 /// Provides a unique identifier for packages in the cache.
@@ -13,6 +13,7 @@ pub struct CacheKey {
     pub(crate) name: String,
     pub(crate) version: String,
     pub(crate) build_string: String,
+    pub(crate) subdir: Option<String>,
     pub(crate) sha256: Option<Sha256Hash>,
     pub(crate) md5: Option<Md5Hash>,
     pub(crate) origin_hash: Option<String>,
@@ -68,6 +69,15 @@ impl CacheKey {
     pub fn md5(&self) -> Option<Md5Hash> {
         self.md5
     }
+
+    /// Returns the cache path for this key, given a base directory.
+    pub fn cache_path(&self, base: &Path) -> PathBuf {
+        if let Some(subdir) = self.subdir.as_deref() {
+            base.join(subdir).join(self.to_string())
+        } else {
+            base.join(self.to_string())
+        }
+    }
 }
 
 impl From<CondaArchiveIdentifier> for CacheKey {
@@ -76,6 +86,7 @@ impl From<CondaArchiveIdentifier> for CacheKey {
             name: pkg.identifier.name,
             version: pkg.identifier.version,
             build_string: pkg.identifier.build_string,
+            subdir: None,
             sha256: None,
             md5: None,
             origin_hash: None,
@@ -89,6 +100,7 @@ impl From<&PackageRecord> for CacheKey {
             name: record.name.as_normalized().to_string(),
             version: record.version.to_string(),
             build_string: record.build.clone(),
+            subdir: Some(record.subdir.clone()),
             sha256: record.sha256,
             md5: record.md5,
             origin_hash: None,

--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -68,6 +68,7 @@ pub struct BucketKey {
     name: String,
     version: String,
     build_string: String,
+    subdir: Option<String>,
     origin_hash: Option<String>,
 }
 
@@ -77,6 +78,7 @@ impl From<CacheKey> for BucketKey {
             name: key.name,
             version: key.version,
             build_string: key.build_string,
+            subdir: key.subdir,
             origin_hash: key.origin_hash,
         }
     }
@@ -171,7 +173,8 @@ impl PackageCacheLayer {
             .ok_or(PackageCacheLayerError::PackageNotFound)?
             .clone();
         let mut cache_entry = cache_entry.lock().await;
-        let cache_path = self.path.join(cache_key.to_string());
+
+        let cache_path = cache_key.cache_path(&self.path);
 
         match validate_package_common::<
             fn(PathBuf) -> _,
@@ -215,7 +218,8 @@ impl PackageCacheLayer {
             .clone();
 
         let mut cache_entry = entry.lock().await;
-        let cache_path = self.path.join(cache_key.to_string());
+
+        let cache_path = cache_key.cache_path(&self.path);
 
         match validate_package_common(
             cache_path,
@@ -358,7 +362,7 @@ impl PackageCache {
         let (_, writable_layers) = self.split_layers();
 
         for layer in self.inner.layers.iter() {
-            let cache_path = layer.path.join(cache_key.to_string());
+            let cache_path = cache_key.cache_path(&layer.path);
 
             if cache_path.exists() {
                 match layer.try_validate(&cache_key).await {
@@ -1542,6 +1546,84 @@ mod test {
         assert!(
             should_run.load(Ordering::Relaxed),
             "fetch function should run again"
+        );
+    }
+
+    fn create_key(url: &Url, subdir: &str, sha: &str) -> CacheKey {
+        let mut key = CacheKey::from(CondaArchiveIdentifier::try_from_url(url).unwrap());
+        key.subdir = Some(subdir.to_string());
+        key.with_sha256(parse_digest_from_hex::<Sha256>(sha).unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_cross_platform_package_cache() {
+        let package_url = Url::parse("https://conda.anaconda.org/robostack/linux-64/ros-noetic-rosbridge-suite-0.11.14-py39h6fdeb60_14.tar.bz2").unwrap();
+        let sha = "4dd9893f1eee45e1579d1a4f5533ef67a84b5e4b7515de7ed0db1dd47adc6bc8".to_string();
+
+        let cache_dir = tempdir().unwrap();
+        let cache = PackageCache::new(cache_dir.path());
+
+        let cache_key_linux = create_key(&package_url, "linux-64", &sha);
+        let cache_key_win = create_key(&package_url, "win-64", &sha);
+
+        let tar_archive_path = tools::download_and_cache_file_async(package_url.clone(), &sha)
+            .await
+            .unwrap();
+
+        let path1 = cache
+            .get_or_fetch(
+                cache_key_linux.clone(),
+                move |destination: PathBuf| {
+                    let tar_archive_path = tar_archive_path.clone();
+                    async move {
+                        rattler_package_streaming::tokio::fs::extract(
+                            &tar_archive_path,
+                            &destination,
+                        )
+                        .await
+                        .map(|_| ())
+                    }
+                },
+                None,
+            )
+            .await
+            .unwrap()
+            .path;
+
+        let tar_archive_path2 = tools::download_and_cache_file_async(package_url, &sha)
+            .await
+            .unwrap();
+
+        let path2 = cache
+            .get_or_fetch(
+                cache_key_win.clone(),
+                move |destination: PathBuf| {
+                    let tar_archive_path = tar_archive_path2.clone();
+                    async move {
+                        rattler_package_streaming::tokio::fs::extract(
+                            &tar_archive_path,
+                            &destination,
+                        )
+                        .await
+                        .map(|_| ())
+                    }
+                },
+                None,
+            )
+            .await
+            .unwrap()
+            .path;
+
+        assert_ne!(path1, path2);
+
+        assert!(
+            path1.components().any(|c| c.as_os_str() == "linux-64"),
+            "linux cache path should contain linux-64"
+        );
+
+        assert!(
+            path2.components().any(|c| c.as_os_str() == "win-64"),
+            "windows cache path should contain win-64"
         );
     }
 }

--- a/crates/rattler_cache/src/run_exports_cache/cache_key.rs
+++ b/crates/rattler_cache/src/run_exports_cache/cache_key.rs
@@ -1,6 +1,7 @@
 use rattler_conda_types::{package::CondaArchiveIdentifier, PackageRecord};
 use rattler_digest::{Md5Hash, Sha256Hash};
 use std::fmt::{Display, Formatter};
+use std::path::{Path, PathBuf};
 
 /// Provides a unique identifier for packages in the cache.
 #[derive(Debug, Hash, Clone, Eq, PartialEq)]
@@ -8,6 +9,7 @@ pub struct CacheKey {
     pub(crate) name: String,
     pub(crate) version: String,
     pub(crate) build_string: String,
+    pub(crate) subdir: Option<String>,
     pub(crate) sha256: Option<Sha256Hash>,
     pub(crate) md5: Option<Md5Hash>,
     pub(crate) extension: String,
@@ -38,6 +40,15 @@ impl CacheKey {
         self.md5
     }
 
+    /// Returns the cache path for this key, given a base directory.
+    pub fn cache_path(&self, base: &Path) -> PathBuf {
+        if let Some(subdir) = self.subdir.as_deref() {
+            base.join(subdir).join(self.to_string())
+        } else {
+            base.join(self.to_string())
+        }
+    }
+
     /// Return the sha256 hash string of the package if it is known.
     pub fn sha256_str(&self) -> String {
         self.sha256()
@@ -54,6 +65,7 @@ impl CacheKey {
             name: record.name.as_normalized().to_string(),
             version: record.version.to_string(),
             build_string: record.build.clone(),
+            subdir: Some(record.subdir.clone()),
             sha256: record.sha256,
             md5: record.md5,
             extension: archive_identifier.archive_type.extension().to_string(),

--- a/crates/rattler_cache/src/run_exports_cache/mod.rs
+++ b/crates/rattler_cache/src/run_exports_cache/mod.rs
@@ -78,6 +78,7 @@ pub struct BucketKey {
     name: String,
     version: String,
     build_string: String,
+    subdir: Option<String>,
     sha256_string: String,
 }
 
@@ -87,6 +88,7 @@ impl From<CacheKey> for BucketKey {
             name: key.name.clone(),
             version: key.version.clone(),
             build_string: key.build_string.clone(),
+            subdir: key.subdir.clone(),
             sha256_string: key.sha256_str(),
         }
     }
@@ -123,7 +125,7 @@ impl RunExportsCache {
         Fut: Future<Output = Result<Option<NamedTempFile>, E>> + Send + 'static,
         E: std::error::Error + Send + Sync + 'static,
     {
-        let cache_path = self.inner.path.join(cache_key.to_string());
+        let cache_path = cache_key.cache_path(&self.inner.path);
         let cache_entry = self
             .inner
             .run_exports


### PR DESCRIPTION
### Description

Fixes #612

Isolates package cache by platform using `subdir` from `PackageRecord` on `CacheKey`.
This prevents caching packages from different platforms over each other in cases where they share the same overarching string formatting pattern (`{name}-{version}-{build}`). E.g., `linux-64` and `win-64` caching the exact same package.

### How Has This Been Tested?

Added tests:
- `package_cache::test::test_cross_platform_package_cache`

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Google Gemini Assistant

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
