### PR TITLE
refactor: Use resolved credentials, like in rattler_index

### DIFF
--- a/crates/rattler_upload/src/lib.rs
+++ b/crates/rattler_upload/src/lib.rs
@@ -62,10 +62,20 @@ pub async fn upload_from_args(args: UploadOpts) -> miette::Result<()> {
         }
         #[cfg(feature = "s3")]
         ServerType::S3(s3_opts) => {
+            let unresolved: Option<rattler_s3::S3Credentials> = s3_opts.credentials.into();
+            let credentials = match unresolved {
+                Some(unresolved) => unresolved
+                    .resolve(&s3_opts.channel, &store)
+                    .ok_or_else(|| miette::miette!(
+                        "Could not find S3 credentials in the authentication storage, and no credentials were provided via the command line."
+                    ))?,
+                None => rattler_s3::ResolvedS3Credentials::from_sdk()
+                    .await
+                    .into_diagnostic()?,
+            };
             upload::upload_package_to_s3(
-                &store,
                 s3_opts.channel,
-                s3_opts.credentials.into(),
+                credentials,
                 &args.package_files,
                 s3_opts.force,
             )

--- a/crates/rattler_upload/src/upload/s3.rs
+++ b/crates/rattler_upload/src/upload/s3.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 use miette::IntoDiagnostic;
 use opendal::{services::S3Config, Configurator, ErrorKind, Operator};
 use rattler_digest::{HashingReader, Md5, Sha256};
-use rattler_networking::AuthenticationStorage;
-use rattler_s3::{ResolvedS3Credentials, S3Credentials};
+use rattler_s3::ResolvedS3Credentials;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio_util::bytes::BytesMut;
 use url::Url;
@@ -14,11 +13,13 @@ use crate::upload::package::ExtractedPackage;
 const DESIRED_CHUNK_SIZE: usize = 1024 * 1024 * 10;
 
 /// Uploads a package to a channel in an S3 bucket.
-#[allow(clippy::too_many_arguments)]
+///
+/// Credentials must already be resolved by the caller (e.g. via
+/// [`rattler_s3::S3Credentials::resolve`] or
+/// [`ResolvedS3Credentials::from_sdk`]).
 pub async fn upload_package_to_s3(
-    auth_storage: &AuthenticationStorage,
     channel: Url,
-    credentials: Option<S3Credentials>,
+    credentials: ResolvedS3Credentials,
     package_files: &Vec<PathBuf>,
     force: bool,
 ) -> miette::Result<()> {
@@ -31,23 +32,13 @@ pub async fn upload_package_to_s3(
     s3_config.root = Some(channel.path().to_string());
     s3_config.bucket = bucket.to_string();
 
-    // Resolve the credentials to use.
-    let resolved_credentials = match credentials {
-        Some(credentials) => credentials
-            .resolve(&channel, auth_storage)
-            .ok_or_else(|| miette::miette!("Could not find S3 credentials in the authentication storage, and no credentials were provided via the command line."))?,
-        None => {
-            ResolvedS3Credentials::from_sdk().await.into_diagnostic()?
-        }
-    };
-
-    s3_config.endpoint = Some(resolved_credentials.endpoint_url.to_string());
-    s3_config.region = Some(resolved_credentials.region);
-    s3_config.access_key_id = Some(resolved_credentials.access_key_id);
-    s3_config.secret_access_key = Some(resolved_credentials.secret_access_key);
-    s3_config.session_token = resolved_credentials.session_token;
+    s3_config.endpoint = Some(credentials.endpoint_url.to_string());
+    s3_config.region = Some(credentials.region);
+    s3_config.access_key_id = Some(credentials.access_key_id);
+    s3_config.secret_access_key = Some(credentials.secret_access_key);
+    s3_config.session_token = credentials.session_token;
     s3_config.enable_virtual_host_style =
-        resolved_credentials.addressing_style == rattler_s3::S3AddressingStyle::VirtualHost;
+        credentials.addressing_style == rattler_s3::S3AddressingStyle::VirtualHost;
 
     let builder = s3_config.into_builder();
     let op = Operator::new(builder).into_diagnostic()?.finish();


### PR DESCRIPTION
We need resolved credentials for rattler_index and then need to provide unresolved ones again for the actual upload. That is pretty annoying.

So require resolved credentials here as well.

Fixes prefix-dev/pixi#6069

### How Has This Been Tested?

The unit tests

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
