### PR TITLE
fix: stop retrying permanent filesystem errors in should_retry()

### DIFF
--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -96,12 +96,20 @@ impl ExtractError {
     /// network streaming operations.
     pub fn should_retry(&self) -> bool {
         match self {
-            // Retry on all I/O errors during streaming - these are typically
-            // transient network issues (broken pipe, connection reset, etc.)
-            // The cache layer will clean up partial files on retry.
-            // TODO: Add more specific checks for transient I/O errors
-            ExtractError::IoError(_) => true,
-            ExtractError::CouldNotCreateDestination(_) => true,
+            // Only retry on I/O errors that are genuinely transient network
+            // conditions.
+            ExtractError::IoError(err) => matches!(
+                err.kind(),
+                std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::BrokenPipe
+                    | std::io::ErrorKind::UnexpectedEof
+                    | std::io::ErrorKind::TimedOut
+                    // transient network interruptions and should be retried.
+                    | std::io::ErrorKind::Interrupted
+            ),
+            // CouldNotCreateDestination covers PermissionDenied, disk full,
+            // and invalid paths — none of which resolve on retry.
+            ExtractError::CouldNotCreateDestination(_) => false,
             #[cfg(feature = "reqwest")]
             ExtractError::ReqwestError(err) => {
                 // Check if this is a connection error (includes broken pipe during connection)
@@ -184,7 +192,7 @@ mod tests {
             std::io::ErrorKind::ConnectionAborted,
             "connection aborted",
         ));
-        assert!(err.should_retry());
+        assert!(!err.should_retry());
     }
 
     #[test]
@@ -193,7 +201,7 @@ mod tests {
             std::io::ErrorKind::ConnectionRefused,
             "connection refused",
         ));
-        assert!(err.should_retry());
+        assert!(!err.should_retry());
     }
 
     #[test]
@@ -202,7 +210,7 @@ mod tests {
             std::io::ErrorKind::NotConnected,
             "not connected",
         ));
-        assert!(err.should_retry());
+        assert!(!err.should_retry());
     }
 
     #[test]
@@ -220,7 +228,7 @@ mod tests {
             std::io::ErrorKind::NotFound,
             "not found",
         ));
-        assert!(err.should_retry());
+        assert!(!err.should_retry());
     }
 
     #[test]
@@ -229,14 +237,14 @@ mod tests {
             std::io::ErrorKind::PermissionDenied,
             "permission denied",
         ));
-        assert!(err.should_retry());
+        assert!(!err.should_retry());
     }
 
     #[test]
     fn test_should_retry_could_not_create_destination() {
         let err =
             ExtractError::CouldNotCreateDestination(std::io::Error::other("could not create"));
-        assert!(err.should_retry());
+        assert!(!err.should_retry());
     }
 
     #[test]


### PR DESCRIPTION

## Summary

  - Narrow `ExtractError::IoError` retry to only genuinely transient network  error kinds: `ConnectionReset`, `BrokenPipe`, `UnexpectedEof`, `TimedOut`
  - Set `ExtractError::CouldNotCreateDestination` to `false` — PermissionDenied, disk full, and invalid paths will never succeed on retry
  - Acknowledged the `TODO` comment properly 

The cache layer retries with exponential backoff, so a permanent `PermissionDenied` would sleep many seconds across 3 pointless attempts before surfacing the error. This makes failures slow and misleading.



Fixes #2217 

### How Has This Been Tested?

  - All CI checks pass
  -  Manual: verify a `PermissionDenied` during extraction returns immediately without retrying


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->


@baszalmstra 