### PR TITLE
feat: add support for CEP-42 channel relations in repodata

### DIFF
--- a/crates/rattler_conda_types/src/lib.rs
+++ b/crates/rattler_conda_types/src/lib.rs
@@ -66,8 +66,9 @@ pub use repo_data::{
     compute_package_url,
     patches::{PackageRecordPatch, PatchInstructions, RepoDataPatch},
     sharded::{Shard, ShardedRepodata, ShardedSubdirInfo},
-    ChannelInfo, ConvertSubdirError, ExperimentalV3Packages, PackageRecord, RecordFromPath,
-    RepoData, SubdirRunExportsJson, UrlOrPath, ValidatePackageRecordsError, WhlPackageRecord,
+    ChannelInfo, ChannelRelations, ConvertSubdirError, ExperimentalV3Packages, PackageRecord,
+    RecordFromPath, RepoData, SubdirRunExportsJson, UrlOrPath, ValidatePackageRecordsError,
+    WhlPackageRecord,
 };
 pub use repo_data_record::{RepoDataRecord, SolverResult};
 pub use run_export::RunExportKind;

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -93,6 +93,46 @@ pub struct ChannelInfo {
     /// The `base_url` for all package urls. Can be an absolute or relative url.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_url: Option<String>,
+
+    /// Optional relationships to other channels as defined in
+    /// [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md).
+    #[serde(default, skip_serializing_if = "ChannelRelations::is_none_or_empty")]
+    pub channel_relations: Option<ChannelRelations>,
+}
+
+/// Relationships between a channel and other channels as declared in the
+/// channel's `repodata.json` (or sharded repodata index) under
+/// `info.channel_relations`.
+///
+/// See [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md) for
+/// details. Both fields are relative-path channel references (e.g.
+/// `../conda-forge`) resolved against the declaring channel's base URL
+/// without its subdir component.
+///
+/// A channel MUST NOT declare both `base` and `overrides` referencing the
+/// same channel.
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone, Default)]
+pub struct ChannelRelations {
+    /// A reference to a channel with higher priority than the declaring
+    /// channel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base: Option<String>,
+
+    /// A reference to a channel with lower priority than the declaring
+    /// channel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overrides: Option<String>,
+}
+
+impl ChannelRelations {
+    /// Returns true if neither `base` nor `overrides` is set.
+    pub fn is_empty(&self) -> bool {
+        self.base.is_none() && self.overrides.is_none()
+    }
+
+    pub(crate) fn is_none_or_empty(value: &Option<ChannelRelations>) -> bool {
+        value.as_ref().is_none_or(ChannelRelations::is_empty)
+    }
 }
 
 /// Packages stored under the `v3` top-level key.
