### PR TITLE
feat(py-rattler): expose write_repodata for wheel metadata

### DIFF
--- a/py-rattler/CHANGELOG.md
+++ b/py-rattler/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose `write_repodata` in py-rattler for repodata generation from record metadata
+
 ## [0.23.2] - 2026-03-19
 
 ### Added

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -3770,6 +3770,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "nix 0.30.1",
+ "opendal",
  "openssl",
  "parking_lot",
  "pep508_rs",

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -28,6 +28,7 @@ anyhow = "1.0.97"
 chrono = { version = "0.4" }
 futures = "0.3.31"
 parking_lot = { version = "0.12.3", features = ["arc_lock", "send_guard"] }
+opendal = { version = "0.55.0", default-features = false, features = ["services-fs"] }
 
 rattler_s3 = { path = "../crates/rattler_s3", features = ["serde"]}
 rattler = { path = "../crates/rattler", default-features = false, features = [

--- a/py-rattler/rattler/index/__init__.py
+++ b/py-rattler/rattler/index/__init__.py
@@ -1,3 +1,3 @@
-from rattler.index.index import index_fs, index_s3, S3Credentials
+from rattler.index.index import S3Credentials, index_fs, index_s3, write_repodata
 
-__all__ = ["index_s3", "index_fs", "S3Credentials"]
+__all__ = ["index_s3", "index_fs", "write_repodata", "S3Credentials"]

--- a/py-rattler/rattler/index/index.py
+++ b/py-rattler/rattler/index/index.py
@@ -5,7 +5,8 @@ import os
 from typing import Optional, Literal
 
 from rattler.platform import Platform
-from rattler.rattler import py_index_fs, py_index_s3
+from rattler.rattler import py_index_fs, py_index_s3, py_write_repodata
+from rattler.repo_data.package_record import PackageRecord
 
 
 @dataclass
@@ -109,4 +110,32 @@ async def index_s3(
         force,
         max_parallel,
         precondition_checks,
+    )
+
+
+async def write_repodata(
+    channel_directory: os.PathLike[str],
+    records: list[PackageRecord],
+    write_zst: bool = True,
+    write_shards: bool = True,
+) -> None:
+    """
+    Write repodata from package metadata without requiring package archives on
+    disk.
+
+    Records are grouped by their `subdir` and written to the corresponding
+    channel subdirectories. Supported inputs include `RepoDataRecord`,
+    `PrefixRecord`, and `WhlPackageRecord` instances.
+
+    Arguments:
+        channel_directory: The filesystem path to the root of the channel.
+        records: Package records to serialize into repodata.
+        write_zst: Whether to also write `repodata.json.zst`.
+        write_shards: Whether to also write sharded repodata.
+    """
+    await py_write_repodata(
+        channel_directory,
+        [record._record for record in records],
+        write_zst,
+        write_shards,
     )

--- a/py-rattler/src/index.rs
+++ b/py-rattler/src/index.rs
@@ -1,16 +1,179 @@
-use pyo3::{pyfunction, Bound, PyAny, PyResult, Python};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
+
+use anyhow::Context;
+use opendal::{services::FsConfig, Configurator, Operator};
+use pyo3::{exceptions::PyTypeError, pyfunction, Bound, PyAny, PyResult, Python};
 use pyo3_async_runtimes::tokio::future_into_py;
-use rattler_conda_types::Platform;
+use rattler_conda_types::{
+    package::{ArchiveIdentifier, CondaArchiveType, DistArchiveType},
+    ChannelInfo, ExperimentalV3Packages, Platform, RepoData, RepoDataRecord, WhlPackageRecord,
+};
 use rattler_config::config::concurrency::default_max_concurrent_solves;
-use rattler_index::{index_fs, index_s3, IndexFsConfig, IndexS3Config};
+use rattler_index::{
+    ensure_channel_initialized, index_fs, index_s3, write_repodata, IndexFsConfig, IndexS3Config,
+    PreconditionChecks, RepodataMetadataCollection,
+};
 use url::Url;
 
-use crate::{error::PyRattlerError, platform::PyPlatform};
+use crate::{error::PyRattlerError, platform::PyPlatform, record::PyRecord};
 use pyo3::exceptions::PyValueError;
 use pythonize::depythonize;
 use rattler_networking::AuthenticationStorage;
 use rattler_s3::{ResolvedS3Credentials, S3Credentials};
-use std::path::PathBuf;
+
+fn archive_identifier_from_whl_record(record: &WhlPackageRecord) -> ArchiveIdentifier {
+    ArchiveIdentifier {
+        name: record.package_record.name.as_source().to_string(),
+        version: record.package_record.version.to_string(),
+        build_string: record.package_record.build.clone(),
+    }
+}
+
+enum RepodataInputRecord {
+    Conda(RepoDataRecord),
+    Whl(WhlPackageRecord),
+}
+
+fn repodata_record_from_py_record(record: PyRecord) -> PyResult<RepodataInputRecord> {
+    match record.inner {
+        crate::record::RecordInner::Prefix(record) => Ok(RepodataInputRecord::Conda(
+            Arc::unwrap_or_clone(record).repodata_record,
+        )),
+        crate::record::RecordInner::RepoData(record) => {
+            Ok(RepodataInputRecord::Conda(Arc::unwrap_or_clone(record)))
+        }
+        crate::record::RecordInner::Whl(record) => {
+            Ok(RepodataInputRecord::Whl(Arc::unwrap_or_clone(record)))
+        }
+        crate::record::RecordInner::Package(_) => Err(PyTypeError::new_err(
+            "write_repodata expects RepoDataRecord, PrefixRecord, or WhlPackageRecord values",
+        )),
+    }
+}
+
+fn repo_data_from_subdir(subdir: Platform) -> RepoData {
+    RepoData {
+        info: Some(ChannelInfo {
+            subdir: Some(subdir.to_string()),
+            base_url: None,
+            channel_relations: None,
+        }),
+        packages: std::iter::empty().collect(),
+        conda_packages: std::iter::empty().collect(),
+        experimental_v3: ExperimentalV3Packages::default(),
+        removed: std::iter::empty().collect(),
+        version: Some(3),
+    }
+}
+
+fn insert_repodata_input(
+    repodata: &mut RepoData,
+    record: RepodataInputRecord,
+) -> anyhow::Result<()> {
+    match record {
+        RepodataInputRecord::Conda(record) => {
+            let RepoDataRecord {
+                package_record,
+                identifier,
+                url,
+                ..
+            } = record;
+
+            let archive_type = identifier.archive_type;
+            match archive_type {
+                DistArchiveType::Conda(CondaArchiveType::TarBz2) => {
+                    repodata.packages.insert(identifier, package_record);
+                }
+                DistArchiveType::Conda(CondaArchiveType::Conda) => {
+                    repodata.conda_packages.insert(identifier, package_record);
+                }
+                DistArchiveType::Wheel(_) => {
+                    let url = url.as_str().parse().context("invalid wheel url")?;
+                    repodata.experimental_v3.whl.insert(
+                        identifier.identifier,
+                        WhlPackageRecord {
+                            package_record,
+                            url,
+                        },
+                    );
+                }
+            }
+        }
+        RepodataInputRecord::Whl(record) => {
+            repodata
+                .experimental_v3
+                .whl
+                .insert(archive_identifier_from_whl_record(&record), record);
+        }
+    }
+
+    Ok(())
+}
+
+async fn write_fs_repodata(
+    channel_directory: PathBuf,
+    records: Vec<RepodataInputRecord>,
+    write_zst: bool,
+    write_shards: bool,
+) -> anyhow::Result<()> {
+    std::fs::create_dir_all(&channel_directory)?;
+
+    let mut config = FsConfig::default();
+    config.root = Some(
+        channel_directory
+            .canonicalize()?
+            .to_string_lossy()
+            .to_string(),
+    );
+    let op = Operator::new(config.into_builder())?.finish();
+
+    ensure_channel_initialized(&op).await?;
+
+    let mut repodata_by_subdir = HashMap::<Platform, RepoData>::new();
+
+    for record in records {
+        let subdir = match &record {
+            RepodataInputRecord::Conda(record) => record.package_record.subdir.as_str(),
+            RepodataInputRecord::Whl(record) => record.package_record.subdir.as_str(),
+        }
+        .parse::<Platform>()
+        .with_context(|| match &record {
+            RepodataInputRecord::Conda(record) => {
+                format!("invalid platform '{}'", record.package_record.subdir)
+            }
+            RepodataInputRecord::Whl(record) => {
+                format!("invalid platform '{}'", record.package_record.subdir)
+            }
+        })?;
+
+        let repodata = repodata_by_subdir
+            .entry(subdir)
+            .or_insert_with(|| repo_data_from_subdir(subdir));
+
+        insert_repodata_input(repodata, record)?;
+    }
+
+    for (subdir, repodata) in repodata_by_subdir {
+        let subdir_path = format!("{subdir}/");
+        if !op.exists(&subdir_path).await? {
+            op.create_dir(&subdir_path).await?;
+        }
+
+        let metadata = RepodataMetadataCollection::new(
+            &op,
+            subdir,
+            false,
+            write_zst,
+            write_shards,
+            PreconditionChecks::Disabled,
+        )
+        .await?;
+
+        write_repodata(repodata, None, subdir, op.clone(), &metadata).await?;
+    }
+
+    Ok(())
+}
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
@@ -39,6 +202,27 @@ pub fn py_index_fs(
         })
         .await
         .map_err(|e| PyRattlerError::from(e).into())
+    })
+}
+
+#[pyfunction]
+#[pyo3(signature = (channel_directory, records, write_zst=true, write_shards=true))]
+pub fn py_write_repodata(
+    py: Python<'_>,
+    channel_directory: PathBuf,
+    records: Vec<PyRecord>,
+    write_zst: bool,
+    write_shards: bool,
+) -> PyResult<Bound<'_, PyAny>> {
+    let records = records
+        .into_iter()
+        .map(repodata_record_from_py_record)
+        .collect::<PyResult<Vec<_>>>()?;
+
+    future_into_py(py, async move {
+        write_fs_repodata(channel_directory, records, write_zst, write_shards)
+            .await
+            .map_err(|e| PyRattlerError::from(e).into())
     })
 }
 

