### PR TITLE
fix: bz2 cache state overwritten with zst state in check_variant_avai…

### DIFF
--- a/crates/rattler_repodata_gateway/src/fetch/with_cache.rs
+++ b/crates/rattler_repodata_gateway/src/fetch/with_cache.rs
@@ -638,7 +638,7 @@ pub async fn check_variant_availability(
     let bz2_future = if has_zst == Some(true) {
         // If we already know that zst is available we simply copy the availability
         // value from the last time we checked.
-        ready(cache_state.and_then(|state| state.has_zst.clone())).right_future()
+        ready(cache_state.and_then(|state| state.has_bz2.clone())).right_future()
     } else {
         // If the zst variant might not be available we need to check whether bz2 is
         // available.


### PR DESCRIPTION
### Description

Small copy-paste bug in `check_variant_availability` — when the cached state already knows `.zst` is available, the code that preserves the existing `has_bz2` state was accidentally cloning `has_zst` instead.

This means every repodata fetch on a channel with `.zst` available overwrites the `has_bz2` field in the `.info.json` cache with the zst info. For channels that serve `.zst` but not `.bz2`, this flips `has_bz2` from `false` to `true` on the second fetch. If `.zst` later goes away, rattler falls back to trying `.bz2`, gets a 404, and fails hard with no further fallback.

**Fix:** one word change — `state.has_zst.clone()` -> `state.has_bz2.clone()` on the line that builds the `bz2_future`.

Fixes #NA

### How Has This Been Tested?

Manually traced through the cache write path to confirm the corrupted value is persisted to `.info.json`. The correct pattern is already used three lines below the bug site (line 649), confirming the intent. A channel that serves `.zst` but not `.bz2` can reproduce this by running two fetches and inspecting the cache file — `has_bz2.value` will incorrectly be `true`.

### AI Disclosure

- [x] This PR contains AI-generated content.
- [x] I have tested any AI-generated content in my PR.
- [x] I take responsibility for any AI-generated content in my PR.

Tools: Chatgpt, Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.