### PR TITLE
fix(rattler_index): Remove non-existent packages from repodata

### DIFF
--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -688,6 +688,10 @@ async fn index_subdir_inner(
         subdir
     );
 
+    for filename in &packages_to_delete {
+        registered_packages.remove(filename);
+    }
+
     let packages_to_add = uploaded_packages
         .difference(&registered_packages.keys().cloned().collect::<HashSet<_>>())
         .cloned()

--- a/crates/rattler_index/tests/integration/basic_indexing.rs
+++ b/crates/rattler_index/tests/integration/basic_indexing.rs
@@ -147,3 +147,61 @@ async fn test_index_empty_directory_creates_noarch_repodata() {
     assert!(repodata_zst_path.is_file());
     assert!(repodata_msgpack_path.is_file());
 }
+
+/// Validates that reindexing removes stale package entries from repodata when
+/// the package file is deleted from disk.
+#[tokio::test]
+async fn test_reindex_removes_deleted_conda_package() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let subdir_path = temp_dir.path().join("noarch");
+    let package_name = "empty-0.1.0-h4616a5c_0.conda";
+    let source_package = test_data_dir().join("packages").join(package_name);
+    let target_package = subdir_path.join(package_name);
+
+    fs::create_dir(&subdir_path).unwrap();
+    fs::copy(source_package, &target_package).unwrap();
+
+    index_fs(IndexFsConfig {
+        channel: temp_dir.path().into(),
+        target_platform: Some(Platform::NoArch),
+        repodata_patch: None,
+        write_zst: false,
+        write_shards: false,
+        force: false,
+        max_parallel: 1,
+        multi_progress: None,
+    })
+    .await
+    .unwrap();
+
+    let repodata_path = subdir_path.join("repodata.json");
+    let repodata_json: Value =
+        serde_json::from_reader(File::open(&repodata_path).unwrap()).unwrap();
+    assert!(repodata_json
+        .get("packages.conda")
+        .unwrap()
+        .get(package_name)
+        .is_some());
+
+    fs::remove_file(target_package).unwrap();
+
+    index_fs(IndexFsConfig {
+        channel: temp_dir.path().into(),
+        target_platform: Some(Platform::NoArch),
+        repodata_patch: None,
+        write_zst: false,
+        write_shards: false,
+        force: false,
+        max_parallel: 1,
+        multi_progress: None,
+    })
+    .await
+    .unwrap();
+
+    let repodata_json: Value = serde_json::from_reader(File::open(repodata_path).unwrap()).unwrap();
+    assert!(repodata_json
+        .get("packages.conda")
+        .unwrap()
+        .get(package_name)
+        .is_none());
+}


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #2195. The example from the issue returns now
```json
{"info":{"subdir":"noarch"},"packages":{},"packages.conda":{},"repodata_version":2}
```

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: codex

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

There is also a `removed` section in repodata.json. I think we explicitly _don't_ want to put it there: https://github.com/conda/ceps/blob/main/cep-0036.md#schema states:

> `removed: list[str]`. List of filenames that were once included in either packages or packages.conda, but are now removed. The corresponding artifacts SHOULD still be accessible via their direct URL.

If the package is not available at all anymore, this was probably done intentionally. At least to me it makes more sense if the removed section is only filled by repodata patches (this is already the case now).

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
