### PR TITLE
chore: reduce size of PackageName and MatchSpec

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/matcher.rs
+++ b/crates/rattler_conda_types/src/match_spec/matcher.rs
@@ -16,12 +16,12 @@ pub enum StringMatcher {
     /// For example, `*` matches any string, `py*` matches any string starting
     /// with `py`, `*37` matches any string ending with `37` and `py*37`
     /// matches any string starting with `py` and ending with `37`.
-    Glob(glob::Pattern),
+    Glob(Box<glob::Pattern>),
     /// Match the string by regex. A regex starts with a `^`, ends with a `$`
     /// and uses the regex syntax. For example, `^py.*37$` matches any
     /// string starting with `py` and ending with `37`. Note that the regex
     /// is anchored, so it must match the entire string.
-    Regex(fancy_regex::Regex),
+    Regex(Box<fancy_regex::Regex>),
 }
 
 impl Hash for StringMatcher {
@@ -81,17 +81,19 @@ impl FromStr for StringMatcher {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.starts_with('^') && s.ends_with('$') {
-            Ok(StringMatcher::Regex(fancy_regex::Regex::new(s).map_err(
-                |_err| StringMatcherParseError::InvalidRegex {
-                    regex: s.to_string(),
-                },
-            )?))
+            Ok(StringMatcher::Regex(Box::new(
+                fancy_regex::Regex::new(s).map_err(|_err| {
+                    StringMatcherParseError::InvalidRegex {
+                        regex: s.to_string(),
+                    }
+                })?,
+            )))
         } else if s.contains('*') {
-            Ok(StringMatcher::Glob(glob::Pattern::new(s).map_err(
-                |_err| StringMatcherParseError::InvalidGlob {
+            Ok(StringMatcher::Glob(Box::new(
+                glob::Pattern::new(s).map_err(|_err| StringMatcherParseError::InvalidGlob {
                     glob: s.to_string(),
-                },
-            )?))
+                })?,
+            )))
         } else {
             Ok(StringMatcher::Exact(s.to_string()))
         }
@@ -146,11 +148,11 @@ mod tests {
             "foo".parse().unwrap()
         );
         assert_eq!(
-            StringMatcher::Glob(glob::Pattern::new("foo*").unwrap()),
+            StringMatcher::Glob(Box::new(glob::Pattern::new("foo*").unwrap())),
             "foo*".parse().unwrap()
         );
         assert_eq!(
-            StringMatcher::Regex(fancy_regex::Regex::new("^foo.*$").unwrap()),
+            StringMatcher::Regex(Box::new(fancy_regex::Regex::new("^foo.*$").unwrap())),
             "^foo.*$".parse().unwrap()
         );
     }

--- a/crates/rattler_conda_types/src/match_spec/package_name_matcher.rs
+++ b/crates/rattler_conda_types/src/match_spec/package_name_matcher.rs
@@ -18,12 +18,12 @@ pub enum PackageNameMatcher {
     /// For example, `*` matches any string, `foo*` matches any string starting
     /// with `foo`, `*bar` matches any string ending with `bar` and `foo*bar`
     /// matches any string starting with `foo` and ending with `bar`.
-    Glob(glob::Pattern),
+    Glob(Box<glob::Pattern>),
     /// Match the string by regex. A regex starts with a `^`, ends with a `$`
     /// and uses the regex syntax. For example, `^foo.*bar$` matches any
     /// string starting with `foo` and ending with `bar`. Note that the regex
     /// is anchored, so it must match the entire string.
-    Regex(fancy_regex::Regex),
+    Regex(Box<fancy_regex::Regex>),
 }
 
 impl Hash for PackageNameMatcher {
@@ -101,7 +101,9 @@ impl PackageNameMatcher {
 
 impl Default for PackageNameMatcher {
     fn default() -> Self {
-        PackageNameMatcher::Glob(glob::Pattern::new("*").expect("wildcard glob is always valid"))
+        PackageNameMatcher::Glob(Box::new(
+            glob::Pattern::new("*").expect("wildcard glob is always valid"),
+        ))
     }
 }
 
@@ -113,13 +115,13 @@ impl From<PackageName> for PackageNameMatcher {
 
 impl From<glob::Pattern> for PackageNameMatcher {
     fn from(value: glob::Pattern) -> Self {
-        PackageNameMatcher::Glob(value)
+        PackageNameMatcher::Glob(Box::new(value))
     }
 }
 
 impl From<fancy_regex::Regex> for PackageNameMatcher {
     fn from(value: fancy_regex::Regex) -> Self {
-        PackageNameMatcher::Regex(value)
+        PackageNameMatcher::Regex(Box::new(value))
     }
 }
 
@@ -156,17 +158,17 @@ impl FromStr for PackageNameMatcher {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.starts_with('^') && s.ends_with('$') {
-            Ok(PackageNameMatcher::Regex(
+            Ok(PackageNameMatcher::Regex(Box::new(
                 fancy_regex::Regex::new(s).map_err(|_err| PackageNameMatcherParseError::Regex {
                     regex: s.to_string(),
                 })?,
-            ))
+            )))
         } else if s.contains('*') {
-            Ok(PackageNameMatcher::Glob(glob::Pattern::new(s).map_err(
-                |_err| PackageNameMatcherParseError::Glob {
+            Ok(PackageNameMatcher::Glob(Box::new(
+                glob::Pattern::new(s).map_err(|_err| PackageNameMatcherParseError::Glob {
                     glob: s.to_string(),
-                },
-            )?))
+                })?,
+            )))
         } else {
             Ok(PackageNameMatcher::Exact(
                 PackageName::from_str(s).map_err(|e| {
@@ -226,11 +228,11 @@ mod tests {
             "foo".parse().unwrap()
         );
         assert_eq!(
-            PackageNameMatcher::Glob(glob::Pattern::new("foo*bar").unwrap()),
+            PackageNameMatcher::Glob(Box::new(glob::Pattern::new("foo*bar").unwrap())),
             "foo*bar".parse().unwrap()
         );
         assert_eq!(
-            PackageNameMatcher::Regex(fancy_regex::Regex::new("^foo.*$").unwrap()),
+            PackageNameMatcher::Regex(Box::new(fancy_regex::Regex::new("^foo.*$").unwrap())),
             "^foo.*$".parse().unwrap()
         );
     }

--- a/crates/rattler_conda_types/src/package_name.rs
+++ b/crates/rattler_conda_types/src/package_name.rs
@@ -21,8 +21,8 @@ use crate::utils::serde::DeserializeFromStrUnchecked;
 /// to make the distinction.
 #[derive(Debug, Clone, Eq, DeserializeFromStr)]
 pub struct PackageName {
-    normalized: Option<String>,
-    source: String,
+    normalized: Option<Box<str>>,
+    source: Box<str>,
 }
 
 impl PackageName {
@@ -32,7 +32,7 @@ impl PackageName {
     pub fn new_unchecked<S: Into<String>>(normalized: S) -> Self {
         Self {
             normalized: None,
-            source: normalized.into(),
+            source: normalized.into().into_boxed_str(),
         }
     }
 
@@ -45,7 +45,7 @@ impl PackageName {
     /// Returns the normalized version of the package name. The normalized string is guaranteed to
     /// be a valid conda package name.
     pub fn as_normalized(&self) -> &str {
-        self.normalized.as_ref().unwrap_or(&self.source)
+        self.normalized.as_deref().unwrap_or(&self.source)
     }
 
     /// Parses the package name part from a matchspec string without parsing
@@ -96,13 +96,13 @@ impl PackageName {
     pub fn from_matchspec_str_unchecked(spec: &str) -> Self {
         let (name, has_upper) = scan_matchspec_name(spec);
         let normalized = if has_upper {
-            Some(name.to_ascii_lowercase())
+            Some(name.to_ascii_lowercase().into_boxed_str())
         } else {
             None
         };
         Self {
             normalized,
-            source: name.to_string(),
+            source: name.to_string().into_boxed_str(),
         }
     }
 
@@ -182,7 +182,7 @@ impl TryFrom<&String> for PackageName {
     type Error = InvalidPackageNameError;
 
     fn try_from(value: &String) -> Result<Self, Self::Error> {
-        value.clone().try_into()
+        value.as_str().try_into()
     }
 }
 
@@ -209,12 +209,15 @@ impl TryFrom<String> for PackageName {
         // Convert all characters to lowercase but only if it actually contains uppercase. This way
         // we dont allocate the memory of the string if it is already lowercase.
         let normalized = if source.bytes().any(|b| b.is_ascii_uppercase()) {
-            Some(source.to_ascii_lowercase())
+            Some(source.to_ascii_lowercase().into_boxed_str())
         } else {
             None
         };
 
-        Ok(Self { normalized, source })
+        Ok(Self {
+            normalized,
+            source: source.into_boxed_str(),
+        })
     }
 }
 
@@ -285,14 +288,14 @@ impl Borrow<str> for PackageName {
 
 /// A package name in its original source form (not normalized).
 ///
-/// This is a newtype around [`String`] that preserves the exact casing and
+/// This is a newtype around [`Box<str>`] that preserves the exact casing and
 /// formatting as written by the user (e.g. `MyPackage` instead of `mypackage`).
 ///
 /// Use this type when you only care about the source name. If you need to
 /// retain both the source and normalized forms, use [`PackageName`] instead.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct SourcePackageName(String);
+pub struct SourcePackageName(Box<str>);
 
 impl SourcePackageName {
     /// Returns the source package name as a string slice.
@@ -309,13 +312,14 @@ impl std::fmt::Display for SourcePackageName {
 
 impl From<PackageName> for SourcePackageName {
     fn from(name: PackageName) -> Self {
-        Self(name.as_source().to_string())
+        Self(name.source)
     }
 }
 
 impl From<SourcePackageName> for PackageName {
     fn from(name: SourcePackageName) -> Self {
-        PackageName::try_from(name.0).expect("SourcePackageName is always a valid PackageName")
+        PackageName::try_from(name.0.into_string())
+            .expect("SourcePackageName is always a valid PackageName")
     }
 }
 
@@ -327,14 +331,14 @@ impl AsRef<str> for SourcePackageName {
 
 /// A normalized package name (always lowercase).
 ///
-/// This is a newtype around [`String`] that guarantees the package name is in
+/// This is a newtype around [`Box<str>`] that guarantees the package name is in
 /// its normalized (lowercase) form.
 ///
 /// Use this type when you only care about the normalized name. If you need to
 /// retain both the source and normalized forms, use [`PackageName`] instead.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct NormalizedPackageName(String);
+pub struct NormalizedPackageName(Box<str>);
 
 impl NormalizedPackageName {
     /// Returns the normalized package name as a string slice.
@@ -351,7 +355,7 @@ impl std::fmt::Display for NormalizedPackageName {
 
 impl From<PackageName> for NormalizedPackageName {
     fn from(name: PackageName) -> Self {
-        Self(name.as_normalized().to_string())
+        Self(name.as_normalized().to_string().into_boxed_str())
     }
 }
 


### PR DESCRIPTION
### Description

Three changes to reduce the inline size of MatchSpec-related types:

1. Box Glob and Regex variants in StringMatcher (144 → 24 bytes) and PackageNameMatcher (144 → 32 bytes). These variants hold large types (fancy_regex::Regex at 144 bytes, glob::Pattern at 56 bytes) that are rarely used compared to the Exact variant.

2. Use Box<str> instead of String in PackageName (48 → 32 bytes). Package names are immutable after creation, so the extra capacity field of String is wasted space.

Combined effect on struct sizes:
- NamelessMatchSpec: 600 → 480 bytes (−20%)
- MatchSpec: 744 → 520 bytes (−30%)


This makes some operations a little slower if they have to chase the Box pointer, but the Glob and Regex variants are use way less often so I think thats fine.

### How Has This Been Tested?

All unit tests still succeed

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
