### PR TITLE
feat(rattler_lock): include run-exports in lockfile v7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5238,6 +5238,7 @@ dependencies = [
  "serde_yaml",
  "similar-asserts",
  "thiserror 2.0.18",
+ "tracing",
  "typed-path",
  "url",
  "xxhash-rust",

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -28,6 +28,7 @@ serde-untagged = { workspace = true }
 serde_repr = { workspace = true }
 serde-value = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 typed-path = { workspace = true }
 xxhash-rust = { workspace = true, features = ["xxh3"] }

--- a/crates/rattler_lock/src/builder.rs
+++ b/crates/rattler_lock/src/builder.rs
@@ -669,6 +669,268 @@ mod test {
         insta::assert_snapshot!(lock_file.render_to_string().unwrap());
     }
 
+    fn make_run_exports() -> rattler_conda_types::package::RunExportsJson {
+        rattler_conda_types::package::RunExportsJson {
+            strong: vec!["libfoo >=1.0,<2".into()],
+            weak: vec!["libbar >=2".into()],
+            ..Default::default()
+        }
+    }
+
+    fn make_binary_record() -> PackageRecord {
+        PackageRecord {
+            subdir: "linux-64".into(),
+            ..PackageRecord::new(
+                PackageName::new_unchecked("foobar"),
+                Version::from_str("1.0.0").unwrap(),
+                "build".into(),
+            )
+        }
+    }
+
+    fn make_binary(record: PackageRecord) -> CondaBinaryData {
+        CondaBinaryData {
+            package_record: record,
+            location: Url::parse("https://prefix.dev/example/linux-64/foobar-1.0.0-build.tar.bz2")
+                .unwrap()
+                .into(),
+            file_name: "foobar-1.0.0-build.tar.bz2"
+                .parse::<DistArchiveIdentifier>()
+                .unwrap(),
+            channel: None,
+        }
+    }
+
+    fn binary_run_exports(
+        lock_file: &LockFile,
+    ) -> Option<rattler_conda_types::package::RunExportsJson> {
+        lock_file
+            .inner
+            .packages
+            .iter()
+            .find_map(crate::LockedPackage::as_binary_conda)
+            .expect("a binary package")
+            .package_record
+            .run_exports
+            .clone()
+    }
+
+    fn linux_64_platform() -> PlatformData {
+        PlatformData {
+            name: PlatformName::try_from("linux-64").unwrap(),
+            subdir: rattler_conda_types::Platform::Linux64,
+            virtual_packages: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_merge_run_exports_unknown_then_known() {
+        // Left record has run_exports = None, right record carries Some(non-empty).
+        // Merge should adopt the right side's run_exports.
+        let unknown = make_binary_record();
+        let known = PackageRecord {
+            run_exports: Some(make_run_exports()),
+            ..make_binary_record()
+        };
+
+        let lock_file = LockFile::builder()
+            .with_platforms(vec![linux_64_platform()])
+            .unwrap()
+            .with_conda_package("default", "linux-64", make_binary(unknown).into())
+            .unwrap()
+            .with_conda_package("default", "linux-64", make_binary(known).into())
+            .unwrap()
+            .finish();
+
+        assert_eq!(binary_run_exports(&lock_file), Some(make_run_exports()));
+    }
+
+    #[test]
+    fn test_merge_run_exports_known_empty_blocks_merge() {
+        // Left record asserts `Some(empty)` (we know there are no run_exports).
+        // A subsequent record carrying Some(non-empty) for the same identifier
+        // must NOT override that — first-writer-wins, and `Some(empty)` is a
+        // valid claim, distinct from `None`.
+        let known_empty = PackageRecord {
+            run_exports: Some(rattler_conda_types::package::RunExportsJson::default()),
+            ..make_binary_record()
+        };
+        let known_nonempty = PackageRecord {
+            run_exports: Some(make_run_exports()),
+            ..make_binary_record()
+        };
+
+        let lock_file = LockFile::builder()
+            .with_platforms(vec![linux_64_platform()])
+            .unwrap()
+            .with_conda_package("default", "linux-64", make_binary(known_empty).into())
+            .unwrap()
+            .with_conda_package("default", "linux-64", make_binary(known_nonempty).into())
+            .unwrap()
+            .finish();
+
+        assert_eq!(
+            binary_run_exports(&lock_file),
+            Some(rattler_conda_types::package::RunExportsJson::default())
+        );
+    }
+
+    #[test]
+    fn test_run_exports_roundtrip_binary() {
+        // Roundtrip a binary record carrying non-empty run_exports through
+        // YAML serialization and parsing.
+        let record = PackageRecord {
+            run_exports: Some(make_run_exports()),
+            ..make_binary_record()
+        };
+
+        let lock_file = LockFile::builder()
+            .with_platforms(vec![linux_64_platform()])
+            .unwrap()
+            .with_conda_package("default", "linux-64", make_binary(record).into())
+            .unwrap()
+            .finish();
+
+        let yaml = lock_file.render_to_string().unwrap();
+        let reparsed = LockFile::from_str_with_base_directory(&yaml, None).unwrap();
+
+        assert_eq!(binary_run_exports(&reparsed), Some(make_run_exports()));
+    }
+
+    #[test]
+    fn test_run_exports_roundtrip_binary_known_empty() {
+        // `Some(empty)` must remain `Some(empty)` after a roundtrip — distinct
+        // from `None` (= unknown). The lockfile encodes it as `run_exports: {}`.
+        let record = PackageRecord {
+            run_exports: Some(rattler_conda_types::package::RunExportsJson::default()),
+            ..make_binary_record()
+        };
+
+        let lock_file = LockFile::builder()
+            .with_platforms(vec![linux_64_platform()])
+            .unwrap()
+            .with_conda_package("default", "linux-64", make_binary(record).into())
+            .unwrap()
+            .finish();
+
+        let yaml = lock_file.render_to_string().unwrap();
+        assert!(
+            yaml.contains("run_exports: {}"),
+            "expected explicit empty run_exports in YAML:\n{yaml}"
+        );
+
+        let reparsed = LockFile::from_str_with_base_directory(&yaml, None).unwrap();
+        assert_eq!(
+            binary_run_exports(&reparsed),
+            Some(rattler_conda_types::package::RunExportsJson::default())
+        );
+    }
+
+    #[test]
+    fn test_run_exports_roundtrip_source() {
+        use std::collections::BTreeMap;
+
+        use typed_path::Utf8TypedPathBuf;
+
+        use crate::{CondaPackageData, CondaSourceData, SourceMetadata, UrlOrPath};
+
+        let mut record = PackageRecord::new(
+            PackageName::new_unchecked("my-pkg"),
+            Version::from_str("0.1.0").unwrap(),
+            "py_0".into(),
+        );
+        record.subdir = "noarch".into();
+        record.run_exports = Some(make_run_exports());
+
+        let source = CondaSourceData {
+            location: UrlOrPath::Path(Utf8TypedPathBuf::from("./my-pkg")),
+            package_build_source: None,
+            variants: BTreeMap::new(),
+            identifier_hash: None,
+            sources: BTreeMap::new(),
+            source_data: crate::SourceData::default(),
+            metadata: SourceMetadata::Full(Box::new(record)),
+        };
+
+        let lock_file = LockFile::builder()
+            .with_platforms(vec![linux_64_platform()])
+            .unwrap()
+            .with_conda_package(
+                "default",
+                "linux-64",
+                CondaPackageData::Source(Box::new(source)),
+            )
+            .unwrap()
+            .finish();
+
+        let yaml = lock_file.render_to_string().unwrap();
+        let reparsed = LockFile::from_str_with_base_directory(&yaml, None).unwrap();
+
+        let parsed_source = reparsed
+            .inner
+            .packages
+            .iter()
+            .find_map(crate::LockedPackage::as_source_conda)
+            .expect("a source package");
+        let SourceMetadata::Full(record) = &parsed_source.metadata else {
+            panic!("expected Full source metadata");
+        };
+        assert_eq!(record.run_exports.as_ref(), Some(&make_run_exports()));
+    }
+
+    #[test]
+    fn test_run_exports_snapshot() {
+        // Visual snapshot of how run_exports renders in the lockfile, for both
+        // a binary record with a non-empty value and a source record with the
+        // same.
+        use std::collections::BTreeMap;
+
+        use typed_path::Utf8TypedPathBuf;
+
+        use crate::{CondaPackageData, CondaSourceData, SourceMetadata, UrlOrPath};
+
+        let binary_record = PackageRecord {
+            run_exports: Some(make_run_exports()),
+            ..make_binary_record()
+        };
+
+        let mut source_record = PackageRecord::new(
+            PackageName::new_unchecked("my-pkg"),
+            Version::from_str("0.1.0").unwrap(),
+            "py_0".into(),
+        );
+        source_record.subdir = "noarch".into();
+        source_record.run_exports = Some(rattler_conda_types::package::RunExportsJson {
+            strong: vec!["libsource >=3".into()],
+            ..Default::default()
+        });
+
+        let source = CondaSourceData {
+            location: UrlOrPath::Path(Utf8TypedPathBuf::from("./my-pkg")),
+            package_build_source: None,
+            variants: BTreeMap::new(),
+            identifier_hash: None,
+            sources: BTreeMap::new(),
+            source_data: crate::SourceData::default(),
+            metadata: SourceMetadata::Full(Box::new(source_record)),
+        };
+
+        let lock_file = LockFile::builder()
+            .with_platforms(vec![linux_64_platform()])
+            .unwrap()
+            .with_conda_package("default", "linux-64", make_binary(binary_record).into())
+            .unwrap()
+            .with_conda_package(
+                "default",
+                "linux-64",
+                CondaPackageData::Source(Box::new(source)),
+            )
+            .unwrap()
+            .finish();
+
+        insta::assert_snapshot!(lock_file.render_to_string().unwrap());
+    }
+
     #[test]
     fn test_pypi_prerelease_mode() {
         let record = PackageRecord {

--- a/crates/rattler_lock/src/conda.rs
+++ b/crates/rattler_lock/src/conda.rs
@@ -677,6 +677,13 @@ fn merge_package_record<'a>(
             run_exports: right.run_exports.clone(),
             ..result.into_owned()
         });
+    } else if let (Some(l), Some(r)) = (&left.run_exports, &right.run_exports) {
+        if l != r {
+            tracing::debug!(
+                package = %left.name.as_normalized(),
+                "merging two records with conflicting run_exports; keeping the existing one"
+            );
+        }
     }
 
     // Merge hashes if the left package doesn't contain them.

--- a/crates/rattler_lock/src/parse/models/v7/conda_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/conda_package_data.rs
@@ -4,8 +4,9 @@ use std::{
 };
 
 use rattler_conda_types::{
-    package::DistArchiveIdentifier, utils::TimestampMs, BuildNumber, ChannelUrl, NoArchType,
-    PackageName, PackageRecord, PackageUrl, VersionWithSource,
+    package::{DistArchiveIdentifier, RunExportsJson},
+    utils::TimestampMs,
+    BuildNumber, ChannelUrl, NoArchType, PackageName, PackageRecord, PackageUrl, VersionWithSource,
 };
 use rattler_digest::{serde::SerializableHash, Md5Hash, Sha256Hash};
 use serde::{Deserialize, Serialize};
@@ -109,6 +110,12 @@ pub(crate) struct CondaPackageDataModel<'a> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub purls: Cow<'a, Option<BTreeSet<PackageUrl>>>,
 
+    /// Run-exports of the package. `None` means the run-exports are unknown;
+    /// `Some(empty)` means we know the package has no run-exports and is
+    /// serialized as `run_exports: {}`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_exports: Option<Cow<'a, RunExportsJson>>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub size: Cow<'a, Option<u64>>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -183,7 +190,7 @@ impl<'a> TryFrom<CondaPackageDataModel<'a>> for CondaBinaryData {
                 .map(Cow::into_owned)
                 .or(derived.version)
                 .ok_or_else(|| ConversionError::Missing("version".to_string()))?,
-            run_exports: None,
+            run_exports: value.run_exports.map(Cow::into_owned),
             python_site_packages_path: value.python_site_packages_path.into_owned(),
         };
 
@@ -281,6 +288,7 @@ impl<'a> From<&'a CondaBinaryData> for CondaPackageDataModel<'a> {
             license: Cow::Borrowed(&package_record.license),
             license_family: Cow::Borrowed(&package_record.license_family),
             python_site_packages_path: Cow::Borrowed(&package_record.python_site_packages_path),
+            run_exports: package_record.run_exports.as_ref().map(Cow::Borrowed),
             variants: None,
         }
     }

