### PR TITLE
feat(solve): add cancellation token for in-flight solves

### DIFF
--- a/crates/rattler_solve/benches/sorting_bench.rs
+++ b/crates/rattler_solve/benches/sorting_bench.rs
@@ -34,6 +34,7 @@ fn bench_sort(c: &mut Criterion, sparse_repo_data: &SparseRepoData, spec: &str) 
                     &[],
                     std::slice::from_ref(&match_spec),
                     None,
+                    None,
                     ChannelPriority::default(),
                     None,
                     rattler_solve::SolveStrategy::Highest,

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -11,6 +11,10 @@ pub mod resolvo;
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use chrono::{DateTime, Utc};
 use rattler_conda_types::{
@@ -79,6 +83,68 @@ impl fmt::Display for SolveError {
                 write!(f, "encountered duplicate records for {filename}")
             }
         }
+    }
+}
+
+/// A token that can be used to signal cancellation of an in-flight solve.
+///
+/// The token is cheap to clone and can be shared across threads. Calling
+/// [`CancellationToken::cancel`] on any clone will signal all associated
+/// solves to stop as soon as possible, in which case the solve returns
+/// [`SolveError::Cancelled`].
+///
+/// # Backend support
+///
+/// Cancellation is currently only observed by the [`resolvo`](crate::resolvo)
+/// backend. Other backends (such as [`libsolv_c`](crate::libsolv_c)) silently
+/// ignore the token and will run to completion.
+///
+/// # Example
+///
+/// ```
+/// use rattler_solve::CancellationToken;
+///
+/// let token = CancellationToken::new();
+/// let token_clone = token.clone();
+///
+/// // From another thread / task, request cancellation:
+/// std::thread::spawn(move || {
+///     token_clone.cancel();
+/// });
+///
+/// assert!(!token.is_cancelled() || token.is_cancelled());
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct CancellationToken {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl PartialEq for CancellationToken {
+    /// Two tokens are considered equal when they share the same underlying
+    /// cancellation state (i.e. one is a clone of the other).
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.cancelled, &other.cancelled)
+    }
+}
+
+impl Eq for CancellationToken {}
+
+impl CancellationToken {
+    /// Creates a new, un-cancelled token.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Signals cancellation. All clones of this token will observe the
+    /// cancelled state.
+    pub fn cancel(&self) {
+        self.cancelled.store(true, Ordering::Relaxed);
+    }
+
+    /// Returns `true` if cancellation has been requested on this token (or any
+    /// of its clones).
+    pub fn is_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Relaxed)
     }
 }
 
@@ -339,6 +405,16 @@ pub struct SolverTask<TAvailablePackagesIterator> {
 
     /// Dependency overrides that replace dependencies of matching packages.
     pub dependency_overrides: Vec<(MatchSpec, MatchSpec)>,
+
+    /// An optional token that can be used to cancel an in-flight solve.
+    ///
+    /// When the token's [`CancellationToken::cancel`] method is invoked from
+    /// another thread, the solver stops as soon as possible and returns
+    /// [`SolveError::Cancelled`].
+    ///
+    /// Only the [`resolvo`](crate::resolvo) backend observes this token.
+    /// Other backends ignore it.
+    pub cancellation_token: Option<CancellationToken>,
 }
 
 impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
@@ -357,6 +433,7 @@ impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
             exclude_newer: None,
             strategy: SolveStrategy::default(),
             dependency_overrides: Vec::new(),
