### PR TITLE
fix(docs): correct rustdoc merge and add /py-rattler/ redirect so docs URLs work

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -109,8 +109,9 @@ jobs:
       - name: Merge rustdoc into gh-pages
         run: |
           git clone --branch gh-pages https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git gh-pages-repo
-          cp -r target/doc gh-pages-repo/rattler
+          cp -r target/doc/. gh-pages-repo/
           echo '<meta http-equiv="refresh" content="0; url=rattler/index.html">' > gh-pages-repo/index.html
+          echo '<meta http-equiv="refresh" content="0; url=latest/">' > gh-pages-repo/py-rattler/index.html
           echo "User-Agent: *" > gh-pages-repo/robots.txt
           echo "Disallow: /" >> gh-pages-repo/robots.txt
           touch gh-pages-repo/.nojekyll
@@ -159,8 +160,9 @@ jobs:
       - name: Merge rustdoc into gh-pages
         run: |
           git clone --branch gh-pages https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git gh-pages-repo
-          cp -r target/doc gh-pages-repo/rattler
+          cp -r target/doc/. gh-pages-repo/
           echo '<meta http-equiv="refresh" content="0; url=rattler/index.html">' > gh-pages-repo/index.html
+          echo '<meta http-equiv="refresh" content="0; url=latest/">' > gh-pages-repo/py-rattler/index.html
           echo "User-Agent: *" > gh-pages-repo/robots.txt
           echo "Disallow: /" >> gh-pages-repo/robots.txt
           touch gh-pages-repo/.nojekyll


### PR DESCRIPTION


### Description

Fixes two docs deployment issues on `rattler.prefix.dev`.

1. `/py-rattler/` had no page because docs were only deployed under `/py-rattler/latest/` and `/py-rattler/dev/`.
   A redirect is added so `https://rattler.prefix.dev/py-rattler/` redirects to `https://rattler.prefix.dev/py-rattler/latest/`.

2. Rust docs were previously deployed with an extra nested directory at `/rattler/rattler/`.
   The deploy step now places the Rustdoc output directly in the correct location.
   The documentation is now served at `https://rattler.prefix.dev/rattler/index.html`.



### How Has This Been Tested?

- Checked the workflow YAML and the copy/redirect steps.
- Deployed from a fork to GitHub Pages and confirmed:
  - **Python docs (latest):** https://anshgrover23.github.io/rattler/py-rattler/latest/
  - **Rust docs:** https://anshgrover23.github.io/rattler/rattler/index.html
 
### Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes

---

**Note for maintainers:** After merging, the fix will apply the next time the docs workflow runs (e.g. on push to `main` or when the workflow is triggered). For `/py-rattler/` to successfully redirect to `latest/`, **you’ll need to do a new release** so the release docs job runs and deploys the `latest` Python docs to gh-pages.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->