### PR TITLE
refactor: rewrite SourceTimestamps ser/de using serde-untagged

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5230,6 +5230,7 @@ dependencies = [
  "rattler_solve",
  "rstest",
  "serde",
+ "serde-untagged",
  "serde-value",
  "serde_json",
  "serde_repr",

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -24,6 +24,7 @@ pep440_rs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
 serde_with = { workspace = true, features = ["indexmap_2"] }
+serde-untagged = { workspace = true }
 serde_repr = { workspace = true }
 serde-value = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -626,6 +626,7 @@ mod test {
     #[case::v7_conda_source_path("v7/conda-path-lock.yml")]
     #[case::v7_derived_channel("v7/derived-channel-lock.yml")]
     #[case::v7_sources("v7/sources-lock.yml")]
+    #[case::v7_source_timestamps_map("v7/source-timestamps-map-lock.yml")]
     #[case::v7_options("v7/options-lock.yml")]
     #[case::v7_pixi_build_pinned_source("v7/pixi-build-pinned-source-lock.yml")]
     #[case::v7_pixi_build_url_source("v7/pixi-build-url-source-lock.yml")]

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__source-timestamps-map-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__source-timestamps-map-lock.yml.snap
@@ -1,0 +1,33 @@
+---
+source: crates/rattler_lock/src/lib.rs
+expression: conda_lock
+---
+version: 7
+platforms:
+  - name: win-64
+environments:
+  default:
+    channels:
+      - url: "https://conda.anaconda.org/conda-forge/"
+      - url: "https://conda.anaconda.org/bioconda/"
+    packages:
+      win-64:
+        - conda_source: "child-package[87dc0b8a] @ child-package"
+packages:
+  - conda_source: "child-package[87dc0b8a] @ child-package"
+    version: 0.1.0
+    build: pyhbf21a9e_0
+    subdir: noarch
+    depends:
+      - path
+    timestamp:
+      latest: 1699280294368
+      channels:
+        "https://conda.anaconda.org/bioconda": ~
+        "https://conda.anaconda.org/conda-forge": 1699280294000
+      packages:
+        numpy: 1699280200000
+        scipy: ~
+    source_depends:
+      path:
+        path: foobar

--- a/crates/rattler_lock/src/source_timestamps.rs
+++ b/crates/rattler_lock/src/source_timestamps.rs
@@ -1,13 +1,14 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
 use rattler_conda_types::{ChannelUrl, PackageName};
-use serde::de::{self, MapAccess, Visitor};
-use serde::ser::SerializeMap;
+use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use url::Url;
+use serde_untagged::UntaggedEnumVisitor;
+use serde_with::serde_as;
 
-use crate::utils::serde::{datetime_to_millis, millis_to_datetime};
+use crate::utils::serde::{datetime_to_millis, millis_to_datetime, Timestamp};
 
 /// Timestamps associated with a source package.
 ///
@@ -19,7 +20,7 @@ use crate::utils::serde::{datetime_to_millis, millis_to_datetime};
 ///
 /// ```yaml
 /// timestamp:
-///   default: 1699280294368
+///   latest: 1699280294368
 ///   channels:
 ///     https://conda.anaconda.org/conda-forge: 1699280294000
 ///   packages:
@@ -76,169 +77,149 @@ impl SourceTimestamps {
 }
 
 // ---------------------------------------------------------------------------
-// Serialization
+// Serialization / Deserialization
 // ---------------------------------------------------------------------------
+
+/// Helper struct mirroring the map form of [`SourceTimestamps`].
+///
+/// Acts as the single source of truth for the map-shaped wire format used by
+/// both serialization and deserialization. The `Cow` fields allow
+/// serialization to borrow from a live `SourceTimestamps` without cloning,
+/// while deserialization produces owned data.
+#[serde_as]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SourceTimestampsMap<'a> {
+    #[serde_as(as = "Timestamp")]
+    latest: DateTime<Utc>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "cow_btree_is_empty",
+        with = "optional_millis_map"
+    )]
+    channels: Cow<'a, BTreeMap<ChannelUrl, Option<DateTime<Utc>>>>,
+
+    #[serde(
+        default,
+        skip_serializing_if = "cow_btree_is_empty",
+        with = "optional_millis_map"
+    )]
+    packages: Cow<'a, BTreeMap<PackageName, Option<DateTime<Utc>>>>,
+}
+
+#[allow(clippy::ptr_arg)] // signature is required by `#[serde(skip_serializing_if = ...)]`
+fn cow_btree_is_empty<K: Clone, V: Clone>(map: &Cow<'_, BTreeMap<K, V>>) -> bool {
+    map.is_empty()
+}
+
+impl From<SourceTimestampsMap<'_>> for SourceTimestamps {
+    fn from(value: SourceTimestampsMap<'_>) -> Self {
+        Self {
+            latest: value.latest,
+            channels: value.channels.into_owned(),
+            packages: value.packages.into_owned(),
+        }
+    }
+}
 
 impl Serialize for SourceTimestamps {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        // Simple case: only default timestamp, serialize as plain i64.
+        // Simple case: only the `latest` timestamp is set; serialize as a
+        // plain integer (milliseconds) for backwards compatibility.
         if self.is_simple() {
             return datetime_to_millis(&self.latest).serialize(serializer);
         }
 
-        // Complex case: serialize as map.
-        let mut count = 1; // always have default
-        if !self.channels.is_empty() {
-            count += 1;
+        // Complex case: delegate to the helper struct, borrowing the
+        // channel/package maps to avoid cloning.
+        SourceTimestampsMap {
+            latest: self.latest,
+            channels: Cow::Borrowed(&self.channels),
+            packages: Cow::Borrowed(&self.packages),
         }
-        if !self.packages.is_empty() {
-            count += 1;
-        }
-
-        let mut map = serializer.serialize_map(Some(count))?;
-        map.serialize_entry("latest", &datetime_to_millis(&self.latest))?;
-
-        if !self.channels.is_empty() {
-            map.serialize_entry("channels", &OptionTimestampMap::Channels(&self.channels))?;
-        }
-
-        if !self.packages.is_empty() {
-            map.serialize_entry("packages", &OptionTimestampMap::Packages(&self.packages))?;
-        }
-
-        map.end()
+        .serialize(serializer)
     }
 }