+            cancellation_token: None,
         }
     }
 }

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -95,9 +95,9 @@ impl fmt::Display for SolveError {
 ///
 /// # Backend support
 ///
-/// Cancellation is currently only observed by the [`resolvo`](crate::resolvo)
-/// backend. Other backends (such as [`libsolv_c`](crate::libsolv_c)) silently
-/// ignore the token and will run to completion.
+/// Cancellation is currently only observed by the `resolvo` backend. Other
+/// backends (such as `libsolv_c`) silently ignore the token and will run to
+/// completion.
 ///
 /// # Example
 ///
@@ -412,8 +412,8 @@ pub struct SolverTask<TAvailablePackagesIterator> {
     /// another thread, the solver stops as soon as possible and returns
     /// [`SolveError::Cancelled`].
     ///
-    /// Only the [`resolvo`](crate::resolvo) backend observes this token.
-    /// Other backends ignore it.
+    /// Only the `resolvo` backend observes this token. Other backends
+    /// ignore it.
     pub cancellation_token: Option<CancellationToken>,
 }
 

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -26,8 +26,8 @@ use resolvo::{
 };
 
 use crate::{
-    resolvo::conda_sorting::CompareStrategy, ChannelPriority, ExcludeNewer, IntoRepoData,
-    SolveError, SolveStrategy, SolverRepoData, SolverTask,
+    resolvo::conda_sorting::CompareStrategy, CancellationToken, ChannelPriority, ExcludeNewer,
+    IntoRepoData, SolveError, SolveStrategy, SolverRepoData, SolverTask,
 };
 
 mod conda_sorting;
@@ -295,6 +295,8 @@ pub struct CondaDependencyProvider<'a> {
 
     stop_time: Option<std::time::SystemTime>,
 
+    cancellation_token: Option<CancellationToken>,
+
     strategy: SolveStrategy,
 
     direct_dependencies: HashSet<NameId>,
@@ -312,6 +314,7 @@ impl<'a> CondaDependencyProvider<'a> {
         virtual_packages: &'a [GenericVirtualPackage],
         match_specs: &[MatchSpec],
         stop_time: Option<std::time::SystemTime>,
+        cancellation_token: Option<CancellationToken>,
         channel_priority: ChannelPriority,
         exclude_newer: Option<&ExcludeNewer>,
         strategy: SolveStrategy,
@@ -555,6 +558,7 @@ impl<'a> CondaDependencyProvider<'a> {
             matchspec_to_highest_version: RefCell::default(),
             parse_match_spec_cache: RefCell::default(),
             stop_time,
+            cancellation_token,
             strategy,
             direct_dependencies,
             dependency_overrides: override_map,
@@ -599,6 +603,10 @@ impl<'a> CondaDependencyProvider<'a> {
 pub enum CancelReason {
     /// The solver was cancelled because the timeout was reached
     Timeout,
+
+    /// The solver was cancelled because a [`CancellationToken`] was triggered
+    /// by the caller.
+    Cancelled,
 }
 
 impl Interner for CondaDependencyProvider<'_> {
@@ -903,6 +911,11 @@ impl DependencyProvider for CondaDependencyProvider<'_> {
     }
 
     fn should_cancel_with_value(&self) -> Option<Box<dyn std::any::Any>> {
+        if let Some(token) = &self.cancellation_token {
+            if token.is_cancelled() {
+                return Some(Box::new(CancelReason::Cancelled));
+            }
+        }
         if let Some(stop_time) = self.stop_time {
             if std::time::SystemTime::now() > stop_time {
                 return Some(Box::new(CancelReason::Timeout));
@@ -949,6 +962,7 @@ impl super::SolverImpl for Solver {
             &task.virtual_packages,
             task.specs.clone().as_ref(),
             stop_time,
+            task.cancellation_token.clone(),
             task.channel_priority,
             task.exclude_newer.as_ref(),
             task.strategy,

--- a/crates/rattler_solve/tests/backends/main.rs
+++ b/crates/rattler_solve/tests/backends/main.rs
@@ -713,6 +713,7 @@ mod libsolv_c {
                 exclude_newer: None,
                 strategy: SolveStrategy::default(),
                 dependency_overrides: Vec::new(),
+                cancellation_token: None,
             })
             .unwrap()
             .records;
@@ -905,6 +906,27 @@ mod resolvo {
         let solve_error = rattler_solve::resolvo::Solver.solve(task).unwrap_err();
 
         assert!(matches!(solve_error, SolveError::Unsolvable(_)));
+    }
+
+    /// Verifies that a [`CancellationToken`] that is already cancelled causes
+    /// the solver to return [`SolveError::Cancelled`] immediately.
+    #[test]
+    fn test_cancellation_token_pre_cancelled() {
+        use rattler_solve::CancellationToken;
+
+        let cancellation_token = CancellationToken::new();
+        cancellation_token.cancel();
+
+        let specs: Vec<MatchSpec> = vec!["foo".parse().unwrap()];
+
+        let task = SolverTask {
+            specs,
+            cancellation_token: Some(cancellation_token),
+            ..SolverTask::from_iter([&[] as &[RepoDataRecord]])
+        };
+
+        let solve_error = rattler_solve::resolvo::Solver.solve(task).unwrap_err();
+        assert!(matches!(solve_error, SolveError::Cancelled));
     }
 
     #[test]

--- a/crates/rattler_solve/tests/sorting.rs
+++ b/crates/rattler_solve/tests/sorting.rs
@@ -48,6 +48,7 @@ fn create_sorting_snapshot(package_name: &str, strategy: SolveStrategy) -> Strin
         &[],
         std::slice::from_ref(&match_spec),
         None,
+        None,
         ChannelPriority::default(),
         None,
         strategy,

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -121,6 +121,7 @@ pub fn py_solve<'a>(
                 exclude_newer,
                 strategy: strategy.map_or_else(Default::default, |v| v.0),
                 dependency_overrides: Vec::new(),
+                cancellation_token: None,
             };
 
             Ok::<_, PyErr>(
@@ -223,6 +224,7 @@ pub fn py_solve_with_sparse_repodata<'py>(
                 exclude_newer,
                 strategy: strategy.map_or_else(Default::default, |v| v.0),
                 dependency_overrides: Vec::new(),
+                cancellation_token: None,
             };
 
             Ok::<_, PyErr>(

--- a/tools/create-resolvo-snapshot/src/main.rs
+++ b/tools/create-resolvo-snapshot/src/main.rs
@@ -74,6 +74,7 @@ async fn main() {
         &[],
         &[],
         None,
+        None,
         ChannelPriority::default(),
         None,
         SolveStrategy::default(),


### PR DESCRIPTION
Introduces `CancellationToken` in `rattler_solve` and a `cancellation_token: Option<CancellationToken>` field on `SolverTask`. When the token is cancelled from another thread, the resolvo backend observes it via `should_cancel_with_value` and returns `SolveError::Cancelled`. The libsolv_c backend ignores the token and runs to completion, matching the behaviour of the existing `timeout` field.
