### PR TITLE
test: Add error case, display roundtrip, and serde roundtrip tests for EntryPoint

### DIFF
--- a/crates/rattler_conda_types/src/package/entry_point.rs
+++ b/crates/rattler_conda_types/src/package/entry_point.rs
@@ -92,4 +92,50 @@ mod test {
 
         insta::assert_yaml_snapshot!(entry_point);
     }
+
+    #[test]
+    fn test_entry_point_errors() {
+        // Missing '=' separator entirely
+        assert!(EntryPoint::from_str("no_equals_sign").is_err());
+
+        // Missing ':' separator between module and function
+        assert!(EntryPoint::from_str("cmd = module_only").is_err());
+
+        // Empty string
+        assert!(EntryPoint::from_str("").is_err());
+    }
+
+    #[test]
+    fn test_entry_point_display_roundtrip() {
+        let original = EntryPoint {
+            command: "my-tool".to_string(),
+            module: "my_package.cli".to_string(),
+            function: "run".to_string(),
+        };
+
+        // Display → string → FromStr should roundtrip
+        let displayed = original.to_string();
+        assert_eq!(displayed, "my-tool = my_package.cli:run");
+
+        let parsed = EntryPoint::from_str(&displayed).unwrap();
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn test_entry_point_serde_roundtrip() {
+        let original = EntryPoint {
+            command: "pip".to_string(),
+            module: "pip._internal.cli.main".to_string(),
+            function: "main".to_string(),
+        };
+
+        // Serialize to JSON
+        let json = serde_json::to_string(&original).unwrap();
+        // Serialization uses Display format (a plain string)
+        assert_eq!(json, r#""pip = pip._internal.cli.main:main""#);
+
+        // Deserialize back
+        let deserialized: EntryPoint = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, original);
+    }
 }


### PR DESCRIPTION
# EntryPoint Parsing Robustness Tests

## Description

Strengthens the robustness of [`EntryPoint`](crates/rattler_conda_types/src/package/entry_point.rs) parsing in `rattler_conda_types` by adding unit tests that cover previously untested code paths.

Added 3 new unit tests to [crates/rattler_conda_types/src/package/entry_point.rs](crates/rattler_conda_types/src/package/entry_point.rs):

- **`test_entry_point_errors`** — Validates that malformed input strings are properly rejected (missing `=`, missing `:`, empty input)
- **`test_entry_point_display_roundtrip`** — Ensures `Display → FromStr` roundtrip produces an identical `EntryPoint`
- **`test_entry_point_serde_roundtrip`** — Verifies JSON serialize/deserialize fidelity with the custom `Serialize`/`Deserialize` implementations

**No production code changes** — test-only additions.

**Fixes** [#2243 ]

## How Has This Been Tested?

All entry_point tests pass:

```bash
cargo test -p rattler_conda_types -- entry_point

test package::entry_point::test::test_entry_point ... ok
test package::entry_point::test::test_entry_point_errors ... ok
test package::entry_point::test::test_entry_point_display_roundtrip ... ok
test package::entry_point::test::test_entry_point_serde_roundtrip ... ok 

test result: ok. 4 passed; 0 failed; 0 ignored
```

## AI Disclosure

- [x] This PR contains AI-generated content
  - [x] I have tested any AI-generated content in my PR
  - [x] I take responsibility for any AI-generated content in my PR

**Tools**: Gemini

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes




