### PR TITLE
perf: preserve Arc when crossing the Python custom-source boundary

### DIFF
--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -286,9 +286,9 @@ pub async fn create(opt: Opt) -> miette::Result<()> {
     // problem that we need to solve. We do this by constructing a
     // `SolverProblem`. This encapsulates all the information required to be
     // able to solve the problem.
-    let locked_packages = installed_packages
+    let locked_packages: Vec<&RepoDataRecord> = installed_packages
         .iter()
-        .map(|record| record.repodata_record.clone())
+        .map(|record| &record.repodata_record)
         .collect();
 
     let solver_task = SolverTask {

--- a/crates/rattler_solve/src/lib.rs
+++ b/crates/rattler_solve/src/lib.rs
@@ -34,7 +34,7 @@ pub trait SolverImpl {
         TAvailablePackagesIterator: IntoIterator<Item = R>,
     >(
         &mut self,
-        task: SolverTask<TAvailablePackagesIterator>,
+        task: SolverTask<'a, TAvailablePackagesIterator>,
     ) -> Result<SolverResult, SolveError>;
 }
 
@@ -362,7 +362,7 @@ pub enum ChannelPriority {
 }
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// Represents a dependency resolution task, to be solved by one of the backends
-pub struct SolverTask<TAvailablePackagesIterator> {
+pub struct SolverTask<'a, TAvailablePackagesIterator> {
     /// An iterator over all available packages
     pub available_packages: TAvailablePackagesIterator,
 
@@ -376,7 +376,11 @@ pub struct SolverTask<TAvailablePackagesIterator> {
     ///
     /// Usually you add the currently installed packages or packages from a
     /// lock-file here.
-    pub locked_packages: Vec<RepoDataRecord>,
+    ///
+    /// Records are passed by reference so the caller keeps ownership of the
+    /// underlying storage (whether that is `Vec<RepoDataRecord>`,
+    /// `Vec<Arc<RepoDataRecord>>` from the gateway, or anything else).
+    pub locked_packages: Vec<&'a RepoDataRecord>,
 
     /// Records of packages that are previously selected and CANNOT be changed.
     ///
@@ -385,7 +389,9 @@ pub struct SolverTask<TAvailablePackagesIterator> {
     /// best possible version. However, if there is a variant available in
     /// the `pinned_packages` field it will always select that version no matter
     /// what even if that means other packages have to be downgraded.
-    pub pinned_packages: Vec<RepoDataRecord>,
+    ///
+    /// See [`Self::locked_packages`] for the borrowing rationale.
+    pub pinned_packages: Vec<&'a RepoDataRecord>,
 
     /// Virtual packages considered active
     pub virtual_packages: Vec<GenericVirtualPackage>,
@@ -433,7 +439,7 @@ pub struct SolverTask<TAvailablePackagesIterator> {
 }
 
 impl<'r, I: IntoIterator<Item = &'r RepoDataRecord>> FromIterator<I>
-    for SolverTask<Vec<RepoDataIter<I>>>
+    for SolverTask<'r, Vec<RepoDataIter<I>>>
 {
     fn from_iter<T: IntoIterator<Item = I>>(iter: T) -> Self {
         Self {

--- a/crates/rattler_solve/src/libsolv_c/mod.rs
+++ b/crates/rattler_solve/src/libsolv_c/mod.rs
@@ -125,7 +125,7 @@ impl super::SolverImpl for Solver {
         TAvailablePackagesIterator: IntoIterator<Item = R>,
     >(
         &mut self,
-        task: SolverTask<TAvailablePackagesIterator>,
+        task: SolverTask<'a, TAvailablePackagesIterator>,
     ) -> Result<SolverResult, SolveError> {
         if task.timeout.is_some() {
             return Err(SolveError::UnsupportedOperations(vec![
@@ -237,19 +237,21 @@ impl super::SolverImpl for Solver {
 
         // Create a special pool for records that are already installed or locked.
         let repo = Repo::new(&pool, "locked", highest_priority);
-        let installed_solvables = add_repodata_records(&pool, &repo, &task.locked_packages, None)?;
+        let installed_solvables =
+            add_repodata_records(&pool, &repo, task.locked_packages.iter().copied(), None)?;
 
         // Also add the installed records to the repodata
         repo_mapping.insert(repo.id(), repo_mapping.len());
-        all_repodata_records.push(task.locked_packages.iter().collect());
+        all_repodata_records.push(task.locked_packages.clone());
 
         // Create a special pool for records that are pinned and cannot be changed.
         let repo = Repo::new(&pool, "pinned", highest_priority);
-        let pinned_solvables = add_repodata_records(&pool, &repo, &task.pinned_packages, None)?;
+        let pinned_solvables =
+            add_repodata_records(&pool, &repo, task.pinned_packages.iter().copied(), None)?;
 
         // Also add the installed records to the repodata
         repo_mapping.insert(repo.id(), repo_mapping.len());
-        all_repodata_records.push(task.pinned_packages.iter().collect());
+        all_repodata_records.push(task.pinned_packages.clone());
 
         // Create data-structures for solving
         pool.create_whatprovides();

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -310,8 +310,8 @@ impl<'a> CondaDependencyProvider<'a> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         repodata: impl IntoIterator<Item = RepoData<'a>>,
-        favored_records: &'a [RepoDataRecord],
-        locked_records: &'a [RepoDataRecord],
+        favored_records: &[&'a RepoDataRecord],
+        locked_records: &[&'a RepoDataRecord],
         virtual_packages: &'a [GenericVirtualPackage],
         match_specs: &[MatchSpec],
         stop_time: Option<std::time::SystemTime>,
@@ -524,7 +524,7 @@ impl<'a> CondaDependencyProvider<'a> {
         }
 
         // Add favored packages to the records
-        for favored_record in favored_records {
+        for &favored_record in favored_records {
             let name = pool.intern_package_name(&favored_record.package_record.name);
             let solvable = pool.intern_solvable(name, SolverPackageRecord::Record(favored_record));
             let candidates = records.entry(name).or_default();
@@ -532,7 +532,7 @@ impl<'a> CondaDependencyProvider<'a> {
             candidates.favored = Some(solvable);
         }
 
-        for locked_record in locked_records {
+        for &locked_record in locked_records {
             let name = pool.intern_package_name(&locked_record.package_record.name);
             let solvable = pool.intern_solvable(name, SolverPackageRecord::Record(locked_record));
             let candidates = records.entry(name).or_default();
@@ -944,7 +944,7 @@ impl super::SolverImpl for Solver {
         TAvailablePackagesIterator: IntoIterator<Item = R>,
     >(
         &mut self,
-        task: SolverTask<TAvailablePackagesIterator>,
+        task: SolverTask<'a, TAvailablePackagesIterator>,
     ) -> Result<SolverResult, SolveError> {
         let stop_time = task
             .timeout

--- a/crates/rattler_solve/tests/backends/helpers/solver_case.rs
+++ b/crates/rattler_solve/tests/backends/helpers/solver_case.rs
@@ -187,8 +187,8 @@ impl<'a> SolverCase<'a> {
         let task = SolverTask {
             specs: self.specs.clone(),
             constraints: self.constraints.clone(),
-            locked_packages: self.locked_packages.clone(),
-            pinned_packages: self.pinned_packages.clone(),
+            locked_packages: self.locked_packages.iter().collect(),
+            pinned_packages: self.pinned_packages.iter().collect(),
             virtual_packages: self.virtual_packages.clone(),
             exclude_newer: self.exclude_newer.clone(),
             strategy: self.strategy,

--- a/crates/rattler_solve/tests/backends/main.rs
+++ b/crates/rattler_solve/tests/backends/main.rs
@@ -1126,11 +1126,11 @@ fn solve<T: SolverImpl + Default>(
         .collect();
 
     let task = SolverTask {
-        locked_packages: task.installed_packages,
+        locked_packages: task.installed_packages.iter().collect(),
         virtual_packages: task.virtual_packages,
         specs,
         constraints,
-        pinned_packages: task.pinned_packages,
+        pinned_packages: task.pinned_packages.iter().collect(),
         exclude_newer: task.exclude_newer.clone(),
         strategy: task.strategy,
         ..SolverTask::from_iter(&repo_data)

--- a/js-rattler/crate/solve.rs
+++ b/js-rattler/crate/solve.rs
@@ -194,7 +194,7 @@ pub async fn simple_solve(
 
     let task = SolverTask {
         specs,
-        locked_packages: installed_packages,
+        locked_packages: installed_packages.iter().collect(),
         ..repodata.iter().collect::<SolverTask<_>>()
     };
 

--- a/py-rattler/src/record.rs
+++ b/py-rattler/src/record.rs
@@ -883,6 +883,30 @@ impl TryFrom<PyRecord> for RepoDataRecord {
     }
 }
 
+/// Extracts the existing `Arc<RepoDataRecord>` out of a `PyRecord` without
+/// deep-cloning the underlying record. Use this on hot paths that just need
+/// to share the record across the Python/Rust boundary; falling through to
+/// `TryFrom<PyRecord> for RepoDataRecord` would `Arc::unwrap_or_clone` and
+/// then re-allocate a fresh Arc, which is exactly what the Arc wrapping is
+/// meant to avoid.
+impl TryFrom<PyRecord> for Arc<RepoDataRecord> {
+    type Error = PyErr;
+    fn try_from(value: PyRecord) -> Result<Self, Self::Error> {
+        match value.inner {
+            RecordInner::RepoData(r) => Ok(r),
+            // PrefixRecord embeds RepoDataRecord by value, so we can't share
+            // its Arc — clone the embedded record into a new one.
+            RecordInner::Prefix(r) => Ok(Arc::new(r.repodata_record.clone())),
+            RecordInner::Package(_) => Err(PyTypeError::new_err(
+                "cannot use object of type 'PackageRecord' as 'RepoDataRecord'",
+            )),
+            RecordInner::Whl(_) => Err(PyTypeError::new_err(
+                "cannot use object of type 'WhlPackageRecord' as 'RepoDataRecord'",
+            )),
+        }
+    }
+}
+
 impl From<WhlPackageRecord> for PyRecord {
     fn from(value: WhlPackageRecord) -> Self {
         Self {

--- a/py-rattler/src/repo_data/source.rs
+++ b/py-rattler/src/repo_data/source.rs
@@ -21,9 +21,13 @@ use crate::record::PyRecord;
 /// caching mechanisms only apply to channel data. If caching is needed for a custom
 /// source, it must be implemented within the source itself.
 ///
-/// **Performance:** Custom sources are slower than channels because data must be
-/// marshaled between Python and Rust for each request. For performance-critical
-/// applications, channels should be preferred when possible.
+/// **Performance:** Records are shared with Python by `Arc`, so calls cost roughly
+/// one Arc bump per record plus the unavoidable Python coroutine round-trip — not
+/// a deep copy. The remaining gap versus the all-Rust path is dominated by
+/// `package_names` being synchronous and by Python coroutine scheduling, not by
+/// per-record marshalling. If a Python source needs to do meaningful work to
+/// answer `package_names`, consider caching the result in the source itself so
+/// the gateway can reuse it across queries.
 pub struct PyRepoDataSource {
     inner: Py<PyAny>,
 }
@@ -74,29 +78,32 @@ impl RepoDataSource for PyRepoDataSource {
             .await
             .map_err(|e| GatewayError::Generic(e.to_string()))?;
 
-        // Extract the records from the Python list
+        // Extract the records from the Python iterable.
+        //
+        // We pull the existing `Arc<RepoDataRecord>` straight out of each `PyRecord`
+        // instead of deep-cloning the record into a fresh Arc — that's the whole point
+        // of wrapping records in Arc on both sides. See `TryFrom<PyRecord> for
+        // Arc<RepoDataRecord>`.
+        //
+        // Iterating via `try_iter` avoids materializing an intermediate
+        // `Vec<Bound<PyAny>>` first; we hit each Python item once.
         Python::with_gil(|py| {
-            // Get the result as a Python list
-            let py_list: Vec<Bound<'_, PyAny>> = result
-                .extract(py)
+            let bound = result.bind(py);
+            let mut rust_records: Vec<Arc<RepoDataRecord>> =
+                Vec::with_capacity(bound.len().unwrap_or(0));
+            let iter = bound
+                .try_iter()
                 .map_err(|e| GatewayError::Generic(e.to_string()))?;
-
-            // Extract each element, handling both direct PyRecord and wrapped RepoDataRecord
-            let mut rust_records = Vec::new();
-            for item in py_list {
-                // Try to extract PyRecord using the TryFrom implementation
-                // which handles the _record attribute lookup
+            for item in iter {
+                let item = item.map_err(|e| GatewayError::Generic(e.to_string()))?;
                 let py_record: PyRecord = item
                     .try_into()
                     .map_err(|e: PyErr| GatewayError::Generic(e.to_string()))?;
-
-                let record: RepoDataRecord = py_record
+                let arc: Arc<RepoDataRecord> = py_record
                     .try_into()
                     .map_err(|e: PyErr| GatewayError::Generic(e.to_string()))?;
-
-                rust_records.push(Arc::new(record));
+                rust_records.push(arc);
             }
-
             Ok(rust_records)
         })
     }

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -1,9 +1,12 @@
+use std::sync::Arc;
+
 use chrono::DateTime;
 use pyo3::{
     exceptions::PyValueError, pybacked::PyBackedStr, pyfunction, types::PyAnyMethods, Bound,
     FromPyObject, PyAny, PyErr, PyResult, Python,
 };
 use pyo3_async_runtimes::tokio::future_into_py;
+use rattler_conda_types::RepoDataRecord;
 use rattler_repodata_gateway::sparse::SparseRepoData;
 use rattler_solve::{
     resolvo::Solver, ExcludeNewer, RepoDataIter, SolveStrategy, SolverImpl, SolverTask,
@@ -100,19 +103,22 @@ pub fn py_solve<'a>(
             parse_exclude_newer(exclude_newer_timestamp_ms, exclude_newer_duration_seconds)?;
 
         let solve_result = tokio::task::spawn_blocking(move || {
+            // Keep the Arcs alive as locals; SolverTask only borrows.
+            let locked_arcs: Vec<Arc<RepoDataRecord>> = locked_packages
+                .into_iter()
+                .map(<Arc<RepoDataRecord>>::try_from)
+                .collect::<PyResult<_>>()?;
+            let pinned_arcs: Vec<Arc<RepoDataRecord>> = pinned_packages
+                .into_iter()
+                .map(<Arc<RepoDataRecord>>::try_from)
+                .collect::<PyResult<_>>()?;
             let task = SolverTask {
                 available_packages: available_packages
                     .iter()
                     .map(RepoDataIter)
                     .collect::<Vec<_>>(),
-                locked_packages: locked_packages
-                    .into_iter()
-                    .map(TryInto::try_into)
-                    .collect::<PyResult<Vec<_>>>()?,
-                pinned_packages: pinned_packages
-                    .into_iter()
-                    .map(TryInto::try_into)
-                    .collect::<PyResult<Vec<_>>>()?,
+                locked_packages: locked_arcs.iter().map(AsRef::as_ref).collect(),
+                pinned_packages: pinned_arcs.iter().map(AsRef::as_ref).collect(),
                 virtual_packages: virtual_packages.into_iter().map(Into::into).collect(),
                 specs: specs.into_iter().map(Into::into).collect(),
                 constraints: constraints.into_iter().map(Into::into).collect(),
@@ -203,19 +209,22 @@ pub fn py_solve_with_sparse_repodata<'py>(
             // Force drop the locks to avoid holding them longer than necessary.
             drop(repo_data_locks);
 
+            // Keep the Arcs alive as locals; SolverTask only borrows.
+            let locked_arcs: Vec<Arc<RepoDataRecord>> = locked_packages
+                .into_iter()
+                .map(<Arc<RepoDataRecord>>::try_from)
+                .collect::<PyResult<_>>()?;
+            let pinned_arcs: Vec<Arc<RepoDataRecord>> = pinned_packages
+                .into_iter()
+                .map(<Arc<RepoDataRecord>>::try_from)
+                .collect::<PyResult<_>>()?;
             let task = SolverTask {
                 available_packages: available_packages
                     .iter()
                     .map(RepoDataIter)
                     .collect::<Vec<_>>(),
-                locked_packages: locked_packages
-                    .into_iter()
-                    .map(TryInto::try_into)
-                    .collect::<PyResult<Vec<_>>>()?,
-                pinned_packages: pinned_packages
-                    .into_iter()
-                    .map(TryInto::try_into)
-                    .collect::<PyResult<Vec<_>>>()?,
+                locked_packages: locked_arcs.iter().map(AsRef::as_ref).collect(),
+                pinned_packages: pinned_arcs.iter().map(AsRef::as_ref).collect(),
                 virtual_packages: virtual_packages.into_iter().map(Into::into).collect(),
                 specs: specs.into_iter().map(Into::into).collect(),
                 constraints: constraints.into_iter().map(Into::into).collect(),


### PR DESCRIPTION
### Description

Custom Python `RepoDataSource` implementations were paying a deep-clone per record returned across the Python/Rust boundary, defeating the `Arc<RepoDataRecord>` wrapping from #2061. This PR removes that clone.

The same pattern applied to `SolverTask::locked_packages` and `pinned_packages`, so they now borrow records (`Vec<&'a RepoDataRecord>`) instead of owning them. Small breaking change in `rattler_solve` (the struct gains a lifetime parameter); callers pass references into whatever storage they already have.

For a recursive `python,numpy,pandas,scipy` query on conda-forge linux-64+noarch (4140 records), going through a Python custom source via `Gateway.query` previously took 42 ms (fetch) / 158 ms (full solve). It now takes 29 ms / 133 ms, a 31% / 16% improvement. For comparison, the equivalent all-Rust path (`solve_with_sparse_repodata`, no Python source involved) takes 26 ms / 124 ms; the custom-source overhead is now within ~12% of the Rust baseline rather than +59%.

The last commit just regenerates `py-rattler/Cargo.lock` and `js-rattler/Cargo.lock` for the `async_http_range_reader` 0.10.0 bump from #2391.

### How Has This Been Tested?

- `cargo nextest run -p rattler_solve`: 135/135 pass.
- `pytest py-rattler/tests/unit/test_custom_source.py`: 10/10 pass.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Claude Code).

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
