### PR TITLE
feat(rattler_lock): expose handle resolution + include source_data pa…

### DIFF
--- a/crates/rattler_lock/src/builder.rs
+++ b/crates/rattler_lock/src/builder.rs
@@ -501,7 +501,7 @@ impl LockFileBuilder {
         let build_packages: Vec<_> = build_packages.into_iter().collect();
         let host_packages: Vec<_> = host_packages.into_iter().collect();
         for handle in build_packages.iter().chain(host_packages.iter()) {
-            handle.get(&self.packages)?;
+            handle.get_from_slice(&self.packages)?;
         }
         Ok(SourceData {
             build_packages: EnvironmentPackages::from_handles(build_packages)?,

--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -151,24 +151,27 @@ pub struct PackageIndex(usize);
 ///
 /// Produced by the crate whenever a package is registered; external callers
 /// only ever see the value by [`Display`] — typically when it surfaces in an
-/// error message. The underlying string representation is intentionally
-/// hidden so the lockfile format can evolve without exposing its encoding.
+/// error message. The underlying representation is intentionally hidden so
+/// the lockfile format can evolve without exposing its encoding.
 ///
-/// The underlying string matches the selector key used in the serialized
+/// The `id` string matches the selector value used in the serialized
 /// lockfile format:
 /// - Binary conda: the location URL/path
 /// - Source conda: `"name[hash] @ location"` ([`SourceIdentifier`] format)
 /// - Pypi: the verbatim location (preserving the original string if present)
-#[derive(Clone, Debug, Eq)]
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) struct SelectorId {
-    full_id: String,
-    short_offset: usize,
+    kind: SelectorKind,
+    id: String,
 }
 
 /// Discriminator for the three kinds of packages that can appear in a
-/// lockfile. Owns the prefix string used to build a [`SelectorId`], so the
-/// prefix choice lives in exactly one place.
-#[derive(Clone, Copy)]
+/// lockfile. Owns the prefix string used in `Display`, so the prefix choice
+/// lives in exactly one place.
+///
+/// Variant declaration order is the canonical sort order for packages:
+/// binary conda first, then conda source, then pypi.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub(crate) enum SelectorKind {
     CondaBinary,
     CondaSource,
@@ -187,10 +190,9 @@ impl SelectorKind {
 
 impl SelectorId {
     pub(crate) fn from_parts(kind: SelectorKind, id: &str) -> Self {
-        let prefix = kind.prefix();
         Self {
-            full_id: format!("{prefix}: {id}"),
-            short_offset: prefix.len() + 2,
+            kind,
+            id: id.to_owned(),
         }
     }
 
@@ -214,41 +216,17 @@ impl SelectorId {
     }
 
     pub(crate) fn as_str(&self) -> &str {
-        &self.full_id[self.short_offset..]
+        &self.id
     }
 
-    pub(crate) fn as_long_str(&self) -> &str {
-        &self.full_id
-    }
-}
-
-impl PartialEq for SelectorId {
-    fn eq(&self, other: &Self) -> bool {
-        self.full_id == other.full_id
-    }
-}
-
-impl Ord for SelectorId {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.full_id.cmp(&other.full_id)
-    }
-}
-
-impl PartialOrd for SelectorId {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl std::hash::Hash for SelectorId {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.full_id.hash(state);
+    pub(crate) fn kind(&self) -> SelectorKind {
+        self.kind
     }
 }
 
 impl std::fmt::Display for SelectorId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.full_id)
+        write!(f, "{}: {}", self.kind.prefix(), self.id)
     }
 }
 
@@ -294,14 +272,24 @@ impl PackageHandle {
         }
     }
 
+    /// Looks up the referenced [`LockedPackage`] in the given [`LockFile`].
+    ///
+    /// Returns [`InvalidPackageHandleError`] if the handle does not refer to
+    /// a package in `lock_file` — typically because the handle came from a
+    /// different lockfile than the one being queried.
+    pub fn get<'a>(
+        &self,
+        lock_file: &'a LockFile,
+    ) -> Result<&'a LockedPackage, InvalidPackageHandleError> {
+        self.get_from_slice(&lock_file.inner.packages)
+    }
+
     /// Looks up the referenced [`LockedPackage`] in the given package list.
     ///
     /// Returns [`InvalidPackageHandleError`] when the handle's index is out
     /// of bounds for `packages`, or when the package at that index has a