--- a/py-rattler/src/lib.rs
+++ b/py-rattler/src/lib.rs
@@ -48,7 +48,7 @@ use exceptions::{
 };
 use explicit_environment_spec::{PyExplicitEnvironmentEntry, PyExplicitEnvironmentSpec};
 use generic_virtual_package::PyGenericVirtualPackage;
-use index::{py_index_fs, py_index_s3};
+use index::{py_index_fs, py_index_s3, py_write_repodata};
 use index_json::PyIndexJson;
 use installer::py_install;
 use lock::{
@@ -187,6 +187,7 @@ fn rattler<'py>(py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(py_install, &m).unwrap())?;
     m.add_function(wrap_pyfunction!(py_index_fs, &m).unwrap())?;
     m.add_function(wrap_pyfunction!(py_index_s3, &m).unwrap())?;
+    m.add_function(wrap_pyfunction!(py_write_repodata, &m).unwrap())?;
 
     m.add_function(wrap_pyfunction!(package_streaming::extract_tar_bz2, &m).unwrap())?;
     m.add_function(wrap_pyfunction!(package_streaming::extract, &m).unwrap())?;

--- a/py-rattler/tests/unit/test_index.py
+++ b/py-rattler/tests/unit/test_index.py
@@ -1,4 +1,5 @@
 # type: ignore
+import json
 import os
 import shutil
 import uuid
@@ -9,8 +10,15 @@ from typing import Iterator
 import boto3
 import pytest
 
-from rattler import Platform
-from rattler.index import index_fs, index_s3
+from rattler import (
+    PackageRecord,
+    Platform,
+    PrefixPaths,
+    PrefixRecord,
+    RepoDataRecord,
+    WhlPackageRecord,
+)
+from rattler.index import index_fs, index_s3, write_repodata
 from rattler.index.index import S3Credentials
 
 
@@ -60,6 +68,72 @@ async def test_index_specific_subdir_noarch(package_directory):
     assert "repodata.json" in os.listdir(package_directory / "noarch")
     with open(package_directory / "noarch/repodata.json") as f:
         assert "pytweening-1.0.4-pyhd8ed1ab_0" in f.read()
+
+
+@pytest.mark.asyncio
+async def test_write_repodata_from_record_metadata(tmp_path: Path) -> None:
+    conda_base_record = PackageRecord(
+        name="requests",
+        version="2.28.0",
+        build="py3_none_any_0",
+        build_number=0,
+        subdir="linux-64",
+        extra_depends={"security": ["cryptography >=3.0"]},
+    )
+    prefix_record = PrefixRecord(
+        RepoDataRecord(
+            conda_base_record,
+            file_name="requests-2.28.0-py3_none_any_0.tar.bz2",
+            url="https://example.com/conda/requests-2.28.0-py3_none_any_0.tar.bz2",
+            channel="https://example.com/conda/linux-64",
+        ),
+        PrefixPaths(),
+    )
+    conda_record = RepoDataRecord(
+        PackageRecord(
+            name="urllib3",
+            version="2.0.7",
+            build="py3_none_any_0",
+            build_number=0,
+            subdir="osx-64",
+        ),
+        file_name="urllib3-2.0.7-py3_none_any_0.conda",
+        url="https://example.com/conda/urllib3-2.0.7-py3_none_any_0.conda",
+        channel="https://example.com/conda/osx-64",
+    )
+    whl_record = WhlPackageRecord(
+        PackageRecord(
+            name="packaging",
+            version="24.1",
+            build="py3_none_any_0",
+            build_number=0,
+            subdir="linux-64",
+        ),
+        "https://example.com/wheels/packaging-24.1-py3-none-any.whl",
+    )
+
+    await write_repodata(
+        tmp_path,
+        [prefix_record, conda_record, whl_record],
+        write_zst=False,
+        write_shards=False,
+    )
+
+    noarch_repodata = json.loads((tmp_path / "noarch" / "repodata.json").read_text())
+    linux_repodata = json.loads((tmp_path / "linux-64" / "repodata.json").read_text())
+    osx_repodata = json.loads((tmp_path / "osx-64" / "repodata.json").read_text())
+
+    assert noarch_repodata["info"]["subdir"] == "noarch"
+    assert noarch_repodata["packages"] == {}
+    assert linux_repodata["repodata_version"] == 3
+    assert linux_repodata["packages"]["requests-2.28.0-py3_none_any_0.tar.bz2"]["extra_depends"] == {
+        "security": ["cryptography >=3.0"]
+    }
+    assert (
+        linux_repodata["v3"]["whl"]["packaging-24.1-py3_none_any_0"]["url"]
+        == "https://example.com/wheels/packaging-24.1-py3-none-any.whl"
+    )
+    assert osx_repodata["packages.conda"]["urllib3-2.0.7-py3_none_any_0.conda"]["name"] == "urllib3"
 
 
 # ---------------------------------------- S3 ---------------------------------------- #


### PR DESCRIPTION
### Description

Expose `rattler.index.write_repodata(...)` in py-rattler so Python callers can write `repodata.json` files with `v3.whl` entries directly from `WhlPackageRecord` metadata.

Issue #2211 asked for three Python-side pieces:
- `WhlPackageRecord(...)`
- `PackageRecord.extra_depends`
- `write_repodata(channel_dir, whl_records, write_zst, write_shards)`

The first two are already available on `main`; this PR adds the remaining async `write_repodata` binding, exports it from `rattler.index`, and covers it with a focused unit test.

Fixes #2211

### How Has This Been Tested?

From the repository root:

- `pixi run cargo-fmt`
- `pixi run cargo-clippy`

From `py-rattler/`:

- `pixi run fmt-python-check`
- `pixi run build`
- `pixi run -e test -x pytest tests/unit/test_index.py -k write_repodata -q`

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: Codex

### Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
