### PR TITLE
fix(rattler_repodata_gateway): apply all matching pattern specs, not just the first

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -1716,4 +1716,73 @@ mod test {
             "glob should find all lib-* packages across both sources and both subdirs"
         );
     }
+
+    /// Regression test: when two patterns both match the same package name,
+    /// ALL matching patterns' specs must be collected, not just the first one.
+    #[tokio::test]
+    async fn test_multi_pattern_all_specs_applied() {
+        use rattler_conda_types::ParseStrictnessWithNameMatcher;
+
+        let gateway = Gateway::new();
+
+        // Source has three python records at different versions.
+        let mut source = MockRepoDataSource::new();
+        source.add_record(
+            Platform::Linux64,
+            make_test_record("python", "2.7.18", "linux-64"),
+        );
+        source.add_record(
+            Platform::Linux64,
+            make_test_record("python", "3.8.20", "linux-64"),
+        );
+        source.add_record(
+            Platform::Linux64,
+            make_test_record("python", "3.10.14", "linux-64"),
+        );
+
+        let spec1 = MatchSpec::from_str(
+            "py* >=3.0",
+            ParseStrictnessWithNameMatcher {
+                parse_strictness: Strict,
+                exact_names_only: false,
+            },
+        )
+        .unwrap();
+        let spec2 = MatchSpec::from_str(
+            "python* <3.9",
+            ParseStrictnessWithNameMatcher {
+                parse_strictness: Strict,
+                exact_names_only: false,
+            },
+        )
+        .unwrap();
+
+        let src: Arc<dyn super::RepoDataSource> = Arc::new(source);
+
+        let records = gateway
+            .query(
+                vec![super::Source::Custom(src)],
+                vec![Platform::Linux64],
+                vec![spec1, spec2].into_iter(),
+            )
+            .recursive(false)
+            .await
+            .unwrap();
+
+        let mut versions: Vec<_> = records
+            .iter()
+            .flat_map(RepoData::iter)
+            .map(|r| r.package_record.version.to_string())
+            .collect();
+        versions.sort();
+
+        assert_eq!(
+            versions,
+            vec!["2.7.18", "3.10.14", "3.8.20"],
+            "all three python versions should be returned: \
+             2.7.18 satisfies the second pattern (<3.9), \
+             3.8.20 and 3.10.14 satisfy the first pattern (>=3.0). \
+             If only 3.8.20 and 3.10.14 are returned the bug is present."
+        );
+    }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -445,23 +445,28 @@ impl QueryExecutor {
                 continue;
             }
 
+            // Skip names already committed via an exact spec or a transitive
+            if self.seen.contains_key(name.as_normalized()) {
+                continue;
+            }
+
+            // Apply ALL matching patterns, not just the first.
             for (matcher, spec) in &self.pending_pattern_specs {
                 if matcher.matches(&name) {
-                    if self
-                        .seen
-                        .insert(name.as_normalized().to_string(), ())
-                        .is_none()
-                    {
-                        let pending = self
-                            .pending_package_specs
-                            .entry(name.clone())
-                            .or_insert_with(|| SourceSpecs::Input(vec![]));
-                        if let SourceSpecs::Input(input_specs) = pending {
-                            input_specs.push(spec.clone());
-                        }
+                    let pending = self
+                        .pending_package_specs
+                        .entry(name.clone())
+                        .or_insert_with(|| SourceSpecs::Input(vec![]));
+                    if let SourceSpecs::Input(input_specs) = pending {
+                        input_specs.push(spec.clone());
                     }
-                    break;
                 }
+            }
+
+            // Mark as seen after the full pattern scan so that all matching
+            // specs are collected before the name is considered committed.
+            if self.pending_package_specs.contains_key(&name) {
+                self.seen.insert(name.as_normalized().to_string(), ());
             }
         }
     }


### PR DESCRIPTION
### Description

- Fixed expand_pattern_specs_for_subdir silently dropping all but the first pattern spec for any package name is
  matched by multiple glob/regex patterns     
 - Added regression test proving all three python versions are returned when queried with two overlapping        
  patterns  

Fixes #2228 

### How Has This Been Tested?

test_multi_pattern_all_specs_applied — a MockRepoDataSource carrying python 2.7.18, 3.8.20, and 3.10.14 is queried with two overlapping patterns (py* >=3.0 and python* <3.9). The test asserts all three versions are returned. Before the fix only 3.8.20 and 3.10.14 are returned, making the regression immediately visible.

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->


@baszalmstra 