### PR TITLE
fix(docs): split workflow into rust and py-rattler jobs, fix tag matching

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -4,12 +4,11 @@ on:
   push:
     branches:
       - main
-    tags:
-      - "v*"
     paths:
       - "py-rattler/docs/**"
       - "py-rattler/mkdocs.yml"
       - "py-rattler/pixi.toml"
+      - "py-rattler/rattler/**"
       - "crates/**"
       - "Cargo.toml"
       - ".github/workflows/docs.yaml"
@@ -20,11 +19,12 @@ on:
       - "py-rattler/docs/**"
       - "py-rattler/mkdocs.yml"
       - "py-rattler/pixi.toml"
+      - "py-rattler/rattler/**"
       - ".github/workflows/docs.yaml"
   workflow_dispatch:
     inputs:
       tag:
-        description: "Tag to deploy (e.g. v0.23.0), or leave empty for dev"
+        description: "Tag to deploy py-rattler docs (e.g. py-rattler-v0.23.0), or leave empty for dev"
         required: false
         default: ""
 
@@ -36,13 +36,10 @@ env:
 permissions:
   contents: read
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
 jobs:
+  # ── PR check: just build, don't deploy ──
   build-docs:
-    if: github.repository == 'conda/rattler' && github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/v')
+    if: github.repository == 'conda/rattler' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -58,21 +55,23 @@ jobs:
       - name: Build Py-rattler Documentation
         run: pixi run --manifest-path py-rattler/pixi.toml build-docs
 
-  docs-release:
-    if: github.repository == 'conda/rattler' && (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag != '' && startsWith(github.event.inputs.tag, 'v')))
+  # ── Rust docs: deploy cargo doc to gh-pages on every push to main ──
+  rust-docs:
+    if: >-
+      github.repository == 'conda/rattler' &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
           submodules: recursive
-
-      - name: Checkout tag
-        if: github.event_name == 'workflow_dispatch'
-        run: git checkout tags/${{ github.event.inputs.tag }}
 
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
         with:
@@ -85,33 +84,11 @@ jobs:
       - name: Build Rattler Documentation
         run: cargo doc --workspace --no-deps --all-features --lib
 
-      - uses: prefix-dev/setup-pixi@82d477f15f3a381dbcc8adc1206ce643fe110fb7 # v0.9.3
-        with:
-          manifest-path: py-rattler/pixi.toml
-          environments: docs
-
-      - name: Configure Git user
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-
-      - name: Extract tag name
-        if: github.event_name != 'workflow_dispatch'
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      - name: Set version from workflow_dispatch
-        if: github.event_name == 'workflow_dispatch'
-        run: echo "RELEASE_VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
-
-      - name: Deploy with mike
-        run: pixi run --manifest-path py-rattler/pixi.toml deploy-latest
-
-      - name: Merge rustdoc into gh-pages
+      - name: Deploy rustdoc to gh-pages
         run: |
           git clone --branch gh-pages https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git gh-pages-repo
           cp -r target/doc/. gh-pages-repo/
           echo '<meta http-equiv="refresh" content="0; url=rattler/index.html">' > gh-pages-repo/index.html
-          echo '<meta http-equiv="refresh" content="0; url=latest/">' > gh-pages-repo/py-rattler/index.html
           echo "User-Agent: *" > gh-pages-repo/robots.txt
           echo "Disallow: /" >> gh-pages-repo/robots.txt
           touch gh-pages-repo/.nojekyll
@@ -119,30 +96,26 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add .
-          git diff --staged --quiet || (git commit -m "docs: add rustdoc and root redirect" && git push)
+          git diff --staged --quiet || (git commit -m "docs: update rustdoc" && git push)
 
-  docs-dev:
-    if: github.repository == 'conda/rattler' && (github.ref == 'refs/heads/main' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.tag == '' || !startsWith(github.event.inputs.tag, 'v'))))
+  # ── py-rattler docs (dev): deploy to "dev" alias on every push to main ──
+  py-rattler-docs-dev:
+    if: >-
+      github.repository == 'conda/rattler' &&
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+       (github.event_name == 'workflow_dispatch' && github.event.inputs.tag == ''))
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           submodules: recursive
-
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
-        with:
-          profile: minimal
-
-      - name: Pre-docs-build
-        run: |
-          echo "<meta name=\"robots\" content=\"noindex\">" > header.html
-
-      - name: Build Rattler Documentation
-        run: cargo doc --workspace --no-deps --all-features --lib
 
       - uses: prefix-dev/setup-pixi@82d477f15f3a381dbcc8adc1206ce643fe110fb7 # v0.9.3
         with:
@@ -157,17 +130,54 @@ jobs:
       - name: Deploy with mike
         run: pixi run --manifest-path py-rattler/pixi.toml deploy-dev
 
