### PR TITLE
fix: replace panicking unwrap/expect in mirror, S3, and GCS middleware

### DIFF
--- a/crates/rattler_networking/src/gcs_middleware.rs
+++ b/crates/rattler_networking/src/gcs_middleware.rs
@@ -127,13 +127,21 @@ impl Middleware for GCSMiddleware {
     ) -> MiddlewareResult<Response> {
         if req.url().scheme() == "gcs" {
             let mut url = req.url().clone();
-            let bucket_name = url.host_str().expect("Host should be present in GCS URL");
+            let bucket_name = url.host_str().ok_or_else(|| {
+                reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                    "Host should be present in GCS URL, got: {url}"
+                ))
+            })?;
             let new_url = format!(
                 "https://storage.googleapis.com/{}{}",
                 bucket_name,
                 url.path()
             );
-            url = Url::parse(&new_url).expect("Failed to parse URL");
+            url = Url::parse(&new_url).map_err(|e| {
+                reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                    "Failed to parse constructed GCS URL '{new_url}': {e}"
+                ))
+            })?;
             *req.url_mut() = url;
             req = self.authenticate(req).await?;
         }

--- a/crates/rattler_networking/src/mirror_middleware.rs
+++ b/crates/rattler_networking/src/mirror_middleware.rs
@@ -118,7 +118,11 @@ impl Middleware for MirrorMiddleware {
                 };
 
                 let mirror = &selected_mirror.mirror;
-                let selected_url = mirror.url.join(url_rest).unwrap();
+                let selected_url = mirror.url.join(url_rest).map_err(|e| {
+                    reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                        "Failed to join mirror URL with '{url_rest}': {e}"
+                    ))
+                })?;
 
                 // Short-circuit if the mirror does not support the file type
                 if url_rest.ends_with(".json.zst") && mirror.no_zstd {

--- a/crates/rattler_networking/src/s3_middleware.rs
+++ b/crates/rattler_networking/src/s3_middleware.rs
@@ -247,7 +247,12 @@ impl Middleware for S3Middleware {
         let url = req.url().clone();
         let presigned_url = self.s3.generate_presigned_s3_url(url, req.method()).await?;
         *req.url_mut() = presigned_url;
-        next.run(req.try_clone().unwrap(), extensions).await
+        let cloned_req = req.try_clone().ok_or_else(|| {
+            reqwest_middleware::Error::Middleware(anyhow::anyhow!(
+                "Failed to clone S3 request: request body is a non-cloneable stream"
+            ))
+        })?;
+        next.run(cloned_req, extensions).await
     }
 }
 


### PR DESCRIPTION
## Summary

  - Replace `mirror.url.join(url_rest).unwrap()` with `?`-propagation in `MirrorMiddleware::handle`
  - Replace `req.try_clone().unwrap()` with `ok_or_else(...)?` in `S3Middleware::handle`
  - Replace two `.expect()` calls in `GCSMiddleware::handle` (`host_str` and `Url::parse`) with
  `ok_or_else`/`map_err` + `?`

  All three middleware `handle` functions already return `Result`, so no public API changes are needed. A malformed URL or non-cloneable request body now surfaces as a `reqwest_middleware::Error` instead of unwinding the async runtime.

Fixes #2215 

### How Has This Been Tested?

All tests pass, also send a request with a `data:` scheme URL through `MirrorMiddleware` and confirm an error is returned, not a panic


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->


@baszalmstra 