### PR TITLE
chore: upgrade reqwest to 0.13 and bump related crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,6 +848,7 @@ checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
+ "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
@@ -6150,7 +6151,6 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1daa54020e05aa0b163ee10434fff35a0f18d28a1cafa142bd1290e1abe630e"
 dependencies = [
- "astral-reqwest-middleware 0.5.1",
+ "astral-reqwest-middleware",
  "reqwest 0.13.3",
  "secrecy",
  "serde",
@@ -182,21 +182,6 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "astral-reqwest-middleware"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "638d02e24aeb92f9537897cd1ff82e2bc98fd9ac9575a503e27bb07cdf64d4d7"
-dependencies = [
- "anyhow",
- "async-trait",
- "http 1.4.0",
- "reqwest 0.12.28",
- "serde",
- "thiserror 2.0.18",
- "tower-service",
-]
-
-[[package]]
-name = "astral-reqwest-middleware"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9"
@@ -212,18 +197,18 @@ dependencies = [
 
 [[package]]
 name = "astral-reqwest-retry"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ab210f6cdf8fd3254d47e5ee27ce60ed34a428ff71b4ae9477b1c84b49498c"
+checksum = "48c76a42c052d7a95249b90b83d44e8f1bbde7c8e08dbed50d49c58321815da3"
 dependencies = [
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "async-trait",
  "futures",
  "getrandom 0.2.17",
  "http 1.4.0",
  "hyper",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "retry-policies",
  "thiserror 2.0.18",
  "tokio",
@@ -249,18 +234,17 @@ dependencies = [
 
 [[package]]
 name = "astral_async_http_range_reader"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddaca0fbbf0d91103cca7c7611790c65f6eff1d456f7fe6bf565d436dc9b8f3"
+checksum = "4a8647866aee8d9707ae6ccc35205803a6df47c0ba83c5339ea6061b79131e4f"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
- "bisection",
+ "astral-reqwest-middleware",
  "futures",
  "http-content-range",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "memmap2",
- "reqwest 0.12.28",
- "thiserror 1.0.69",
+ "reqwest 0.13.3",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -1113,12 +1097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bisection"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3"
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,7 +1706,7 @@ dependencies = [
  "rattler_networking",
  "rattler_repodata_gateway",
  "rattler_solve",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "resolvo",
  "serde_json",
  "tokio",
@@ -3037,13 +3015,13 @@ dependencies = [
 
 [[package]]
 name = "http-cache-semantics"
-version = "2.1.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4311240f94cb6fe622337dc580b09ddd6ae4a891eb121dba20cf4f77ca4e7129"
+checksum = "0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7"
 dependencies = [
  "http 1.4.0",
  "http-serde",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde",
  "time",
 ]
@@ -3148,7 +3126,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -5054,7 +5031,7 @@ version = "0.42.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "axum",
  "clap",
  "console 0.16.3",
@@ -5088,7 +5065,7 @@ dependencies = [
  "rayon",
  "reflink-copy",
  "regex",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "rstest",
  "serde",
  "serde_json",
@@ -5113,7 +5090,7 @@ name = "rattler-bin"
 version = "0.1.9"
 dependencies = [
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "chrono",
  "clap",
  "clap_complete",
@@ -5135,7 +5112,7 @@ dependencies = [
  "rattler_solve",
  "rattler_upload",
  "rattler_virtual_packages",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "tokio",
  "tracing-subscriber",
  "url",
@@ -5148,7 +5125,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "assert_matches",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "axum",
  "bytes",
@@ -5166,7 +5143,7 @@ dependencies = [
  "rattler_package_streaming",
  "rattler_redaction",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "rstest",
  "serde_json",
  "simple_spawn_blocking",
@@ -5275,12 +5252,12 @@ dependencies = [
 name = "rattler_git"
 version = "0.1.2"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "dashmap",
  "dunce",
  "fs-err",
  "rattler_prefix_guard",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
@@ -5313,7 +5290,7 @@ dependencies = [
  "rattler_networking",
  "rattler_package_streaming",
  "rattler_s3",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "retry-policies",
  "rmp-serde",
  "serde",
@@ -5417,7 +5394,7 @@ name = "rattler_networking"
 version = "0.26.12"
 dependencies = [
  "anyhow",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "async-once-cell",
  "async-trait",
@@ -5436,7 +5413,7 @@ dependencies = [
  "keyring",
  "netrc-rs",
  "rattler_config",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "retry-policies",
  "rstest",
  "serde",
@@ -5456,7 +5433,7 @@ name = "rattler_package_streaming"
 version = "0.25.1"
 dependencies = [
  "assert_matches",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-tokio-tar",
  "astral_async_http_range_reader",
  "astral_async_zip",
@@ -5477,7 +5454,7 @@ dependencies = [
  "rattler_digest",
  "rattler_networking",
  "rattler_redaction",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "rstest",
  "rstest_reuse",
  "serde_json",
@@ -5522,8 +5499,8 @@ dependencies = [
 name = "rattler_redaction"
 version = "0.1.15"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
- "reqwest 0.12.28",
+ "astral-reqwest-middleware",
+ "reqwest 0.13.3",
  "url",
 ]
 
@@ -5534,7 +5511,7 @@ dependencies = [
  "ahash",
  "anyhow",
  "assert_matches",
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "async-compression",
  "async-fd-lock",
  "async-trait",
@@ -5575,7 +5552,7 @@ dependencies = [
  "rattler_package_streaming",
  "rattler_redaction",
  "regex",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "retry-policies",
  "rmp-serde",
  "rstest",
@@ -5680,7 +5657,7 @@ dependencies = [
 name = "rattler_upload"
 version = "0.6.1"
 dependencies = [
- "astral-reqwest-middleware 0.4.2",
+ "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "axum",
  "base64 0.22.1",
@@ -5698,7 +5675,7 @@ dependencies = [
  "rattler_redaction",
  "rattler_s3",
  "rattler_solve",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5888,6 +5865,41 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
  "encoding_rs",
  "futures-channel",
  "futures-core",
@@ -5909,8 +5921,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5925,50 +5937,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "h2",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -7567,7 +7536,7 @@ dependencies = [
  "fs-err",
  "fslock",
  "rattler_digest",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -8088,6 +8057,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8138,15 +8120,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ async-compression = { version = "0.4", features = [
   "zstd",
 ] }
 async-fd-lock = "0.2.0"
-async_http_range_reader = { package = "astral_async_http_range_reader", version = "0.9.1" }
+async_http_range_reader = { package = "astral_async_http_range_reader", version = "0.11.0" }
 fs4 = "0.13.1"
 async-once-cell = "0.5.4"
 async-trait = "0.1.88"
@@ -95,8 +95,7 @@ hashbrown = "0.16"
 hex = "0.4.3"
 hex-literal = "1.0.0"
 http = "1.4"
-# Pinned to 2.x because 3.0 requires reqwest 0.13, and we're still on 0.12
-http-cache-semantics = "2.1.0"
+http-cache-semantics = "3.0.0"
 humansize = "2.1.3"
 humantime = "2.2.0"
 indexmap = "2.13.0"
@@ -137,12 +136,11 @@ rand = "0.10.0"
 rayon = "1.10.0"
 reflink-copy = "0.1.26"
 regex = "1.11.1"
-reqwest = { version = "0.12.15", default-features = false }
-reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.4.2" }
-reqwest-retry = { package = "astral-reqwest-retry", version = "0.8.0" }
+reqwest = { version = "0.13.3", default-features = false }
+reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.5.1" }
+reqwest-retry = { package = "astral-reqwest-retry", version = "0.9.1" }
 resolvo = { version = "0.10.0" }
-# hold back at 0.4.0 until `reqwest-retry` is updated
-retry-policies = { version = "0.5.0", default-features = false }
+retry-policies = { version = "0.5.1", default-features = false }
 rmp = { version = "0.8.14" }
 rmp-serde = { version = "1.3.0" }
 rstest = { version = "0.26.1" }

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -67,7 +67,7 @@ rattler_package_streaming = { workspace = true, default-features = false, featur
 ] }
 rattler_upload = { workspace = true }
 rattler_shell = { workspace = true, default-features = false }
-reqwest = { workspace = true, features = ["stream"] }
+reqwest = { workspace = true, features = ["stream", "query"] }
 reqwest-middleware = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -25,8 +25,7 @@ native-tls = [
   "rattler_cache/native-tls",
 ]
 rustls-tls = [
-  "reqwest/rustls-tls",
-  "reqwest/rustls-tls-native-roots",
+  "reqwest/rustls",
   "rattler/rustls-tls",
   "rattler_repodata_gateway/rustls-tls",
   "rattler_networking/rustls-tls",

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -15,7 +15,7 @@ default = ['rustls-tls']
 native-tls = ['reqwest/native-tls', 'rattler_package_streaming/native-tls', 'rattler_cache/native-tls', 'rattler_networking/native-tls']
 rustls-tls = ['reqwest/rustls', 'rattler_package_streaming/rustls-tls', 'rattler_cache/rustls-tls', 'rattler_networking/rustls-tls']
 oauth = ["dep:openidconnect", "dep:open"]
-cli-tools = ['dep:clap', 'reqwest/blocking', 'oauth']
+cli-tools = ['dep:clap', 'oauth']
 indicatif = ['dep:indicatif', 'dep:console']
 
 [package.metadata.docs.rs]
@@ -48,7 +48,7 @@ path_resolver = { workspace = true, default-features = false }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
-reqwest = { workspace = true, features = ["stream", "json", "gzip", "form"] }
+reqwest = { workspace = true, features = ["json", "form"] }
 reqwest-middleware = { workspace = true }
 smallvec = { workspace = true }
 simple_spawn_blocking = { workspace = true, features = ["tokio"] }

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -13,7 +13,7 @@ readme.workspace = true
 [features]
 default = ['rustls-tls']
 native-tls = ['reqwest/native-tls', 'rattler_package_streaming/native-tls', 'rattler_cache/native-tls', 'rattler_networking/native-tls']
-rustls-tls = ['reqwest/rustls-tls', 'rattler_package_streaming/rustls-tls', 'rattler_cache/rustls-tls', 'rattler_networking/rustls-tls']
+rustls-tls = ['reqwest/rustls', 'rattler_package_streaming/rustls-tls', 'rattler_cache/rustls-tls', 'rattler_networking/rustls-tls']
 oauth = ["dep:openidconnect", "dep:open"]
 cli-tools = ['dep:clap', 'reqwest/blocking', 'oauth']
 indicatif = ['dep:indicatif', 'dep:console']
@@ -48,7 +48,7 @@ path_resolver = { workspace = true, default-features = false }
 rayon = { workspace = true }
 reflink-copy = { workspace = true }
 regex = { workspace = true }
-reqwest = { workspace = true, features = ["stream", "json", "gzip"] }
+reqwest = { workspace = true, features = ["stream", "json", "gzip", "form"] }
 reqwest-middleware = { workspace = true }
 smallvec = { workspace = true }
 simple_spawn_blocking = { workspace = true, features = ["tokio"] }

--- a/crates/rattler/src/cli/auth/oauth.rs
+++ b/crates/rattler/src/cli/auth/oauth.rs
@@ -125,6 +125,10 @@ pub enum OAuthError {
     #[error(transparent)]
     Network(#[from] reqwest::Error),
 
+    /// A network error occurred during the OIDC flow.
+    #[error(transparent)]
+    OidcNetwork(#[from] openidconnect::reqwest::Error),
+
     /// An I/O error occurred.
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -171,11 +175,11 @@ pub async fn perform_oauth_login(config: OAuthConfig) -> Result<Authentication, 
 
     let user_agent = config.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
 
-    let http_client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
+    let http_client = openidconnect::reqwest::Client::builder()
+        .redirect(openidconnect::reqwest::redirect::Policy::none())
         .user_agent(user_agent)
         .build()
-        .map_err(OAuthError::Network)?;
+        .map_err(OAuthError::OidcNetwork)?;
 
     // 1. OIDC Discovery
     let endpoints = discover_endpoints(&http_client, &config.issuer_url).await?;
@@ -267,7 +271,7 @@ pub async fn perform_oauth_login(config: OAuthConfig) -> Result<Authentication, 
 /// `revocation_endpoint` and `device_authorization_endpoint` fields are
 /// deserialized from the discovery document in a single request.
 async fn discover_endpoints(
-    http_client: &reqwest::Client,
+    http_client: &openidconnect::reqwest::Client,
     issuer_url: &str,
 ) -> Result<DiscoveredEndpoints, OAuthError> {
     let oidc_issuer =
@@ -308,7 +312,7 @@ async fn auth_code_flow(
     client_secret: Option<&str>,
     scopes: &HashSet<String>,
     redirect_uri: Option<&str>,
-    http_client: &reqwest::Client,
+    http_client: &openidconnect::reqwest::Client,
 ) -> Result<OAuthTokens, OAuthError> {
     // If the caller pinned a redirect URI (because the IdP requires an
     // exact match against what was registered), bind there. Otherwise
@@ -530,7 +534,7 @@ async fn device_code_flow(
     client_id: &str,
     client_secret: Option<&str>,
     scopes: &HashSet<String>,
-    http_client: &reqwest::Client,
+    http_client: &openidconnect::reqwest::Client,
 ) -> Result<OAuthTokens, OAuthError> {
     let device_auth_url = endpoints
         .device_authorization_endpoint

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -31,7 +31,7 @@ rattler_digest = { workspace = true, default-features = false }
 rattler_redaction = { workspace = true, default-features = false }
 rattler_networking = { workspace = true, default-features = false }
 rattler_package_streaming = { workspace = true, default-features = false, features = ["reqwest"] }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["stream"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 tracing = { workspace = true }

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -11,7 +11,7 @@ readme.workspace = true
 
 [features]
 default = ["rustls-tls"]
-rustls-tls = ["reqwest/rustls-tls", "reqwest-middleware/rustls-tls", "rattler_networking/rustls-tls", "rattler_package_streaming/rustls-tls"]
+rustls-tls = ["reqwest/rustls", "reqwest-middleware/rustls", "rattler_networking/rustls-tls", "rattler_package_streaming/rustls-tls"]
 native-tls = ["reqwest/native-tls", "rattler_networking/native-tls", "rattler_package_streaming/native-tls"]
 
 [dependencies]

--- a/crates/rattler_git/Cargo.toml
+++ b/crates/rattler_git/Cargo.toml
@@ -11,7 +11,7 @@ dashmap = { workspace = true }
 dunce = { workspace = true }
 fs-err = { workspace = true, features = ["tokio"] }
 rattler_prefix_guard = { workspace = true }
-reqwest = { workspace = true, features = ["blocking"] }
+reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -15,14 +15,12 @@ default-run = "rattler-index"
 default = ["rustls-tls", "s3", "rattler_config"]
 native-tls = [
   "reqwest/native-tls",
-  "reqwest/native-tls-alpn",
   "rattler_package_streaming/native-tls",
   "rattler_networking/native-tls",
   "rattler_s3?/native-tls",
 ]
 rustls-tls = [
-  "reqwest/rustls-tls",
-  "reqwest/rustls-tls-native-roots",
+  "reqwest/rustls",
   "rattler_package_streaming/rustls-tls",
   "rattler_networking/rustls-tls",
   "rattler_s3?/rustls-tls",
@@ -60,7 +58,7 @@ rattler_package_streaming = { workspace = true, default-features = false }
 rattler_s3 = { workspace = true, optional = true, features = ["clap"] }
 reqwest = { workspace = true, default-features = false, features = [
   "http2",
-  "macos-system-configuration",
+  "system-proxy",
   "charset",
 ] }
 rmp-serde = { workspace = true }

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -13,7 +13,7 @@ readme.workspace = true
 [features]
 default = ["rustls-tls", "system-integration"]
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls = ["reqwest/rustls"]
 gcs = ["google-cloud-auth", "tokio/sync"]
 s3 = ["aws-config", "aws-sdk-s3", "aws-smithy-http-client"]
 system-integration = ["keyring", "netrc-rs", "dirs"]
@@ -50,7 +50,7 @@ keyring = { workspace = true, optional = true, features = [
     "crypto-rust",
 ] }
 netrc-rs = { workspace = true, optional = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "form"] }
 reqwest-middleware = { workspace = true }
 retry-policies = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -34,12 +34,14 @@ aws-config = { workspace = true, optional = true, features = [
     "sso",
     "credentials-login",
     "credentials-process",
+    "default-https-client",
 ] }
 aws-sdk-s3 = { workspace = true, optional = true, features = [
     "rt-tokio",
     "sigv4a",
+    "default-https-client",
 ] }
-aws-smithy-http-client = { workspace = true, optional = true, features = ["rustls-ring"] }
+aws-smithy-http-client = { workspace = true, optional = true, features = ["rustls-aws-lc"] }
 http = { workspace = true }
 itertools = { workspace = true }
 keyring = { workspace = true, optional = true, features = [

--- a/crates/rattler_networking/src/s3_middleware.rs
+++ b/crates/rattler_networking/src/s3_middleware.rs
@@ -5,7 +5,6 @@ use anyhow::{Context, Error};
 use async_once_cell::OnceCell;
 use async_trait::async_trait;
 use aws_config::BehaviorVersion;
-use aws_sdk_s3::config::SharedHttpClient;
 use aws_sdk_s3::presigning::PresigningConfig;
 use http::Method;
 use reqwest::{Request, Response};
@@ -88,23 +87,6 @@ impl S3 {
         }
     }
 
-    /// Returns the default HTTP client.
-    fn default_http_client() -> SharedHttpClient {
-        use aws_smithy_http_client::{
-            tls::{self, rustls_provider::CryptoMode},
-            Builder,
-        };
-
-        static CLIENT: std::sync::OnceLock<SharedHttpClient> = std::sync::OnceLock::new();
-        CLIENT
-            .get_or_init(|| {
-                Builder::new()
-                    .tls_provider(tls::Provider::Rustls(CryptoMode::Ring))
-                    .build_https()
-            })
-            .clone()
-    }
-
     /// Create an S3 client.
     ///
     /// # Arguments
@@ -115,11 +97,7 @@ impl S3 {
     pub async fn create_s3_client(&self, url: Url) -> Result<aws_sdk_s3::Client, Error> {
         let sdk_config = self
             .default_client
-            .get_or_init(
-                aws_config::defaults(BehaviorVersion::latest())
-                    .http_client(Self::default_http_client())
-                    .load(),
-            )
+            .get_or_init(aws_config::defaults(BehaviorVersion::latest()).load())
             .await;
 
         let bucket_name = url
@@ -275,6 +253,37 @@ mod tests {
 
     use super::*;
     use crate::authentication_storage::backends::file::FileStorage;
+
+    /// Guard against regressions in the AWS SDK / reqwest crypto provider
+    /// alignment.
+    ///
+    /// `reqwest` 0.13's `rustls` feature uses `aws-lc-rs` as its rustls
+    /// crypto backend. We rely on `aws-smithy-http-client/rustls-aws-lc`
+    /// (plus `default-https-client` on `aws-config` and `aws-sdk-s3`) to
+    /// make the AWS SDK pick the same backend, so the process only pulls
+    /// in one rustls crypto crate and we don't have to hand-build an HTTP
+    /// client to align them.
+    ///
+    /// Without those features, building an SDK operation panics with
+    /// "a `http_client` is required". This exercises that path so a
+    /// regression surfaces here, alongside reqwest, in the same process.
+    #[tokio::test]
+    async fn aws_sdk_and_reqwest_share_default_https_client() {
+        // Force reqwest to initialize its rustls stack (uses aws-lc-rs via
+        // the `rustls` feature in reqwest 0.13).
+        let _reqwest_client = reqwest::Client::builder()
+            .build()
+            .expect("reqwest client builds");
+
+        // Force the AWS SDK to initialize its default HTTPS client and
+        // build an operation. If `default-https-client` /
+        // `rustls-aws-lc` are not wired up, this panics.
+        let s3 = S3::new(HashMap::new(), AuthenticationStorage::empty());
+        let _ = s3
+            .create_s3_client(Url::parse("s3://example-bucket/key").unwrap())
+            .await
+            .expect("S3 client builds");
+    }
 
     #[tokio::test]
     async fn test_presigned_s3_request_endpoint_url() {

--- a/crates/rattler_redaction/Cargo.toml
+++ b/crates/rattler_redaction/Cargo.toml
@@ -12,8 +12,8 @@ readme.workspace = true
 
 [features]
 default = ["rustls-tls"]
-native-tls = ["reqwest/native-tls", "reqwest/native-tls-alpn"]
-rustls-tls = ["reqwest/rustls-tls", "reqwest/rustls-tls-native-roots"]
+native-tls = ["reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls"]
 
 [dependencies]
 url = { workspace = true }

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -104,8 +104,8 @@ url = { workspace = true }
 
 [features]
 default = ['rustls-tls']
-native-tls = ['reqwest/native-tls', 'reqwest/native-tls-alpn', 'rattler_networking/native-tls', 'rattler_cache/native-tls', 'rattler_redaction/native-tls']
-rustls-tls = ['reqwest/rustls-tls', 'rattler_networking/rustls-tls', 'rattler_cache/rustls-tls', 'rattler_redaction/rustls-tls']
+native-tls = ['reqwest/native-tls', 'rattler_networking/native-tls', 'rattler_cache/native-tls', 'rattler_redaction/native-tls']
+rustls-tls = ['reqwest/rustls', 'rattler_networking/rustls-tls', 'rattler_cache/rustls-tls', 'rattler_redaction/rustls-tls']
 sparse = ["rattler_conda_types", "memmap2", "self_cell", "superslice", "itertools", "serde_json/raw_value"]
 gateway = ["sparse", "http", "http-cache-semantics", "parking_lot", "async-trait", "rattler_package_streaming"]
 

--- a/crates/rattler_s3/Cargo.toml
+++ b/crates/rattler_s3/Cargo.toml
@@ -15,7 +15,7 @@ default = ["rustls-tls"]
 # This feature is provided for API compatibility with other rattler crates but
 # will use rustls under the hood.
 native-tls = ["rustls-tls"]
-rustls-tls = ["aws-smithy-http-client/rustls-ring"]
+rustls-tls = ["aws-smithy-http-client/rustls-aws-lc"]
 
 [dependencies]
 clap = { workspace = true, optional = true }
@@ -28,8 +28,9 @@ aws-config = { workspace = true, features = [
   "credentials-process",
   "rt-tokio",
   "credentials-login",
+  "default-https-client",
 ] }
-aws-sdk-s3 = { workspace = true, features = ["rt-tokio"] }
+aws-sdk-s3 = { workspace = true, features = ["rt-tokio", "default-https-client"] }
 aws-smithy-http-client = { workspace = true }
 aws-credential-types = { workspace = true }
 

--- a/crates/rattler_s3/src/lib.rs
+++ b/crates/rattler_s3/src/lib.rs
@@ -3,7 +3,7 @@ pub mod clap;
 
 use aws_config::{BehaviorVersion, Region};
 use aws_credential_types::provider::error::CredentialsError;
-use aws_sdk_s3::config::{Credentials, ProvideCredentials, SharedHttpClient};
+use aws_sdk_s3::config::{Credentials, ProvideCredentials};
 use rattler_networking::{Authentication, AuthenticationStorage};
 use url::Url;
 
@@ -87,29 +87,9 @@ pub enum FromSDKError {
     CredentialsError(CredentialsError),
 }
 
-/// Returns the default HTTP client to use by the aws SDK.
-fn default_http_client() -> SharedHttpClient {
-    use aws_smithy_http_client::{
-        tls::{self, rustls_provider::CryptoMode},
-        Builder,
-    };
-
-    static CLIENT: std::sync::OnceLock<SharedHttpClient> = std::sync::OnceLock::new();
-    CLIENT
-        .get_or_init(|| {
-            Builder::new()
-                .tls_provider(tls::Provider::Rustls(CryptoMode::Ring))
-                .build_https()
-        })
-        .clone()
-}
-
 impl ResolvedS3Credentials {
     pub async fn from_sdk() -> Result<Self, FromSDKError> {
-        let config = aws_config::defaults(BehaviorVersion::latest())
-            .http_client(default_http_client())
-            .load()
-            .await;
+        let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
         let s3_config = aws_sdk_s3::config::Builder::from(&config).build();
 
         let region = s3_config

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -16,7 +16,7 @@ readme.workspace = true
 [features]
 default = ["rustls-tls", "s3", "sigstore-sign"]
 rustls-tls = [
-  "reqwest/rustls-tls",
+  "reqwest/rustls",
   "rattler_networking/rustls-tls",
   "rattler_package_streaming/rustls-tls",
   "sigstore-sign?/rustls",

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -54,6 +54,8 @@ reqwest-retry = { workspace = true }
 tokio-util = { workspace = true, features = ["codec", "compat"] }
 reqwest = { workspace = true, default-features = false, features = [
   "multipart",
+  "query",
+  "stream",
 ] }
 url = { workspace = true }
 tracing = { workspace = true }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [features]
 default = ["rustls-tls"]
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls = ["reqwest/rustls"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/js-rattler/Cargo.lock
+++ b/js-rattler/Cargo.lock
@@ -53,15 +53,14 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "astral-reqwest-middleware"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "638d02e24aeb92f9537897cd1ff82e2bc98fd9ac9575a503e27bb07cdf64d4d7"
+checksum = "98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9"
 dependencies = [
  "anyhow",
  "async-trait",
  "http",
  "reqwest",
- "serde",
  "thiserror 2.0.18",
  "tower-service",
 ]
@@ -84,18 +83,17 @@ dependencies = [
 
 [[package]]
 name = "astral_async_http_range_reader"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddaca0fbbf0d91103cca7c7611790c65f6eff1d456f7fe6bf565d436dc9b8f3"
+checksum = "4a8647866aee8d9707ae6ccc35205803a6df47c0ba83c5339ea6061b79131e4f"
 dependencies = [
  "astral-reqwest-middleware",
- "bisection",
  "futures",
  "http-content-range",
- "itertools 0.13.0",
+ "itertools",
  "memmap2",
  "reqwest",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -186,16 +184,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bisection"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3"
 
 [[package]]
 name = "bit-set"
@@ -282,10 +296,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee"
 
 [[package]]
-name = "cc"
-version = "1.2.41"
+name = "cast"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -326,11 +346,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "coalesced_map"
 version = "0.1.2"
 dependencies = [
  "dashmap",
  "tokio",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -544,6 +583,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,7 +668,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 name = "file_url"
 version = "0.3.0"
 dependencies = [
- "itertools 0.14.0",
+ "itertools",
  "percent-encoding",
  "thiserror 2.0.18",
  "typed-path",
@@ -644,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -722,6 +767,12 @@ dependencies = [
  "tokio",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fslock"
@@ -1017,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "http-cache-semantics"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92baf25cf0b8c9246baecf3a444546360a97b569168fdf92563ee6a47829920c"
+checksum = "0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7"
 dependencies = [
  "http",
  "http-serde",
@@ -1097,12 +1148,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1302,25 +1351,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,6 +1364,55 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if 1.0.4",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1372,10 +1451,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if 1.0.4",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1541,9 +1622,9 @@ checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "minicov"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27fe9f1cc3c22e1687f9446c2083c4c5fc7f0bcf1c7a86bdbded14985895b4b"
+checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
@@ -1589,6 +1670,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1618,6 +1709,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -1809,6 +1906,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -1896,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1907,7 +2005,7 @@ dependencies = [
  "fs-err",
  "fs4",
  "futures",
- "itertools 0.14.0",
+ "itertools",
  "parking_lot",
  "rattler_conda_types",
  "rattler_digest",
@@ -1927,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -1939,7 +2037,7 @@ dependencies = [
  "glob",
  "hex",
  "indexmap 2.13.0",
- "itertools 0.14.0",
+ "itertools",
  "lazy-regex",
  "memmap2",
  "nom",
@@ -1993,7 +2091,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.26.11"
+version = "0.26.12"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -2003,7 +2101,7 @@ dependencies = [
  "fs-err",
  "getrandom 0.4.2",
  "http",
- "itertools 0.14.0",
+ "itertools",
  "reqwest",
  "retry-policies",
  "serde",
@@ -2016,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -2053,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "astral-reqwest-middleware",
  "reqwest",
@@ -2062,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2088,7 +2186,7 @@ dependencies = [
  "http-cache-semantics",
  "humansize",
  "humantime",
- "itertools 0.14.0",
+ "itertools",
  "json-patch",
  "libc",
  "memmap2",
@@ -2123,12 +2221,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "chrono",
  "futures",
  "humantime",
- "itertools 0.14.0",
+ "itertools",
  "rattler_conda_types",
  "rattler_digest",
  "resolvo",
@@ -2228,9 +2326,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -2249,8 +2347,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2266,7 +2364,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -2281,7 +2378,7 @@ dependencies = [
  "event-listener",
  "futures",
  "indexmap 2.13.0",
- "itertools 0.14.0",
+ "itertools",
  "petgraph",
  "tracing",
 ]
@@ -2338,6 +2435,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,8 +2475,8 @@ version = "0.23.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2400,11 +2506,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2683,6 +2817,16 @@ dependencies = [
  "serde_json",
  "simdutf8",
  "value-trait",
+]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
 ]
 
 [[package]]
@@ -3005,20 +3149,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3193,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -3206,22 +3350,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
- "cfg-if 1.0.4",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3229,9 +3370,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3242,36 +3383,51 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.55"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc379bfb624eb59050b509c13e77b4eb53150c350db69628141abce842f2373"
+checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
 dependencies = [
+ "async-trait",
+ "cast",
  "js-sys",
+ "libm",
  "minicov",
+ "nu-ansi-term",
+ "num-traits",
+ "oorandom",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
+ "wasm-bindgen-test-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.55"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "085b2df989e1e6f9620c1311df6c996e83fe16f57792b272ce1e024ac16a90f1"
+checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "wasm-bindgen-test-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
 
 [[package]]
 name = "wasm-encoder"
@@ -3297,9 +3453,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3336,9 +3492,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3355,10 +3511,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "1.0.3"
+name = "webpki-root-certs"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/js-rattler/Cargo.toml
+++ b/js-rattler/Cargo.toml
@@ -42,8 +42,8 @@ rattler_solve = { path = "../crates/rattler_solve", default-features = false, fe
 url = "2.5.4"
 
 chrono = { version = "0.4.40", features = ["wasmbind"] }
-reqwest = { version = "0.12.24", default-features = false }
-reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.4.2", default-features = false }
+reqwest = { version = "0.13.3", default-features = false }
+reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.5.1", default-features = false }
 
 # We have transient dependencies on getrandom 0.2 and 0.3 which need WASM features enabled.
 [dependencies.getrandom_v02]

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -128,24 +128,23 @@ dependencies = [
 
 [[package]]
 name = "astral-reqwest-middleware"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "638d02e24aeb92f9537897cd1ff82e2bc98fd9ac9575a503e27bb07cdf64d4d7"
+checksum = "98e1c6be25cfbf1bb4fea1a9da51bc05d3259a9062df4e53f54e5607895e33c9"
 dependencies = [
  "anyhow",
  "async-trait",
  "http 1.4.0",
- "reqwest 0.12.28",
- "serde",
+ "reqwest 0.13.3",
  "thiserror 2.0.18",
  "tower-service",
 ]
 
 [[package]]
 name = "astral-reqwest-retry"
-version = "0.8.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ab210f6cdf8fd3254d47e5ee27ce60ed34a428ff71b4ae9477b1c84b49498c"
+checksum = "48c76a42c052d7a95249b90b83d44e8f1bbde7c8e08dbed50d49c58321815da3"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -154,7 +153,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.0",
  "hyper",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "retry-policies",
  "thiserror 2.0.18",
  "tokio",
@@ -180,18 +179,17 @@ dependencies = [
 
 [[package]]
 name = "astral_async_http_range_reader"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddaca0fbbf0d91103cca7c7611790c65f6eff1d456f7fe6bf565d436dc9b8f3"
+checksum = "4a8647866aee8d9707ae6ccc35205803a6df47c0ba83c5339ea6061b79131e4f"
 dependencies = [
  "astral-reqwest-middleware",
- "bisection",
  "futures",
  "http-content-range",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "memmap2",
- "reqwest 0.12.28",
- "thiserror 1.0.69",
+ "reqwest 0.13.3",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -911,12 +909,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "bisection"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e079a1bab0ecce6cf4b4b74c0c37afa4a697136eb3b127875c84a8f04a8c3"
 
 [[package]]
 name = "bit-set"
@@ -2191,7 +2183,7 @@ dependencies = [
  "bytes",
  "google-cloud-gax",
  "http 1.4.0",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rustc_version",
  "rustls",
  "rustls-pki-types",
@@ -2439,13 +2431,13 @@ dependencies = [
 
 [[package]]
 name = "http-cache-semantics"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92baf25cf0b8c9246baecf3a444546360a97b569168fdf92563ee6a47829920c"
+checksum = "0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7"
 dependencies = [
  "http 1.4.0",
  "http-serde",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde",
  "time",
 ]
@@ -2524,7 +2516,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -3831,7 +3822,7 @@ dependencies = [
  "rattler_shell",
  "rattler_solve",
  "rattler_virtual_packages",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -4114,7 +4105,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -4143,7 +4134,7 @@ dependencies = [
  "rayon",
  "reflink-copy",
  "regex",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "simple_spawn_blocking",
@@ -4158,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4177,7 +4168,7 @@ dependencies = [
  "rattler_package_streaming",
  "rattler_redaction",
  "rayon",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde_json",
  "simple_spawn_blocking",
  "tempfile",
@@ -4189,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.46.0"
+version = "0.46.1"
 dependencies = [
  "ahash",
  "chrono",
@@ -4229,7 +4220,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.3.11"
+version = "0.3.12"
 dependencies = [
  "console",
  "fs-err",
@@ -4262,7 +4253,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4282,7 +4273,7 @@ dependencies = [
  "rattler_networking",
  "rattler_package_streaming",
  "rattler_s3",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "retry-policies",
  "rmp-serde",
  "serde",
@@ -4299,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "ahash",
  "chrono",
@@ -4334,7 +4325,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.58"
+version = "0.2.59"
 dependencies = [
  "chrono",
  "configparser",
@@ -4363,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.26.11"
+version = "0.26.12"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -4381,7 +4372,7 @@ dependencies = [
  "itertools 0.14.0",
  "keyring",
  "netrc-rs",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "retry-policies",
  "serde",
  "serde_json",
@@ -4394,7 +4385,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -4415,7 +4406,7 @@ dependencies = [
  "rattler_digest",
  "rattler_networking",
  "rattler_redaction",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde_json",
  "simple_spawn_blocking",
  "tar",
@@ -4441,16 +4432,16 @@ dependencies = [
 
 [[package]]
 name = "rattler_redaction"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "astral-reqwest-middleware",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "url",
 ]
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4489,7 +4480,7 @@ dependencies = [
  "rattler_networking",
  "rattler_package_streaming",
  "rattler_redaction",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "retry-policies",
  "rmp-serde",
  "self_cell",
@@ -4512,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4528,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.26.11"
+version = "0.26.12"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4547,7 +4538,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "6.0.1"
+version = "6.0.2"
 dependencies = [
  "chrono",
  "futures",
@@ -4564,7 +4555,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.3.20"
+version = "2.3.21"
 dependencies = [
  "archspec",
  "libloading",
@@ -4732,6 +4723,41 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+dependencies = [
+ "base64",
+ "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -4751,8 +4777,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -4767,46 +4793,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
-dependencies = [
- "base64",
- "bytes",
- "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "rustls-platform-verifier",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -6347,6 +6334,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6397,15 +6397,6 @@ name = "webpki-root-certs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -18,7 +18,7 @@ native-tls = [
 rustls-tls = [
     "rattler_networking/rustls-tls",
     "rattler_repodata_gateway/rustls-tls",
-    "reqwest/rustls-tls-native-roots",
+    "reqwest/rustls",
 ]
 vendored-openssl = ["openssl", "openssl/vendored"]
 pty = ["rattler_pty", "nix"]
@@ -65,9 +65,9 @@ pyo3-async-runtimes = { version = "0.25.0", features = ["tokio-runtime"] }
 pythonize = "0.25.0"
 tokio = { version = "1.46.1" }
 
-reqwest = { version = "0.12.15", default-features = false }
-reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.4.2" }
-reqwest-retry = { package = "astral-reqwest-retry", version = "0.8.0" }
+reqwest = { version = "0.13.3", default-features = false }
+reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.5.1" }
+reqwest-retry = { package = "astral-reqwest-retry", version = "0.9.1" }
 async-trait = "0.1"
 http = "1.2"
 

--- a/tools/create-resolvo-snapshot/Cargo.toml
+++ b/tools/create-resolvo-snapshot/Cargo.toml
@@ -17,7 +17,7 @@ rattler_conda_types = { path = "../../crates/rattler_conda_types" }
 rattler_repodata_gateway = { path = "../../crates/rattler_repodata_gateway", default-features = false, version = "*" }
 rattler_networking = { path = "../../crates/rattler_networking", default-features = false, version = "*" }
 rattler_solve = { path = "../../crates/rattler_solve" }
-reqwest = { workspace = true, default-features = false, features = ["rustls-tls"] }
+reqwest = { workspace = true, default-features = false, features = ["rustls"] }
 resolvo = { workspace = true, features = ["serde"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }


### PR DESCRIPTION
### Description

Bumps reqwest from 0.12.15 to 0.13.3, along with the small cluster of crates whose public types are tied to the reqwest version:

- `reqwest` 0.12.15 → 0.13.3
- `astral-reqwest-middleware` 0.4.2 → 0.5.1
- `astral-reqwest-retry` 0.8.0 → 0.9.1
- `astral_async_http_range_reader` 0.9.1 → 0.11.0
- `http-cache-semantics` 2.1.0 → 3.0.0 (the previous pin comment called out reqwest 0.13 as the blocker)
- `retry-policies` 0.5.0 → 0.5.1 (similarly held back for `reqwest-retry`)

No other workspace dependencies were touched.

Adjustments required by reqwest 0.13:

- Feature renames: `rustls-tls` → `rustls`, `macos-system-configuration` → `system-proxy`.
- Feature consolidations: `rustls-tls-native-roots` and `native-tls-alpn` no longer exist as separate features (the `rustls` feature now uses `rustls-platform-verifier`, and `native-tls` includes ALPN by default).
- The `form` method now requires the `form` feature; added it where it was used (`rattler`, `rattler_networking`).
- `openidconnect` 4.x still depends on `reqwest` 0.12, so the OIDC flow in `crates/rattler/src/cli/auth/oauth.rs` now uses the `openidconnect::reqwest` re-export for its HTTP client. A separate `OidcNetwork` error variant was added for `openidconnect::reqwest::Error`.
- Lockfiles for the three workspaces (root, `js-rattler`, `py-rattler`) were refreshed.

### How Has This Been Tested?

- `cargo check --workspace --all-targets`
- `cargo check --target wasm32-unknown-unknown` in `js-rattler`
- `cargo check` in `py-rattler`
- `cargo clippy --workspace --all-targets` (clean)
- `cargo fmt --all --check` (clean)
- `cargo test -p rattler_networking --lib` (21 passed)
- `cargo test -p rattler_repodata_gateway --lib` (13 passed)

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation