### PR TITLE
feat(rattler_lock): preserve license on partial source records

### DIFF
--- a/crates/rattler_lock/src/conda.rs
+++ b/crates/rattler_lock/src/conda.rs
@@ -273,6 +273,9 @@ pub struct PartialSourceMetadata {
     /// Variant-selection flags declared by the recipe.
     pub flags: Vec<Flag>,
 
+    /// License of the package (SPDX expression or free-form string).
+    pub license: Option<String>,
+
     /// PURLs (Package URLs) describing this package in other ecosystems.
     pub purls: Option<BTreeSet<PackageUrl>>,
 
@@ -461,6 +464,7 @@ impl CondaSourceData<SourceMetadata> {
         constrains: Vec<String>,
         experimental_extra_depends: BTreeMap<String, Vec<String>>,
         flags: Vec<Flag>,
+        license: Option<String>,
         purls: Option<BTreeSet<PackageUrl>>,
         run_exports: Option<RunExportsJson>,
         sources: BTreeMap<String, SourceLocation>,
@@ -478,6 +482,7 @@ impl CondaSourceData<SourceMetadata> {
                 constrains,
                 experimental_extra_depends,
                 flags,
+                license,
                 purls,
                 run_exports,
             })),

--- a/crates/rattler_lock/src/parse/models/v7/source_package_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/source_package_data.rs
@@ -172,6 +172,7 @@ impl<'a> SourcePackageDataModel<'a> {
                 constrains: self.constrains.into_owned(),
                 experimental_extra_depends: self.experimental_extra_depends.into_owned(),
                 flags: self.flags.into_owned(),
+                license: self.license.into_owned(),
                 purls: self.purls.into_owned(),
                 run_exports: Some(self.run_exports.into_owned()),
             }))
@@ -256,7 +257,7 @@ impl<'a> From<&'a CondaSourceData> for SourcePackageDataModel<'a> {
                 features: Cow::Owned(None),
                 flags: Cow::Borrowed(&partial.flags),
                 track_features: Cow::Borrowed(&[]),
-                license: Cow::Owned(None),
+                license: Cow::Borrowed(&partial.license),
                 license_family: Cow::Owned(None),
                 python_site_packages_path: Cow::Owned(None),
                 source: value.package_build_source.clone(),

--- a/crates/rattler_lock/src/source_identifier.rs
+++ b/crates/rattler_lock/src/source_identifier.rs
@@ -711,6 +711,7 @@ mod tests {
             vec![],
             None,
             None,
+            None,
             BTreeMap::new(),
         );
         assert!(partial.into_full().is_none());
@@ -762,6 +763,7 @@ mod tests {
             vec![],
             BTreeMap::new(),
             vec![],
+            None,
             None,
             None,
             BTreeMap::new(),


### PR DESCRIPTION
### Description

Lockfile v7's `PartialSourceMetadata` previously dropped the `license` field, so a recipe whose license was already known but whose package record had not yet been evaluated would lose that information across a serialize/deserialize round-trip. (`license_family` remains dropped on partial records — flagged for a possible follow-up.)

This PR adds `license: Option<String>` to `PartialSourceMetadata`, threads it through the `CondaSourceData::partial` constructor, and wires both directions of the v7 `SourcePackageDataModel` so the field round-trips alongside the other recipe-level metadata (`flags`, `purls`, `run_exports`).

The field is intentionally **not** added to the source-identifier hash, matching how `license` is treated as non-identifying on the full `PackageRecord` in `compute_source_hash`.

v6 is unaffected: it has no partial/full split, always materializes a full `PackageRecord` (which already carries `license`), and source records upgraded to v7 land in `SourceMetadata::Full`.

Fixes #N/A

### How Has This Been Tested?

- `cargo build -p rattler_lock`
- `cargo test -p rattler_lock` — 196 passed, 0 failed
- `cargo clippy -p rattler_lock --all-targets -- -D warnings` — clean
- `cargo fmt -p rattler_lock`

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Claude Code)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.