-      - name: Merge rustdoc into gh-pages
+  # ── py-rattler docs (release): deploy to "latest" alias via manual trigger ──
+  py-rattler-docs-release:
+    if: >-
+      github.repository == 'conda/rattler' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.event.inputs.tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Checkout tag
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: git checkout "tags/$INPUT_TAG"
+
+      - uses: prefix-dev/setup-pixi@82d477f15f3a381dbcc8adc1206ce643fe110fb7 # v0.9.3
+        with:
+          manifest-path: py-rattler/pixi.toml
+          environments: docs
+
+      - name: Configure Git user
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Set version
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+        run: echo "RELEASE_VERSION=${INPUT_TAG#py-rattler-}" >> $GITHUB_ENV
+
+      - name: Deploy with mike
+        run: pixi run --manifest-path py-rattler/pixi.toml deploy-latest
+
+      - name: Add py-rattler redirect to latest
         run: |
           git clone --branch gh-pages https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git gh-pages-repo
-          cp -r target/doc/. gh-pages-repo/
-          echo '<meta http-equiv="refresh" content="0; url=rattler/index.html">' > gh-pages-repo/index.html
           echo '<meta http-equiv="refresh" content="0; url=latest/">' > gh-pages-repo/py-rattler/index.html
-          echo "User-Agent: *" > gh-pages-repo/robots.txt
-          echo "Disallow: /" >> gh-pages-repo/robots.txt
-          touch gh-pages-repo/.nojekyll
           cd gh-pages-repo
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
           git add .
-          git diff --staged --quiet || (git commit -m "docs: add rustdoc and root redirect" && git push)
+          git diff --staged --quiet || (git commit -m "docs: update py-rattler redirect" && git push)

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -481,3 +481,49 @@ jobs:
             --target "${{ inputs.sha || github.sha }}" \
             --title "py-rattler v${{ inputs.tag }}" \
             --notes '${{ needs.extract-changelog.outputs.release_notes }}'
+
+  deploy-release-docs:
+    name: Deploy release docs
+    runs-on: ubuntu-latest
+    needs: tag-release
+    if: ${{ inputs.tag }}
+    permissions:
+      contents: write
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.sha }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - uses: prefix-dev/setup-pixi@82d477f15f3a381dbcc8adc1206ce643fe110fb7 # v0.9.3
+        with:
+          manifest-path: py-rattler/pixi.toml
+          environments: docs
+
+      - name: Configure Git user
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Set version
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: echo "RELEASE_VERSION=v${INPUT_TAG}" >> $GITHUB_ENV
+
+      - name: Deploy with mike
+        run: pixi run --manifest-path py-rattler/pixi.toml deploy-latest
+
+      - name: Add py-rattler redirect to latest
+        run: |
+          git clone --branch gh-pages https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git gh-pages-repo
+          echo '<meta http-equiv="refresh" content="0; url=latest/">' > gh-pages-repo/py-rattler/index.html
+          cd gh-pages-repo
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add .
+          git diff --staged --quiet || (git commit -m "docs: update py-rattler redirect" && git push)


### PR DESCRIPTION
## Summary

The docs workflow had two problems: the `latest` alias for py-rattler docs was never deployed (404 at `rattler.prefix.dev/py-rattler/latest/`), and the workflow structure made it easy for jobs to race on gh-pages pushes.

### Root cause of the 404
The old workflow triggered release docs on `v*` tags, but py-rattler releases are tagged as `py-rattler-v*`. The release job never matched.

### Why not a separate tag-triggered workflow?
Tags created by `GITHUB_TOKEN` in a workflow [cannot trigger other workflows](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow). Since `release-python.yml` creates the `py-rattler-v*` tag, a separate docs workflow listening for that tag would never fire. Instead, the release docs deploy is added directly to `release-python.yml`.

### Changes

**`docs.yaml`** — split into independent jobs, removed release doc deployment:
  - `build-docs` — PR build check only
  - `rust-docs` — deploys cargo doc to gh-pages (push to main only)
  - `py-rattler-docs-dev` — deploys Mike `dev` alias (push to main / manual dispatch without tag)
  - `py-rattler-docs-release` — deploys Mike `latest` alias (manual dispatch with tag, as fallback)

**`release-python.yml`** — added `deploy-release-docs` job:
  - Runs after `tag-release`, deploys Mike `latest` alias automatically on every release
  - This is the primary automated path for release docs

**Other improvements:**
- All gh-pages-pushing jobs share `concurrency: { group: gh-pages-deploy, cancel-in-progress: false }` to prevent races
- Each job owns its redirect: `rust-docs` writes root `index.html`, release jobs write `py-rattler/index.html`
- py-rattler jobs no longer build rust docs — no cargo/rustc needed
- Added `py-rattler/rattler/**` to paths filter so Python source/docstring changes trigger doc rebuilds
- Fixed shell injection: workflow_dispatch tag input passed via `env:` instead of direct `${{ }}` interpolation

## After merging

Manually trigger `docs.yaml` (**Actions > Deploy Docs > Run workflow**) with the latest release tag (e.g. `py-rattler-v0.34.0`) to populate the `latest` alias and fix the 404 at `rattler.prefix.dev/py-rattler/latest/`.

## Test plan

- [ ] Verify PR check (`build-docs`) runs on this PR
- [ ] After merge, verify `rust-docs` and `py-rattler-docs-dev` both run on push to main
- [ ] Manually trigger `docs.yaml` with latest release tag to deploy `latest`
- [ ] Verify `rattler.prefix.dev/py-rattler/latest/` resolves
- [ ] On next py-rattler release, verify `deploy-release-docs` runs in `release-python.yml`