### PR TITLE
feat: expose PackageCache in py-rattler

### DIFF
--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -153,6 +153,11 @@ impl From<PackageCacheLayerError> for PackageCacheError {
 }
 
 impl PackageCacheLayer {
+    /// Returns the path of this cache layer.
+    pub fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+
     /// Determine if the layer is read-only in the filesystem
     pub fn is_readonly(&self) -> bool {
         self.path
@@ -314,6 +319,14 @@ impl PackageCache {
         }
     }
 
+    /// Returns all cache layer paths in their original insertion order.
+    pub fn paths(&self) -> Vec<&std::path::Path> {
+        self.inner
+            .layers
+            .iter()
+            .map(PackageCacheLayer::path)
+            .collect()
+    }
     /// Returns a tuple containing two sets of layers:
     /// - A collection of read-only layers.
     /// - A collection of writable layers.

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -3714,6 +3714,7 @@ dependencies = [
  "pyo3-file",
  "pythonize",
  "rattler",
+ "rattler_cache",
  "rattler_conda_types",
  "rattler_config",
  "rattler_digest",

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -33,6 +33,7 @@ rattler_s3 = { path = "../crates/rattler_s3", features = ["serde"]}
 rattler = { path = "../crates/rattler", default-features = false, features = [
     "indicatif",
 ] }
+rattler_cache = { path = "../crates/rattler_cache", default-features = false }
 rattler_repodata_gateway = { path = "../crates/rattler_repodata_gateway", default-features = false, features = [
     "sparse",
     "gateway",

--- a/py-rattler/rattler/__init__.py
+++ b/py-rattler/rattler/__init__.py
@@ -44,6 +44,7 @@ from rattler.lock import (
     PypiLockedPackage,
 )
 from rattler.solver import solve, solve_with_sparse_repodata
+from rattler.package_cache import PackageCache, ValidationMode
 
 __version__ = _get_rattler_version()
 del _get_rattler_version
@@ -103,6 +104,8 @@ __all__ = [
     "NoArchLiteral",
     "Link",
     "LinkType",
+    "PackageCache",
+    "ValidationMode",
 ]
 
 # PTY support - only available on Unix platforms

--- a/py-rattler/rattler/exceptions.py
+++ b/py-rattler/rattler/exceptions.py
@@ -22,6 +22,7 @@ try:
         InvalidVersionSpecError,
         IoError,
         LinkError,
+        PackageCacheError,
         PackageNameMatcherParseError,
         ParseArchError,
         ParseCondaLockError,
@@ -105,6 +106,9 @@ except ImportError:
     class LinkError(Exception):  # type: ignore[no-redef]
         """An error that can occur when linking a package"""
 
+    class PackageCacheError(Exception):  # type: ignore[no-redef]
+        """An error that can occur when interacting with the package cache."""
+
     class PackageNameMatcherParseError(Exception):  # type: ignore[no-redef]
         """Error that can occur when parsing a package name matcher"""
 
@@ -165,6 +169,7 @@ __all__ = [
     "InvalidVersionSpecError",
     "IoError",
     "LinkError",
+    "PackageCacheError",
     "PackageNameMatcherParseError",
     "ParseArchError",
     "ParseCondaLockError",

--- a/py-rattler/rattler/package_cache.py
+++ b/py-rattler/rattler/package_cache.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+from typing import List
+
+from rattler.rattler import PyPackageCache, PyValidationMode
+
+
+class ValidationMode(Enum):
+    """Controls how cached packages are validated."""
+
+    Skip = PyValidationMode.Skip
+    Fast = PyValidationMode.Fast
+    Full = PyValidationMode.Full
+
+
+class PackageCache:
+    """Manages a cache of extracted Conda packages on disk.
+
+    Supports single-directory and layered (multi-directory) configurations.
+    In a layered setup, layers are queried in the order they were provided.
+    The first writable layer is used for storing newly fetched packages.
+
+    Examples
+    --------
+    >>> from pathlib import Path
+    >>> import tempfile, os
+    >>> d = tempfile.mkdtemp()
+    >>> cache = PackageCache(Path(d))
+    >>> os.path.isdir(d)
+    True
+    """
+
+    def __init__(
+        self,
+        path: Path,
+        *,
+        cache_origin: bool = False,
+        validation_mode: ValidationMode = ValidationMode.Skip,
+    ) -> None:
+        self._inner = PyPackageCache(path, cache_origin, validation_mode.value)
+
+    @classmethod
+    def new_layered(
+        cls,
+        paths: List[Path],
+        *,
+        cache_origin: bool = False,
+        validation_mode: ValidationMode = ValidationMode.Skip,
+    ) -> PackageCache:
+        """Construct a layered PackageCache from multiple directories.
+
+        Parameters
+        ----------
+        paths : list of Path
+            Cache directories in priority order.
+        cache_origin : bool, optional
+            Include the origin in the cache key. Defaults to ``False``.
+        validation_mode : ValidationMode, optional
+            Validation level. Defaults to ``ValidationMode.Skip``.
+
+        Examples
+        --------
+        >>> import tempfile
+        >>> d1, d2 = tempfile.mkdtemp(), tempfile.mkdtemp()
+        >>> cache = PackageCache.new_layered([Path(d1), Path(d2)])
+        >>> len(cache.paths()) == 2
+        True
+        """
+        cache = cls.__new__(cls)
+        cache._inner = PyPackageCache.new_layered(paths, cache_origin, validation_mode.value)
+        return cache
+
+    def paths(self) -> List[Path]:
+        """Returns all cache layer paths in their original insertion order."""
+        return [Path(p) for p in self._inner.paths()]
+
+    def writable_paths(self) -> List[Path]:
+        """Returns only writable cache layer paths."""
+        return [Path(p) for p in self._inner.writable_paths()]
+
+    def readonly_paths(self) -> List[Path]:
+        """Returns only read-only cache layer paths."""
+        return [Path(p) for p in self._inner.readonly_paths()]
+
+    def __repr__(self) -> str:
+        return f"PackageCache(paths={self.paths()!r})"

--- a/py-rattler/src/error.rs
+++ b/py-rattler/src/error.rs
@@ -93,6 +93,8 @@ pub enum PyRattlerError {
     InvalidHeaderValueError(#[from] reqwest::header::InvalidHeaderValue),
     #[error(transparent)]
     FromSdkError(#[from] rattler_s3::FromSDKError),
+    #[error(transparent)]
+    PackageCacheError(#[from] rattler::package_cache::PackageCacheError),
 }
 
 fn pretty_print_error(mut err: &dyn Error) -> String {
@@ -208,6 +210,9 @@ impl From<PyRattlerError> for PyErr {
             }
             PyRattlerError::InvalidHeaderValueError(err) => {
                 crate::exceptions::InvalidHeaderValueError::new_err(pretty_print_error(&err))
+            }
+            PyRattlerError::PackageCacheError(err) => {
+                crate::exceptions::PackageCacheError::new_err(pretty_print_error(&err))
             }
             PyRattlerError::FromSdkError(err) => PyValueError::new_err(pretty_print_error(&err)),
         }

--- a/py-rattler/src/exceptions.rs
+++ b/py-rattler/src/exceptions.rs
@@ -35,3 +35,4 @@ create_exception!(exceptions, AuthenticationStorageError, PyException);
 create_exception!(exceptions, ShellError, PyException);
 create_exception!(exceptions, InvalidHeaderNameError, PyException);
 create_exception!(exceptions, InvalidHeaderValueError, PyException);
+create_exception!(exceptions, PackageCacheError, PyException);

--- a/py-rattler/src/lib.rs
+++ b/py-rattler/src/lib.rs
@@ -29,6 +29,7 @@ mod virtual_package;
 
 mod exceptions;
 mod index_json;
+mod package_cache;
 mod run_exports_json;
 
 use std::ops::Deref;
@@ -41,10 +42,10 @@ use exceptions::{
     ConversionError, ConvertSubdirError, DetectVirtualPackageError, EnvironmentCreationError,
     FetchRepoDataError, InvalidChannelError, InvalidHeaderNameError, InvalidHeaderValueError,
     InvalidMatchSpecError, InvalidPackageNameError, InvalidUrlError, InvalidVersionError,
-    InvalidVersionSpecError, IoError, LinkError, PackageNameMatcherParseError, ParseArchError,
-    ParseCondaLockError, ParseExplicitEnvironmentSpecError, ParsePlatformError, RequirementError,
-    ShellError, SolverError, TransactionError, ValidatePackageRecordsError, VersionBumpError,
-    VersionExtendError,
+    InvalidVersionSpecError, IoError, LinkError, PackageCacheError, PackageNameMatcherParseError,
+    ParseArchError, ParseCondaLockError, ParseExplicitEnvironmentSpecError, ParsePlatformError,
+    RequirementError, ShellError, SolverError, TransactionError, ValidatePackageRecordsError,
+    VersionBumpError, VersionExtendError,
 };
 use explicit_environment_spec::{PyExplicitEnvironmentEntry, PyExplicitEnvironmentSpec};
 use generic_virtual_package::PyGenericVirtualPackage;
@@ -64,6 +65,7 @@ use networking::middleware::{
 };
 use networking::{client::PyClientWithMiddleware, py_fetch_repo_data};
 use no_arch_type::PyNoArchType;
+use package_cache::{PyPackageCache, PyValidationMode};
 use package_name::PyPackageName;
 use package_name_matcher::PyPackageNameMatcher;
 use paths_json::{PyFileMode, PyPathType, PyPathsEntry, PyPathsJson, PyPrefixPlaceholder};
@@ -200,6 +202,8 @@ fn rattler<'py>(py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()> {
     // Explicit environment specification
     m.add_class::<PyExplicitEnvironmentSpec>()?;
     m.add_class::<PyExplicitEnvironmentEntry>()?;
+    m.add_class::<PyPackageCache>()?;
+    m.add_class::<PyValidationMode>()?;
 
     // Exceptions
     m.add("InvalidVersionError", py.get_type::<InvalidVersionError>())?;
@@ -281,6 +285,8 @@ fn rattler<'py>(py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()> {
         "InvalidHeaderValueError",
         py.get_type::<InvalidHeaderValueError>(),
     )?;
+
+    m.add("PackageCacheError", py.get_type::<PackageCacheError>())?;
 
     Ok(())
 }

--- a/py-rattler/src/package_cache.rs
+++ b/py-rattler/src/package_cache.rs
@@ -1,0 +1,76 @@
+use std::path::PathBuf;
+
+use pyo3::prelude::*;
+use rattler::package_cache::PackageCache;
+use rattler_cache::validation::ValidationMode;
+
+#[pyclass(eq, eq_int)]
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub enum PyValidationMode {
+    Skip,
+    Fast,
+    Full,
+}
+
+impl From<PyValidationMode> for ValidationMode {
+    fn from(mode: PyValidationMode) -> Self {
+        match mode {
+            PyValidationMode::Skip => ValidationMode::Skip,
+            PyValidationMode::Fast => ValidationMode::Fast,
+            PyValidationMode::Full => ValidationMode::Full,
+        }
+    }
+}
+
+impl From<ValidationMode> for PyValidationMode {
+    fn from(mode: ValidationMode) -> Self {
+        match mode {
+            ValidationMode::Skip => PyValidationMode::Skip,
+            ValidationMode::Fast => PyValidationMode::Fast,
+            ValidationMode::Full => PyValidationMode::Full,
+        }
+    }
+}
+
+#[pyclass]
+#[repr(transparent)]
+pub struct PyPackageCache {
+    pub(crate) inner: PackageCache,
+}
+
+#[pymethods]
+impl PyPackageCache {
+    #[new]
+    #[pyo3(signature = (path, cache_origin=false, validation_mode=PyValidationMode::Skip))]
+    pub fn new(path: PathBuf, cache_origin: bool, validation_mode: PyValidationMode) -> Self {
+        let inner =
+            PackageCache::new_layered(std::iter::once(path), cache_origin, validation_mode.into());
+        Self { inner }
+    }
+
+    #[staticmethod]
+    #[pyo3(signature = (paths, cache_origin=false, validation_mode=PyValidationMode::Skip))]
+    pub fn new_layered(
+        paths: Vec<PathBuf>,
+        cache_origin: bool,
+        validation_mode: PyValidationMode,
+    ) -> Self {
+        Self {
+            inner: PackageCache::new_layered(paths, cache_origin, validation_mode.into()),
+        }
+    }
+
+    pub fn paths(&self) -> Vec<PathBuf> {
+        self.inner.paths().iter().map(|p| p.to_path_buf()).collect()
+    }
+
+    pub fn writable_paths(&self) -> Vec<PathBuf> {
+        let (_, writable) = self.inner.split_layers();
+        writable.iter().map(|l| l.path().to_path_buf()).collect()
+    }
+
+    pub fn readonly_paths(&self) -> Vec<PathBuf> {
+        let (readonly, _) = self.inner.split_layers();
+        readonly.iter().map(|l| l.path().to_path_buf()).collect()
+    }
+}

--- a/py-rattler/tests/unit/test_package_cache.py
+++ b/py-rattler/tests/unit/test_package_cache.py
@@ -1,0 +1,125 @@
+import pathlib
+import sys
+import tempfile
+
+import pytest
+
+from rattler import PackageCache, ValidationMode
+
+
+def test_single_dir_paths() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        cache = PackageCache(pathlib.Path(d))
+        assert cache.paths() == [pathlib.Path(d)]
+
+
+def test_single_dir_with_options_paths() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        cache = PackageCache(
+            pathlib.Path(d),
+            cache_origin=True,
+            validation_mode=ValidationMode.Full,
+        )
+        assert cache.paths() == [pathlib.Path(d)]
+
+
+def test_layered_dirs_preserves_insertion_order() -> None:
+    with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
+        cache = PackageCache.new_layered([pathlib.Path(d1), pathlib.Path(d2)])
+        paths = cache.paths()
+        assert paths == [pathlib.Path(d1), pathlib.Path(d2)]
+
+
+def test_layered_dirs_with_options() -> None:
+    with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
+        cache = PackageCache.new_layered(
+            [pathlib.Path(d1), pathlib.Path(d2)],
+            cache_origin=True,
+            validation_mode=ValidationMode.Fast,
+        )
+        paths = cache.paths()
+        assert len(paths) == 2
+        assert paths[0] == pathlib.Path(d1)
+        assert paths[1] == pathlib.Path(d2)
+
+
+def test_writable_paths_includes_normal_dir() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        cache = PackageCache(pathlib.Path(d))
+        assert pathlib.Path(d) in cache.writable_paths()
+
+
+def test_writable_dir_has_no_readonly_paths() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        cache = PackageCache(pathlib.Path(d))
+        assert cache.readonly_paths() == []
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="readonly dir permissions are not reliable on Windows",
+)
+def test_readonly_layer_is_not_in_writable_paths() -> None:
+    with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
+        pathlib.Path(d1).chmod(0o555)
+        try:
+            cache = PackageCache.new_layered([pathlib.Path(d1), pathlib.Path(d2)])
+            assert pathlib.Path(d1) in cache.readonly_paths()
+            assert pathlib.Path(d1) not in cache.writable_paths()
+        finally:
+            pathlib.Path(d1).chmod(0o755)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="readonly dir permissions are not reliable on Windows",
+)
+def test_writable_layer_is_not_in_readonly_paths() -> None:
+    with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
+        pathlib.Path(d1).chmod(0o555)
+        try:
+            cache = PackageCache.new_layered([pathlib.Path(d1), pathlib.Path(d2)])
+            assert pathlib.Path(d2) in cache.writable_paths()
+            assert pathlib.Path(d2) not in cache.readonly_paths()
+        finally:
+            pathlib.Path(d1).chmod(0o755)
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="readonly dir permissions are not reliable on Windows",
+)
+def test_paths_preserves_order_with_mixed_permissions() -> None:
+    with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2, tempfile.TemporaryDirectory() as d3:
+        pathlib.Path(d2).chmod(0o555)
+        try:
+            cache = PackageCache.new_layered([pathlib.Path(d1), pathlib.Path(d2), pathlib.Path(d3)])
+            assert cache.paths() == [
+                pathlib.Path(d1),
+                pathlib.Path(d2),
+                pathlib.Path(d3),
+            ]
+        finally:
+            pathlib.Path(d2).chmod(0o755)
+
+
+def test_repr_contains_path() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        cache = PackageCache(pathlib.Path(d))
+        assert d in repr(cache)
+        assert repr(cache).startswith("PackageCache(paths=")
+
+
+def test_repr_layered_contains_all_paths() -> None:
+    with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
+        cache = PackageCache.new_layered([pathlib.Path(d1), pathlib.Path(d2)])
+        r = repr(cache)
+        assert d1 in r
+        assert d2 in r
+
+
+def test_writable_paths_preserve_order() -> None:
+    with tempfile.TemporaryDirectory() as d1, tempfile.TemporaryDirectory() as d2:
+        cache = PackageCache.new_layered([pathlib.Path(d1), pathlib.Path(d2)])
+        writable = cache.writable_paths()
+        assert writable == [pathlib.Path(d1), pathlib.Path(d2)]


### PR DESCRIPTION
### Description

PR #1003 added a layered package cache to the Rust core but it was never exposed to Python. This PR adds the Python bindings for `PackageCache` and `ValidationMode`.

Users can now do:
```python
from rattler import PackageCache, ValidationMode
from pathlib import Path

cache = PackageCache(Path("/tmp/cache"))

# or with multiple layers
cache = PackageCache.new_layered(
    [Path("/slow/cache"), Path("/fast/cache")],
    validation_mode=ValidationMode.Fast,
)

cache.paths()
cache.writable_paths()
cache.readonly_paths()
```

Fixes #632 

### How Has This Been Tested?

Added 12 unit tests in `py-rattler/tests/unit/test_package_cache.py`.
```bash
cd py-rattler && pytest tests/unit/test_package_cache.py -v
```

### AI Disclosure

- [x] This PR contains AI-generated content.(testfile has been written with the help of ai)
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.