### PR TITLE
fix: only retry transient I/O errors in should_retry

### DIFF
--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -96,12 +96,22 @@ impl ExtractError {
     /// network streaming operations.
     pub fn should_retry(&self) -> bool {
         match self {
-            // Retry on all I/O errors during streaming - these are typically
-            // transient network issues (broken pipe, connection reset, etc.)
-            // The cache layer will clean up partial files on retry.
-            // TODO: Add more specific checks for transient I/O errors
-            ExtractError::IoError(_) => true,
-            ExtractError::CouldNotCreateDestination(_) => true,
+            // Only retry on transient network-related I/O errors. Permanent filesystem
+            // errors (PermissionDenied, NotFound, etc.) will never succeed on retry.
+            ExtractError::IoError(io_err) => matches!(
+                io_err.kind(),
+                std::io::ErrorKind::BrokenPipe
+                    | std::io::ErrorKind::ConnectionReset
+                    | std::io::ErrorKind::ConnectionAborted
+                    | std::io::ErrorKind::ConnectionRefused
+                    | std::io::ErrorKind::NotConnected
+                    | std::io::ErrorKind::Interrupted
+                    | std::io::ErrorKind::UnexpectedEof
+                    | std::io::ErrorKind::TimedOut
+                    | std::io::ErrorKind::WouldBlock
+            ),
+            // CouldNotCreateDestination is always a local filesystem error — never retry.
+            ExtractError::CouldNotCreateDestination(_) => false,
             #[cfg(feature = "reqwest")]
             ExtractError::ReqwestError(err) => {
                 // Check if this is a connection error (includes broken pipe during connection)
@@ -220,7 +230,7 @@ mod tests {
             std::io::ErrorKind::NotFound,
             "not found",
         ));
-        assert!(err.should_retry());
+        assert!(!err.should_retry());
     }
 
     #[test]
@@ -229,14 +239,14 @@ mod tests {
             std::io::ErrorKind::PermissionDenied,
             "permission denied",
         ));
-        assert!(err.should_retry());
+        assert!(!err.should_retry());
     }
 
     #[test]
     fn test_should_retry_could_not_create_destination() {
         let err =
             ExtractError::CouldNotCreateDestination(std::io::Error::other("could not create"));
-        assert!(err.should_retry());
+        assert!(!err.should_retry());
     }
 
     #[test]

--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -109,6 +109,12 @@ impl ExtractError {
                     | std::io::ErrorKind::UnexpectedEof
                     | std::io::ErrorKind::TimedOut
                     | std::io::ErrorKind::WouldBlock
+                    // `Other` covers decompressor/zip-reader errors that arise from a
+                    // truncated network stream (e.g. async_zip maps upstream failures to
+                    // `std::io::Error::other`).  Permanent errors like `PermissionDenied`
+                    // and `NotFound` have their own explicit `ErrorKind` variants and are
+                    // never wrapped as `Other`, so this does not reintroduce the original bug.
+                    | std::io::ErrorKind::Other
             ),
             // CouldNotCreateDestination is always a local filesystem error — never retry.
             ExtractError::CouldNotCreateDestination(_) => false,
@@ -221,6 +227,13 @@ mod tests {
             std::io::ErrorKind::UnexpectedEof,
             "unexpected eof",
         ));
+        assert!(err.should_retry());
+    }
+
+    #[test]
+    fn test_should_retry_io_error_other() {
+        // `Other` covers decompressor/zip-reader errors from a truncated network stream.
+        let err = ExtractError::IoError(std::io::Error::other("zip reader failed"));
         assert!(err.should_retry());
     }
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -4509,7 +4509,7 @@ packages:
   license: BSD-3-Clause
 - conda: crates/rattler_index
   name: rattler_index
-  version: 0.27.16
+  version: 0.27.17
   build: h63dd304_0
   subdir: win-64
   variants:
@@ -4523,7 +4523,7 @@ packages:
   license: BSD-3-Clause
 - conda: crates/rattler_index
   name: rattler_index
-  version: 0.27.16
+  version: 0.27.17
   build: h81443ed_0
   subdir: linux-64
   variants:
@@ -4536,7 +4536,7 @@ packages:
   license: BSD-3-Clause
 - conda: crates/rattler_index
   name: rattler_index
-  version: 0.27.16
+  version: 0.27.17
   build: had755fd_0
   subdir: osx-arm64
   variants:
@@ -4547,7 +4547,7 @@ packages:
   license: BSD-3-Clause
 - conda: crates/rattler_index
   name: rattler_index
-  version: 0.27.16
+  version: 0.27.17
   build: hd97dafd_0
   subdir: osx-64
   variants:


### PR DESCRIPTION
## **Description**

Improve `ExtractError::should_retry()` to only retry transient I/O errors. Currently, permanent errors like `PermissionDenied` and `NotFound` are retried, causing slow failures and confusing logs during installs. This change makes it fail fast and resolves the existing TODO.



## **Fixes**

Retries are now limited to transient errors (e.g. `ConnectionReset`, `TimedOut`), while permanent errors like `PermissionDenied`, `NotFound`, and `CouldNotCreateDestination` no longer retry, reducing delays and improving error clarity.


## **How Has This Been Tested?**

Tests were updated to reflect the new behavior. Also verified manually with a read-only directory, which now fails immediately without retries.


## **AI Disclosure**

* [x] This PR includes AI-assisted content
* [x] All AI-generated contributions were tested
* [x] I take full responsibility for the changes

Tools: ChatGPT, Claude

## **Checklist**

* [x] Tests updated
* [x] No breaking changes
* [x] Small, self-contained change
* [x] Improves real-world behavior

