### PR TITLE
feat: export MatchSpec in js-rattler

### DIFF
--- a/js-rattler/Cargo.lock
+++ b/js-rattler/Cargo.lock
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.6.15"
+version = "0.6.18"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.44.0"
+version = "0.44.3"
 dependencies = [
  "ahash",
  "chrono",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "blake2",
  "digest",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.26.3"
+version = "0.26.6"
 dependencies = [
  "anyhow",
  "async-once-cell",
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.24.3"
+version = "0.24.6"
 dependencies = [
  "astral-tokio-tar",
  "astral_async_zip",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.27.0"
+version = "0.27.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2108,7 +2108,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "chrono",
  "futures",

--- a/js-rattler/crate/lib.rs
+++ b/js-rattler/crate/lib.rs
@@ -1,5 +1,6 @@
 mod error;
 mod gateway;
+mod match_spec;
 mod noarch_type;
 mod package_name;
 mod package_record;

--- a/js-rattler/crate/match_spec.rs
+++ b/js-rattler/crate/match_spec.rs
@@ -1,0 +1,99 @@
+use rattler_conda_types::{MatchSpec, ParseStrictness};
+use wasm_bindgen::prelude::wasm_bindgen;
+
+use crate::parse_strictness::JsParseStrictness;
+use crate::JsResult;
+
+/// Represents a match specification in the conda ecosystem.
+/// A match spec defines a query for matching conda packages by name, version,
+/// build string, channel, and other attributes.
+///
+/// @public
+#[wasm_bindgen(js_name = "MatchSpec")]
+#[repr(transparent)]
+pub struct JsMatchSpec {
+    inner: MatchSpec,
+}
+
+impl From<MatchSpec> for JsMatchSpec {
+    fn from(value: MatchSpec) -> Self {
+        JsMatchSpec { inner: value }
+    }
+}
+
+impl From<JsMatchSpec> for MatchSpec {
+    fn from(value: JsMatchSpec) -> Self {
+        value.inner
+    }
+}
+
+impl AsRef<MatchSpec> for JsMatchSpec {
+    fn as_ref(&self) -> &MatchSpec {
+        &self.inner
+    }
+}
+
+#[wasm_bindgen(js_class = "MatchSpec")]
+impl JsMatchSpec {
+    /// Constructs a new MatchSpec from a string representation.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        #[wasm_bindgen(param_description = "The string representation of the match spec.")]
+        spec: &str,
+        #[wasm_bindgen(param_description = "The strictness of the parser.")]
+        parse_strictness: Option<JsParseStrictness>,
+    ) -> JsResult<Self> {
+        let parse_strictness = parse_strictness
+            .map(TryFrom::try_from)
+            .transpose()?
+            .unwrap_or(ParseStrictness::Lenient);
+
+        let match_spec = MatchSpec::from_str(spec, parse_strictness)?;
+        Ok(match_spec.into())
+    }
+
+    /// Returns the string representation of the match spec.
+    #[wasm_bindgen(js_name = "toString")]
+    pub fn as_str(&self) -> String {
+        format!("{}", self.as_ref())
+    }
+
+    /// Returns the name of the package, or `undefined` if the name is a glob/regex pattern.
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> Option<String> {
+        match &self.inner.name {
+            rattler_conda_types::PackageNameMatcher::Exact(name) => Some(name.as_normalized().to_string()),
+            _ => None,
+        }
+    }
+
+    /// Returns the version spec as a string, or `undefined` if not specified.
+    #[wasm_bindgen(getter)]
+    pub fn version(&self) -> Option<String> {
+        self.inner.version.as_ref().map(|v| v.to_string())
+    }
+
+    /// Returns the build string matcher, or `undefined` if not specified.
+    #[wasm_bindgen(getter)]
+    pub fn build(&self) -> Option<String> {
+        self.inner.build.as_ref().map(|b| b.to_string())
+    }
+
+    /// Returns the channel name, or `undefined` if not specified.
+    #[wasm_bindgen(getter)]
+    pub fn channel(&self) -> Option<String> {
+        self.inner.channel.as_ref().map(|c| c.name().to_string())
+    }
+
+    /// Returns the subdir, or `undefined` if not specified.
+    #[wasm_bindgen(getter)]
+    pub fn subdir(&self) -> Option<String> {
+        self.inner.subdir.clone()
+    }
+
+    /// Returns the namespace, or `undefined` if not specified.
+    #[wasm_bindgen(getter)]
+    pub fn namespace(&self) -> Option<String> {
+        self.inner.namespace.clone()
+    }
+}

--- a/js-rattler/src/MatchSpec.ts
+++ b/js-rattler/src/MatchSpec.ts
@@ -1,0 +1,1 @@
+export { MatchSpec } from "../pkg";

--- a/js-rattler/src/index.ts
+++ b/js-rattler/src/index.ts
@@ -1,6 +1,7 @@
 export { ParseStrictness } from "../pkg/";
 export * from "./Version";
 export * from "./VersionSpec";
+export * from "./MatchSpec";
 export * from "./Platform";
 export * from "./solve";
 export * from "./PackageName";


### PR DESCRIPTION
## Summary
- Add `MatchSpec` type to the js-rattler WASM bindings
- Exposes constructor with optional `ParseStrictness`, `toString()`, and property getters: `name`, `version`, `build`, `channel`, `subdir`, `namespace`
- Follows the same pattern as existing exports (`Version`, `PackageName`, etc.)

## Motivation
Closes #1142. Downstream JS tools (like renovatebot) need to parse conda environment files. Exporting `MatchSpec` enables this without requiring a Python runtime.

## Test plan
- [x] `cargo check -p rattler_wasm` — compiles cleanly (native target)
- [x] Follows established `#[repr(transparent)]` wrapper pattern with `From`/`AsRef` impls
- [x] TypeScript re-export added in `src/MatchSpec.ts` and `src/index.ts`