-    /// different selector id than the handle stores. Both indicate the
-    /// handle is being used against a lockfile other than the one that
-    /// produced it.
-    pub fn get<'a>(
+    /// different selector id than the handle stores.
+    pub(crate) fn get_from_slice<'a>(
         &self,
         packages: &'a [LockedPackage],
     ) -> Result<&'a LockedPackage, InvalidPackageHandleError> {
@@ -315,8 +303,8 @@ impl PackageHandle {
         if actual_selector_id != self.selector_id {
             return Err(InvalidPackageHandleError::SelectorMismatch {
                 index: self.index.0,
-                expected: self.selector_id.as_long_str().to_string(),
-                actual: actual_selector_id.as_long_str().to_string(),
+                expected: self.selector_id.to_string(),
+                actual: actual_selector_id.to_string(),
             });
         }
         Ok(package)
@@ -390,25 +378,25 @@ impl EnvironmentPackages {
             .collect()
     }
 
-    /// Builds an `EnvironmentPackages` by resolving a list of selector-id
-    /// strings (as read from the serialized lockfile) to [`PackageHandle`]s
+    /// Builds an `EnvironmentPackages` by resolving a list of selector
+    /// entries (as read from the serialized lockfile) to [`PackageHandle`]s
     /// via the caller-supplied `resolve` closure.
     ///
     /// The closure's `Err` path lets callers produce a context-rich error
-    /// when a selector string does not correspond to a known package.
+    /// when a selector does not correspond to a known package.
     /// `FromSelectorIdsError` wraps either that error or a consistency
     /// violation ([`InconsistentInsertError`]) when two entries reuse an
     /// index or a selector id with a different counterpart.
-    pub(crate) fn from_selector_ids<I, E>(
-        strings: I,
-        mut resolve: impl FnMut(&str) -> Result<PackageHandle, E>,
+    pub(crate) fn from_selector_ids<I, T, E>(
+        items: I,
+        mut resolve: impl FnMut(&T) -> Result<PackageHandle, E>,
     ) -> Result<Self, FromSelectorIdsError<E>>
     where
-        I: IntoIterator<Item = String>,
+        I: IntoIterator<Item = T>,
     {
         let mut environment_packages = Self::default();
-        for selector_id in strings {
-            let handle = resolve(&selector_id).map_err(FromSelectorIdsError::Resolve)?;
+        for item in items {
+            let handle = resolve(&item).map_err(FromSelectorIdsError::Resolve)?;
             environment_packages
                 .insert(handle)
                 .map_err(FromSelectorIdsError::Inconsistent)?;
@@ -484,9 +472,26 @@ impl EnvironmentPackages {
         self.entries.is_empty()
     }
 
-    /// Returns an iterator over the contained [`PackageHandle`]s in
+    /// Returns an iterator over the resolved [`LockedPackage`]s in
     /// sorted-by-selector-id order.
-    pub fn iter(&self) -> std::slice::Iter<'_, PackageHandle> {
+    ///
+    /// Each item is a [`Result`] because `lock_file` may not be the one the
+    /// handles in this set originated from; a mismatch surfaces as
+    /// [`InvalidPackageHandleError`] rather than a panic.
+    pub fn iter<'a>(
+        &'a self,
+        lock_file: &'a LockFile,
+    ) -> impl Iterator<Item = Result<&'a LockedPackage, InvalidPackageHandleError>> + 'a {
+        self.entries
+            .iter()
+            .map(move |h| h.get_from_slice(&lock_file.inner.packages))
+    }
+
+    /// Returns an iterator over the raw [`PackageHandle`]s in the set.
+    ///
+    /// Crate-private because the handle type is primarily a builder-side
+    /// concern; external callers should use [`Self::iter`] with a lockfile.
+    pub(crate) fn handles(&self) -> std::slice::Iter<'_, PackageHandle> {
         self.entries.iter()
     }
 }
@@ -505,15 +510,6 @@ pub enum FromSelectorIdsError<E> {
     /// but are paired with different counterparts.
     #[error(transparent)]
     Inconsistent(#[from] InconsistentInsertError),
-}
-
-impl<'a> IntoIterator for &'a EnvironmentPackages {
-    type Item = &'a PackageHandle;
-    type IntoIter = std::slice::Iter<'a, PackageHandle>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.entries.iter()
-    }
 }
 
 /// The packages needed to build a source package.
@@ -731,8 +727,12 @@ impl<'lock> Environment<'lock> {
             self.data()
                 .packages
                 .get(&platform.index)?
-                .iter()
-                .map(|handle| &self.lock_file.inner.packages[handle.index.0]),
+                .handles()
+                .map(|handle| {
+                    handle
+                        .get(self.lock_file)
+                        .expect("environment handle must be valid for its own lock file")
+                }),
         )
     }
 
@@ -755,8 +755,11 @@ impl<'lock> Environment<'lock> {
             .map(move |(platform, data)| {
                 (
                     platform,
-                    data.iter()
-                        .map(|handle| &self.lock_file.inner.packages[handle.index.0]),
+                    data.handles().map(|handle| {
+                        handle
+                            .get(self.lock_file)
+                            .expect("environment handle must be valid for its own lock file")
+                    }),
                 )
             })
     }
@@ -1536,9 +1539,9 @@ packages:
     }
 
     /// Verify that pypi source packages with relative paths (both `./` and
