### PR TITLE
chore: prepare py-rattler v0.23.2 release

### DIFF
--- a/py-rattler/CHANGELOG.md
+++ b/py-rattler/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.2] - 2026-03-19
+
+### Added
+
+- Expose `WhlPackageRecord` to Python by @Anshgrover23 in [#2221](https://github.com/conda/rattler/pull/2221)
+- Add custom progress reporter callbacks to installer by @ritankarsaha in [#2187](https://github.com/conda/rattler/pull/2187)
+- Add FreeBSD 32-bit and ARM64 platform support by @wolfv in [#2227](https://github.com/conda/rattler/pull/2227)
+
+### Changed
+
+- Bump dependency versions in [#2237](https://github.com/conda/rattler/pull/2237)
+- Improve Windows GUI app launching and file extension registration in [#2135](https://github.com/conda/rattler/pull/2135)
+
+### Fixed
+
+- Handle invalid characters in LibC family for virtual packages in [#2209](https://github.com/conda/rattler/pull/2209)
+- Fall back to AWS SDK credential chain for S3 when no rattler credentials are set in [#2222](https://github.com/conda/rattler/pull/2222)
+- Fix upload token matching for anaconda.org in [#2231](https://github.com/conda/rattler/pull/2231)
+- Preserve mirror URL path when rewriting requests in [#2183](https://github.com/conda/rattler/pull/2183)
+- Replace panicking unwrap/expect in mirror, S3, and GCS middleware in [#2216](https://github.com/conda/rattler/pull/2216)
+- Keep removed package metadata in repodata in [#2210](https://github.com/conda/rattler/pull/2210)
+
 ## [0.23.1] - 2026-03-10
 
 ### Added

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-rattler"
-version = "0.23.1"
+version = "0.23.2"
 edition = "2021"
 license = "BSD-3-Clause"
 publish = false


### PR DESCRIPTION
## Summary

Bump py-rattler version to 0.23.2 with changelog for changes since 0.23.1.

### Added
- Expose `WhlPackageRecord` to Python (#2221)
- Add custom progress reporter callbacks to installer (#2187)
- Add FreeBSD 32-bit and ARM64 platform support (#2227)

### Changed
- Bump dependency versions (#2237)
- Improve Windows GUI app launching and file extension registration (#2135)

### Fixed
- Handle invalid characters in LibC family for virtual packages (#2209)
- Fall back to AWS SDK credential chain for S3 (#2222)
- Fix upload token matching for anaconda.org (#2231)
- Preserve mirror URL path when rewriting requests (#2183)
- Replace panicking unwrap/expect in mirror, S3, and GCS middleware (#2216)
- Keep removed package metadata in repodata (#2210)