### PR TITLE
fix: logic bug in collect_env_vars causing spurious warnings

### DIFF
--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -860,7 +860,7 @@ mod tests {
         }
     }
 
-    /// Regression test for: https://github.com/conda/rattler/issues/2253
+    /// Regression test for: <https://github.com/conda/rattler/issues/2253>
     ///
     /// `collect_env_vars` used to check `state_env_vars.contains_key(key)` while
     /// iterating `state_env_vars` — always true, so a spurious "already defined" warning


### PR DESCRIPTION
## Description

This PR fixes a logic bug in `rattler_shell/src/activation.rs` where the `collect_env_vars` function incorrectly checks for key existence in the `state_env_vars` map while iterating over it, resulting in a spurious "already defined" warning for every variable in the `conda-meta/state` file.

The check has been updated to compare against `env_vars` (the accumulated map populated from `env_vars.d` files), ensuring warnings only fire when a real conflict exists.

## Changes
- Updated `contains_key` logic in `crates/rattler_shell/src/activation.rs`.
- Added a regression test `test_collect_env_vars_no_spurious_conflict_warnings` to verify the fix.

## Related Issues
Fixes #2253