### PR TITLE
fix: normalize channel names to canonical URLs using ChannelConfig

### DIFF
--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -14,7 +14,8 @@ use std::fmt;
 
 use chrono::{DateTime, Utc};
 use rattler_conda_types::{
-    utils::TimestampMs, GenericVirtualPackage, MatchSpec, PackageName, RepoDataRecord, SolverResult,
+    utils::TimestampMs, ChannelConfig, GenericVirtualPackage, MatchSpec, PackageName,
+    RepoDataRecord, SolverResult,
 };
 
 /// Represents a solver implementation, capable of solving [`SolverTask`]s
@@ -339,6 +340,18 @@ pub struct SolverTask<TAvailablePackagesIterator> {
 
     /// Dependency overrides that replace dependencies of matching packages.
     pub dependency_overrides: Vec<(MatchSpec, MatchSpec)>,
+
+    /// Channel configuration used to normalize short channel names (e.g.
+    /// `conda-forge`) in [`MatchSpec`]s to their canonical base URLs before
+    /// comparing them with the channel stored in each [`RepoDataRecord`].
+    ///
+    /// When a [`MatchSpec`] is parsed with a different [`ChannelConfig`] than
+    /// the one used to load the repodata (e.g. a custom `channel_alias`), the
+    /// expanded URLs can differ, causing channel-pinned specs to silently match
+    /// the wrong packages.  Providing the same [`ChannelConfig`] here as the
+    /// one used when loading packages guarantees that the comparison is
+    /// performed on canonical URLs.
+    pub channel_config: ChannelConfig,
 }
 
 impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
@@ -357,6 +370,9 @@ impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
             exclude_newer: None,
             strategy: SolveStrategy::default(),
             dependency_overrides: Vec::new(),
