### PR TITLE
fix: Hammer down the sort order of conda source packages

### DIFF
--- a/crates/rattler_lock/src/conda.rs
+++ b/crates/rattler_lock/src/conda.rs
@@ -581,7 +581,13 @@ impl Ord for CondaPackageData {
                 (Some(src_a), Some(src_b)) => src_a
                     .variants
                     .cmp(&src_b.variants)
-                    .then_with(|| src_a.package_build_source.cmp(&src_b.package_build_source)),
+                    .then_with(|| src_a.package_build_source.cmp(&src_b.package_build_source))
+                    .then_with(|| match (&src_a.timestamp, &src_b.timestamp) {
+                        (Some(a), Some(b)) => (a.latest).cmp(&b.latest),
+                        (Some(_), None) => Ordering::Less,
+                        (None, Some(_)) => Ordering::Greater,
+                        (None, None) => Ordering::Equal,
+                    }),
                 _ => Ordering::Equal,
             })
     }


### PR DESCRIPTION
Take the timestamp into account: We may have the same package several times for different platforms -- which will all have different timestamps. So we need to take timestamps into account when sorting, or the sources will move around the lock file on re-updates.

### How Has This Been Tested?

A crater run

### AI Disclosure

No AI

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.