### PR TITLE
fix: Fall back to mkdir when clonefile fails on non-APFS filesystems

### DIFF
--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -695,7 +695,7 @@ pub fn link_package_sync(
     } else {
         LinkType::Copy
     };
-    let allow_ref_links = options.allow_ref_links.unwrap_or_else(|| {
+    let mut allow_ref_links = options.allow_ref_links.unwrap_or_else(|| {
         match reflink_copy::check_reflink_support(package_dir, target_dir) {
             Ok(reflink_copy::ReflinkSupport::Supported) => true,
             Ok(reflink_copy::ReflinkSupport::NotSupported) | Err(_) => false,
@@ -806,7 +806,14 @@ pub fn link_package_sync(
                     paths_by_directory = non_matching;
                 }
                 Err(e) if e.kind() == ErrorKind::AlreadyExists => (),
-                Err(e) => return Err(InstallError::FailedToCreateDirectory(full_path, e)),
+                Err(_) => {
+                    allow_ref_links = false;
+                    match fs::create_dir(&full_path) {
+                        Ok(_) => (),
+                        Err(e) if e.kind() == ErrorKind::AlreadyExists => (),
+                        Err(e) => return Err(InstallError::FailedToCreateDirectory(full_path, e)),
+                    }
+                }
             }
         } else {
             match fs::create_dir(&full_path) {


### PR DESCRIPTION
### Description

I think the macOS directory clonefile optimization (using reflinks) implemented in https://github.com/conda/rattler/pull/995 overlooked the case for filesystems which do not support reflinks. I noticed an error like this
```
Error:   × failed to link libuv-1.51.0-h58003a5_1.conda
  ├─▶ failed to create directory '/some/path/.pixi/envs/some-env/include'
  ╰─▶ Operation not supported (os error 45)
```
and in my case this is on a HFS+ filesystem, but I think the bug would also occur on NFS, SMB, exFAT and so on.

In the case of single files, there is some fallback logic if reflinks are not supported, see the following

https://github.com/conda/rattler/blob/64620495ec8c4a8b02096d033d425f80850536f8/crates/rattler/src/install/link.rs#L426-L443

but for the directory case there is no such fallback logic and it just errors, see the following

https://github.com/conda/rattler/blob/64620495ec8c4a8b02096d033d425f80850536f8/crates/rattler/src/install/mod.rs#L792-L811

The fix adds a catch-all fallback that creates the directory and disables further clonefile attempts for the remaining directories in the package. Individual files are then linked via hardlink (or copy).

This mirrors the approach already used by the single file reflink code and restores installation on non-APFS macOS volumes.

**Open question**: Currently I'm changing `allow_ref_links` to be mutable such that after the first clonefile failure we set it to false to no spam further failures. But I'm not sure if this is a clean solution.

### How Has This Been Tested?

- All existing tests pass
- Manually tested on an HFS+ disk image:
  1. Create and mount: `hdiutil create -size 2g -fs HFS+ -volname testhfs /tmp/testhfs.dmg && hdiutil attach /tmp/testhfs.dmg`
  2. Init a pixi project on the volume: `cd /Volumes/testhfs/project && pixi init && pixi add python`
  3. First install to populate the cache on HFS+: `PIXI_CACHE_DIR=/Volumes/testhfs/cache pixi install`
  4. Remove the environment and reinstall (cache and target now both on HFS+, so `allow_ref_links = true`): `rm -rf .pixi && PIXI_CACHE_DIR=/Volumes/testhfs/cache pixi install`
  - **Before fix:** step 4 fails with `failed to create directory ... Operation not supported (os error 45)`
  - **After fix:** step 4 completes successfully, packages installed via hardlinks


### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Claude Code with Opus 4.6

### Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
