### PR TITLE
feat(py): Add download methods

### DIFF
--- a/py-rattler/rattler/package_streaming/__init__.py
+++ b/py-rattler/rattler/package_streaming/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 from rattler.networking.client import Client
 from rattler.rattler import download_bytes as py_download_bytes
 from rattler.rattler import download_to_path as py_download_to_path
+from rattler.rattler import download_to_writer as py_download_to_writer
 from rattler.rattler import download_and_extract as py_download_and_extract
 from rattler.rattler import extract as py_extract
 from rattler.rattler import extract_tar_bz2 as py_extract_tar_bz2
@@ -21,13 +22,35 @@ def extract_tar_bz2(path: PathLike[str], dest: PathLike[str]) -> Tuple[bytes, by
 
 
 async def download_to_path(client: Client, url: str, dest: PathLike[str]) -> None:
-    """Download a package archive from a URL to a destination path."""
+    """
+    Stream a package archive from a URL to a destination path.
+
+    This method does not buffer the whole response in Python memory. Response
+    bytes are fetched incrementally and written directly to `dest`.
+    """
     await py_download_to_path(client._client, url, dest)
 
 
 async def download_bytes(client: Client, url: str) -> bytes:
-    """Download a package archive from a URL into memory."""
+    """
+    Download a package archive from a URL into memory.
+
+    This is a convenience API. The full response body is buffered before the
+    `bytes` object is returned, so peak memory use scales with the artifact
+    size.
+    """
     return await py_download_bytes(client._client, url)
+
+
+async def download_to_writer(client: Client, url: str, writer: object) -> None:
+    """
+    Stream a package archive from a URL into a Python writer.
+
+    The response body is fetched incrementally. For each chunk, `writer.write`
+    is called with a `bytes` object. The writer must provide a synchronous
+    `write(bytes)` method, for example `io.BytesIO()` or an open binary file.
+    """
+    await py_download_to_writer(client._client, url, writer)
 
 
 async def download_and_extract(

--- a/py-rattler/src/lib.rs
+++ b/py-rattler/src/lib.rs
@@ -191,6 +191,7 @@ fn rattler<'py>(py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(package_streaming::extract, &m).unwrap())?;
     m.add_function(wrap_pyfunction!(package_streaming::download_to_path, &m).unwrap())?;
     m.add_function(wrap_pyfunction!(package_streaming::download_bytes, &m).unwrap())?;
+    m.add_function(wrap_pyfunction!(package_streaming::download_to_writer, &m).unwrap())?;
     m.add_function(wrap_pyfunction!(package_streaming::download_and_extract, &m).unwrap())?;
     m.add_function(
         wrap_pyfunction!(package_streaming::fetch_raw_package_file_from_url, &m).unwrap(),

--- a/py-rattler/src/package_streaming/mod.rs
+++ b/py-rattler/src/package_streaming/mod.rs
@@ -187,3 +187,38 @@ pub fn download_bytes<'a>(
 
     future_into_py(py, future)
 }
+
+#[pyfunction]
+pub fn download_to_writer<'a>(
+    py: Python<'a>,
+    client: PyClientWithMiddleware,
+    url: String,
+    writer: Py<PyAny>,
+) -> PyResult<Bound<'a, PyAny>> {
+    let url = parse_url(&url)?;
+    let future = async move {
+        let client: reqwest_middleware::ClientWithMiddleware = client.into();
+        let response = client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?
+            .error_for_status()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(io_error)?;
+            Python::with_gil(|py| {
+                writer
+                    .bind(py)
+                    .call_method1("write", (PyBytes::new(py, &chunk),))
+                    .map(|_| ())
+            })?;
+        }
+
+        Ok(())
+    };
+
+    future_into_py(py, future)
+}

--- a/py-rattler/tests/unit/test_package_streaming.py
+++ b/py-rattler/tests/unit/test_package_streaming.py
@@ -1,3 +1,5 @@
+import io
+
 import pytest
 from pathlib import Path
 from rattler.networking.middleware import MirrorMiddleware, OciMiddleware, GCSMiddleware
@@ -5,6 +7,7 @@ from rattler.package_streaming import (
     download_and_extract,
     download_bytes,
     download_to_path,
+    download_to_writer,
     extract,
 )
 from rattler.networking.client import Client
@@ -57,6 +60,29 @@ async def test_download_bytes(tmpdir: Path) -> None:
         "https://repo.prefix.dev/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_0.conda",
     )
 
+    assert bytes_data
+
+    destination.write_bytes(bytes_data)
+    extract(destination, extract_dest)
+
+    assert (extract_dest / "info").exists()
+    assert (extract_dest / "info" / "index.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_download_to_writer(tmpdir: Path) -> None:
+    destination = Path(tmpdir) / "download_to_writer.conda"
+    extract_dest = Path(tmpdir) / "download_to_writer_extract"
+    client = Client.default_client()
+    writer = io.BytesIO()
+
+    await download_to_writer(
+        client,
+        "https://repo.prefix.dev/conda-forge/noarch/boltons-24.0.0-pyhd8ed1ab_0.conda",
+        writer,
+    )
+
+    bytes_data = writer.getvalue()
     assert bytes_data
 
     destination.write_bytes(bytes_data)


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

there is currently no way of downloading a file given a client. this is necessary for https://github.com/pavelzw/pixi-browse/pull/7

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: codex

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
