### PR TITLE
feat: add RichInstallerReporter and deprecate show_progress

### DIFF
--- a/py-rattler/pyproject.toml
+++ b/py-rattler/pyproject.toml
@@ -29,6 +29,9 @@ Documentation = "https://conda.github.io/rattler/py-rattler/"
 Repository = "https://github.com/conda/rattler"
 Issues = "https://github.com/conda/rattler/labels/python-bindings"
 
+[project.optional-dependencies]
+rich = ["rich>=10.0.0"]
+
 [tool.maturin]
 features = ["pyo3/extension-module"]
 
@@ -45,6 +48,10 @@ disable_error_code = ["empty-body"]
 
 [[tool.mypy.overrides]]
 module = ["rattler.rattler"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["rich", "rich.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/py-rattler/rattler/__init__.py
+++ b/py-rattler/rattler/__init__.py
@@ -31,7 +31,7 @@ from rattler.package import (
 from rattler.prefix import PrefixRecord, PrefixPaths, PrefixPathsEntry, PrefixPathType, Link, LinkType
 from rattler.platform import Platform
 from rattler.utils.rattler_version import get_rattler_version as _get_rattler_version
-from rattler.install import install, InstallerReporter
+from rattler.install import install, InstallerReporter, RichInstallerReporter
 from rattler.index import index
 from rattler.lock import (
     LockFile,
@@ -90,6 +90,7 @@ __all__ = [
     "Platform",
     "install",
     "InstallerReporter",
+    "RichInstallerReporter",
     "index",
     "AboutJson",
     "RunExportsJson",

--- a/py-rattler/rattler/install/__init__.py
+++ b/py-rattler/rattler/install/__init__.py
@@ -1,3 +1,4 @@
 from rattler.install.installer import install, InstallerReporter
+from rattler.install.rich_reporter import RichInstallerReporter
 
-__all__ = ["install", "InstallerReporter"]
+__all__ = ["install", "InstallerReporter", "RichInstallerReporter"]

--- a/py-rattler/rattler/install/installer.py
+++ b/py-rattler/rattler/install/installer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import os
+import warnings
 from typing import List, Optional, Protocol, runtime_checkable
 
 from rattler.match_spec import MatchSpec
@@ -312,7 +313,7 @@ async def install(
     ...     records = await solve(sources=["conda-forge"], specs=["python 3.9.*"])
     ...
     ...     # Link the environment in a temporary directory (you can pass any kind of path here).
-    ...     await install(records, target_prefix=temp_dir.name)
+    ...     await install(records, target_prefix=temp_dir.name, show_progress=False)
     ...
     ...     # That's it! The environment is now created.
     ...     # You will find Python under `f"{temp_dir.name}/bin/python"` or `f"{temp_dir.name}/python.exe"` on Windows.
@@ -339,7 +340,9 @@ async def install(
         execute_link_scripts: whether to execute the post-link and pre-unlink scripts
                 that may be part of a package. Defaults to False.
         show_progress: If set to `True` a progress bar will be shown on the CLI.
-                Ignored when `reporter` is provided.
+                **Deprecated** — pass `reporter=RichInstallerReporter()` instead
+                (`pip install py-rattler[rich]`). This parameter will be removed in a
+                future release.
         client: An authenticated client to use for downloading packages. If not specified a default
                 client will be used.
         requested_specs: A list of `MatchSpec`s that were originally requested. These will be used
@@ -347,8 +350,17 @@ async def install(
                 If `None`, the `requested_specs` field will remain empty.
         reporter: An optional :class:`InstallerReporter` instance that receives progress
                 callbacks during installation. When provided, `show_progress` is ignored.
-                Subclass :class:`InstallerReporter` and override the methods you need.
+                Use :class:`rattler.install.RichInstallerReporter` for a rich-powered
+                progress display (requires ``rich``).
     """
+
+    if show_progress and reporter is None:
+        warnings.warn(
+            "The 'show_progress' parameter is deprecated and will be removed in a future release. "
+            "Use 'reporter=RichInstallerReporter()' instead for rich progress output.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     await py_install(
         records=records,

--- a/py-rattler/rattler/install/rich_reporter.py
+++ b/py-rattler/rattler/install/rich_reporter.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+try:
+    from rich.console import Group
+    from rich.live import Live
+    from rich.progress import (
+        BarColumn,
+        DownloadColumn,
+        MofNCompleteColumn,
+        Progress,
+        SpinnerColumn,
+        TaskID,
+        TextColumn,
+        TimeRemainingColumn,
+        TransferSpeedColumn,
+    )
+
+    _RICH_AVAILABLE = True
+except ImportError:
+    _RICH_AVAILABLE = False
+
+from rattler.install.installer import InstallerReporter
+
+
+class RichInstallerReporter(InstallerReporter):
+    """
+    An :class:`InstallerReporter` that renders live progress bars using
+    `rich <https://github.com/Textualize/rich>`_.
+
+    Requires the ``rich`` package::
+
+        pip install rich
+        # or, using the extras declared by py-rattler:
+        pip install py-rattler[rich]
+
+    The display consists of three stacked progress panels:
+
+    * **Overall** — a single progress bar tracking completed / total packages with ETA.
+    * **Downloads** — one transient bar per active download with bytes, speed, and ETA.
+    * **Links / Unlinks** — one transient spinner row per active link or unlink operation.
+
+    Example
+    -------
+    ```python
+    from rattler import solve, install
+    from rattler.install import RichInstallerReporter
+    import asyncio
+
+    async def main():
+        records = await solve(["conda-forge"], ["python 3.11.*"])
+        await install(records, "/tmp/myenv", reporter=RichInstallerReporter())
+
+    asyncio.run(main())
+    ```
+    """
+
+    def __init__(self) -> None:
+        if not _RICH_AVAILABLE:
+            raise ImportError(
+                "The 'rich' package is required to use RichInstallerReporter.\n"
+                "Install it with:  pip install rich\n"
+                "or:               pip install py-rattler[rich]"
+            )
+
+        self._overall_progress: Progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[bold green]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeRemainingColumn(),
+        )
+
+        self._download_progress: Progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[cyan]{task.description:<40}"),
+            BarColumn(),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+            TimeRemainingColumn(),
+        )
+
+        self._link_progress: Progress = Progress(
+            SpinnerColumn(),
+            TextColumn("{task.description}"),
+        )
+
+        self._live: Live = Live(
+            Group(
+                self._overall_progress,
+                self._download_progress,
+                self._link_progress,
+            ),
+            refresh_per_second=10,
+        )
+
+        self._overall_task: Optional[TaskID] = None
+        self._total_operations: int = 0
+        self._completed_operations: int = 0
+        self._cache_entry_names: Dict[int, str] = {}
+        self._download_tasks: Dict[int, TaskID] = {}
+        self._link_tasks: Dict[int, TaskID] = {}
+
+    def on_transaction_start(self, total_operations: int) -> None:
+        self._total_operations = total_operations
+        self._live.start()
+        self._overall_task = self._overall_progress.add_task(
+            f"Installing {total_operations} package{'s' if total_operations != 1 else ''}",
+            total=total_operations,
+        )
+
+    def on_transaction_complete(self) -> None:
+        if self._overall_task is not None:
+            self._overall_progress.update(
+                self._overall_task,
+                description="[bold green]✓ Installation complete",
+                completed=self._total_operations,
+            )
+        self._live.stop()
+
+    def on_populate_cache_start(self, operation: int, package_name: str) -> int:
+        self._cache_entry_names[operation] = package_name
+        return operation
+
+    def on_populate_cache_complete(self, cache_entry: int) -> None:
+        self._cache_entry_names.pop(cache_entry, None)
+
+    def on_download_start(self, cache_entry: int) -> int:
+        package_name = self._cache_entry_names.get(cache_entry, "unknown")
+        task_id = self._download_progress.add_task(
+            f"Downloading {package_name}",
+            total=None,
+            start=True,
+        )
+        download_idx = int(task_id)
+        self._download_tasks[download_idx] = task_id
+        return download_idx
+
+    def on_download_progress(self, download_idx: int, progress: int, total: Optional[int]) -> None:
+        task_id = self._download_tasks.get(download_idx)
+        if task_id is not None:
+            self._download_progress.update(task_id, completed=progress, total=total)
+
+    def on_download_completed(self, download_idx: int) -> None:
+        task_id = self._download_tasks.pop(download_idx, None)
+        if task_id is not None:
+            self._download_progress.remove_task(task_id)
+
+    def on_link_start(self, operation: int, package_name: str) -> int:
+        task_id = self._link_progress.add_task(
+            f"[blue]Linking   [bold]{package_name}",
+            total=None,
+        )
+        link_idx = int(task_id)
+        self._link_tasks[link_idx] = task_id
+        return link_idx
+
+    def on_link_complete(self, index: int) -> None:
+        task_id = self._link_tasks.pop(index, None)
+        if task_id is not None:
+            self._link_progress.remove_task(task_id)
+        self._completed_operations += 1
+        if self._overall_task is not None:
+            self._overall_progress.update(self._overall_task, advance=1)
+
+    def on_unlink_start(self, operation: int, package_name: str) -> int:
+        task_id = self._link_progress.add_task(
+            f"[yellow]Removing  [bold]{package_name}",
+            total=None,
+        )
+        unlink_idx = int(task_id)
+        self._link_tasks[unlink_idx] = task_id
+        return unlink_idx
+
+    def on_unlink_complete(self, index: int) -> None:
+        task_id = self._link_tasks.pop(index, None)
+        if task_id is not None:
+            self._link_progress.remove_task(task_id)
+        self._completed_operations += 1
+        if self._overall_task is not None:
+            self._overall_progress.update(self._overall_task, advance=1)


### PR DESCRIPTION
### Description

### Summary

Follow-up to #2187. The  InstallerReporter is a @runtime_checkable Protocol, this PR ships a first-party rich-powered implementation so users get a beautiful live progress display without writing their own reporter.

https://github.com/conda/rattler/pull/2187#pullrequestreview-3942559500 addressed this comment and implemented this properly
@baszalmstra 


This PR implements a ready-to-use InstallerReporter backed by rich that renders three stacked live panels:

 
``` ┌─────────────────┬─────────────────────────────────────────────────────────────────────────────┐
  │      Panel      │                                   Content                                   │
  ├─────────────────┼─────────────────────────────────────────────────────────────────────────────┤
  │ Overall         │ Transaction progress bar — packages done / total with ETA                   │
  ├─────────────────┼─────────────────────────────────────────────────────────────────────────────┤
  │ Downloads       │ One transient bar per active download with bytes, speed, and time remaining │
  ├─────────────────┼─────────────────────────────────────────────────────────────────────────────┤
  │ Links / Unlinks │ One transient spinner row per active link or unlink operation               │
  └─────────────────┴─────────────────────────────────────────────────────────────────────────────┘
```

  Also raises a clear ImportError with install instructions when rich is not available.


  # Before

```python
  await install(records, prefix)
```

  # After

```python
  from rattler.install import RichInstallerReporter
  await install(records, prefix, reporter=RichInstallerReporter())
```

  RichInstallerReporter is re-exported from both rattler.install and the top-level rattler package.



### How Has This Been Tested?

  - Manual: pip install py-rattler[rich] and run an install verify the three live panels render
  - Manual: without rich installed, RichInstallerReporter() raises ImportError with instructions
  - Manual: install(records, prefix) without reporter emits DeprecationWarning



### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->



@baszalmstra 