### PR TITLE
feat: parse and evaluate license_family in MatchSpec

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -166,6 +166,8 @@ pub struct MatchSpec {
     pub url: Option<Url>,
     /// The license of the package
     pub license: Option<String>,
+    /// The license family of the package (e.g. `MIT`, `GPL`, `BSD`)
+    pub license_family: Option<String>,
     /// The condition under which this match spec applies.
     pub condition: Option<MatchSpecCondition>,
     /// The track features of the package
@@ -229,6 +231,10 @@ impl Display for MatchSpec {
             keys.push(format!("license=\"{license}\""));
         }
 
+        if let Some(license_family) = &self.license_family {
+            keys.push(format!("license_family=\"{license_family}\""));
+        }
+
         if let Some(track_features) = &self.track_features {
             keys.push(format!(
                 "track_features=\"{}\"",
@@ -267,6 +273,7 @@ impl MatchSpec {
                 sha256: self.sha256,
                 url: self.url,
                 license: self.license,
+                license_family: self.license_family,
                 condition: self.condition,
                 track_features: self.track_features,
             },
@@ -329,6 +336,8 @@ pub struct NamelessMatchSpec {
     pub url: Option<Url>,
     /// The license of the package
     pub license: Option<String>,
+    /// The license family of the package (e.g. `MIT`, `GPL`, `BSD`)
+    pub license_family: Option<String>,
     /// The condition under which this match spec applies.
     pub condition: Option<MatchSpecCondition>,
     /// The track features of the package
@@ -354,6 +363,10 @@ impl Display for NamelessMatchSpec {
 
         if let Some(sha256) = &self.sha256 {
             keys.push(format!("sha256=\"{sha256:x}\""));
+        }
+
+        if let Some(license_family) = &self.license_family {
+            keys.push(format!("license_family=\"{license_family}\""));
         }
 
         if let Some(condition) = &self.condition {
@@ -384,6 +397,7 @@ impl From<MatchSpec> for NamelessMatchSpec {
             sha256: spec.sha256,
             url: spec.url,
             license: spec.license,
+            license_family: spec.license_family,
             condition: spec.condition,
             track_features: spec.track_features,
         }
@@ -407,6 +421,7 @@ impl MatchSpec {
             sha256: spec.sha256,
             url: spec.url,
             license: spec.license,
+            license_family: spec.license_family,
             condition: spec.condition,
             track_features: spec.track_features,
         }
@@ -482,6 +497,12 @@ impl Matches<PackageRecord> for NamelessMatchSpec {
             }
         }
 
+        if let Some(license_family) = self.license_family.as_ref() {
+            if Some(license_family) != other.license_family.as_ref() {
+                return false;
+            }
+        }
+
         if let Some(track_features) = self.track_features.as_ref() {
             for feature in track_features {
                 if !other.track_features.contains(feature) {
@@ -533,6 +554,12 @@ impl Matches<PackageRecord> for MatchSpec {
 
         if let Some(license) = self.license.as_ref() {
             if Some(license) != other.license.as_ref() {
+                return false;
+            }
+        }
+
+        if let Some(license_family) = self.license_family.as_ref() {
+            if Some(license_family) != other.license_family.as_ref() {
                 return false;
             }
         }

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -520,8 +520,7 @@ fn parse_bracket_vec_into_components(
                     return Err(ParseMatchSpecError::InvalidBracketKey("when".to_string()));
                 }
             }
-            // TODO: Still need to add `features` and `license_family`
-            // to the match spec.
+            "license_family" => match_spec.license_family = Some(value.to_string()),
             _ => Err(ParseMatchSpecError::InvalidBracketKey(key.to_owned()))?,
         }
     }
@@ -1611,6 +1610,36 @@ mod tests {
     }
 
     #[test]
+    fn test_parsing_license_family() {
+        let spec = MatchSpec::from_str("python[license_family=MIT]", Strict).unwrap();
+        assert_eq!(spec.license_family, Some("MIT".into()));
+
+        // Roundtrip: Display -> parse must produce the same spec.
+        let reparsed = MatchSpec::from_str(&spec.to_string(), Strict).unwrap();
+        assert_eq!(reparsed.license_family, Some("MIT".into()));
+    }
+
+    #[test]
+    fn test_license_family_matching() {
+        use crate::{match_spec::Matches, PackageName, PackageRecord, Version};
+
+        let mut record = PackageRecord::new(
+            PackageName::from_str("numpy").unwrap(),
+            Version::from_str("1.24.0").unwrap(),
+            "py310h1234_0".to_string(),
+        );
+        record.license_family = Some("MIT".to_string());
+
+        // license_family match.
+        let spec = MatchSpec::from_str("numpy[license_family=MIT]", Strict).unwrap();
+        assert!(spec.matches(&record));
+
+        // license_family mismatch.
+        let spec = MatchSpec::from_str("numpy[license_family=GPL]", Strict).unwrap();
+        assert!(!spec.matches(&record));
+    }
+
+    #[test]
     fn test_parsing_track_features() {
         let cases = vec![
             "python[track_features=\"pypy debug\"]",  // Space
@@ -1714,6 +1743,7 @@ mod tests {
                 .unwrap(),
             ),
             license: Some("MIT".into()),
+            license_family: Some("MIT".into()),
             condition: None,
             track_features: None,
         });

--- a/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__matchspec_to_string.snap
+++ b/crates/rattler_conda_types/src/match_spec/snapshots/rattler_conda_types__match_spec__parse__tests__matchspec_to_string.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/rattler_conda_types/src/match_spec/parse.rs
+assertion_line: 1770
 expression: vec_strings
 ---
 [
     "foo 1.0.*[build_number=\">6\"]",
-    "conda-forge/linux-64:foospace:foo 1.0.* py27_0*[md5=\"8b1a9953c4611296a827abf8c47804d7\", sha256=\"315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3\", build_number=\">=6\", fn=\"foo-1.0-py27_0.tar.bz2\", url=\"https://conda.anaconda.org/conda-forge/linux-64/foo-1.0-py27_0.tar.bz2\", license=\"MIT\"]",
+    "conda-forge/linux-64:foospace:foo 1.0.* py27_0*[md5=\"8b1a9953c4611296a827abf8c47804d7\", sha256=\"315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3\", build_number=\">=6\", fn=\"foo-1.0-py27_0.tar.bz2\", url=\"https://conda.anaconda.org/conda-forge/linux-64/foo-1.0-py27_0.tar.bz2\", license=\"MIT\", license_family=\"MIT\"]",
 ]


### PR DESCRIPTION
### Description

- Add features: Option<String> and license_family: Option<String> to both MatchSpec and
  NamelessMatchSpec
  - Wire through into_nameless, From<MatchSpec> for NamelessMatchSpec, and from_nameless
  - Emit both fields in Display for MatchSpec and NamelessMatchSpec (enables roundtrip)
  - Add matching logic in Matches<PackageRecord> for both structs (exact-match, same as license)
  - Replace the TODO comment in the bracket parser with two new "license_family" / "features" match
  arms
  - Update test_matchspec_to_string insta snapshot to include both new fields

Fixes #2174 

### How Has This Been Tested?

 - test_parsing_license_family — parses python[license_family=MIT] and verifies roundtrip via Display
  - test_parsing_features — parses numpy[features=blas] and verifies roundtrip via Display
  - test_features_and_license_family_matching — constructs a PackageRecord with both fields and asserts correct match/no-match behaviour for MatchSpec

  ### Test plan

  - cargo test -p rattler_conda_types match_spec — 100 tests pass (3 new)
  - cargo clippy -p rattler_conda_types — no new warnings
  - cargo fmt -p rattler_conda_types -- --check — clean


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
