### PR TITLE
fix: set PYTHONUTF8=1 for Windows test task

### DIFF
--- a/py-rattler/pixi.toml
+++ b/py-rattler/pixi.toml
@@ -21,6 +21,11 @@ build-release = "PIP_REQUIRE_VIRTUALENV=false maturin develop --release --featur
 build = "PIP_REQUIRE_VIRTUALENV=false maturin develop"
 build-release = "PIP_REQUIRE_VIRTUALENV=false maturin develop --release"
 
+[feature.test.target.win-64.tasks]
+test = { cmd = "pytest --doctest-modules --ignore=rattler/pty/pty_process.py --ignore=rattler/pty/pty_session.py", depends-on = [
+  "build",
+], env = { PYTHONUTF8 = "1" } }
+
 [feature.build.target.linux-64.dependencies]
 patchelf = "~=0.17.2"
 


### PR DESCRIPTION
Set the PYTHONUTF8 environment variable to 1 for the Windows (win-64) test task in py-rattler/pixi.toml to fix charmap encoding errors on Windows systems.

- Added Windows-specific test task configuration
- Sets PYTHONUTF8=1 environment variable for UTF-8 encoding
- Applies to pytest runs with existing ignore patterns