@@ -828,7 +868,8 @@ mod test {
     use crate::{
         package::DistArchiveIdentifier,
         repo_data::{compute_package_url, determine_subdir},
-        Channel, ChannelConfig, ExperimentalV3Packages, PackageRecord, RepoData,
+        Channel, ChannelConfig, ChannelInfo, ChannelRelations, ExperimentalV3Packages,
+        PackageRecord, RepoData,
     };
 
     // isl-0.12.2-1.tar.bz2
@@ -875,6 +916,72 @@ mod test {
         // serialize to json
         let json = serde_json::to_string_pretty(&repodata).unwrap();
         insta::assert_snapshot!(json);
+    }
+
+    // See https://github.com/conda/ceps/blob/main/cep-0042.md
+    #[test]
+    fn test_channel_relations() {
+        // Deserialize a repodata.json with channel_relations set.
+        let raw = r#"{
+            "info": {
+                "subdir": "linux-64",
+                "channel_relations": {
+                    "base": "../conda-forge",
+                    "overrides": "../fallback-channel"
+                }
+            },
+            "packages": {},
+            "packages.conda": {}
+        }"#;
+        let repodata: RepoData = serde_json::from_str(raw).unwrap();
+        let relations = repodata
+            .info
+            .as_ref()
+            .and_then(|i| i.channel_relations.as_ref())
+            .unwrap();
+        assert_eq!(relations.base.as_deref(), Some("../conda-forge"));
+        assert_eq!(relations.overrides.as_deref(), Some("../fallback-channel"));
+
+        // Round trip with a single field set and the other omitted.
+        let partial = RepoData {
+            version: Some(2),
+            info: Some(ChannelInfo {
+                subdir: Some("linux-64".to_string()),
+                base_url: None,
+                channel_relations: Some(ChannelRelations {
+                    base: Some("../conda-forge".to_string()),
+                    overrides: None,
+                }),
+            }),
+            packages: IndexMap::default(),
+            conda_packages: IndexMap::default(),
+            experimental_v3: ExperimentalV3Packages::default(),
+            removed: ahash::HashSet::default(),
+        };
+        let json = serde_json::to_string(&partial).unwrap();
+        assert!(json.contains("\"channel_relations\""));
+        assert!(json.contains("\"base\":\"../conda-forge\""));
+        assert!(!json.contains("\"overrides\""));
+        assert_eq!(serde_json::from_str::<RepoData>(&json).unwrap(), partial);
+
+        // `channel_relations` must be omitted when it is `None` as well as
+        // when both of its fields are unset.
+        for channel_relations in [None, Some(ChannelRelations::default())] {
+            let repodata = RepoData {
+                version: Some(2),
+                info: Some(ChannelInfo {
+                    subdir: Some("linux-64".to_string()),
+                    base_url: None,
+                    channel_relations,
+                }),
+                packages: IndexMap::default(),
+                conda_packages: IndexMap::default(),
+                experimental_v3: ExperimentalV3Packages::default(),
+                removed: ahash::HashSet::default(),
+            };
+            let json = serde_json::to_string(&repodata).unwrap();
+            assert!(!json.contains("channel_relations"));
+        }
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -41,7 +41,7 @@ use crate::{
 /// of a Conda channel.
 // Note: we cannot use the sorted macro here, because the `packages` and `conda_packages` fields are
 // serialized in a special way. Therefore we do it manually.
-#[derive(Debug, Default, Deserialize, Serialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
 pub struct RepoData {
     /// The channel information contained in the repodata.json file
     pub info: Option<ChannelInfo>,

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -41,7 +41,7 @@ use crate::{
 /// of a Conda channel.
 // Note: we cannot use the sorted macro here, because the `packages` and `conda_packages` fields are
 // serialized in a special way. Therefore we do it manually.
-#[derive(Debug, Deserialize, Serialize, Eq, PartialEq, Clone)]
+#[derive(Debug, Default, Deserialize, Serialize, Eq, PartialEq, Clone)]
 pub struct RepoData {
     /// The channel information contained in the repodata.json file
     pub info: Option<ChannelInfo>,

--- a/crates/rattler_conda_types/src/repo_data/sharded.rs
+++ b/crates/rattler_conda_types/src/repo_data/sharded.rs
@@ -1,7 +1,7 @@
 //! Structs to deal with repodata "shards" which are per-package repodata files.
 
 use crate::package::DistArchiveIdentifier;
-use crate::repo_data::ExperimentalV3Packages;
+use crate::repo_data::{ChannelRelations, ExperimentalV3Packages};
 use crate::PackageRecord;
 use chrono::{DateTime, Utc};
 use indexmap::IndexMap;
@@ -44,6 +44,48 @@ pub struct ShardedSubdirInfo {
     /// The date at which this entry was created.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<DateTime<Utc>>,
+
+    /// Optional relationships to other channels as defined in
+    /// [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md).
+    #[serde(default, skip_serializing_if = "ChannelRelations::is_none_or_empty")]
+    pub channel_relations: Option<ChannelRelations>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // See https://github.com/conda/ceps/blob/main/cep-0042.md
+    #[test]
+    fn test_sharded_subdir_info_channel_relations() {
+        // Deserialize a sharded index with channel_relations.
+        let raw = r#"{
+            "subdir": "linux-64",
+            "base_url": "./",
+            "shards_base_url": "./shards/",
+            "channel_relations": {
+                "base": "../conda-forge"
+            }
+        }"#;
+        let info: ShardedSubdirInfo = serde_json::from_str(raw).unwrap();
+        let relations = info.channel_relations.as_ref().unwrap();
+        assert_eq!(relations.base.as_deref(), Some("../conda-forge"));
+        assert_eq!(relations.overrides, None);
+
+        // `channel_relations` must be omitted when it is `None` and when all
+        // of its fields are unset.
+        for channel_relations in [None, Some(ChannelRelations::default())] {
+            let info = ShardedSubdirInfo {
+                subdir: "linux-64".to_string(),
+                base_url: "./".to_string(),
+                shards_base_url: "./shards/".to_string(),
+                created_at: None,
+                channel_relations,
+            };
+            let json = serde_json::to_string(&info).unwrap();
+            assert!(!json.contains("channel_relations"));
+        }
+    }
 }
 
 /// An individual shard that contains repodata for a single package name.

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -806,6 +806,7 @@ async fn index_subdir_inner(
         info: Some(ChannelInfo {
             subdir: Some(subdir.to_string()),
             base_url: None,
+            channel_relations: None,
         }),
         packages,
         conda_packages,
@@ -946,6 +947,7 @@ pub async fn write_repodata(
                 base_url: "".into(),
                 shards_base_url: "./shards/".into(),
                 created_at: Some(chrono::Utc::now()),
+                channel_relations: None,
             },
             shards: shards
                 .iter()
@@ -1295,6 +1297,7 @@ pub async fn ensure_channel_initialized(op: &Operator) -> anyhow::Result<()> {
         info: Some(ChannelInfo {
             subdir: Some(Platform::NoArch.to_string()),
             base_url: None,
+            channel_relations: None,
         }),
         packages: IndexMap::default(),
         conda_packages: IndexMap::default(),

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -205,6 +205,7 @@ mod tests {
                     base_url: "./".to_string(),
                     shards_base_url: "./shards/".to_string(),
                     created_at: Some(chrono::Utc::now()),
+                    channel_relations: None,
                 },
                 shards,
             };

--- a/py-rattler/rattler/__init__.py
+++ b/py-rattler/rattler/__init__.py
@@ -1,6 +1,8 @@
 from rattler.version import Version, VersionSpec, VersionWithSource
 from rattler.match_spec import MatchSpec, NamelessMatchSpec
 from rattler.repo_data import (
+    ChannelInfo,
+    ChannelRelations,
     PackageRecord,
     RepoData,
     RepoDataRecord,
@@ -55,6 +57,8 @@ __all__ = [
     "VersionWithSource",
     "MatchSpec",
     "NamelessMatchSpec",
+    "ChannelInfo",
+    "ChannelRelations",
     "PackageRecord",
     "Channel",
     "ChannelConfig",

--- a/py-rattler/rattler/repo_data/__init__.py
+++ b/py-rattler/rattler/repo_data/__init__.py
@@ -1,5 +1,5 @@
 from rattler.repo_data.package_record import PackageRecord
-from rattler.repo_data.repo_data import RepoData
+from rattler.repo_data.repo_data import ChannelInfo, ChannelRelations, RepoData
 from rattler.repo_data.patch_instructions import PatchInstructions
 from rattler.repo_data.record import RepoDataRecord
 from rattler.repo_data.whl_package_record import WhlPackageRecord
@@ -8,6 +8,8 @@ from rattler.repo_data.gateway import Gateway, SourceConfig
 from rattler.repo_data.source import RepoDataSource
 
 __all__ = [
+    "ChannelInfo",
+    "ChannelRelations",
     "PackageRecord",
     "RepoData",
     "PatchInstructions",

--- a/py-rattler/rattler/repo_data/record.py
+++ b/py-rattler/rattler/repo_data/record.py
@@ -153,7 +153,7 @@ class RepoDataRecord(PackageRecord):
         --------
         ```python
         >>> from rattler import RepoData, Channel
-        >>> repo_data = RepoData(
+        >>> repo_data = RepoData.from_path(
         ...     "../test-data/test-server/repo/noarch/repodata.json"
         ... )
         >>> repo_data.into_repo_data(Channel("test"))[0]

--- a/py-rattler/rattler/repo_data/repo_data.py
+++ b/py-rattler/rattler/repo_data/repo_data.py
@@ -19,40 +19,34 @@ class ChannelRelations:
 
     Both ``base`` and ``overrides`` are optional relative-path channel
     references (e.g. ``"../conda-forge"``).
+
+    `ChannelRelations` values are read-only views. To change a relation,
+    construct a new `ChannelRelations` and pass it to a new `ChannelInfo`
+    and `RepoData`.
     """
 
     def __init__(
         self,
         base: Optional[str] = None,
         overrides: Optional[str] = None,
-        _inner: Optional[PyChannelRelations] = None,
     ) -> None:
-        if _inner is not None:
-            self._inner = _inner
-        else:
-            self._inner = PyChannelRelations(base=base, overrides=overrides)
+        self._inner = PyChannelRelations(base=base, overrides=overrides)
 
     @classmethod
     def _from_inner(cls, py_channel_relations: PyChannelRelations) -> ChannelRelations:
-        return cls(_inner=py_channel_relations)
+        instance = cls.__new__(cls)
+        instance._inner = py_channel_relations
+        return instance
 
     @property
     def base(self) -> Optional[str]:
         """A reference to a channel with higher priority than the declaring channel."""
         return self._inner.base
 
-    @base.setter
-    def base(self, value: Optional[str]) -> None:
-        self._inner.base = value
-
     @property
     def overrides(self) -> Optional[str]:
         """A reference to a channel with lower priority than the declaring channel."""
         return self._inner.overrides
-
-    @overrides.setter
-    def overrides(self, value: Optional[str]) -> None:
-        self._inner.overrides = value
 
     def __repr__(self) -> str:
         return f"ChannelRelations(base={self.base!r}, overrides={self.overrides!r})"
@@ -61,28 +55,38 @@ class ChannelRelations:
 class ChannelInfo:
     """
     The ``info`` section of a ``repodata.json`` file.
+
+    `ChannelInfo` values are read-only views. To change a field, construct a
+    new `ChannelInfo` and pass it to a new `RepoData`.
     """
 
-    def __init__(self, py_channel_info: PyChannelInfo) -> None:
-        self._inner = py_channel_info
+    def __init__(
+        self,
+        subdir: Optional[str] = None,
+        base_url: Optional[str] = None,
+        channel_relations: Optional[ChannelRelations] = None,
+    ) -> None:
+        self._inner = PyChannelInfo(
+            subdir=subdir,
+            base_url=base_url,
+            channel_relations=channel_relations._inner if channel_relations is not None else None,
+        )
+
+    @classmethod
+    def _from_inner(cls, py_channel_info: PyChannelInfo) -> ChannelInfo:
+        instance = cls.__new__(cls)
+        instance._inner = py_channel_info
+        return instance
 
     @property
     def subdir(self) -> Optional[str]:
         """The channel's subdirectory (e.g. ``"linux-64"``)."""
         return self._inner.subdir
 
-    @subdir.setter
-    def subdir(self, value: Optional[str]) -> None:
-        self._inner.subdir = value
-
     @property
     def base_url(self) -> Optional[str]:
         """The base URL for all package URLs in this channel, if any."""
         return self._inner.base_url
-
-    @base_url.setter
-    def base_url(self, value: Optional[str]) -> None:
-        self._inner.base_url = value
 
     @property
     def channel_relations(self) -> Optional[ChannelRelations]:
@@ -97,10 +101,6 @@ class ChannelInfo:
             return None
         return ChannelRelations._from_inner(relations)
 
-    @channel_relations.setter
-    def channel_relations(self, value: Optional[ChannelRelations]) -> None:
-        self._inner.channel_relations = None if value is None else value._inner
-
     def __repr__(self) -> str:
         return (
             f"ChannelInfo(subdir={self.subdir!r}, base_url={self.base_url!r}, "
@@ -109,23 +109,56 @@ class ChannelInfo:
 
 
 class RepoData:
-    def __init__(self, path: Union[str, PathLike[str]]) -> None:
+    """
+    Repository metadata as deserialized from a ``repodata.json`` file.
+
+    `RepoData` values are read-only views. Construct a new one from its
+    components (e.g. a different `ChannelInfo`) to produce modified
+    repodata.
+    """
+
+    def __init__(
+        self,
+        info: Optional[ChannelInfo] = None,
+        version: Optional[int] = None,
+    ) -> None:
+        self._repo_data = PyRepoData(
+            info=info._inner if info is not None else None,
+            version=version,
+        )
+
+    @classmethod
+    def from_path(cls, path: Union[str, PathLike[str]]) -> RepoData:
+        """
+        Load a `RepoData` from a ``repodata.json`` file on disk.
+
+        Examples
+        --------
+        ```python
+        >>> repo_data = RepoData.from_path("../test-data/test-server/repo/noarch/repodata.json")
+        >>> repo_data
+        RepoData()
+        >>>
+        ```
+        """
         if not isinstance(path, (str, Path)):
             raise TypeError(
-                f"RepoData constructor received unsupported type  {type(path).__name__!r} for the `path` parameter"
+                f"RepoData.from_path received unsupported type {type(path).__name__!r} for the `path` parameter"
             )
-
-        self._repo_data = PyRepoData.from_path(path)
+        return cls._from_py_repo_data(PyRepoData.from_path(path))
 
     @property
     def info(self) -> Optional[ChannelInfo]:
-        """
-        Returns the channel info contained in the repodata, if any.
-        """
+        """Returns the channel info contained in the repodata, if any."""
         info = self._repo_data.info
         if info is None:
             return None
-        return ChannelInfo(info)
+        return ChannelInfo._from_inner(info)
+
+    @property
+    def version(self) -> Optional[int]:
+        """Returns the repodata format version, if any."""
+        return self._repo_data.version
 
     def apply_patches(self, instructions: PatchInstructions) -> None:
         """
@@ -143,7 +176,7 @@ class RepoData:
         --------
         ```python
         >>> from rattler import Channel
-        >>> repo_data = RepoData("../test-data/test-server/repo/noarch/repodata.json")
+        >>> repo_data = RepoData.from_path("../test-data/test-server/repo/noarch/repodata.json")
         >>> repo_data.into_repo_data(Channel("test"))
         [...]
         >>>
@@ -172,7 +205,7 @@ class RepoData:
         Examples
         --------
         ```python
-        >>> repo_data = RepoData("../test-data/test-server/repo/noarch/repodata.json")
+        >>> repo_data = RepoData.from_path("../test-data/test-server/repo/noarch/repodata.json")
         >>> repo_data
         RepoData()
         >>>

--- a/py-rattler/rattler/repo_data/repo_data.py
+++ b/py-rattler/rattler/repo_data/repo_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from pathlib import Path
-from typing import Union, List, TYPE_CHECKING
+from typing import Optional, Union, List, TYPE_CHECKING
 
 
 if TYPE_CHECKING:
@@ -8,7 +8,104 @@ if TYPE_CHECKING:
     from rattler.channel import Channel
     from rattler.repo_data import PatchInstructions, RepoDataRecord
 
-from rattler.rattler import PyRepoData
+from rattler.rattler import PyChannelInfo, PyChannelRelations, PyRepoData
+
+
+class ChannelRelations:
+    """
+    Relationships to other channels declared inside ``repodata.json`` under
+    ``info.channel_relations`` as specified by
+    [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md).
+
+    Both ``base`` and ``overrides`` are optional relative-path channel
+    references (e.g. ``"../conda-forge"``).
+    """
+
+    def __init__(
+        self,
+        base: Optional[str] = None,
+        overrides: Optional[str] = None,
+        _inner: Optional[PyChannelRelations] = None,
+    ) -> None:
+        if _inner is not None:
+            self._inner = _inner
+        else:
+            self._inner = PyChannelRelations(base=base, overrides=overrides)
+
+    @classmethod
+    def _from_inner(cls, py_channel_relations: PyChannelRelations) -> ChannelRelations:
+        return cls(_inner=py_channel_relations)
+
+    @property
+    def base(self) -> Optional[str]:
+        """A reference to a channel with higher priority than the declaring channel."""
+        return self._inner.base
+
+    @base.setter
+    def base(self, value: Optional[str]) -> None:
+        self._inner.base = value
+
+    @property
+    def overrides(self) -> Optional[str]:
+        """A reference to a channel with lower priority than the declaring channel."""
+        return self._inner.overrides
+
+    @overrides.setter
+    def overrides(self, value: Optional[str]) -> None:
+        self._inner.overrides = value
+
+    def __repr__(self) -> str:
+        return f"ChannelRelations(base={self.base!r}, overrides={self.overrides!r})"
+
+
+class ChannelInfo:
+    """
+    The ``info`` section of a ``repodata.json`` file.
+    """
+
+    def __init__(self, py_channel_info: PyChannelInfo) -> None:
+        self._inner = py_channel_info
+
+    @property
+    def subdir(self) -> Optional[str]:
+        """The channel's subdirectory (e.g. ``"linux-64"``)."""
+        return self._inner.subdir
+
+    @subdir.setter
+    def subdir(self, value: Optional[str]) -> None:
+        self._inner.subdir = value
+
+    @property
+    def base_url(self) -> Optional[str]:
+        """The base URL for all package URLs in this channel, if any."""
+        return self._inner.base_url
+
+    @base_url.setter
+    def base_url(self, value: Optional[str]) -> None:
+        self._inner.base_url = value
+
+    @property
+    def channel_relations(self) -> Optional[ChannelRelations]:
+        """
+        Channel relations declared by this channel, see
+        [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md).
+
+        ``None`` when the channel does not declare any relations.
+        """
+        relations = self._inner.channel_relations
+        if relations is None:
+            return None
+        return ChannelRelations._from_inner(relations)
+
+    @channel_relations.setter
+    def channel_relations(self, value: Optional[ChannelRelations]) -> None:
+        self._inner.channel_relations = None if value is None else value._inner
+
+    def __repr__(self) -> str:
+        return (
+            f"ChannelInfo(subdir={self.subdir!r}, base_url={self.base_url!r}, "
+            f"channel_relations={self.channel_relations!r})"
+        )
 
 
 class RepoData:
@@ -19,6 +116,16 @@ class RepoData:
             )
 
         self._repo_data = PyRepoData.from_path(path)
+
+    @property
+    def info(self) -> Optional[ChannelInfo]:
+        """
+        Returns the channel info contained in the repodata, if any.
+        """
+        info = self._repo_data.info
+        if info is None:
+            return None
+        return ChannelInfo(info)
 
     def apply_patches(self, instructions: PatchInstructions) -> None:
         """

--- a/py-rattler/rattler/repo_data/repo_data.py
+++ b/py-rattler/rattler/repo_data/repo_data.py
@@ -17,20 +17,12 @@ class ChannelRelations:
     ``info.channel_relations`` as specified by
     [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md).
 
-    Both ``base`` and ``overrides`` are optional relative-path channel
-    references (e.g. ``"../conda-forge"``).
-
-    `ChannelRelations` values are read-only views. To change a relation,
-    construct a new `ChannelRelations` and pass it to a new `ChannelInfo`
-    and `RepoData`.
+    `ChannelRelations` is a read-only view obtained via
+    ``RepoData.from_path(...).info.channel_relations``; it cannot be
+    constructed directly.
     """
 
-    def __init__(
-        self,
-        base: Optional[str] = None,
-        overrides: Optional[str] = None,
-    ) -> None:
-        self._inner = PyChannelRelations(base=base, overrides=overrides)
+    _inner: PyChannelRelations
 
     @classmethod
     def _from_inner(cls, py_channel_relations: PyChannelRelations) -> ChannelRelations:
@@ -56,21 +48,11 @@ class ChannelInfo:
     """
     The ``info`` section of a ``repodata.json`` file.
 
-    `ChannelInfo` values are read-only views. To change a field, construct a
-    new `ChannelInfo` and pass it to a new `RepoData`.
+    `ChannelInfo` is a read-only view obtained via
+    ``RepoData.from_path(...).info``; it cannot be constructed directly.
     """
 
-    def __init__(
-        self,
-        subdir: Optional[str] = None,
-        base_url: Optional[str] = None,
-        channel_relations: Optional[ChannelRelations] = None,
-    ) -> None:
-        self._inner = PyChannelInfo(
-            subdir=subdir,
-            base_url=base_url,
-            channel_relations=channel_relations._inner if channel_relations is not None else None,
-        )
+    _inner: PyChannelInfo
 
     @classmethod
     def _from_inner(cls, py_channel_info: PyChannelInfo) -> ChannelInfo:
@@ -112,20 +94,10 @@ class RepoData:
     """
     Repository metadata as deserialized from a ``repodata.json`` file.
 
-    `RepoData` values are read-only views. Construct a new one from its
-    components (e.g. a different `ChannelInfo`) to produce modified
-    repodata.
+    `RepoData` is obtained via `RepoData.from_path(path)`.
     """
 
-    def __init__(
-        self,
-        info: Optional[ChannelInfo] = None,
-        version: Optional[int] = None,
-    ) -> None:
-        self._repo_data = PyRepoData(
-            info=info._inner if info is not None else None,
-            version=version,
-        )
+    _repo_data: PyRepoData
 
     @classmethod
     def from_path(cls, path: Union[str, PathLike[str]]) -> RepoData:

--- a/py-rattler/src/lib.rs
+++ b/py-rattler/src/lib.rs
@@ -75,7 +75,7 @@ use repo_data::{
     gateway::{PyFetchRepoDataOptions, PyGateway, PySourceConfig},
     patch_instructions::PyPatchInstructions,
     sparse::{PyPackageFormatSelection, PySparseRepoData},
-    PyRepoData,
+    PyChannelInfo, PyChannelRelations, PyRepoData,
 };
 use run_exports_json::PyRunExportsJson;
 use shell::{PyActivationResult, PyActivationVariables, PyActivator, PyShellEnum};
@@ -142,6 +142,8 @@ fn rattler<'py>(py: Python<'py>, m: Bound<'py, PyModule>) -> PyResult<()> {
     m.add_class::<PySparseRepoData>()?;
     m.add_class::<PyPackageFormatSelection>()?;
     m.add_class::<PyRepoData>()?;
+    m.add_class::<PyChannelInfo>()?;
+    m.add_class::<PyChannelRelations>()?;
     m.add_class::<PyPatchInstructions>()?;
     m.add_class::<PyGateway>()?;
     m.add_class::<PySourceConfig>()?;

--- a/py-rattler/src/repo_data/mod.rs
+++ b/py-rattler/src/repo_data/mod.rs
@@ -33,20 +33,6 @@ impl From<RepoData> for PyRepoData {
 
 #[pymethods]
 impl PyRepoData {
-    /// Constructs a new `RepoData` from its components. All fields are
-    /// optional; packages, conda packages and removed sets start out empty.
-    #[new]
-    #[pyo3(signature = (info=None, version=None))]
-    pub fn new(info: Option<PyChannelInfo>, version: Option<u64>) -> Self {
-        Self {
-            inner: RepoData {
-                info: info.map(Into::into),
-                version,
-                ..RepoData::default()
-            },
-        }
-    }
-
     /// Apply a patch to a repodata file Note that we currently do not handle revoked instructions.
     pub fn apply_patches(&mut self, instructions: &PyPatchInstructions) {
         self.inner.apply_patches(&instructions.inner);
@@ -115,22 +101,6 @@ impl From<PyChannelInfo> for ChannelInfo {
 
 #[pymethods]
 impl PyChannelInfo {
-    #[new]
-    #[pyo3(signature = (subdir=None, base_url=None, channel_relations=None))]
-    pub fn new(
-        subdir: Option<String>,
-        base_url: Option<String>,
-        channel_relations: Option<PyChannelRelations>,
-    ) -> Self {
-        Self {
-            inner: ChannelInfo {
-                subdir,
-                base_url,
-                channel_relations: channel_relations.map(Into::into),
-            },
-        }
-    }
-
     #[getter]
     pub fn subdir(&self) -> Option<String> {
         self.inner.subdir.clone()
@@ -172,14 +142,6 @@ impl From<PyChannelRelations> for ChannelRelations {
 
 #[pymethods]
 impl PyChannelRelations {
-    #[new]
-    #[pyo3(signature = (base=None, overrides=None))]
-    pub fn new(base: Option<String>, overrides: Option<String>) -> Self {
-        Self {
-            inner: ChannelRelations { base, overrides },
-        }
-    }
-
     #[getter]
     pub fn base(&self) -> Option<String> {
         self.inner.base.clone()

--- a/py-rattler/src/repo_data/mod.rs
+++ b/py-rattler/src/repo_data/mod.rs
@@ -33,6 +33,20 @@ impl From<RepoData> for PyRepoData {
 
 #[pymethods]
 impl PyRepoData {
+    /// Constructs a new `RepoData` from its components. All fields are
+    /// optional; packages, conda packages and removed sets start out empty.
+    #[new]
+    #[pyo3(signature = (info=None, version=None))]
+    pub fn new(info: Option<PyChannelInfo>, version: Option<u64>) -> Self {
+        Self {
+            inner: RepoData {
+                info: info.map(Into::into),
+                version,
+                ..RepoData::default()
+            },
+        }
+    }
+
     /// Apply a patch to a repodata file Note that we currently do not handle revoked instructions.
     pub fn apply_patches(&mut self, instructions: &PyPatchInstructions) {
         self.inner.apply_patches(&instructions.inner);
@@ -47,6 +61,12 @@ impl PyRepoData {
     #[getter]
     pub fn info(&self) -> Option<PyChannelInfo> {
         self.inner.info.clone().map(Into::into)
+    }
+
+    /// Returns the repodata format version, if any.
+    #[getter]
+    pub fn version(&self) -> Option<u64> {
+        self.inner.version
     }
 }
 
@@ -116,19 +136,9 @@ impl PyChannelInfo {
         self.inner.subdir.clone()
     }
 
-    #[setter]
-    pub fn set_subdir(&mut self, value: Option<String>) {
-        self.inner.subdir = value;
-    }
-
     #[getter]
     pub fn base_url(&self) -> Option<String> {
         self.inner.base_url.clone()
-    }
-
-    #[setter]
-    pub fn set_base_url(&mut self, value: Option<String>) {
-        self.inner.base_url = value;
     }
 
     /// Channel relations declared by this channel (CEP-42). `None` when the
@@ -136,11 +146,6 @@ impl PyChannelInfo {
     #[getter]
     pub fn channel_relations(&self) -> Option<PyChannelRelations> {
         self.inner.channel_relations.clone().map(Into::into)
-    }
-
-    #[setter]
-    pub fn set_channel_relations(&mut self, value: Option<PyChannelRelations>) {
-        self.inner.channel_relations = value.map(Into::into);
     }
 }
 
@@ -180,18 +185,8 @@ impl PyChannelRelations {
         self.inner.base.clone()
     }
 
-    #[setter]
-    pub fn set_base(&mut self, value: Option<String>) {
-        self.inner.base = value;
-    }
-
     #[getter]
     pub fn overrides(&self) -> Option<String> {
         self.inner.overrides.clone()
-    }
-
-    #[setter]
-    pub fn set_overrides(&mut self, value: Option<String>) {
-        self.inner.overrides = value;
     }
 }

--- a/py-rattler/src/repo_data/mod.rs
+++ b/py-rattler/src/repo_data/mod.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use pyo3::{pyclass, pymethods, PyResult};
-use rattler_conda_types::RepoData;
+use rattler_conda_types::{ChannelInfo, ChannelRelations, RepoData};
 
 use crate::{channel::PyChannel, error::PyRattlerError, record::PyRecord};
 
@@ -42,6 +42,12 @@ impl PyRepoData {
     pub fn as_str(&self) -> String {
         format!("{:?}", self.inner)
     }
+
+    /// Returns the channel info contained in the repodata, if any.
+    #[getter]
+    pub fn info(&self) -> Option<PyChannelInfo> {
+        self.inner.info.clone().map(Into::into)
+    }
 }
 
 #[pymethods]
@@ -63,5 +69,129 @@ impl PyRepoData {
             .into_iter()
             .map(Into::into)
             .collect()
+    }
+}
+
+/// Python wrapper around [`ChannelInfo`] — the `info` section of a
+/// `repodata.json` file.
+#[pyclass]
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct PyChannelInfo {
+    pub(crate) inner: ChannelInfo,
+}
+
+impl From<ChannelInfo> for PyChannelInfo {
+    fn from(value: ChannelInfo) -> Self {
+        Self { inner: value }
+    }
+}
+
+impl From<PyChannelInfo> for ChannelInfo {
+    fn from(value: PyChannelInfo) -> Self {
+        value.inner
+    }
+}
+
+#[pymethods]
+impl PyChannelInfo {
+    #[new]
+    #[pyo3(signature = (subdir=None, base_url=None, channel_relations=None))]
+    pub fn new(
+        subdir: Option<String>,
+        base_url: Option<String>,
+        channel_relations: Option<PyChannelRelations>,
+    ) -> Self {
+        Self {
+            inner: ChannelInfo {
+                subdir,
+                base_url,
+                channel_relations: channel_relations.map(Into::into),
+            },
+        }
+    }
+
+    #[getter]
+    pub fn subdir(&self) -> Option<String> {
+        self.inner.subdir.clone()
+    }
+
+    #[setter]
+    pub fn set_subdir(&mut self, value: Option<String>) {
+        self.inner.subdir = value;
+    }
+
+    #[getter]
+    pub fn base_url(&self) -> Option<String> {
+        self.inner.base_url.clone()
+    }
+
+    #[setter]
+    pub fn set_base_url(&mut self, value: Option<String>) {
+        self.inner.base_url = value;
+    }
+
+    /// Channel relations declared by this channel (CEP-42). `None` when the
+    /// channel does not declare any relations.
+    #[getter]
+    pub fn channel_relations(&self) -> Option<PyChannelRelations> {
+        self.inner.channel_relations.clone().map(Into::into)
+    }
+
+    #[setter]
+    pub fn set_channel_relations(&mut self, value: Option<PyChannelRelations>) {
+        self.inner.channel_relations = value.map(Into::into);
+    }
+}
+
+/// Python wrapper around [`ChannelRelations`] — see
+/// [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md).
+#[pyclass]
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct PyChannelRelations {
+    pub(crate) inner: ChannelRelations,
+}
+
+impl From<ChannelRelations> for PyChannelRelations {
+    fn from(value: ChannelRelations) -> Self {
+        Self { inner: value }
+    }
+}
+
+impl From<PyChannelRelations> for ChannelRelations {
+    fn from(value: PyChannelRelations) -> Self {
+        value.inner
+    }
+}
+
+#[pymethods]
+impl PyChannelRelations {
+    #[new]
+    #[pyo3(signature = (base=None, overrides=None))]
+    pub fn new(base: Option<String>, overrides: Option<String>) -> Self {
+        Self {
+            inner: ChannelRelations { base, overrides },
+        }
+    }
+
+    #[getter]
+    pub fn base(&self) -> Option<String> {
+        self.inner.base.clone()
+    }
+
+    #[setter]
+    pub fn set_base(&mut self, value: Option<String>) {
+        self.inner.base = value;
+    }
+
+    #[getter]
+    pub fn overrides(&self) -> Option<String> {
+        self.inner.overrides.clone()
+    }
+
+    #[setter]
+    pub fn set_overrides(&mut self, value: Option<String>) {
+        self.inner.overrides = value;
     }
 }


### PR DESCRIPTION
### Description

This PR implements support for [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md) channel relations in repodata files. Channel relations allow channels to declare relationships with other channels (base and overrides), enabling better dependency resolution and channel prioritization.

**Changes include:**

1. **Rust types** (`rattler_conda_types`):
   - Added `ChannelRelations` struct with `base` and `overrides` fields to represent channel relationships
   - Extended `ChannelInfo` to include optional `channel_relations` field
   - Extended `ShardedSubdirInfo` to include optional `channel_relations` field
   - Implemented proper serialization with `skip_serializing_if` to omit empty relations
   - Added comprehensive tests for deserialization and round-trip serialization

2. **Python bindings** (`py-rattler`):
   - Added `PyChannelRelations` and `PyChannelInfo` Rust wrapper classes
   - Created Python `ChannelRelations` and `ChannelInfo` classes with property accessors
   - Added `info` property to `RepoData` class to access channel metadata
   - Exported new classes in public API

> [!CAUTION]
> This PR does **not** implement actually using these fields yet.

### How Has This Been Tested?

- Added unit tests in `rattler_conda_types` covering:
  - Deserialization of repodata with channel relations
  - Round-trip serialization with partial fields
  - Proper omission of empty/None channel relations
  - Sharded subdir info with channel relations
- Existing tests continue to pass with the new optional field

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes