### PR TITLE
Fix panic in sort_paths when path is not relative to base_path

### DIFF
--- a/crates/rattler_package_streaming/src/write.rs
+++ b/crates/rattler_package_streaming/src/write.rs
@@ -70,18 +70,36 @@ impl Read for ProgressBarReader {
 /// a function that sorts paths into two iterators, one that starts with `info/`
 /// and one that does not both iterators are sorted alphabetically for
 /// reproducibility
-fn sort_paths<'a>(paths: &'a [PathBuf], base_path: &'a Path) -> (Vec<PathBuf>, Vec<PathBuf>) {
+fn sort_paths(
+    paths: &[PathBuf],
+    base_path: &Path,
+) -> Result<(Vec<PathBuf>, Vec<PathBuf>), io::Error> {
     let info = Path::new("info/");
-    let (mut info_paths, mut other_paths): (Vec<_>, Vec<_>) = paths
+    let stripped: Vec<PathBuf> = paths
         .iter()
-        .map(|p| p.strip_prefix(base_path).unwrap())
-        .map(Path::to_path_buf)
-        .partition(|path| path.starts_with(info));
+        .map(|p| {
+            p.strip_prefix(base_path)
+                .map(Path::to_path_buf)
+                .map_err(|_| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "path `{}` is not relative to base path `{}`",
+                            p.display(),
+                            base_path.display()
+                        ),
+                    )
+                })
+        })
+        .collect::<Result<_, _>>()?;
+
+    let (mut info_paths, mut other_paths): (Vec<_>, Vec<_>) =
+        stripped.into_iter().partition(|p| p.starts_with(info));
 
     info_paths.sort();
     other_paths.sort();
 
-    (info_paths, other_paths)
+    Ok((info_paths, other_paths))
 }
 
 fn total_size(base_path: &Path, paths: &[PathBuf]) -> u64 {
@@ -146,7 +164,7 @@ pub fn write_tar_bz2_package<W: Write>(
     progress_bar_wrapper.set_total(total_size);
 
     // sort paths alphabetically, and sort paths beginning with `info/` first
-    let (info_paths, other_paths) = sort_paths(paths, base_path);
+    let (info_paths, other_paths) = sort_paths(paths, base_path)?;
     for path in info_paths.iter().chain(other_paths.iter()) {
         append_path_to_archive(
             &mut archive,
@@ -281,7 +299,7 @@ pub fn write_conda_package<W: Write + Seek>(
     outer_archive.start_file("metadata.json", options)?;
     outer_archive.write_all(package_metadata.as_bytes())?;
 
-    let (info_paths, other_paths) = sort_paths(paths, base_path);
+    let (info_paths, other_paths) = sort_paths(paths, base_path)?;
 
     let archive_path = format!("pkg-{out_name}.tar.zst");
 


### PR DESCRIPTION
## Summary

This PR fixes a long-standing panic in `rattler_package_streaming` where providing a path outside the `base_path` would crash the process. I've updated the private `sort_paths` helper to return a proper `io::Error` instead of using `.unwrap()`, bringing the code in line with our documented API contract.

---

## Fix

The issue was a "hidden" panic. While our public functions claimed to return errors for invalid paths, the internal logic used `.unwrap()` on `strip_prefix`, causing an unrecoverable crash if a caller passed a path from a different root.

### Before

```rust
.map(|p| p.strip_prefix(base_path).unwrap())
// ...
let (info_paths, other_paths) = sort_paths(paths, base_path);

```

### After

```rust
.map(|p| {
    p.strip_prefix(base_path)
        .map(Path::to_path_buf)
        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, format!("path `{}` is not relative...", p.display())))
})
.collect::<Result<Vec<_>, _>>()?;
// ...
let (info_paths, other_paths) = sort_paths(paths, base_path)?;

```

---

## Verification

To test this, pass a `PathBuf` from a different root (e.g., `/etc/hosts`) to `write_tar_bz2_package` while setting the `base_path` to your local build directory.

* **Expected**: The function should now return an `Err` containing the string `"is not relative to base path"`.
* **Result**: No more process-terminating panics during package creation.