### PR TITLE
fix: CLI crash on malformed virtual package version

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -255,7 +255,7 @@ pub async fn create(opt: Opt) -> miette::Result<()> {
                         version: elems
                             .get(1)
                             .map_or(Version::from_str("0"), |s| Version::from_str(s))
-                            .expect("Could not parse virtual package version"),
+                            .into_diagnostic()?,
                         build_string: (*elems.get(2).unwrap_or(&"")).to_string(),
                     })
                 })


### PR DESCRIPTION
Fixes #2326

### Summary
Replace `.expect()` with proper error propagation to prevent a CLI panic when parsing malformed virtual package versions.

### Details
The CLI previously used `.expect("Could not parse virtual package version")`, which caused a runtime panic on invalid input.

This change replaces it with `.into_diagnostic()?`, allowing the error to be propagated via `miette::Result<()>` and handled gracefully.

### Impact
- Prevents CLI crashes on malformed `--virtual-package` input
- Minimal change, no behavioral side effects