### PR TITLE
fix: upload token matching for anaconda.org

### DIFF
--- a/crates/rattler_upload/src/upload/mod.rs
+++ b/crates/rattler_upload/src/upload/mod.rs
@@ -220,12 +220,12 @@ pub async fn upload_package_to_anaconda(
 ) -> Result<(), anaconda::AnacondaError> {
     let token = match anaconda_data.api_key {
         Some(token) => token,
-        None => match storage.get("anaconda.org") {
-            Ok(Some(Authentication::CondaToken(token))) => token,
-            Ok(Some(_)) => {
+        None => match storage.get_by_url(Url::from(anaconda_data.url.clone())) {
+            Ok((_, Some(Authentication::CondaToken(token)))) => token,
+            Ok((_, Some(_))) => {
                 return Err(anaconda::AnacondaError::WrongAuthenticationType);
             }
-            Ok(None) => {
+            Ok((_, None)) => {
                 return Err(anaconda::AnacondaError::MissingApiKey);
             }
             Err(e) => {


### PR DESCRIPTION
### Description

Fixes uploading to Anaconda.org with the token coming from `pixi auth` / `rattler auth`. We store a wildcard token (`*.anaconda.org`) that was not properly matched.


### How Has This Been Tested?

Tested with new `pixi publish`.

### AI Disclosure

Tools: Claude