+            channel_config: ChannelConfig::default_with_root_dir(
+                std::env::current_dir().unwrap_or_default(),
+            ),
         }
     }
 }

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -14,8 +14,9 @@ use rattler_conda_types::MatchSpecCondition;
 use rattler_conda_types::{
     package::{ArchiveIdentifier, DistArchiveType},
     utils::TimestampMs,
-    GenericVirtualPackage, MatchSpec, Matches, NamelessMatchSpec, PackageName, PackageNameMatcher,
-    ParseMatchSpecError, ParseMatchSpecOptions, RepoDataRecord, SolverResult,
+    Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, Matches, NamelessMatchSpec,
+    PackageName, PackageNameMatcher, ParseMatchSpecError, ParseMatchSpecOptions, RepoDataRecord,
+    SolverResult,
 };
 use resolvo::{
     utils::{Pool, VersionSet},
@@ -316,6 +317,7 @@ impl<'a> CondaDependencyProvider<'a> {
         exclude_newer: Option<&ExcludeNewer>,
         strategy: SolveStrategy,
         dependency_overrides: Vec<DependencyOverride>,
+        channel_config: &ChannelConfig,
     ) -> Result<Self, SolveError> {
         let pool = Pool::default();
         let mut records: HashMap<NameId, Candidates> = HashMap::default();
@@ -335,11 +337,23 @@ impl<'a> CondaDependencyProvider<'a> {
             .map(|name| pool.intern_package_name(name))
             .collect();
 
-        // TODO: Normalize these channel names to urls so we can compare them correctly.
-        let channel_specific_specs = match_specs
+        // Build a list of (spec, normalized_channel_url) pairs for every
+        // channel-pinned spec
+        let channel_specific_specs: Vec<(&MatchSpec, String)> = match_specs
             .iter()
-            .filter(|spec| spec.channel.is_some())
-            .collect::<Vec<_>>();
+            .filter_map(|spec| {
+                spec.channel.as_ref().map(|chan| {
+                    // If the channel was originally given as a short name,
+                    // re-expand it with the provided config
+                    let normalized_url = chan
+                        .name
+                        .as_ref()
+                        .map(|name| Channel::from_name(name, channel_config).canonical_name())
+                        .unwrap_or_else(|| chan.canonical_name());
+                    (spec, normalized_url)
+                })
+            })
+            .collect();
 
         // Hashmap that maps the package name to the channel it was first found in.
         let mut package_name_found_in_channel = HashMap::<String, &Option<String>>::new();
@@ -446,35 +460,40 @@ impl<'a> CondaDependencyProvider<'a> {
 
                 // Add to excluded when package is not in the specified channel.
                 if !channel_specific_specs.is_empty() {
-                    if let Some(spec) = channel_specific_specs.iter().find(|&&spec| {
-                        spec.name
-                            .as_exact()
-                            .expect("expecting an exact package name")
-                            .as_normalized()
-                            == record.package_record.name.as_normalized()
-                    }) {
-                        // Check if the spec has a channel, and compare it to the repodata
-                        // channel
-                        if let Some(spec_channel) = &spec.channel {
-                            if record.channel.as_ref() != Some(&spec_channel.canonical_name()) {
-                                tracing::debug!("Ignoring {} {} because it was not requested from that channel.", &record.package_record.name.as_normalized(), match &record.channel {
-                                        Some(channel) => format!("from {}", &channel),
-                                        None => "without a channel".to_string(),
-                                    });
-                                // Add record to the excluded with reason of being in the non
-                                // requested channel.
-                                let message = format!(
-                                    "candidate not in requested channel: '{}'",
-                                    spec_channel
-                                        .name
-                                        .clone()
-                                        .unwrap_or(spec_channel.base_url.to_string())
-                                );
-                                candidates
-                                    .excluded
-                                    .push((solvable_id, pool.intern_string(message)));
-                                continue;
-                            }
+                    if let Some((_, spec_channel_url)) =
+                        channel_specific_specs.iter().find(|(spec, _)| {
+                            spec.name
+                                .as_exact()
+                                .expect("expecting an exact package name")
+                                .as_normalized()
+                                == record.package_record.name.as_normalized()
+                        })
+                    {
+                        // Normalize the record's channel string to a canonical URL
+                        let record_channel_url = record.channel.as_ref().map(|ch| {
+                            Channel::from_str(ch, channel_config)
+                                .map(|c| c.canonical_name())
+                                .unwrap_or_else(|_| ch.clone())
+                        });
+
+                        if record_channel_url.as_deref() != Some(spec_channel_url.as_str()) {
+                            tracing::debug!(
+                                "Ignoring {} {} because it was not requested from that channel.",
+                                &record.package_record.name.as_normalized(),
+                                match &record.channel {
+                                    Some(channel) => format!("from {}", &channel),
+                                    None => "without a channel".to_string(),
+                                }
+                            );
+                            // Add record to the excluded with reason of being in the non
+                            // requested channel.
+                            let message = format!(
+                                "candidate not in requested channel: '{spec_channel_url}'"
+                            );
+                            candidates
+                                .excluded
+                                .push((solvable_id, pool.intern_string(message)));
+                            continue;
                         }
                     }
                 }
@@ -953,6 +972,7 @@ impl super::SolverImpl for Solver {
             task.exclude_newer.as_ref(),
             task.strategy,
             dependency_overrides,
+            &task.channel_config,
         )?;
 
         // Construct the requirements that the solver needs to satisfy.


### PR DESCRIPTION
### Description

Adds a channel_config: ChannelConfig field to SolverTask (defaulting to the standard conda.anaconda.org alias for backward compatibility) and threads it through to `CondaDependencyProvider::new`.                                                                
                                                            
  The TODO block that previously just collected channel-pinned specs is replaced by apre-computation step that maps each spec to its canonical channel URL, re-expanding short names through the caller-provided config. During per-record filtering, record.channel is likewise normalized through the same config before comparison. This ensures that a spec like my-channel::numpy correctly matches or rejects records regardless of which channel alias was active when the MatchSpec was parsed.

Fixes #2294 




### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->


@baszalmstra 