### PR TITLE
docs(repodata_gateway): document Safety contract for SparseRepoData mmap

### DIFF
--- a/crates/rattler_repodata_gateway/src/sparse/mod.rs
+++ b/crates/rattler_repodata_gateway/src/sparse/mod.rs
@@ -164,6 +164,30 @@ impl SparseRepoData {
         #[cfg(not(windows))]
         let file = std::fs::File::from(fs_err::File::open(path.as_ref())?);
 
+        // SAFETY: `memmap2::Mmap::map` requires that the mapped file is not
+        // concurrently modified by this process or another process while the
+        // mapping is live; violating this is undefined behaviour (SIGBUS or
+        // torn reads).
+        //
+        // We uphold that as follows:
+        //   * `file` is opened read-only and is moved into this function; no
+        //     code in this crate writes to an already-open repodata file.
+        //   * `file` is kept alive for the lifetime of the `Mmap` via the
+        //     self-referential `SparseRepoDataInner::Memmapped` built below,
+        //     so the OS will not drop the backing storage while the mapping
+        //     exists.
+        //   * On Windows the file is opened with `FILE_SHARE_READ | WRITE |
+        //     DELETE` (see the block above) so another process renaming or
+        //     deleting the file does not invalidate the existing mapping.
+        //   * Writers in the repodata gateway use write-then-rename (temp
+        //     file + atomic rename) to publish a new repodata.json, so an
+        //     existing `Mmap` continues to refer to its original inode.
+        //
+        // External processes that bypass these conventions and truncate the
+        // file in place can still cause SIGBUS; that is a system-integrity
+        // violation outside the library's contract, not a latent library
+        // bug. If stricter safety is ever required, switch to `fs::read`
+        // and pay the memory cost of fully buffering large repodata files.
         let memory_map = unsafe { memmap2::Mmap::map(&file) }?;
         Ok(SparseRepoData {
             inner: SparseRepoDataInner::Memmapped(MemmappedSparseRepoDataInner::try_new(


### PR DESCRIPTION
The `unsafe { memmap2::Mmap::map(&file) }` call in SparseRepoData::from_file had no accompanying // SAFETY comment, even though the invariants it relies on are concrete and upheld by this crate.

Document them inline so future changes to file lifetime, Windows sharing flags, or the gateway's write-then-rename publishing scheme remain aware of the contract. Also note the residual system-integrity caveat (external truncation in place) and the escape hatch (fs::read) for callers who cannot accept that.

No behavior change. Pure documentation.

Verified:
- `NamedTempFile::persist` is used by fetch/with_cache.rs:449 to publish repodata atomically, consistent with the Safety note.
- Windows `FILE_SHARE_*` flags are set in the block immediately above.

### Description

<!--- Please include a summary of the change and which issue is fixed. --->
<!--- Please also include relevant motivation and context. -->

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

Fixes #{issue}

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [ ] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [ ] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: {e.g., Claude, Codex, GitHub Copilot, ChatGPT, etc.}

### Checklist:
<!--- Remove the non relevant items. --->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
