### PR TITLE
fix: handle missing symlinks on Windows install path

### DIFF
--- a/crates/rattler/src/install/link.rs
+++ b/crates/rattler/src/install/link.rs
@@ -163,7 +163,7 @@ pub fn link_file(
     apple_codesign_behavior: AppleCodeSignBehavior,
     modification_time: filetime::FileTime,
     external_symlink_policy: ExternalSymlinkPolicy,
-) -> Result<LinkedFile, LinkFileError> {
+) -> Result<Option<LinkedFile>, LinkFileError> {
     let source_path = package_dir.join(&path_json_entry.relative_path);
 
     let destination_path = target_dir.path().join(&destination_relative_path);
@@ -287,15 +287,34 @@ pub fn link_file(
         reflink_to_destination(&source_path, &destination_path, allow_hard_links)?
     } else if path_json_entry.path_type == PathType::HardLink && allow_hard_links {
         hardlink_to_destination(&source_path, &destination_path)?
-    } else if path_json_entry.path_type == PathType::SoftLink && allow_symbolic_links {
-        symlink_to_destination(
-            &source_path,
-            &destination_path,
-            target_dir.path(),
-            external_symlink_policy,
-        )?
     } else if path_json_entry.path_type == PathType::SoftLink {
-        copy_symlink_target_to_destination(&source_path, &destination_path)?
+        // The source for a SoftLink may be missing if extraction skipped it (this
+        // happens on Windows when the user lacks the privileges required to create
+        // symlinks; see `rattler_package_streaming::tokio::shared`). Convert the
+        // resulting NotFound into a skip rather than failing the whole install.
+        let dispatch = if allow_symbolic_links {
+            symlink_to_destination(
+                &source_path,
+                &destination_path,
+                target_dir.path(),
+                external_symlink_policy,
+            )
+        } else {
+            copy_symlink_target_to_destination(&source_path, &destination_path)
+        };
+        match dispatch {
+            Ok(method) => method,
+            Err(LinkFileError::FailedToReadSymlink(io) | LinkFileError::FailedToLink(_, io))
+                if io.kind() == ErrorKind::NotFound =>
+            {
+                tracing::warn!(
+                    "skipping symlink entry '{}': source missing in package cache (likely skipped during extraction)",
+                    path_json_entry.relative_path.display()
+                );
+                return Ok(None);
+            }
+            Err(e) => return Err(e),
+        }
     } else {
         copy_to_destination(&source_path, &destination_path)?
     };
@@ -343,14 +362,14 @@ pub fn link_file(
         .as_ref()
         .map(|p| p.placeholder.clone());
 
-    Ok(LinkedFile {
+    Ok(Some(LinkedFile {
         clobbered: false,
         sha256,
         file_size,
         relative_path: destination_relative_path,
         method: link_method,
         prefix_placeholder,
-    })
+    }))
 }
 
 /// Either a memory mapped file or the complete contents of a file read to memory.
@@ -966,6 +985,7 @@ mod test {
             modification_time,
             ExternalSymlinkPolicy::Deny,
         )
+        .unwrap()
         .unwrap();
 
         assert_eq!(result.method, super::LinkMethod::Patched(FileMode::Text));
@@ -1026,6 +1046,7 @@ mod test {
             modification_time,
             ExternalSymlinkPolicy::Deny,
         )
+        .unwrap()
         .unwrap();
 
         assert_ne!(
@@ -1042,6 +1063,60 @@ mod test {
         assert_eq!(
             dest_mtime, source_time,
             "unpatched file should keep source mtime ({source_time}), not modification_time ({modification_time})",
+        );
+    }
+
+    /// A `SoftLink` entry whose source is missing on disk (because extraction
+    /// skipped it, e.g. on Windows without symlink privileges) should be
+    /// skipped with `Ok(None)` instead of failing the whole install.
+    #[test]
+    fn test_missing_symlink_source_is_skipped() {
+        use super::AppleCodeSignBehavior;
+        use rattler_conda_types::package::{PathType, PathsEntry};
+        use rattler_conda_types::prefix::Prefix;
+        use std::path::PathBuf;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        let package_dir = temp_dir.path().join("package");
+        fs::create_dir_all(&package_dir).unwrap();
+        // Intentionally do NOT create `missing-link` in package_dir.
+
+        let target_dir = Prefix::create(temp_dir.path().join("target")).unwrap();
+        let modification_time = filetime::FileTime::from_unix_time(2_000_000, 0);
+
+        let entry = PathsEntry {
+            relative_path: PathBuf::from("missing-link"),
+            no_link: false,
+            path_type: PathType::SoftLink,
+            prefix_placeholder: None,
+            sha256: None,
+            size_in_bytes: None,
+        };
+
+        let result = super::link_file(
+            &entry,
+            PathBuf::from("missing-link"),
+            &package_dir,
+            &target_dir,
+            target_dir.path().to_str().unwrap(),
+            true,
+            true,
+            true,
+            Platform::Linux64,
+            AppleCodeSignBehavior::DoNothing,
+            modification_time,
+            ExternalSymlinkPolicy::Deny,
+        )
+        .unwrap();
+
+        assert!(
+            result.is_none(),
+            "expected Ok(None) for missing symlink source"
+        );
+        assert!(
+            !target_dir.path().join("missing-link").exists(),
+            "no destination file should have been created"
         );
     }
 

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -466,7 +466,8 @@ pub async fn link_package(
             .await
             .map_err(JoinError::try_into_panic)
             {
-                Ok(Ok(linked_file)) => linked_file,
+                Ok(Ok(Some(linked_file))) => linked_file,
+                Ok(Ok(None)) => return Ok(vec![]),
                 Ok(Err(e)) => {
                     return Err(InstallError::FailedToLink(entry.relative_path.clone(), e));
                 }
@@ -903,7 +904,8 @@ pub fn link_package_sync(
                 );
 
                 let result = match link_result {
-                    Ok(linked_file) => linked_file,
+                    Ok(Some(linked_file)) => linked_file,
+                    Ok(None) => continue,
                     Err(e) => {
                         return vec![Err(InstallError::FailedToLink(
                             entry.relative_path.clone(),

--- a/crates/rattler_package_streaming/src/tokio/shared.rs
+++ b/crates/rattler_package_streaming/src/tokio/shared.rs
@@ -33,21 +33,26 @@ pub(super) async fn unpack_tar_archive<R: tokio::io::AsyncRead + Unpin>(
     while let Some(entry) = entries.next().await {
         let mut file = entry.map_err(ExtractError::IoError)?;
 
-        // On Windows, skip symlink entries as they require special privileges
-        if cfg!(windows) && file.header().entry_type().is_symlink() {
-            tracing::warn!(
-                "Skipping symlink in tar archive: {}",
-                file.path().map_err(ExtractError::IoError)?.display()
-            );
-            continue;
-        }
-
         // Unpack the file into the destination directory
         #[cfg_attr(not(unix), allow(unused_variables))]
-        let unpacked_path = file
-            .unpack_in_raw(&destination, &mut memo)
-            .await
-            .map_err(ExtractError::IoError)?;
+        let unpacked_path = match file.unpack_in_raw(&destination, &mut memo).await {
+            Ok(path) => path,
+            Err(e) => {
+                // On Windows, creating symlinks requires Developer Mode, admin
+                // privileges, or a Dev Drive. If unpacking a symlink fails (typically
+                // permission denied), warn and skip the entry rather than failing the
+                // whole extraction. Users with the right setup still get the symlink.
+                #[cfg(windows)]
+                if file.header().entry_type().is_symlink() {
+                    tracing::warn!(
+                        "skipping symlink in tar archive: {}: {e}",
+                        file.path().map_err(ExtractError::IoError)?.display()
+                    );
+                    continue;
+                }
+                return Err(ExtractError::IoError(e));
+            }
+        };
 
         // Preserve the executable bit on Unix systems
         #[cfg(unix)]


### PR DESCRIPTION
## Summary

When a conda package contains symlinks, extracting them on Windows requires Developer Mode, admin privileges, or a Dev Drive. Previously `rattler_package_streaming` unconditionally skipped every symlink entry on Windows, but `rattler::install::link::link_file` still tried to link from the (now non-existent) source, failing the whole install with `could not open source file` / `os error 2`.

Fix has two halves, addressing both ends of the broken contract:

- **`rattler_package_streaming::tokio::shared::unpack_tar_archive`**: instead of unconditionally skipping symlinks on Windows, attempt to extract first and only fall back to skip-with-warning if creation fails. Users with the right setup (Developer Mode, admin, or a Dev Drive) now actually get the symlink, matching micromamba behaviour.
- **`rattler::install::link::link_file`**: if a `SoftLink` entry has no source on disk (because extraction skipped it), catch the resulting `NotFound` from `read_link`/`fs::copy` and return `Ok(None)` instead of crashing. The function now returns `Result<Option<LinkedFile>, _>` and both callers in `install/mod.rs` handle the `None` case. No upfront `symlink_metadata` syscall, the existing I/O surfaces `NotFound` already.

Fixes prefix-dev/pixi#5984.

## Note on API change

`pub fn link_file` returns `Result<Option<LinkedFile>, LinkFileError>` instead of `Result<LinkedFile, _>`. `Ok(None)` means "this entry was intentionally skipped (no error)". Callers in this repo are updated; external callers will need a one-line adjustment.

## Test plan

- [x] New unit test `test_missing_symlink_source_is_skipped` in `crates/rattler/src/install/link.rs` covers the link-side fix
- [x] Existing tests in `rattler_package_streaming` still pass
- [x] `cargo clippy` clean on both crates
- [x] **Manual verification on Windows reproduces and fixes the issue.** Built pixi against this branch and ran the exact repro from prefix-dev/pixi#5984:

  Before (released pixi 0.67.2):
  ```
  × failed to link quarto-1.9.37-h0e8a320_0.conda
  ├─▶ failed to link 'Library/share/quarto/extension-subtrees/julia-engine/CLAUDE.md'
  ├─▶ failed to copy file to destination
  ╰─▶ failed to copy file from F:\packages\pixi\pkgs\... (os error 2)
  ```

  After (pixi patched to use this branch):
  ```
  WARN skipping symlink entry 'Library/share/quarto/extension-subtrees/julia-engine/CLAUDE.md':
       source missing in package cache (likely skipped during extraction)
  ✔ Added quarto==1.9.37
  ```

  My machine hits the `FailedToLink(Copy, NotFound)` variant (no symlink privileges, so `allow_symbolic_links=false` falls through to copy). The original reporter hit `FailedToReadSymlink(NotFound)` (had symlink privileges, so the symlink branch ran); the or-pattern in the fix covers both.
