### PR TITLE
fix(shell): gracefully degrade when cygpath fails unexpectedly

### DIFF
--- a/crates/rattler_shell/src/shell/mod.rs
+++ b/crates/rattler_shell/src/shell/mod.rs
@@ -321,7 +321,15 @@ impl Shell for Bash {
                     // When cygpath isn't found, join the paths with the posix separator.
                     paths_vec.join(":")
                 }
-                Err(e) => panic!("{e}"),
+                Err(e) => {
+                    // cygpath is present but failed unexpectedly. Prefer graceful
+                    // degradation (same fallback as NotFound) over panicking in a
+                    // library path — a malformed PATH shouldn't crash callers.
+                    tracing::warn!(
+                        "`cygpath` failed to convert PATH, falling back to POSIX separator: {e}"
+                    );
+                    paths_vec.join(":")
+                }
             }
         } else {
             paths_vec.join(":")
@@ -370,7 +378,14 @@ impl Shell for Bash {
                         // case we just ignore any conversion and use the windows path directly.
                         completions_dir.to_string_lossy().to_string()
                     }
-                    Err(e) => panic!("{e}"),
+                    Err(e) => {
+                        // cygpath was found but failed for another reason (e.g. invoke error).
+                        // Degrade the same way as the NotFound branch instead of panicking.
+                        tracing::warn!(
+                            "`cygpath` failed to convert completions path, using native path: {e}"
+                        );
+                        completions_dir.to_string_lossy().to_string()
+                    }
                 }
             } else {
                 completions_dir.to_string_lossy().to_string()


### PR DESCRIPTION
native_path_to_unix in the Bash shell driver panicked on any cygpath error other than NotFound (e.g. invocation failure, non-UTF8 stdout). The NotFound branch already falls back to the raw path or POSIX separator join; extend that same fallback to all error kinds and emit a tracing::warn instead of aborting the process.

Scope: crates/rattler_shell/src/shell/mod.rs lines 324 and 373 (impl
Shell for Bash :: set_path and :: source_completions).

Behavior: on non-Windows unchanged (cfg!(windows) gate). On Windows when cygpath succeeds, unchanged. On Windows when cygpath fails for any reason, the shell now logs a warning and continues with a sane fallback path instead of panicking library callers.

### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #{issue}

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