-    /// `../`) roundtrip correctly and that the `SerializablePackageSelector`
-    /// values in the environment section always match the `pypi:` keys in
-    /// the top-level `packages` section.
+    /// `../`) roundtrip correctly and that the `PackageSelector` values in
+    /// the environment section always match the `pypi:` keys in the
+    /// top-level `packages` section.
     #[test]
     fn test_pypi_relative_source_packages_roundtrip() {
         let lock_file_str = "\
@@ -1627,9 +1630,9 @@ packages:
 
         // Parse the rendered YAML and verify that every pypi selector in the
         // environment section has a matching pypi key in the packages section.
-        // This catches mismatches between SerializablePackageSelector (which
-        // serializes the inner UrlOrPath via Display) and the package data
-        // (which serializes via Verbatim, preferring the `given` string).
+        // This catches mismatches between PackageSelector (which serializes
+        // the inner UrlOrPath via Display) and the package data (which
+        // serializes via Verbatim, preferring the `given` string).
         let yaml: serde_yaml::Value = serde_yaml::from_str(&rendered).unwrap();
 
         let package_pypi_keys: std::collections::HashSet<&str> = yaml["packages"]
@@ -1667,8 +1670,8 @@ packages:
     /// Verify that `file:///` URLs in pypi package locations produce matching
     /// selectors. `UrlOrPath::from_str("file:///...")` normalizes to a bare
     /// path internally, but `Verbatim` preserves the original `file:///`
-    /// string. `SerializablePackageSelector` serializes the inner `UrlOrPath`
-    /// (bare path) while the package data serializes the `Verbatim` wrapper
+    /// string. `PackageSelector` serializes the inner `UrlOrPath` (bare
+    /// path) while the package data serializes the `Verbatim` wrapper
     /// (`file:///`), causing a mismatch.
     #[test]
     fn test_pypi_file_url_selector_matches_package() {

--- a/crates/rattler_lock/src/parse/deserialize.rs
+++ b/crates/rattler_lock/src/parse/deserialize.rs
@@ -14,7 +14,7 @@ use serde_yaml::Value;
 use crate::{
     file_format_version::FileFormatVersion,
     parse::{
-        models::{self, legacy::LegacyCondaPackageData, v6, v7},
+        models::{self, legacy::LegacyCondaPackageData, v6, v7, v7::PackageSelector},
         V5, V6, V7,
     },
     platform::{ParsePlatformError, PlatformData, PlatformName},
@@ -133,7 +133,7 @@ impl From<PypiPackageData> for PypiPackageDataRaw {
 /// Package data enum used during V7+ deserialization.
 ///
 /// Source variants carry the raw `build_packages` / `host_packages` selector
-/// strings as-read from the YAML; these are resolved to [`PackageIndex`]
+/// entries as-read from the YAML; these are resolved to [`PackageIndex`]
 /// values in a second pass after all packages have been indexed.
 #[allow(clippy::large_enum_variant)]
 enum PackageData {
@@ -142,13 +142,13 @@ enum PackageData {
     /// Source conda package.
     CondaSource {
         data: CondaSourceData,
-        build_packages: Vec<String>,
-        host_packages: Vec<String>,
+        build_packages: Vec<PackageSelector>,
+        host_packages: Vec<PackageSelector>,
     },
     Pypi {
         data: PypiPackageDataRaw,
-        build_packages: Vec<String>,
-        host_packages: Vec<String>,
+        build_packages: Vec<PackageSelector>,
+        host_packages: Vec<PackageSelector>,
     },
 }
 
@@ -802,7 +802,11 @@ fn parse_from_lock<P>(
     let (mut packages, pending_source_data) = {
         let num_packages = raw.packages.len();
         let mut packages = Vec::with_capacity(num_packages);
-        let mut pending_source_data: Vec<(PackageIndex, Vec<String>, Vec<String>)> = Vec::new();
+        let mut pending_source_data: Vec<(
+            PackageIndex,
+            Vec<PackageSelector>,
+            Vec<PackageSelector>,
+        )> = Vec::new();
 
         for (index, package) in raw.packages.into_iter().enumerate() {
             let index = PackageIndex(index);
@@ -848,30 +852,32 @@ fn parse_from_lock<P>(
         .collect();
     selector_index.sort_by(|a, b| a.0.cmp(&b.0));
 
-    // Resolve build_packages/host_packages selector strings to PackageIndex
-    // values. The strings in the lockfile are the full (kind-prefixed)
-    // SelectorId form, so we binary-search `selector_index` directly.
-    let resolve_index = |s: &str| -> Result<PackageIndex, ParseCondaLockError> {
+    // Resolve a `PackageSelector` (as read from the lockfile) to a
+    // `PackageIndex` by rebuilding its full `SelectorId` and binary-searching
+    // `selector_index`.
+    let resolve_index = |selector: &PackageSelector| -> Result<PackageIndex, ParseCondaLockError> {
+        let id = selector.to_selector_id();
         selector_index
-            .binary_search_by(|(sel, _)| sel.as_long_str().cmp(s))
+            .binary_search_by(|(sel, _)| sel.cmp(&id))
             .map(|pos| selector_index[pos].1)
             .map_err(|_not_found| ParseCondaLockError::MissingPackage {
                 environment: String::new(),
                 platform: String::new(),
-                location: s.to_owned(),
+                location: selector.id().to_owned(),
             })
     };
 
-    for (pkg_idx, build_strings, host_strings) in pending_source_data {
+    for (pkg_idx, build_selectors, host_selectors) in pending_source_data {
         // Resolve in a scoped block so the immutable borrow of `packages`
         // that the closure takes is dropped before we mutate `packages`.
         let (build_packages, host_packages) = {
-            let resolve = |s: &str| -> Result<PackageHandle, ParseCondaLockError> {
-                let index = resolve_index(s)?;
-                Ok(PackageHandle::new(index, &packages[index.0]))
-            };
-            let build = EnvironmentPackages::from_selector_ids(build_strings, &resolve)?;
-            let host = EnvironmentPackages::from_selector_ids(host_strings, &resolve)?;
+            let resolve =
+                |selector: &PackageSelector| -> Result<PackageHandle, ParseCondaLockError> {
+                    let index = resolve_index(selector)?;
+                    Ok(PackageHandle::new(index, &packages[index.0]))
+                };
+            let build = EnvironmentPackages::from_selector_ids(build_selectors, &resolve)?;
+            let host = EnvironmentPackages::from_selector_ids(host_selectors, &resolve)?;
             (build, host)
         };
 

--- a/crates/rattler_lock/src/parse/models/v7/mod.rs
+++ b/crates/rattler_lock/src/parse/models/v7/mod.rs
@@ -1,8 +1,10 @@
 mod conda_package_data;
+mod package_selector;
 mod pypi_package_data;
 mod source_data;
 mod source_package_data;
 
 pub(crate) use conda_package_data::CondaPackageDataModel;
+pub(crate) use package_selector::PackageSelector;
 pub(crate) use pypi_package_data::PypiPackageDataModel;
 pub(crate) use source_package_data::SourcePackageDataModel;

--- a/crates/rattler_lock/src/parse/models/v7/package_selector.rs
+++ b/crates/rattler_lock/src/parse/models/v7/package_selector.rs
@@ -1,0 +1,48 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{SelectorId, SelectorKind};
+
+/// A tagged reference to another package in the lockfile.
+///
+/// Serializes as a single-key YAML mapping whose key is the package kind
+/// (`conda`, `conda_source`, or `pypi`) and whose value is the kind-specific
+/// id. This matches how top-level environment package entries are emitted,
+/// so `build_packages` and `host_packages` entries read the same way.
+#[derive(Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Clone, Debug, Hash)]
+#[serde(untagged, rename_all = "snake_case")]
+pub(crate) enum PackageSelector {
+    Conda { conda: String },
+    CondaSource { conda_source: String },
+    Pypi { pypi: String },
+}
+
+impl PackageSelector {
+    pub(crate) fn kind(&self) -> SelectorKind {
+        match self {
+            Self::Conda { .. } => SelectorKind::CondaBinary,
+            Self::CondaSource { .. } => SelectorKind::CondaSource,
+            Self::Pypi { .. } => SelectorKind::Pypi,
+        }
+    }
+
+    pub(crate) fn id(&self) -> &str {
+        match self {
+            Self::Conda { conda } => conda,
+            Self::CondaSource { conda_source } => conda_source,
+            Self::Pypi { pypi } => pypi,
+        }
+    }
+
+    pub(crate) fn to_selector_id(&self) -> SelectorId {
+        SelectorId::from_parts(self.kind(), self.id())
+    }
+
+    pub(crate) fn from_selector_id(id: &SelectorId) -> Self {
+        let raw = id.as_str().to_string();
+        match id.kind() {
+            SelectorKind::CondaBinary => Self::Conda { conda: raw },
+            SelectorKind::CondaSource => Self::CondaSource { conda_source: raw },
+            SelectorKind::Pypi => Self::Pypi { pypi: raw },
+        }
+    }
+}

--- a/crates/rattler_lock/src/parse/models/v7/pypi_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/pypi_package_data.rs
@@ -5,6 +5,7 @@ use pep508_rs::{PackageName, VersionOrUrl};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
 
+use super::package_selector::PackageSelector;
 use crate::{
     parse::deserialize::PypiPackageDataRaw, PackageHashes, PypiPackageData, UrlOrPath, Verbatim,
 };
@@ -43,15 +44,15 @@ pub(crate) struct PypiPackageDataModel<'a> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub requires_python: Cow<'a, Option<VersionSpecifiers>>,
 
-    /// Selector ids for packages in the build environment (pypi source
+    /// Selectors for packages in the build environment (pypi source
     /// packages only — empty for wheel distributions).
     /// Populated at lockfile serialization time; empty for standalone package
     /// serialization. Resolved to indices after deserialization.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub build_packages: Vec<String>,
-    /// Selector ids for packages in the host environment.
+    pub build_packages: Vec<PackageSelector>,
+    /// Selectors for packages in the host environment.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub host_packages: Vec<String>,
+    pub host_packages: Vec<PackageSelector>,
 }
 
 impl<'a> From<PypiPackageDataModel<'a>> for PypiPackageDataRaw {

--- a/crates/rattler_lock/src/parse/models/v7/source_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/source_package_data.rs
@@ -7,7 +7,10 @@ use rattler_conda_types::{BuildNumber, NoArchType, PackageRecord, PackageUrl, Ve
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
-use super::source_data::{PackageBuildSourceSerializer, SourceLocationSerializer};
+use super::{
+    package_selector::PackageSelector,
+    source_data::{PackageBuildSourceSerializer, SourceLocationSerializer},
+};
 use crate::{
     conda::{
         CondaSourceData, PackageBuildSource, PartialSourceMetadata, SourceMetadata, VariantValue,
@@ -93,14 +96,14 @@ pub(crate) struct SourcePackageDataModel<'a> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub python_site_packages_path: Cow<'a, Option<String>>,
 
-    /// Selector ids for packages in the build environment.
+    /// Selectors for packages in the build environment.
     /// Populated at lockfile serialization time; empty for standalone package
     /// serialization. Resolved to indices after deserialization.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub build_packages: Vec<String>,
-    /// Selector ids for packages in the host environment.
+    pub build_packages: Vec<PackageSelector>,
+    /// Selectors for packages in the host environment.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub host_packages: Vec<String>,
+    pub host_packages: Vec<PackageSelector>,
 }
 
 fn is_zero(value: &BuildNumber) -> bool {

--- a/crates/rattler_lock/src/parse/serialize.rs
+++ b/crates/rattler_lock/src/parse/serialize.rs
@@ -10,15 +10,13 @@ use serde_with::{serde_as, SerializeAs};
 
 use crate::{
     file_format_version::FileFormatVersion,
-    parse::{models::v7, V7},
+    parse::{models::v7, models::v7::PackageSelector, V7},
     Channel, CondaPackageData, EnvironmentData, LockFile, LockFileInner, LockedPackage,
     PackageIndex, PlatformData, PypiIndexes, PypiPackageData, SelectorId, SolveOptions,
 };
 
-fn selector_ids_to_strings(ids: Vec<SelectorId>) -> Vec<String> {
-    ids.into_iter()
-        .map(|id| id.as_long_str().to_string())
-        .collect()
+fn selector_ids_to_package_selectors(ids: Vec<SelectorId>) -> Vec<PackageSelector> {
+    ids.iter().map(PackageSelector::from_selector_id).collect()
 }
 
 #[serde_as]
@@ -63,7 +61,7 @@ struct SerializableEnvironment<'a> {
     indexes: Option<&'a PypiIndexes>,
     #[serde(default, skip_serializing_if = "crate::utils::serde::is_default")]
     options: SolveOptions,
-    packages: BTreeMap<String, Vec<SerializablePackageSelector>>,
+    packages: BTreeMap<String, Vec<PackageSelector>>,
 }
 
 impl<'a> SerializableEnvironment<'a> {
@@ -85,9 +83,11 @@ impl<'a> SerializableEnvironment<'a> {
                     (
                         platform_name,
                         packages
-                            .iter()
+                            .handles()
                             .map(|handle| {
-                                SerializablePackageSelector::from_lock_file(inner, handle.index)
+                                PackageSelector::from_selector_id(&SelectorId::new(
+                                    &inner.packages[handle.index.0],
+                                ))
                             })
                             .sorted()
                             .collect(),
@@ -115,74 +115,17 @@ impl<'a> From<PackageData<'a>> for SerializablePackageDataV7<'a> {
             }
             LockedPackage::Conda(CondaPackageData::Source(source)) => {
                 let mut model = v7::SourcePackageDataModel::from(source.as_ref());
-                model.build_packages = selector_ids_to_strings(package.build_packages);
-                model.host_packages = selector_ids_to_strings(package.host_packages);
+                model.build_packages = selector_ids_to_package_selectors(package.build_packages);
+                model.host_packages = selector_ids_to_package_selectors(package.host_packages);
                 Self::Source(model)
             }
             LockedPackage::Pypi(p) => {
                 let mut model = v7::PypiPackageDataModel::from(p);
-                model.build_packages = selector_ids_to_strings(package.build_packages);
-                model.host_packages = selector_ids_to_strings(package.host_packages);
+                model.build_packages = selector_ids_to_package_selectors(package.build_packages);
+                model.host_packages = selector_ids_to_package_selectors(package.host_packages);
                 Self::Pypi(model)
             }
         }
-    }
-}
-
-/// Package selector for V7+ environments.
-///
-/// For V7+, each package variant is uniquely identified by its
-/// [`LockedPackage::selector_id`](crate::LockedPackage::selector_id) string,
-/// stored under the appropriate YAML key (`conda`, `conda_source`, or `pypi`).
-#[derive(Serialize, Eq, PartialEq)]
-#[serde(untagged, rename_all = "snake_case")]
-enum SerializablePackageSelector {
-    Conda { conda: String },
-    CondaSource { conda_source: String },
-    Pypi { pypi: String },
-}
-
-impl SerializablePackageSelector {
-    fn from_lock_file(inner: &LockFileInner, package: PackageIndex) -> Self {
-        let pkg = &inner.packages[package.0];
-        let id = SelectorId::new(pkg).as_str().to_string();
-        match pkg {
-            LockedPackage::Conda(CondaPackageData::Binary(_)) => Self::Conda { conda: id },
-            LockedPackage::Conda(CondaPackageData::Source(_)) => {
-                Self::CondaSource { conda_source: id }
-            }
-            LockedPackage::Pypi(_) => Self::Pypi { pypi: id },
-        }
-    }
-
-    fn id(&self) -> &str {
-        match self {
-            Self::Conda { conda } => conda,
-            Self::CondaSource { conda_source } => conda_source,
-            Self::Pypi { pypi } => pypi,
-        }
-    }
-}
-
-impl PartialOrd for SerializablePackageSelector {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for SerializablePackageSelector {
-    fn cmp(&self, other: &Self) -> Ordering {
-        fn type_order(selector: &SerializablePackageSelector) -> u8 {
-            match selector {
-                SerializablePackageSelector::Conda { .. } => 0,
-                SerializablePackageSelector::CondaSource { .. } => 1,
-                SerializablePackageSelector::Pypi { .. } => 2,
-            }
-        }
-
-        type_order(self)
-            .cmp(&type_order(other))
-            .then_with(|| self.id().cmp(other.id()))
     }
 }
 
@@ -202,13 +145,35 @@ impl Serialize for LockFile {
     {
         let inner = self.inner.as_ref();
 
-        // Determine the package indexes that are used in the lock-file.
-        let used_packages: HashSet<PackageIndex> = inner
+        // Determine the package indexes that are used in the lock-file,
+        // including those referenced transitively via source-package
+        // `build_packages` / `host_packages`.
+        let mut used_packages: HashSet<PackageIndex> = inner
             .environments
             .iter()
             .flat_map(|env| env.packages.values())
-            .flat_map(|packages| packages.iter().map(|handle| handle.index))
+            .flat_map(|packages| packages.handles().map(|handle| handle.index))
             .collect();
+        let mut worklist: Vec<PackageIndex> = used_packages.iter().copied().collect();
+        while let Some(idx) = worklist.pop() {
+            let source_data = match &inner.packages[idx.0] {
+                LockedPackage::Conda(CondaPackageData::Source(source)) => Some(&source.source_data),
+                LockedPackage::Pypi(pypi) => pypi.as_source().map(|s| &s.source_data),
+                LockedPackage::Conda(_) => None,
+            };
+            let Some(source_data) = source_data else {
+                continue;
+            };
+            for handle in source_data
+                .build_packages
+                .handles()
+                .chain(source_data.host_packages.handles())
+            {
+                if used_packages.insert(handle.index) {
+                    worklist.push(handle.index);
+                }
+            }
+        }
 
         // Collect all environments
         let environments = inner

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__conda-source-build-host-packages-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__conda-source-build-host-packages-lock.yml.snap
@@ -23,6 +23,6 @@ packages:
     build: py_0
     subdir: noarch
     build_packages:
-      - "conda: https://conda.anaconda.org/conda-forge/linux-64/build-tool-1.0.0-h0.conda"
+      - conda: "https://conda.anaconda.org/conda-forge/linux-64/build-tool-1.0.0-h0.conda"
     host_packages:
-      - "conda: https://conda.anaconda.org/conda-forge/linux-64/host-lib-2.0.0-h0.conda"
+      - conda: "https://conda.anaconda.org/conda-forge/linux-64/host-lib-2.0.0-h0.conda"

--- a/test-data/conda-lock/v7/conda-source-build-host-packages-lock.yml
+++ b/test-data/conda-lock/v7/conda-source-build-host-packages-lock.yml
@@ -18,6 +18,6 @@ packages:
     build: py_0
     subdir: noarch
     build_packages:
-      - "conda: https://conda.anaconda.org/conda-forge/linux-64/build-tool-1.0.0-h0.conda"
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/build-tool-1.0.0-h0.conda
     host_packages:
-      - "conda: https://conda.anaconda.org/conda-forge/linux-64/host-lib-2.0.0-h0.conda"
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/host-lib-2.0.0-h0.conda


### PR DESCRIPTION
…ckages in serialized used-set

- `PackageHandle::get(&LockFile) -> Result<&LockedPackage, InvalidPackageHandleError>` replaces the old slice-based lookup as the public API; the slice form is renamed `get_from_slice` and demoted to `pub(crate)` for the builder's pre-lockfile validation path.
- `EnvironmentPackages::iter(&LockFile)` yields `Result<&LockedPackage, InvalidPackageHandleError>`; the old handle iterator is renamed `handles()` and demoted to `pub(crate)`. The public `IntoIterator for &EnvironmentPackages` impl is removed so `PackageHandle` no longer leaks on the read side.
- Internal callers in `lib.rs` (Environment::packages, packages_by_platform) migrate to `handle.get(self.lock_file).expect(...)` instead of reaching into `inner.packages[handle.index.0]`.
- Fix `LockFile` serialization: the "used packages" set that filters the top-level packages table now transitively walks `source_data.build_packages` / `host_packages`, so packages referenced only via a source package's build/host envs aren't dropped.

### How Has This Been Tested?

By running the tests.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.