--- a/crates/rattler_lock/src/parse/models/v7/source_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/source_package_data.rs
@@ -3,7 +3,9 @@ use std::{
     collections::{BTreeMap, BTreeSet},
 };
 
-use rattler_conda_types::{BuildNumber, NoArchType, PackageRecord, PackageUrl, VersionWithSource};
+use rattler_conda_types::{
+    package::RunExportsJson, BuildNumber, NoArchType, PackageRecord, PackageUrl, VersionWithSource,
+};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
@@ -82,6 +84,12 @@ pub(crate) struct SourcePackageDataModel<'a> {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub purls: Cow<'a, Option<BTreeSet<PackageUrl>>>,
 
+    /// Run-exports of the package. Source packages always know their
+    /// run-exports once evaluated, so this field is non-optional. An absent
+    /// or empty value in the lockfile means there are no run-exports.
+    #[serde(default, skip_serializing_if = "RunExportsJson::is_empty")]
+    pub run_exports: Cow<'a, RunExportsJson>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub size: Cow<'a, Option<u64>>,
 
@@ -150,7 +158,7 @@ impl<'a> SourcePackageDataModel<'a> {
                 size: self.size.into_owned(),
                 timestamp: None,
                 track_features: self.track_features.into_owned(),
-                run_exports: None,
+                run_exports: Some(self.run_exports.into_owned()),
                 python_site_packages_path: self.python_site_packages_path.into_owned(),
             }))
         } else {
@@ -198,6 +206,11 @@ impl<'a> From<&'a CondaSourceData> for SourcePackageDataModel<'a> {
                 noarch: full.noarch,
                 variants,
                 purls: Cow::Borrowed(&full.purls),
+                run_exports: full
+                    .run_exports
+                    .as_ref()
+                    .map(Cow::Borrowed)
+                    .unwrap_or_default(),
                 depends: Cow::Borrowed(&full.depends),
                 constrains: Cow::Borrowed(&full.constrains),
                 experimental_extra_depends: Cow::Borrowed(&full.experimental_extra_depends),
@@ -221,6 +234,7 @@ impl<'a> From<&'a CondaSourceData> for SourcePackageDataModel<'a> {
                 noarch: NoArchType::default(),
                 variants,
                 purls: Cow::Owned(None),
+                run_exports: Cow::Owned(RunExportsJson::default()),
                 depends: Cow::Borrowed(&partial.depends),
                 constrains: Cow::Borrowed(&[]),
                 experimental_extra_depends: Cow::Owned(BTreeMap::new()),

--- a/crates/rattler_lock/src/snapshots/rattler_lock__builder__test__run_exports_snapshot.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__builder__test__run_exports_snapshot.snap
@@ -1,0 +1,29 @@
+---
+source: crates/rattler_lock/src/builder.rs
+expression: lock_file.render_to_string().unwrap()
+---
+version: 7
+platforms:
+- name: linux-64
+environments:
+  default:
+    channels: []
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/example/linux-64/foobar-1.0.0-build.tar.bz2
+      - conda_source: my-pkg[abf1cfe6] @ ./my-pkg
+packages:
+- conda: https://prefix.dev/example/linux-64/foobar-1.0.0-build.tar.bz2
+  channel: null
+  run_exports:
+    weak:
+    - libbar >=2
+    strong:
+    - libfoo >=1.0,<2
+- conda_source: my-pkg[abf1cfe6] @ ./my-pkg
+  version: 0.1.0
+  build: py_0
+  subdir: noarch
+  run_exports:
+    strong:
+    - libsource >=3


### PR DESCRIPTION
Adds `run_exports` to the v7 conda binary and source models so the field actually round-trips through the lockfile.

- **Binary records:** `Option<RunExportsJson>` — `None` = unknown, `Some(empty)` = known-empty (serialized as `run_exports: {}`), `Some(non-empty)` rendered inline. The pre-existing merge in `merge_package_record` now does real work: when one record knows the run-exports and another doesn't, the known value wins. A `tracing::debug!` fires when two non-equal `Some` values are merged (first-writer-wins kept).
- **Source records:** non-`Option`. Source packages always know their run-exports once evaluated; absent in YAML means none.

## Test plan

- [x] `cargo test -p rattler_lock` (187 passed)
- [x] `cargo clippy -p rattler_lock --tests` (clean)
- [x] New unit tests cover unknown→known merge, `Some(empty)` blocking merge, and binary/source round-trip
- [x] Insta snapshot showing run_exports rendered for both binary and source records