### PR TITLE
feat: `rattler create` doc improvements and `conda create` alignment

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -43,7 +43,7 @@ pub struct Opt {
     /// Channel to search for packages
     ///
     /// Example: -c conda-forge -c main
-    #[clap(short, long = "channel", visible_alias = "channels")]
+    #[clap(short, long = "channel")]
     channels: Option<Vec<String>>,
 
     /// Package specs to install


### PR DESCRIPTION
### Description

Hackathon addition

Summary:
- Modified long cli option to align with `conda create`
  - Only -c before now `--channel` and -c are now provided.
  - target-prefix is now an alias to -p/prefix matching `conda create`
- Added description to `rattler create` command
- Added descriptions to rattler create commands

### How Has This Been Tested?

Local testing on the command line for visible_alias and changes

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