-
-/// Helper to serialize `BTreeMap<K, Option<DateTime<Utc>>>` where each value
-/// is either milliseconds or `null`.
-enum OptionTimestampMap<'a> {
-    Channels(&'a BTreeMap<ChannelUrl, Option<DateTime<Utc>>>),
-    Packages(&'a BTreeMap<PackageName, Option<DateTime<Utc>>>),
-}
-
-impl Serialize for OptionTimestampMap<'_> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self {
-            OptionTimestampMap::Channels(map) => {
-                let mut m = serializer.serialize_map(Some(map.len()))?;
-                for (k, v) in *map {
-                    m.serialize_entry(k.as_str(), &v.as_ref().map(datetime_to_millis))?;
-                }
-                m.end()
-            }
-            OptionTimestampMap::Packages(map) => {
-                let mut m = serializer.serialize_map(Some(map.len()))?;
-                for (k, v) in *map {
-                    m.serialize_entry(k.as_normalized(), &v.as_ref().map(datetime_to_millis))?;
-                }
-                m.end()
-            }
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Deserialization
-// ---------------------------------------------------------------------------
 
 impl<'de> Deserialize<'de> for SourceTimestamps {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_any(SourceTimestampsVisitor)
+        UntaggedEnumVisitor::new()
+            .expecting("an integer (milliseconds) or a map with latest/channels/packages")
+            .i64(|v| {
+                millis_to_datetime(v)
+                    .map(SourceTimestamps::from_default)
+                    .ok_or_else(|| serde_untagged::de::Error::custom("timestamp out of range"))
+            })
+            .u64(|v| {
+                let v = i64::try_from(v).map_err(serde_untagged::de::Error::custom)?;
+                millis_to_datetime(v)
+                    .map(SourceTimestamps::from_default)
+                    .ok_or_else(|| serde_untagged::de::Error::custom("timestamp out of range"))
+            })
+            .map(|map| map.deserialize::<SourceTimestampsMap<'_>>().map(Into::into))
+            .deserialize(deserializer)
     }
 }
 
-struct SourceTimestampsVisitor;
+/// Serialization helpers for `Cow<'_, BTreeMap<K, Option<DateTime<Utc>>>>`
+/// where the timestamp values are stored on the wire as milliseconds since
+/// the Unix epoch (or `null`).
+mod optional_millis_map {
+    use std::borrow::Cow;
+    use std::collections::BTreeMap;
 
-impl<'de> Visitor<'de> for SourceTimestampsVisitor {
-    type Value = SourceTimestamps;
+    use chrono::{DateTime, Utc};
+    use serde::de::Error as _;
+    use serde::ser::SerializeMap;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("an integer (milliseconds) or a map with default/channels/packages")
-    }
+    use crate::utils::serde::{datetime_to_millis, millis_to_datetime};
 
-    fn visit_i64<E: de::Error>(self, v: i64) -> Result<Self::Value, E> {
-        let dt = millis_to_datetime(v).ok_or_else(|| E::custom("timestamp out of range"))?;
-        Ok(SourceTimestamps::from_default(dt))
-    }
+    type TimestampMap<K> = BTreeMap<K, Option<DateTime<Utc>>>;
 
-    fn visit_u64<E: de::Error>(self, v: u64) -> Result<Self::Value, E> {
-        self.visit_i64(v as i64)
-    }
-
-    fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-        let mut latest: Option<DateTime<Utc>> = None;
-        let mut channels: BTreeMap<ChannelUrl, Option<DateTime<Utc>>> = BTreeMap::new();
-        let mut packages: BTreeMap<PackageName, Option<DateTime<Utc>>> = BTreeMap::new();
-
-        while let Some(key) = map.next_key::<&str>()? {
-            match key {
-                "latest" => {
-                    let millis: i64 = map.next_value()?;
-                    latest = Some(
-                        millis_to_datetime(millis)
-                            .ok_or_else(|| de::Error::custom("default timestamp out of range"))?,
-                    );
-                }
-                "channels" => {
-                    let raw: BTreeMap<String, Option<i64>> = map.next_value()?;
-                    for (url_str, ms) in raw {
-                        let url: ChannelUrl =
-                            Url::parse(&url_str).map_err(de::Error::custom)?.into();
-                        let dt = ms
-                            .map(|m| {
-                                millis_to_datetime(m).ok_or_else(|| {
-                                    de::Error::custom(format!(
-                                        "channel timestamp out of range for {url_str}"
-                                    ))
-                                })
-                            })
-                            .transpose()?;
-                        channels.insert(url, dt);
-                    }
-                }
-                "packages" => {
-                    let raw: BTreeMap<String, Option<i64>> = map.next_value()?;
-                    for (name_str, ms) in raw {
-                        let name = PackageName::new_unchecked(name_str);
-                        let dt = ms
-                            .map(|m| {
-                                millis_to_datetime(m).ok_or_else(|| {
-                                    de::Error::custom(format!(
-                                        "package timestamp out of range for {}",
-                                        name.as_normalized()
-                                    ))
-                                })
-                            })
-                            .transpose()?;
-                        packages.insert(name, dt);
-                    }
-                }
-                other => {
-                    return Err(de::Error::unknown_field(
-                        other,
-                        &["default", "channels", "packages"],
-                    ));
-                }
-            }
+    #[allow(clippy::ptr_arg)] // signature is required by `#[serde(with = ...)]`
+    pub(super) fn serialize<S, K>(
+        map: &Cow<'_, TimestampMap<K>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+        K: Serialize + Ord + Clone,
+    {
+        let mut m = serializer.serialize_map(Some(map.len()))?;
+        for (key, value) in map.iter() {
+            m.serialize_entry(key, &value.as_ref().map(datetime_to_millis))?;
         }
+        m.end()
+    }
 
-        let default = latest.ok_or_else(|| de::Error::missing_field("latest"))?;
-
-        Ok(SourceTimestamps {
-            latest: default,
-            channels,
-            packages,
-        })
+    pub(super) fn deserialize<'de, 'a, D, K>(
+        deserializer: D,
+    ) -> Result<Cow<'a, TimestampMap<K>>, D::Error>
+    where
+        D: Deserializer<'de>,
+        K: Deserialize<'de> + Ord + Clone,
+    {
+        let raw = BTreeMap::<K, Option<i64>>::deserialize(deserializer)?;
+        let mut out = BTreeMap::new();
+        for (key, value) in raw {
+            let dt = match value {
+                Some(millis) => Some(
+                    millis_to_datetime(millis)
+                        .ok_or_else(|| D::Error::custom("timestamp out of range"))?,
+                ),
+                None => None,
+            };
+            out.insert(key, dt);
+        }
+        Ok(Cow::Owned(out))
     }
 }
 
@@ -254,10 +235,20 @@ impl From<DateTime<Utc>> for SourceTimestamps {
 
 #[cfg(test)]
 mod tests {
+    use url::Url;
+
     use super::*;
 
     fn dt(millis: i64) -> DateTime<Utc> {
         millis_to_datetime(millis).unwrap()
+    }
+
+    fn channel(url: &str) -> ChannelUrl {
+        ChannelUrl::from(Url::parse(url).unwrap())
+    }
+
+    fn pkg(name: &str) -> PackageName {
+        PackageName::new_unchecked(name.to_string())
     }
 
     #[test]
@@ -274,10 +265,10 @@ mod tests {
         let ts = SourceTimestamps {
             latest: dt(1699280294368),
             channels: BTreeMap::from([(
-                ChannelUrl::from(Url::parse("https://conda.anaconda.org/conda-forge/").unwrap()),
+                channel("https://conda.anaconda.org/conda-forge/"),
                 Some(dt(1699280294000)),
             )]),
-            packages: BTreeMap::from([(PackageName::new_unchecked("numpy".to_string()), None)]),
+            packages: BTreeMap::from([(pkg("numpy"), None)]),
         };
         let yaml = serde_yaml::to_string(&ts).unwrap();
         assert!(yaml.contains("latest:"));
@@ -300,10 +291,69 @@ mod tests {
         let simple = SourceTimestamps::from_default(dt(1000));
         assert!(simple.is_simple());
 
-        let complex = simple.with_package(
-            PackageName::new_unchecked("foo".to_string()),
-            Some(dt(2000)),
-        );
+        let complex = simple.with_package(pkg("foo"), Some(dt(2000)));
         assert!(!complex.is_simple());
+    }
+
+    #[test]
+    fn deserialize_map_form() {
+        let yaml = r#"
+latest: 1699280294368
+channels:
+  https://conda.anaconda.org/conda-forge: 1699280294000
+  https://conda.anaconda.org/bioconda: null
+packages:
+  numpy: 1699280200000
+  scipy: null
+"#;
+        let ts: SourceTimestamps = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(ts.latest, dt(1699280294368));
+        assert_eq!(
+            ts.channels[&channel("https://conda.anaconda.org/conda-forge/")],
+            Some(dt(1699280294000))
+        );
+        assert_eq!(
+            ts.channels[&channel("https://conda.anaconda.org/bioconda/")],
+            None
+        );
+        assert_eq!(ts.packages[&pkg("numpy")], Some(dt(1699280200000)));
+        assert_eq!(ts.packages[&pkg("scipy")], None);
+    }
+
+    #[test]
+    fn deserialize_map_form_missing_channels_packages_uses_defaults() {
+        let yaml = "latest: 1699280294368\n";
+        let ts: SourceTimestamps = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(ts.latest, dt(1699280294368));
+        assert!(ts.is_simple());
+    }
+
+    #[test]
+    fn deserialize_map_form_unknown_field_is_rejected() {
+        let yaml = "latest: 1\nunknown: 2\n";
+        let err = serde_yaml::from_str::<SourceTimestamps>(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown"), "error was: {msg}");
+    }
+
+    #[test]
+    fn map_roundtrip_multiple_channels_and_packages() {
+        let ts = SourceTimestamps {
+            latest: dt(1699280294368),
+            channels: BTreeMap::from([
+                (
+                    channel("https://conda.anaconda.org/conda-forge/"),
+                    Some(dt(1699280294000)),
+                ),
+                (channel("https://conda.anaconda.org/bioconda/"), None),
+            ]),
+            packages: BTreeMap::from([
+                (pkg("numpy"), Some(dt(1699280200000))),
+                (pkg("scipy"), None),
+            ]),
+        };
+        let yaml = serde_yaml::to_string(&ts).unwrap();
+        let back: SourceTimestamps = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(ts, back);
     }
 }

--- a/test-data/conda-lock/v7/source-timestamps-map-lock.yml
+++ b/test-data/conda-lock/v7/source-timestamps-map-lock.yml
@@ -1,0 +1,29 @@
+version: 7
+platforms:
+  - name: win-64
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+      - url: https://conda.anaconda.org/bioconda/
+    packages:
+      win-64:
+        - conda_source: "child-package[87dc0b8a] @ child-package"
+packages:
+  - conda_source: "child-package[87dc0b8a] @ child-package"
+    version: 0.1.0
+    build: pyhbf21a9e_0
+    subdir: noarch
+    depends:
+      - path
+    source_depends:
+      path:
+        path: "foobar"
+    timestamp:
+      latest: 1699280294368
+      channels:
+        https://conda.anaconda.org/bioconda: null
+        https://conda.anaconda.org/conda-forge: 1699280294000
+      packages:
+        numpy: 1699280200000
+        scipy: null


### PR DESCRIPTION
### Description

Rewrites the `SourceTimestamps` (de)serialization in `rattler_lock`:

- Replaces the hand-written `deserialize_any` / `Visitor` implementation with `serde_untagged::UntaggedEnumVisitor` for the integer-or-map shape.
- Unifies ser and de onto a single `SourceTimestampsMap<'a>` helper with `#[derive(Serialize, Deserialize)]`. Its `channels` / `packages` fields are `Cow<'_, BTreeMap<..>>` so the serialize path can borrow from the live `SourceTimestamps` without cloning, while deserialization still produces owned data.
- Moves the ms/DateTime conversion into a small generic `optional_millis_map` helper module used via `#[serde(with = ...)]`. The `latest` field reuses the existing `Timestamp` serde_with adapter, and `#[serde(deny_unknown_fields)]` gives unknown-field rejection for free.
- Fixes a stale doc comment (`default:` -> `latest:`).

Fixes #{issue}

### How Has This Been Tested?

- Added unit tests in `source_timestamps.rs` covering the map form (multi-channel / multi-package with a mix of `Some`/`null`), the `latest`-only map form, unknown-field rejection, and a multi-entry roundtrip.
- Added a new v7 fixture `test-data/conda-lock/v7/source-timestamps-map-lock.yml` that exercises the map form end-to-end through `test_parse` (insta snapshot) and `test_roundtrip` in `lib.rs`.
- `cargo fmt`, `cargo clippy -p rattler_lock --all-targets -- -D warnings`, and `cargo test -p rattler_lock` (179 tests) all pass.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.