### PR TITLE
fix: StrictVersion Ord contract violation

### DIFF
--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -1034,7 +1034,7 @@ impl<'v> SegmentIter<'v> {
 /// this is not equal. Useful in ranges where we are talking
 /// about equality over version ranges instead of specific
 /// version instances
-#[derive(Clone, PartialOrd, Ord, Eq, Debug, Deserialize)]
+#[derive(Clone, Eq, Debug, Deserialize)]
 pub struct StrictVersion(pub Version);
 
 impl PartialEq for StrictVersion {
@@ -1066,6 +1066,22 @@ impl Hash for StrictVersion {
         self.0.epoch().hash(state);
         hash_segments(state, self.0.segments());
         hash_segments(state, self.0.local_segments());
+    }
+}
+
+impl Ord for StrictVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Use Version's semantic ordering as the primary key, then break ties
+        // using the raw component count.
+        self.0
+            .cmp(&other.0)
+            .then_with(|| self.0.components.len().cmp(&other.0.components.len()))
+    }
+}
+
+impl PartialOrd for StrictVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 
@@ -1273,18 +1289,75 @@ mod test {
 
     #[test]
     fn strict_version_test() {
-        let v_1_0 = StrictVersion::from_str("1.0.0").unwrap();
+        let v_1_0_0 = StrictVersion::from_str("1.0.0").unwrap();
         // Should be equal to itself
-        assert_eq!(v_1_0, v_1_0);
-        let v_1_0_0 = StrictVersion::from_str("1.0").unwrap();
-        // Strict version should not discard zero's
-        assert_ne!(v_1_0, v_1_0_0);
-        // Ordering should stay the same as version
-        assert_eq!(v_1_0.cmp(&v_1_0_0), Ordering::Equal);
+        assert_eq!(v_1_0_0, v_1_0_0);
+        let v_1_0 = StrictVersion::from_str("1.0").unwrap();
+        // Strict version should not discard trailing zeros
+        assert_ne!(v_1_0_0, v_1_0);
 
-        // Hashing should consider v_1_0 and v_1_0_0 as unequal
-        assert_eq!(get_hash(&v_1_0), get_hash(&v_1_0));
-        assert_ne!(get_hash(&v_1_0), get_hash(&v_1_0_0));
+        // Hashing should consider v_1_0_0 and v_1_0 as unequal
+        assert_eq!(get_hash(&v_1_0_0), get_hash(&v_1_0_0));
+        assert_ne!(get_hash(&v_1_0_0), get_hash(&v_1_0));
+    }
+
+    /// Regression test: `StrictVersion::cmp` must not return `Equal` for
+    /// versions that `StrictVersion::eq` considers different.
+    #[test]
+    fn strict_version_ord_contract() {
+        let v100 = StrictVersion::from_str("1.0.0").unwrap();
+        let v10 = StrictVersion::from_str("1.0").unwrap();
+
+        // PartialEq: distinct strict versions
+        assert_ne!(v100, v10);
+
+        // Ord: must not return Equal for unequal values
+        assert_ne!(v100.cmp(&v10), Ordering::Equal);
+        assert_ne!(v10.cmp(&v100), Ordering::Equal);
+
+        // Ordering must be antisymmetric
+        assert_eq!(v10.cmp(&v100), Ordering::Less);
+        assert_eq!(v100.cmp(&v10), Ordering::Greater);
+
+        // Reflexivity
+        assert_eq!(v100.cmp(&v100), Ordering::Equal);
+        assert_eq!(v10.cmp(&v10), Ordering::Equal);
+
+        // BTreeSet must hold both as distinct entries
+        let mut set = std::collections::BTreeSet::new();
+        set.insert(v10.clone());
+        set.insert(v100.clone());
+        assert_eq!(set.len(), 2, "BTreeSet lost one entry due to Ord violation");
+
+        // Sort and dedup must preserve both entries
+        let mut vec = vec![v100.clone(), v10.clone(), v100.clone()];
+        vec.sort();
+        vec.dedup();
+        assert_eq!(vec.len(), 2, "dedup collapsed distinct strict versions");
+
+        // Semantic comparison via the inner Version is still Equal
+        assert_eq!(v100.0.cmp(&v10.0), Ordering::Equal);
+    }
+
+    #[test]
+    fn strict_version_ord_with_genuine_differences() {
+        // Versions that are genuinely less/greater should order correctly
+        let cases: &[(&str, &str)] = &[
+            ("1.0", "2.0"),
+            ("1.0.0", "2.0.0"),
+            ("1.0", "1.1"),
+            ("1.0.0", "1.0.1"),
+        ];
+        for (lesser, greater) in cases {
+            let a = StrictVersion::from_str(lesser).unwrap();
+            let b = StrictVersion::from_str(greater).unwrap();
+            assert_eq!(
+                a.cmp(&b),
+                Ordering::Less,
+                "{lesser} should be Less than {greater}"
+            );
+            assert_eq!(b.cmp(&a), Ordering::Greater);
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Description

### Problem                                                                                                       
  
  StrictVersion derived Ord and PartialOrd, delegating to Version::Ord. Version::Ord collapses trailing zeros —  so "1.0".cmp("1.0.0") == Ordering::Equal. But StrictVersion::PartialEq is manually implemented and checks raw component counts first, making "1.0" != "1.0.0".                                                              
                                                                                                              
  This violates Rust's Ord contract: a.cmp(b) == Equal if and only if a == b.                                   
  
  ### Consequences:                                                                                                 
  - BTreeMap<StrictVersion, _> and BTreeSet<StrictVersion> silently lose entries ("1.0" and "1.0.0" as keys may
  collide)                                                                                                      
  - sort() + dedup() on Vec<StrictVersion> collapses distinct versions
  - VersionSpec (which derives Ord and has a StrictRange(_, StrictVersion) variant) inherits the broken         
  invariant                                                                                                     

The existing strict_version_test even asserted the broken behavior (assert_eq!(v_1_0.cmp(&v_1_0_0), Ordering::Equal)).   

Fixes #2224 

### How Has This Been Tested?

- Updated strict_version_test, replaced the assertion of the broken behavior with the correct expected       
  ordering                                                                                                      
  - Added strict_version_ord_contract which verifies cmp != Equal for unequal values, antisymmetry, BTreeSet        
  correctness (both entries survive), and sort+dedup correctness                                                
  - Added strict_version_ord_with_genuine_differences that verifies that semantically ordered versions ("1.0" < 
  "2.0", etc.) still order correctly after the fix.


### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
