### PR TITLE
fix: only retry transient I/O errors in should_retry()

### DIFF
--- a/crates/rattler_package_streaming/src/lib.rs
+++ b/crates/rattler_package_streaming/src/lib.rs
@@ -91,17 +91,29 @@ impl From<Cancelled> for ExtractError {
 impl ExtractError {
     /// Returns true if this error is transient and the operation should be retried.
     ///
-    /// This checks for common transient I/O errors like broken pipes,
-    /// connection resets, and unexpected EOF that can occur during
-    /// network streaming operations.
+    /// Only specific I/O error kinds are considered transient (e.g. broken pipe,
+    /// connection reset, timeout). Permanent failures like `PermissionDenied`,
+    /// `NotFound`, or `InvalidInput` return `false`.
     pub fn should_retry(&self) -> bool {
+        use std::io::ErrorKind;
+
+        let is_transient_io = |err: &std::io::Error| {
+            matches!(
+                err.kind(),
+                ErrorKind::BrokenPipe
+                    | ErrorKind::ConnectionReset
+                    | ErrorKind::ConnectionAborted
+                    | ErrorKind::ConnectionRefused
+                    | ErrorKind::NotConnected
+                    | ErrorKind::TimedOut
+                    | ErrorKind::UnexpectedEof
+                    | ErrorKind::Interrupted
+            )
+        };
+
         match self {
-            // Retry on all I/O errors during streaming - these are typically
-            // transient network issues (broken pipe, connection reset, etc.)
-            // The cache layer will clean up partial files on retry.
-            // TODO: Add more specific checks for transient I/O errors
-            ExtractError::IoError(_) => true,
-            ExtractError::CouldNotCreateDestination(_) => true,
+            ExtractError::IoError(err) => is_transient_io(err),
+            ExtractError::CouldNotCreateDestination(err) => is_transient_io(err),
             #[cfg(feature = "reqwest")]
             ExtractError::ReqwestError(err) => {
                 // Check if this is a connection error (includes broken pipe during connection)
@@ -215,27 +227,38 @@ mod tests {
     }
 
     #[test]
-    fn test_should_retry_io_error_not_found() {
+    fn test_should_not_retry_io_error_not_found() {
         let err = ExtractError::IoError(std::io::Error::new(
             std::io::ErrorKind::NotFound,
             "not found",
         ));
-        assert!(err.should_retry());
+        assert!(!err.should_retry());
     }
 
     #[test]
-    fn test_should_retry_io_error_permission_denied() {
+    fn test_should_not_retry_io_error_permission_denied() {
         let err = ExtractError::IoError(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
             "permission denied",
         ));
-        assert!(err.should_retry());
+        assert!(!err.should_retry());
     }
 
     #[test]
-    fn test_should_retry_could_not_create_destination() {
+    fn test_should_not_retry_could_not_create_destination() {
+        // ErrorKind::Other (non-transient) must not trigger a retry.
         let err =
             ExtractError::CouldNotCreateDestination(std::io::Error::other("could not create"));
+        assert!(!err.should_retry());
+    }
+
+    #[test]
+    fn test_should_retry_could_not_create_destination_transient() {
+        // A broken-pipe variant of CouldNotCreateDestination is transient.
+        let err = ExtractError::CouldNotCreateDestination(std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "broken pipe",
+        ));
         assert!(err.should_retry());
     }
 


### PR DESCRIPTION


### Description

  - `should_retry()` was returning `true` for all `IoError` and `CouldNotCreateDestination` variants, regardless of error kind
  - Permanent failures like `PermissionDenied`, `NotFound`, and `Other` would retry forever — the TODO comment in the code also acknowledged this was wrong
  - Now checks `err.kind()` and only retries genuinely transient kinds: `BrokenPipe`, `ConnectionReset`, `ConnectionAborted`, `ConnectionRefused`, `NotConnected`, `TimedOut`, `UnexpectedEof`, `Interrupted`
  - Tests updated to assert permanent errors do NOT retry; added a new test for `CouldNotCreateDestination` with a transient error kind


Fixes #2316 



### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->


@baszalmstra what do you think ? Any more changes required? 