### PR TITLE
fix!: Fix rattler_lock version to 0.28.0

### DIFF
--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rattler_lock"
-version = "0.27.7"
+version = "0.28.0"
 edition.workspace = true
 authors = ["Bas Zalmstra <zalmstra.bas@gmail.com>"]
 description = "Rust data types for conda lock files"


### PR DESCRIPTION
Release-plz is confused as it tries to assign 0.27.7 to the next release and that has been yanked at crates.io.

Yanked versions severely confuse release-plz and they can apparently not fix that at this time.