### PR TITLE
fix: detect and remove stale shards/zst files in rattler-index

### DIFF
--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -999,6 +999,46 @@ pub async fn write_repodata(
             .await?;
         }
     }
+
+    // Check for stale files that exist from previous runs but are no longer being written.
+    if metadata.repodata_zst.is_none() {
+        let zst_path = format!("{subdir}/{REPODATA}.zst");
+        if op.exists(&zst_path).await.unwrap_or(false) {
+            tracing::warn!(
+                "Stale file detected: {zst_path} exists but write_zst is disabled. \
+                 Removing to prevent inconsistent repository state."
+            );
+            if let Err(e) = op.delete(&zst_path).await {
+                tracing::warn!("Failed to remove stale file {zst_path}: {e}");
+            }
+        }
+    }
+
+    if metadata.repodata_shards.is_none() {
+        let shards_index_path = format!("{subdir}/{REPODATA_SHARDS}");
+        if op.exists(&shards_index_path).await.unwrap_or(false) {
+            tracing::warn!(
+                "Stale file detected: {shards_index_path} exists but write_shards is disabled. \
+                 Removing to prevent inconsistent repository state."
+            );
+            if let Err(e) = op.delete(&shards_index_path).await {
+                tracing::warn!("Failed to remove stale file {shards_index_path}: {e}");
+            }
+        }
+
+        // Also check for the shards directory
+        let shards_dir = format!("{subdir}/shards/");
+        if op.exists(&shards_dir).await.unwrap_or(false) {
+            tracing::warn!(
+                "Stale directory detected: {shards_dir} exists but write_shards is disabled. \
+                 Removing to prevent inconsistent repository state."
+            );
+            if let Err(e) = op.remove_all(&shards_dir).await {
+                tracing::warn!("Failed to remove stale directory {shards_dir}: {e}");
+            }
+        }
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
### Description

When rattler-index runs with `--write-zst=false` or `--write-shards=false`, 
files created by previous indexing runs (like `repodata.json.zst`, 
`repodata_shards.msgpack.zst`, and the `shards/` directory) are left behind 
on the disk itself so,this can confuse the users/clients that fetch stale data not matching the existing 
current `repodata.json`.

This PR basically cleans up at the end of `write_repodata()` in 
`crates/rattler_index/src/lib.rs` that:
- Checks if `repodata.json.zst` exists when `write_zst` is disabled, and removes it so that stale data is not fetched
- Checks if `repodata_shards.msgpack.zst` and the `shards/` directory exist 
  when `write_shards` is disabled, and removes them
- there will be log warnings when stale files are found and cleaned up
- Handles removal failures gracefully

Uses the same `op.exists()`, `op.delete()`, and `op.remove_all()` APIs 
already used elsewhere in the crate.

Fixes #1856

### How Has This Been Tested?

- Ran `cargo check -p rattler_index` — compiles cleanly
- Ran `cargo fmt --check` — no formatting issues
- Verified the logic follows the same opendal patterns used in the rest 
  of the indexing code (e.g. `op.exists()` calls in `index()` function)

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
 Tools: Claude Code



### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
