### PR TITLE
fix(ci): update pixi.lock and sync it in release workflow

### DIFF
--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -94,3 +94,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Set up pixi
+        if: steps.release-plz.outputs.prs_created == 'true'
+        uses: prefix-dev/setup-pixi@82d477f15f3a381dbcc8adc1206ce643fe110fb7 # v0.9.3
+
+      - name: Update pixi lockfile on release branch
+        if: steps.release-plz.outputs.prs_created == 'true'
+        env:
+          RELEASE_BRANCH: ${{ fromJSON(steps.release-plz.outputs.pr).head_branch }}
+        run: |
+          git checkout "$RELEASE_BRANCH"
+          pixi install
+          if git diff --quiet pixi.lock; then
+            echo "pixi.lock is already up-to-date"
+          else
+            git add pixi.lock
+            git commit -m "chore: update pixi.lock"
+            git push origin "$RELEASE_BRANCH"
+          fi

--- a/pixi.lock
+++ b/pixi.lock
@@ -4509,7 +4509,7 @@ packages:
   license: BSD-3-Clause
 - conda: crates/rattler_index
   name: rattler_index
-  version: 0.27.17
+  version: 0.27.18
   build: h63dd304_0
   subdir: win-64
   variants:
@@ -4523,7 +4523,7 @@ packages:
   license: BSD-3-Clause
 - conda: crates/rattler_index
   name: rattler_index
-  version: 0.27.17
+  version: 0.27.18
   build: h81443ed_0
   subdir: linux-64
   variants:
@@ -4536,7 +4536,7 @@ packages:
   license: BSD-3-Clause
 - conda: crates/rattler_index
   name: rattler_index
-  version: 0.27.17
+  version: 0.27.18
   build: had755fd_0
   subdir: osx-arm64
   variants:
@@ -4547,7 +4547,7 @@ packages:
   license: BSD-3-Clause
 - conda: crates/rattler_index
   name: rattler_index
-  version: 0.27.17
+  version: 0.27.18
   build: hd97dafd_0
   subdir: osx-64
   variants:


### PR DESCRIPTION
### Description

The release PR #2232 bumped all `Cargo.toml` versions but didn't regenerate `pixi.lock`, leaving `pixi install --locked` broken on main. Additionally, the release PR had no CI checks because PRs created by `GITHUB_TOKEN` don't trigger workflows.

This PR:
- Updates `pixi.lock` to match the current `Cargo.toml` versions
- Adds steps to the `release-plz-pr` job in `release-rust.yaml` to run `pixi install` and commit the updated lockfile to the release branch after release-plz creates a PR
- The follow-up push uses `RELEASE_PLZ_TOKEN` (a PAT via the checkout step), which also triggers CI on release PRs

### How Has This Been Tested?

- Verified `pixi install --locked` fails on current `main` and passes with the updated `pixi.lock`
- The workflow changes will be validated on the next release-plz run

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code