### PR TITLE
feat: Add `Hash` derive to `SolveStrategy` enum

### DIFF
--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -454,7 +454,7 @@ impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
 }
 
 /// Represents the strategy to use when solving dependencies
-#[derive(Debug, Clone, Copy, Default, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum SolveStrategy {


### PR DESCRIPTION
### Description

Add `Hash` trait derivation to the `SolveStrategy` enum. This enables `SolveStrategy` to be used as a key in hash-based collections (e.g., `HashMap`, `HashSet`), which is a common requirement when the type needs to be hashable in addition to its existing equality semantics.

The change is minimal and non-breaking, as `SolveStrategy` already derives `Eq` and `PartialEq`, making it suitable for hashing.

### How Has This Been Tested?

No testing needed. This is a straightforward trait derivation that enables additional functionality without changing existing behavior. The Rust compiler ensures the `Hash` implementation is correct.

### Checklist:
- [x] I have performed a self-review of my own code