### PR TITLE
feat: Add `Hash` derive to `ChannelPriority` enum

### DIFF
--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -343,7 +343,7 @@ impl From<std::time::Duration> for ExcludeNewer {
 }
 
 /// Represents the channel priority option to use during solves.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum ChannelPriority {


### PR DESCRIPTION
### Description

Add `Hash` derive to the `ChannelPriority` enum in `rattler_solve`. This enables the enum to be used as a key in hash-based collections like `HashMap` and `HashSet`, which is useful for caching and deduplication scenarios.

The `ChannelPriority` enum already derives `Debug`, `Clone`, `Copy`, `PartialEq`, `Eq`, and `Default`. Since it now also derives `Hash`, it becomes fully hashable and can be used in any context requiring hashable types.

### How Has This Been Tested?

No testing needed. This is a straightforward derive macro addition that enables a standard trait implementation. The change is purely additive and doesn't modify any logic.

### Checklist:
- [x] I have performed a self-review of my own code