### PR TITLE
chore: Rename `index-url` to `index` in v7 python packages

### DIFF
--- a/crates/rattler_lock/src/parse/models/v7/pypi_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/pypi_package_data.rs
@@ -37,7 +37,7 @@ pub(crate) struct PypiPackageDataModel<'a> {
     #[serde(default, skip_serializing_if = "Option::is_none", flatten)]
     pub hash: Cow<'a, Option<PackageHashes>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub index_url: Option<Cow<'a, url::Url>>,
+    pub index: Option<Cow<'a, url::Url>>,
     #[serde(default, skip_serializing_if = "<[String]>::is_empty")]
     pub requires_dist: Cow<'a, [String]>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -48,7 +48,7 @@ impl<'a> From<PypiPackageDataModel<'a>> for PypiPackageDataRaw {
     fn from(value: PypiPackageDataModel<'a>) -> Self {
         let index_url = match value.location.inner() {
             UrlOrPath::Url(_) => value
-                .index_url
+                .index
                 .map(std::borrow::Cow::into_owned)
                 .or_else(|| Some((*PYPI_URL).clone())),
             UrlOrPath::Path(_) => None,
@@ -89,7 +89,7 @@ impl<'a> From<&'a PypiPackageData> for PypiPackageDataModel<'a> {
             version: value.version.as_ref().map(Cow::Borrowed),
             location: Cow::Borrowed(&value.location),
             hash: Cow::Borrowed(&value.hash),
-            index_url,
+            index: index_url,
             requires_dist: requires_dist.into(),
             requires_python: Cow::Borrowed(&value.requires_python),
         }
@@ -172,7 +172,7 @@ mod tests {
             name: Cow::Owned("test-pkg".parse::<PackageName>().unwrap()),
             version: None,
             hash: Cow::Owned(None),
-            index_url: index_url.map(Cow::Owned),
+            index: index_url.map(Cow::Owned),
             requires_dist: Cow::Owned(vec![]),
             requires_python: Cow::Owned(None),
         }
@@ -219,7 +219,7 @@ mod tests {
         };
         let model = PypiPackageDataModel::from(&data);
         assert!(
-            model.index_url.is_none(),
+            model.index.is_none(),
             "default pypi.org URL should be elided"
         );
     }
@@ -237,7 +237,7 @@ mod tests {
             requires_python: None,
         };
         let model = PypiPackageDataModel::from(&data);
-        assert_eq!(model.index_url.as_deref(), Some(&custom),);
+        assert_eq!(model.index.as_deref(), Some(&custom),);
     }
 
     #[test]
@@ -252,6 +252,6 @@ mod tests {
             requires_python: None,
         };
         let model = PypiPackageDataModel::from(&data);
-        assert!(model.index_url.is_none());
+        assert!(model.index.is_none());
     }
 }

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__pypi_custom_index.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__pypi_custom_index.yml.snap
@@ -30,5 +30,5 @@ packages:
     name: requests
     version: 2.31.0
     sha256: 942c5a758f98d790eaed1a29cb6eefc7f0edf3fcb0fce8aea3fbd5951d1cae1b
-    index_url: "https://my-custom-index.example.com/simple"
+    index: "https://my-custom-index.example.com/simple"
     requires_python: ">=3.7"

--- a/test-data/conda-lock/v7/pypi_custom_index.yml
+++ b/test-data/conda-lock/v7/pypi_custom_index.yml
@@ -16,7 +16,7 @@ packages:
   - pypi: https://my-custom-index.example.com/packages/requests-2.31.0-py3-none-any.whl
     name: requests
     version: 2.31.0
-    index_url: https://my-custom-index.example.com/simple
+    index: https://my-custom-index.example.com/simple
     sha256: 942c5a758f98d790eaed1a29cb6eefc7f0edf3fcb0fce8aea3fbd5951d1cae1b
     requires_python: ">=3.7"
   - pypi: https://files.pythonhosted.org/packages/numpy-1.26.0-cp311-cp311-linux_x86_64.whl


### PR DESCRIPTION
Benefit: This is 4 letters shorter.

### How Has This Been Tested?

With the existing unit tests (which needed a bit of an update).

### AI Disclosure

None

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
