### PR TITLE
fix: skip existing upload to prefix

### DIFF
--- a/crates/rattler_upload/src/upload/prefix.rs
+++ b/crates/rattler_upload/src/upload/prefix.rs
@@ -395,7 +395,7 @@ pub async fn upload_package_to_prefix(
                     if prefix_data.skip_existing.is_enabled() {
                         progress_bar.finish();
                         info!("Skip existing package: {}", filename);
-                        return Ok(());
+                        break;
                     } else {
                         return Err(PrefixUploadError::Conflict { body });
                     }
@@ -499,6 +499,40 @@ mod test {
         let prefix_data = make_prefix_data(url, true);
         let result =
             upload_package_to_prefix(&storage, &vec![test_package_path()], prefix_data).await;
+        assert!(result.is_ok(), "{:?}", result.unwrap_err());
+    }
+
+    #[tokio::test]
+    async fn test_prefix_upload_skip_existing_continues_remaining() {
+        // First package returns 409, second returns 200 — both should succeed overall
+        use axum::extract::State;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let call_count = Arc::new(AtomicUsize::new(0));
+
+        async fn handler(
+            State(count): State<Arc<AtomicUsize>>,
+            _body: axum::body::Bytes,
+        ) -> StatusCode {
+            let n = count.fetch_add(1, Ordering::SeqCst);
+            if n == 0 {
+                StatusCode::CONFLICT
+            } else {
+                StatusCode::OK
+            }
+        }
+
+        let router = Router::new().fallback(handler).with_state(call_count);
+        let url = start_test_server(router).await;
+        let storage = AuthenticationStorage::empty();
+        let prefix_data = make_prefix_data(url, true);
+        let result = upload_package_to_prefix(
+            &storage,
+            &vec![test_package_path(), test_package_path()],
+            prefix_data,
+        )
+        .await;
         assert!(result.is_ok(), "{:?}", result.unwrap_err());
     }
 

--- a/crates/rattler_upload/src/upload/prefix.rs
+++ b/crates/rattler_upload/src/upload/prefix.rs
@@ -509,8 +509,6 @@ mod test {
         use std::sync::atomic::{AtomicUsize, Ordering};
         use std::sync::Arc;
 
-        let call_count = Arc::new(AtomicUsize::new(0));
-
         async fn handler(
             State(count): State<Arc<AtomicUsize>>,
             _body: axum::body::Bytes,
@@ -523,6 +521,7 @@ mod test {
             }
         }
 
+        let call_count = Arc::new(AtomicUsize::new(0));
         let router = Router::new().fallback(handler).with_state(call_count);
         let url = start_test_server(router).await;
         let storage = AuthenticationStorage::empty();


### PR DESCRIPTION
### Description

Turns out the problem was in rattler-upload. We called `return Ok(...)` on the first skip, instead of continuing the loop.

Fixes an issue that we saw in `robostack-rolling` uploads.

### How Has This Been Tested?

Test in the code.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [ ] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.