### PR TITLE
fix: don't assume path is a file:// url

### DIFF
--- a/crates/rattler_repodata_gateway/src/gateway/run_exports_extractor.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/run_exports_extractor.rs
@@ -164,7 +164,7 @@ impl RunExportExtractor {
             if _record.url.scheme() != "file" {
                 return None;
             }
-            return _record.url.to_file_path().ok();
+            _record.url.to_file_path().ok()
         }
         #[cfg(target_arch = "wasm32")]
         None

--- a/crates/rattler_repodata_gateway/src/gateway/run_exports_extractor.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/run_exports_extractor.rs
@@ -158,7 +158,14 @@ impl RunExportExtractor {
     /// Returns the path to the package file if the URL is a file URL.
     fn path_to_package(_record: &RepoDataRecord) -> Option<PathBuf> {
         #[cfg(not(target_arch = "wasm32"))]
-        return _record.url.to_file_path().ok();
+        {
+            // `Url::to_file_path` is documented to *not* check the URL's
+            // scheme so we must do it ourselves
+            if _record.url.scheme() != "file" {
+                return None;
+            }
+            return _record.url.to_file_path().ok();
+        }
         #[cfg(target_arch = "wasm32")]
         None
     }


### PR DESCRIPTION
### Description

`RunExportExtractor::path_to_package` uses `Url::to_file_path()` to detect `file://` URLs and short-circuit `extract` to read run_exports straight off disk. But [`Url::to_file_path` is documented](https://github.com/servo/rust-url/issues/24) to *not* check the URL's scheme — it returns `Ok` for any URL whose host is empty or `"localhost"`. So records served from `http://localhost:<port>/...` (e.g. a local conda channel proxy) match the file-URL short-circuit, `read_from_package_file` calls `File::open` on a host-less URL path, ENOENTs, and the resolve aborts with:

```
× Could not collect run exports
├─▶ failed to decode run exports from /<subdir>/<filename>.conda
╰─▶ No such file or directory (os error 2)
```

Triggers reliably whenever:
1. A channel is served on `localhost` (any scheme/port — `http://localhost:8000` is enough), and
2. At least one solved record has no `run_exports` advertised in repodata, so `extract` is reached at all (typical for packages built without `requirements.run_exports`).

Fix is a one-line scheme gate before delegating to `to_file_path`. After the change, `localhost`-hosted records fall through to the normal HTTP extraction path, which already handles missing `run_exports` cleanly (404 on subdir `run_exports.json`, then `from_package_directory(...).ok()` swallows a missing `info/run_exports.json` to `Ok(None)`).

### How Has This Been Tested?

End-to-end A/B reproduction of the failure and the fix:

1. **Leaf recipe** with no `requirements.run_exports` — rattler-build elides empty run_exports, so the resulting `.conda` carries no `info/run_exports.json` and the channel's `repodata.json` advertises no `run_exports` for it.
2. **Channel** containing the leaf, served via `python -m http.server 9000`.
3. **Downstream recipe** that lists the leaf in its host requirements, forcing `ensure_run_exports` to call `extract` for the leaf.
4. **Unpatched rattler-build** (release `0.64.1`, depending on `rattler_repodata_gateway 0.28.1`) → reproduces the exact CI error:
   ```
   × Could not collect run exports
   ├─▶ failed to decode run exports from /noarch/tiny-leaf-1.0-h4616a5c_0.conda
   ╰─▶ No such file or directory (os error 2)
   ```
5. **Patched rattler-build** (same `0.64.1` source, `rattler_repodata_gateway` patched via `[patch.crates-io]`) → builds the downstream package cleanly, run_exports collection completes with empty run_exports for the leaf as expected.

Reproduced against `http://localhost:8000/...`, `http://localhost/...` and `https://localhost/...` URL shapes; confirmed `https://example.com/...` (non-localhost) was unaffected before and after, and `file:///...` plus `file://localhost/...` URLs still match the local-path short-circuit after the patch.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Sonnet) — used to trace the flow from rattler-build's `ensure_run_exports` call site down through `RunExportExtractor::extract` into `Url::to_file_path`'s documented behavior, and to draft the patch and PR body. The diff and reproduction were reviewed and tested manually.

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas


This is my first time contributing to open source so if I need to do anything else/differently please let me know!