### PR TITLE
fix: fail when uploading with --generate-attestation and api key

### DIFF
--- a/crates/rattler_upload/src/upload/prefix.rs
+++ b/crates/rattler_upload/src/upload/prefix.rs
@@ -53,6 +53,14 @@ pub enum PrefixUploadError {
     #[error("attestation requested but trusted publishing is not configured")]
     AttestationRequiresTrustedPublishing,
 
+    /// Attestation was requested but an API key was provided, which bypasses trusted publishing.
+    #[error("--generate-attestation cannot be used with an API key")]
+    #[diagnostic(help(
+        "Attestation requires trusted publishing (OIDC). Remove the API key / PREFIX_API_KEY \
+         environment variable and configure trusted publishing on prefix.dev instead."
+    ))]
+    AttestationWithApiKey,
+
     /// The server returned an authentication error (HTTP 401 or 403).
     #[error("authentication failed (HTTP {status})")]
     AuthenticationFailed {
@@ -187,7 +195,12 @@ pub async fn upload_package_to_prefix(
     // Check if we're using trusted publishing and if we should generate attestations
     #[cfg(feature = "sigstore-sign")]
     let (token, should_generate_attestation) = match prefix_data.api_key {
-        Some(api_key) => (api_key, false),
+        Some(api_key) => {
+            if wants_attestation {
+                return Err(PrefixUploadError::AttestationWithApiKey);
+            }
+            (api_key, false)
+        }
         None => match check_trusted_publishing(&client, &prefix_data.url).await {
             TrustedPublishResult::Configured(token) => {
                 // When using trusted publishing, we can generate attestations


### PR DESCRIPTION
### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

currently `--generate-attestation` together with api key authentication to prefix.dev only uploads without generating an attestation.

Fixes #{issue}

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
