### PR TITLE
fix: normalize channel names to URLs for correct comparison in solver

### DIFF
--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -326,7 +326,6 @@ impl<'a> CondaDependencyProvider<'a> {
             .map(|name| pool.intern_package_name(name))
             .collect();
 
-        // TODO: Normalize these channel names to urls so we can compare them correctly.
         let channel_specific_specs = match_specs
             .iter()
             .filter(|spec| spec.channel.is_some())
@@ -475,7 +474,21 @@ impl<'a> CondaDependencyProvider<'a> {
                         // Check if the spec has a channel, and compare it to the repodata
                         // channel
                         if let Some(spec_channel) = &spec.channel {
-                            if record.channel.as_ref() != Some(&spec_channel.canonical_name()) {
+                            let spec_channel_name = spec_channel.canonical_name();
+                            let spec_base_url =
+                                spec_channel.base_url.as_str().trim_end_matches('/');
+
+                            let is_match = match &record.channel {
+                                Some(record_channel) => {
+                                    let record_channel_trimmed =
+                                        record_channel.trim_end_matches('/');
+                                    record_channel_trimmed == spec_channel_name
+                                        || record_channel_trimmed == spec_base_url
+                                }
+                                None => false,
+                            };
+
+                            if !is_match {
                                 tracing::debug!("Ignoring {} {} because it was not requested from that channel.", &record.package_record.name.as_normalized(), match &record.channel {
                                         Some(channel) => format!("from {}", &channel),
                                         None => "without a channel".to_string(),


### PR DESCRIPTION
### Description

When a user specifies a channel-specific dependency like `conda-forge::python`, the solver compares the requested channel against each repodata record's channel. Previously, this comparison used only `canonical_name()` (e.g., `conda-forge`), but `record.channel` can be a full URL (e.g., `https://conda.anaconda.org/conda-forge/`), causing valid packages to be incorrectly filtered out.

This PR normalizes the channel comparison by matching against both the canonical name and the base URL, with trailing slash stripping. This resolves a TODO in the codebase at [crates/rattler_solve/src/resolvo/mod.rs](cci:7://file:///d:/open%20source/rattler/crates/rattler_solve/src/resolvo/mod.rs:0:0-0:0).

**Before:**
```rust
if record.channel.as_ref() != Some(&spec_channel.canonical_name()) {
```
**After:**
```rust
let spec_channel_name = spec_channel.canonical_name();
let spec_base_url = spec_channel.base_url.as_str().trim_end_matches('/');

let is_match = match &record.channel {
    Some(record_channel) => {
        let record_channel_trimmed = record_channel.trim_end_matches('/');
        record_channel_trimmed == spec_channel_name
            || record_channel_trimmed == spec_base_url
    }
    None => false,
};
```


### How Has This Been Tested?
- All existing `rattler_solve` tests pass (9 tests): `cargo test -p rattler_solve`
- `cargo fmt --check -p rattler_solve` passes cleanly
- `cargo clippy -p rattler_solve -- -D warnings` passes with no warnings

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}
Claude

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
