### PR TITLE
chore: automerge passing lockfile bumps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,6 +8,7 @@
   labels: ["dependencies"],
   schedule: ["before 4am on Tuesday"],
   prHourlyLimit: 10,
+  prConcurrentLimit: 3,
   cargo: {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy
     rangeStrategy: "update-lockfile",
@@ -27,7 +28,8 @@
     {
       "groupName": "Pixi-Lock",
       "matchManagers": ["pixi"],
-      "matchUpdateTypes": ["lockFileMaintenance"]
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "automerge": true,
     },
     {
       description: "We want to update Rust manually and keep it in sync with rust-toolchain",
@@ -42,9 +44,16 @@
       description: "Weekly update of Rust development dependencies",
     },
     {
+      description: "Automerge Cargo patch bumps (only touches Cargo.lock via update-lockfile).",
+      matchManagers: ["cargo"],
+      matchUpdateTypes: ["patch"],
+      automerge: true,
+    },
+    {
       "groupName": "Npm-Lock",
       "matchManagers": ["npm"],
-      "matchUpdateTypes": ["lockFileMaintenance"]
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "automerge": true,
     },
   ],
   vulnerabilityAlerts: {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,8 +7,7 @@
   ignorePaths: ["**/test-data/**"],
   labels: ["dependencies"],
   schedule: ["before 4am on Tuesday"],
-  prHourlyLimit: 10,
-  prConcurrentLimit: 3,
+  prHourlyLimit: 2,
   cargo: {
     // See https://docs.renovatebot.com/configuration-options/#rangestrategy
     rangeStrategy: "update-lockfile",


### PR DESCRIPTION
Just automerge PRs that pass CI and dont affect version bounds. Also reduce the number of PRs per hour to avoid rate limiting with the merge gatekeeper.