### PR TITLE
fix: ordering of dev and post components

### DIFF
--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -1231,8 +1231,10 @@ mod test {
 
     #[test]
     fn dev_is_only_special_for_exact_runs() {
+        // Because 1.2.devdev is not considered a dev version, it must sort after 1.2dev
         assert!(Version::from_str("1.2dev").unwrap() < Version::from_str("1.2.devdev").unwrap());
         assert!(Version::from_str("1.2dev").unwrap() < Version::from_str("1.2devdev").unwrap());
+        // Same with post
         assert!(Version::from_str("1.2postpost").unwrap() < Version::from_str("1.2post").unwrap());
 
         // 1.2dev is a dev version, but 1.2devdev is not.

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -1220,6 +1220,13 @@ mod test {
     }
 
     #[test]
+    fn dev_is_only_special_for_exact_runs() {
+        assert!(Version::from_str("1.2dev").unwrap() < Version::from_str("1.2.devdev").unwrap());
+        assert!(Version::from_str("1.2dev").unwrap() < Version::from_str("1.2devdev").unwrap());
+        assert!(Version::from_str("1.2postpost").unwrap() < Version::from_str("1.2post").unwrap());
+    }
+
+    #[test]
     fn test_pep440() {
         // this list must be in sorted order (slightly modified from the PEP 440 test
         // suite https://github.com/pypa/packaging/blob/master/tests/test_version.py)

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -1224,6 +1224,11 @@ mod test {
         assert!(Version::from_str("1.2dev").unwrap() < Version::from_str("1.2.devdev").unwrap());
         assert!(Version::from_str("1.2dev").unwrap() < Version::from_str("1.2devdev").unwrap());
         assert!(Version::from_str("1.2postpost").unwrap() < Version::from_str("1.2post").unwrap());
+
+        // 1.2dev is a dev version, but 1.2devdev is not.
+        assert!(Version::from_str("1.2dev").unwrap().is_dev());
+        assert!(!Version::from_str("1.2devdev").unwrap().is_dev());
+        assert!(!Version::from_str("1.2.devdev").unwrap().is_dev());
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/version/mod.rs
+++ b/crates/rattler_conda_types/src/version/mod.rs
@@ -324,6 +324,16 @@ impl Version {
             .any(Component::is_dev)
     }
 
+    /// Returns true if this is considered a post version.
+    ///
+    /// If a version has a single component named "post" it is considered to be
+    /// a post version.
+    pub fn is_post(&self) -> bool {
+        self.segments()
+            .flat_map(|segment| segment.components())
+            .any(Component::is_post)
+    }
+
     /// Check if this version version and local strings start with the same as
     /// other.
     pub fn starts_with(&self, other: &Self) -> bool {
@@ -1229,6 +1239,11 @@ mod test {
         assert!(Version::from_str("1.2dev").unwrap().is_dev());
         assert!(!Version::from_str("1.2devdev").unwrap().is_dev());
         assert!(!Version::from_str("1.2.devdev").unwrap().is_dev());
+
+        // 1.2post is a post version, but 1.2postpost is not.
+        assert!(Version::from_str("1.2post").unwrap().is_post());
+        assert!(!Version::from_str("1.2postpost").unwrap().is_post());
+        assert!(!Version::from_str("1.2.postpost").unwrap().is_post());
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/version/parse.rs
+++ b/crates/rattler_conda_types/src/version/parse.rs
@@ -3,9 +3,8 @@ use crate::version::flags::Flags;
 use crate::version::segment::Segment;
 use crate::version::{ComponentVec, SegmentVec};
 use nom::branch::alt;
-use nom::bytes::complete::tag_no_case;
 use nom::character::complete::{alpha1, char, digit1, one_of};
-use nom::combinator::{map, opt, value};
+use nom::combinator::{map, opt};
 use nom::error::{ErrorKind, FromExternalError, ParseError};
 use nom::sequence::terminated;
 use nom::{IResult, Parser};
@@ -132,12 +131,15 @@ fn component_parser<'i>(input: &'i str) -> IResult<&'i str, Component, ParseVers
     alt((
         // Parse a numeral
         map(numeral_parser, Component::Numeral),
-        // Parse special case components
-        value(Component::Post, tag_no_case("post")),
-        value(Component::Dev, tag_no_case("dev")),
-        // Parse an identifier
+        // Parse an identifier. `dev` and `post` are only special when they make up the entire
+        // non-numeric run; longer identifiers such as `devdev` remain plain strings.
         map(alpha1, |alpha: &'i str| {
-            Component::Iden(alpha.to_lowercase().into_boxed_str())
+            let alpha = alpha.to_lowercase();
+            match alpha.as_str() {
+                "post" => Component::Post,
+                "dev" => Component::Dev,
+                _ => Component::Iden(alpha.into_boxed_str()),
+            }
         }),
     ))
     .parse(input)


### PR DESCRIPTION
### Description

This PR fixes a small bug with `dev` and `post` components in versions that I found while working on adding version interval ranges support to rattler. It also adds a new `is_post` method to mirror the `is_dev` method.

Basically, I found that rattler was considering a version `1.2devdev` to be smaller than `1.2dev`. This I think is wrong based on https://github.com/conda/ceps/blob/main/cep-0033.md and `conda.models.version.VersionOrder` agrees with that.

The same problem also happened with the `post` component, but in reverse.

```python
>>> import rattler
>>> rattler.Version('1.2dev') < rattler.Version('1.2devdev')
False
>>> rattler.Version('1.2post') > rattler.Version('1.2postpost')
False
```

while in conda:
```python
>>> conda.models.version.VersionOrder('1.2dev') < conda.models.version.VersionOrder('1.2devdev')
True
>>> conda.models.version.VersionOrder('1.2post') > conda.models.version.VersionOrder('1.2postpost')
True
```

The problem seem to stem from the fact that `tag_no_case` kind of matched on the prefix, I think. I'm still very new to rust, so I might be wrong. But the fix seems legit to me.

The docs on `tag_no_case` say (emphasis mine):
>will return **the part of the input that matches** the argument with no regard to case.

(https://docs.rs/nom/latest/nom/bytes/fn.tag_no_case.html)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Amp (see https://ampcode.com/threads/T-019d36ed-fd10-7368-b400-481c3646f900, in this case it used gpt 5.4 in its deepest thinking mode)

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
