### PR TITLE
fix: skip serializing v3 packages in shards if empty

### DIFF
--- a/crates/rattler_conda_types/src/repo_data/sharded.rs
+++ b/crates/rattler_conda_types/src/repo_data/sharded.rs
@@ -106,7 +106,11 @@ pub struct Shard {
     pub conda_packages: IndexMap<DistArchiveIdentifier, PackageRecord, ahash::RandomState>,
 
     /// Packages stored under the `v3` top-level key.
-    #[serde(default, rename = "v3")]
+    #[serde(
+        default,
+        rename = "v3",
+        skip_serializing_if = "ExperimentalV3Packages::is_empty"
+    )]
     pub experimental_v3: ExperimentalV3Packages,
 
     /// The file names of all removed for this shard


### PR DESCRIPTION
### Description

I added some smoke tests to our server and this was flagged.

### How Has This Been Tested?

In our backend.