### PR TITLE
feat(gateway): prefer full repodata over sharded for pattern/glob queries

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/builder.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/builder.rs
@@ -164,6 +164,7 @@ impl GatewayBuilder {
         Gateway {
             inner: Arc::new(GatewayInner {
                 subdirs: CoalescedMap::new(),
+                full_repodata_subdirs: CoalescedMap::new(),
                 client,
                 channel_config: self.channel_config,
                 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -240,6 +240,9 @@ impl Gateway {
         self.inner.subdirs.retain(|key, _| {
             key.0.base_url != channel.base_url || !subdirs.contains(key.1.as_str())
         });
+        self.inner.full_repodata_subdirs.retain(|key, _| {
+            key.0.base_url != channel.base_url || !subdirs.contains(key.1.as_str())
+        });
 
         #[cfg(not(target_arch = "wasm32"))]
         if mode == CacheClearMode::InMemoryAndDisk {
@@ -283,6 +286,11 @@ impl Gateway {
 struct GatewayInner {
     /// A map of subdirectories for each channel and platform.
     subdirs: CoalescedMap<(Channel, Platform), Arc<Subdir>>,
+
+    /// A separate cache for non-sharded (full repodata) subdirectories.
+    /// Used when queries contain pattern specs where fetching full repodata
+    /// is more efficient than thousands of individual shard requests.
+    full_repodata_subdirs: CoalescedMap<(Channel, Platform), Arc<Subdir>>,
 
     /// The client to use to fetch repodata.
     client: LazyClient,
@@ -348,6 +356,49 @@ impl GatewayInner {
         SubdirBuilder::new(self, channel.clone(), platform, reporter)
             .build()
             .await
+    }
+
+    /// Returns a [`Subdir`] that always uses full repodata (never sharded).
+    ///
+    /// This is used when queries contain pattern/glob specs that would
+    /// match a large number of packages. In such cases, fetching a single
+    /// full repodata file is far more efficient than making thousands of
+    /// individual shard HTTP requests.
+    ///
+    /// These subdirs are cached separately from normal (potentially sharded)
+    /// subdirs to avoid interfering with exact-name queries that benefit
+    /// from sharded repodata.
+    #[instrument(skip(self, reporter, channel), fields(channel = %channel.base_url), err(level = Level::INFO))]
+    async fn get_or_create_non_sharded_subdir(
+        &self,
+        channel: &Channel,
+        platform: Platform,
+        reporter: Option<Arc<dyn Reporter>>,
+    ) -> Result<Arc<Subdir>, GatewayError> {
+        let key = (channel.clone(), platform);
+        let channel = channel.clone();
+
+        self.full_repodata_subdirs
+            .get_or_try_init(key, || async move {
+                tracing::info!(
+                    "using full repodata for {}/{} (query contains pattern specs)",
+                    channel.canonical_name(),
+                    platform
+                );
+                let subdir = SubdirBuilder::new(self, channel.clone(), platform, reporter)
+                    .skip_sharded(true)
+                    .build()
+                    .await?;
+                Ok(Arc::new(subdir))
+            })
+            .await
+            .map_err(|e| match e {
+                CoalescedGetError::Init(gateway_err) => gateway_err,
+                CoalescedGetError::CoalescedRequestFailed => GatewayError::IoError(
+                    "a coalesced request failed".to_string(),
+                    std::io::ErrorKind::Other.into(),
+                ),
+            })
     }
 }
 
@@ -1715,5 +1766,58 @@ mod test {
                 .collect::<std::collections::BTreeSet<_>>(),
             "glob should find all lib-* packages across both sources and both subdirs"
         );
+    }
+
+    /// Verify that pattern/glob queries against a remote channel succeed by
+    /// using full repodata instead of sharded. This exercises the heuristic
+    /// that avoids thousands of individual shard HTTP requests when the
+    /// query contains pattern specs.
+    #[tokio::test]
+    async fn test_pattern_query_uses_full_repodata() {
+        use rattler_conda_types::ParseStrictnessWithNameMatcher;
+
+        let gateway = Gateway::new();
+        let index = remote_conda_forge().await;
+
+        // Use a glob pattern that would match multiple packages.
+        let matchspec = MatchSpec::from_str(
+            "pytho*",
+            ParseStrictnessWithNameMatcher {
+                parse_strictness: Lenient,
+                exact_names_only: false,
+            },
+        )
+        .unwrap();
+
+        let records = gateway
+            .query(
+                vec![index.channel()],
+                vec![Platform::Linux64, Platform::NoArch],
+                vec![matchspec].into_iter(),
+            )
+            .recursive(false)
+            .await
+            .unwrap();
+
+        let total_records: usize = records.iter().map(RepoData::len).sum();
+        assert!(
+            total_records > 0,
+            "pattern query should return matching records"
+        );
+
+        // Verify that the matched records actually match the pattern.
+        for repo_data in &records {
+            for record in repo_data.iter() {
+                assert!(
+                    record
+                        .package_record
+                        .name
+                        .as_normalized()
+                        .starts_with("pytho"),
+                    "record name '{}' should match the pattern 'pytho*'",
+                    record.package_record.name.as_normalized()
+                );
+            }
+        }
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -224,6 +224,14 @@ impl QueryExecutor {
         let mut subdir_handles = Vec::with_capacity(sources_and_platforms.len());
         let pending_subdirs = FuturesUnordered::new();
 
+        // When the query contains pattern specs (glob/regex), prefer full
+        // repodata over sharded. With sharded repodata, each matching package
+        // triggers a separate HTTP request for its shard. Broad patterns like
+        // `*` can match >10k packages, resulting in thousands of individual
+        // shard fetches. Fetching a single full repodata file is far more
+        // efficient in these cases.
+        let has_pattern_specs = !pending_pattern_specs.is_empty();
+
         for (subdir_idx, (source, platform)) in sources_and_platforms.into_iter().enumerate() {
             let barrier = Arc::new(BarrierCell::new());
             subdir_handles.push(SubdirHandle {
@@ -236,9 +244,15 @@ impl QueryExecutor {
                     let inner = gateway.clone();
                     let reporter = reporter.clone();
                     box_future(async move {
-                        let subdir = inner
-                            .get_or_create_subdir(&channel, platform, reporter)
-                            .await?;
+                        let subdir = if has_pattern_specs {
+                            inner
+                                .get_or_create_non_sharded_subdir(&channel, platform, reporter)
+                                .await?
+                        } else {
+                            inner
+                                .get_or_create_subdir(&channel, platform, reporter)
+                                .await?
+                        };
                         barrier.set(subdir.clone()).expect("subdir was set twice");
                         Ok(subdir)
                     })

--- a/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir_builder.rs
@@ -22,6 +22,11 @@ pub struct SubdirBuilder<'g> {
     platform: Platform,
     reporter: Option<Arc<dyn Reporter>>,
     gateway: &'g GatewayInner,
+    /// When true, skip sharded repodata and always use full repodata.json.
+    /// This is used when the query contains broad pattern specs where
+    /// fetching full repodata is more efficient than thousands of individual
+    /// shard requests.
+    skip_sharded: bool,
 }
 
 impl<'g> SubdirBuilder<'g> {
@@ -36,7 +41,18 @@ impl<'g> SubdirBuilder<'g> {
             platform,
             reporter,
             gateway,
+            skip_sharded: false,
         }
+    }
+
+    /// When set to true, sharded repodata will be skipped and full
+    /// repodata.json will always be used. This is useful when the query is
+    /// expected to match a large number of packages (e.g. pattern/glob
+    /// queries), where fetching one full repodata file is far more efficient
+    /// than thousands of individual shard HTTP requests.
+    pub fn skip_sharded(mut self, skip: bool) -> Self {
+        self.skip_sharded = skip;
+        self
     }
 
     pub async fn build(self) -> Result<Subdir, GatewayError> {
@@ -58,9 +74,9 @@ impl<'g> SubdirBuilder<'g> {
         {
             let source_config = self.gateway.channel_config.get(&self.channel.base_url);
 
-            // Use sharded repodata if enabled
-            let subdir_data = if source_config.sharded_enabled
-                || gateway::force_sharded_repodata(&url)
+            // Use sharded repodata if enabled and not explicitly skipped
+            let subdir_data = if !self.skip_sharded
+                && (source_config.sharded_enabled || gateway::force_sharded_repodata(&url))
             {
                 match self.build_sharded(source_config).await {
                     Ok(client) => Some(client),


### PR DESCRIPTION
### Description

When a query contains pattern or glob specs (e.g. `rattler search '* >=3'`), the repodata gateway now skips sharded repodata and uses full `repodata.json` instead.

With sharded repodata, each matching package triggers a separate HTTP request to fetch its individual shard. Broad patterns like `*` can match >10,000 packages, resulting in thousands of individual shard fetches that are orders of magnitude slower than downloading a single full repodata file.

The heuristic: if the query contains any glob or regex `PackageNameMatcher` specs, use full repodata for all channel-based subdirs in that query. Exact-name queries (the common case for dependency resolution) continue to use sharded repodata as before.

Non-sharded subdirs are cached separately from sharded ones in the gateway, so pattern queries don't interfere with the sharded cache used by exact-name queries.

Fixes #2292

### How Has This Been Tested?

- Added `test_pattern_query_uses_full_repodata` test that verifies glob pattern queries succeed and return correct results against a remote channel.
- All 84 existing tests in `rattler_repodata_gateway` continue to pass (including `test_remote_gateway`, `test_clear_cache`, and existing glob pattern tests).
- Verified with `cargo clippy` (no warnings) and `cargo fmt` (clean).
- Full workspace compilation verified.

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.