### PR TITLE
refactor: remove reqwest 0.12

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --no-default-features --features rustls-tls
+          args: --release --out dist --no-default-features --features rustls
       - name: "Test wheel"
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
@@ -121,7 +121,7 @@ jobs:
           working-directory: py-rattler
           target: ${{ matrix.target }}
           manylinux: auto
-          args: --release --out dist --no-default-features --features rustls-tls,pty
+          args: --release --out dist --no-default-features --features rustls,pty
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
@@ -158,7 +158,7 @@ jobs:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
           manylinux: "2_28"
-          args: --release --out dist  --no-default-features --features rustls-tls,pty
+          args: --release --out dist  --no-default-features --features rustls,pty
       - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
         if: matrix.platform.arch != 'ppc64'
         name: Test wheel
@@ -244,14 +244,14 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
-      - name: "Build wheels (rustls-tls)"
+      - name: "Build wheels (rustls)"
         if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:
           working-directory: py-rattler
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
-          args: --release --out dist --no-default-features --features rustls-tls,pty
+          args: --release --out dist --no-default-features --features rustls,pty
       - name: "Build wheels (native-tls)"
         if: matrix.target != 'x86_64-unknown-linux-musl'
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
@@ -301,7 +301,7 @@ jobs:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
-          args: --release --out dist --no-default-features --features rustls-tls,pty
+          args: --release --out dist --no-default-features --features rustls,pty
       - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
         name: Test wheel
         with:
@@ -335,7 +335,7 @@ jobs:
         with:
           working-directory: py-rattler
           target: x86_64
-          args: --release --out dist --no-default-features --features rustls-tls,pty
+          args: --release --out dist --no-default-features --features rustls,pty
       - name: "Test wheel - x86_64"
         run: |
           pip install py-rattler/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
@@ -360,7 +360,7 @@ jobs:
       - name: "Build wheels - universal2"
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:
-          args: --release --target universal2-apple-darwin --out dist --no-default-features --features rustls-tls,pty
+          args: --release --target universal2-apple-darwin --out dist --no-default-features --features rustls,pty
           working-directory: py-rattler
       - name: "Test wheel - universal2"
         run: |

--- a/.github/workflows/rust-compile.yml
+++ b/.github/workflows/rust-compile.yml
@@ -142,7 +142,7 @@ jobs:
         id: build-options
         if: contains(matrix.target, '-musl') || startsWith(matrix.target, 'powerpc') || startsWith(matrix.target, 's390x')
         run: |
-          echo "CARGO_BUILD_OPTIONS=${CARGO_BUILD_OPTIONS} --no-default-features --features rustls-tls" >> $GITHUB_OUTPUT
+          echo "CARGO_BUILD_OPTIONS=${CARGO_BUILD_OPTIONS} --no-default-features --features rustls" >> $GITHUB_OUTPUT
 
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1259,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2951,15 +2951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3462,10 +3453,12 @@ checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
+ "js-sys",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "wasm-bindgen",
  "windows-sys 0.61.2",
 ]
 
@@ -3815,6 +3808,15 @@ checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
  "digest 0.11.3",
+]
+
+[[package]]
+name = "mea"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6747f54621d156e1b47eb6b25f39a941b9fc347f98f67d25d8881ff99e8ed832"
+dependencies = [
+ "slab",
 ]
 
 [[package]]
@@ -4218,31 +4220,88 @@ dependencies = [
 
 [[package]]
 name = "opendal"
-version = "0.55.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d075ab8a203a6ab4bc1bce0a4b9fe486a72bf8b939037f4b78d95386384bc80a"
+checksum = "97b31d3d8e99a85d83b73ec26647f5607b80578ed9375810b6e44ffa3590a236"
+dependencies = [
+ "opendal-core",
+ "opendal-layer-retry",
+ "opendal-service-fs",
+ "opendal-service-s3",
+]
+
+[[package]]
+name = "opendal-core"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1849dd2687e173e776d3af5fce1ba3ae47b9dd37a09d1c4deba850ef45fe00ca"
 dependencies = [
  "anyhow",
- "backon",
  "base64 0.22.1",
  "bytes",
- "crc32c",
  "futures",
- "getrandom 0.2.17",
  "http 1.4.0",
  "http-body 1.0.1",
  "jiff",
  "log",
  "md-5 0.10.6",
+ "mea",
  "percent-encoding",
  "quick-xml 0.38.4",
- "reqsign",
- "reqwest 0.12.28",
+ "reqsign-core",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tokio",
  "url",
  "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "opendal-layer-retry"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eac134ffa4ddda6131a640a84a5315996424b9416c85052f8c64c1a33b70ad4"
+dependencies = [
+ "backon",
+ "log",
+ "opendal-core",
+]
+
+[[package]]
+name = "opendal-service-fs"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf0be0417abeeb0053376d816b90fceb9ca98f20dfb54ebf1f2a282729f83663"
+dependencies = [
+ "bytes",
+ "log",
+ "opendal-core",
+ "serde",
+ "tokio",
+ "xattr",
+]
+
+[[package]]
+name = "opendal-service-s3"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dadddeb9bb50b0d30927dd914c298c4ddca47e4c1cfa7674d311f0cf9b051c8"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "crc32c",
+ "http 1.4.0",
+ "log",
+ "md-5 0.10.6",
+ "opendal-core",
+ "quick-xml 0.38.4",
+ "reqsign-aws-v4",
+ "reqsign-core",
+ "reqsign-file-read-tokio",
+ "serde",
+ "url",
 ]
 
 [[package]]
@@ -4836,7 +4895,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -4856,6 +4914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -5830,31 +5889,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
-name = "reqsign"
-version = "0.16.5"
+name = "reqsign-aws-v4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43451dbf3590a7590684c25fb8d12ecdcc90ed3ac123433e500447c7d77ed701"
+checksum = "44eaca382e94505a49f1a4849658d153aebf79d9c1a58e5dd3b10361511e9f43"
 dependencies = [
  "anyhow",
- "async-trait",
- "base64 0.22.1",
- "chrono",
+ "bytes",
  "form_urlencoded",
- "getrandom 0.2.17",
- "hex",
- "hmac 0.12.1",
- "home",
  "http 1.4.0",
  "log",
  "percent-encoding",
- "quick-xml 0.37.5",
- "rand 0.8.6",
- "reqwest 0.12.28",
+ "quick-xml 0.39.3",
+ "reqsign-core",
  "rust-ini",
  "serde",
  "serde_json",
+ "serde_urlencoded",
+ "sha1 0.10.6",
+]
+
+[[package]]
+name = "reqsign-core"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b10302cf0a7d7e7352ba211fc92c3c5bebf1286153e49cc5aa87348078a8e102"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "futures",
+ "hex",
+ "hmac 0.12.1",
+ "http 1.4.0",
+ "jiff",
+ "log",
+ "percent-encoding",
  "sha1 0.10.6",
  "sha2 0.10.9",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "reqsign-file-read-tokio"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d89295b3d17abea31851cc8de55d843d89c52132c864963c38d41920613dc5"
+dependencies = [
+ "anyhow",
+ "reqsign-core",
  "tokio",
 ]
 
@@ -5867,7 +5951,6 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
- "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -5882,14 +5965,12 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
  "web-sys",
 ]
 
@@ -5938,7 +6019,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -8041,19 +8122,6 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
-]
-
-[[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1daa54020e05aa0b163ee10434fff35a0f18d28a1cafa142bd1290e1abe630e"
 dependencies = [
  "astral-reqwest-middleware",
- "reqwest 0.13.3",
+ "reqwest",
  "secrecy",
  "serde",
  "serde_json",
@@ -189,7 +189,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.4.0",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "thiserror 2.0.18",
  "tower-service",
@@ -208,7 +208,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.0",
  "hyper",
- "reqwest 0.13.3",
+ "reqwest",
  "retry-policies",
  "thiserror 2.0.18",
  "tokio",
@@ -243,7 +243,7 @@ dependencies = [
  "http-content-range",
  "itertools 0.14.0",
  "memmap2",
- "reqwest 0.13.3",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -1707,7 +1707,7 @@ dependencies = [
  "rattler_networking",
  "rattler_repodata_gateway",
  "rattler_solve",
- "reqwest 0.13.3",
+ "reqwest",
  "resolvo",
  "serde_json",
  "tokio",
@@ -2734,7 +2734,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 1.4.0",
- "reqwest 0.13.3",
+ "reqwest",
  "rustc_version",
  "rustls",
  "rustls-pki-types",
@@ -3013,7 +3013,7 @@ checksum = "0603b99309a1e404c2c0945650c0f775b50bb72ac90ae570cb93f9ff05d9efe7"
 dependencies = [
  "http 1.4.0",
  "http-serde",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "time",
 ]
@@ -4152,13 +4152,22 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.0",
  "rand 0.8.6",
- "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "oauth2-reqwest"
+version = "0.1.0-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234fb5c965bbce983ee5de636a7a51d6a3223da8067ea02f9ab2d2d78ac08be2"
+dependencies = [
+ "oauth2",
+ "reqwest",
 ]
 
 [[package]]
@@ -4249,7 +4258,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml 0.38.4",
  "reqsign-core",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -5108,6 +5117,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "mockito",
+ "oauth2-reqwest",
  "once_cell",
  "open",
  "openidconnect",
@@ -5125,7 +5135,7 @@ dependencies = [
  "rayon",
  "reflink-copy",
  "regex",
- "reqwest 0.13.3",
+ "reqwest",
  "rstest",
  "serde",
  "serde_json",
@@ -5172,7 +5182,7 @@ dependencies = [
  "rattler_solve",
  "rattler_upload",
  "rattler_virtual_packages",
- "reqwest 0.13.3",
+ "reqwest",
  "tokio",
  "tracing-subscriber",
  "url",
@@ -5203,7 +5213,7 @@ dependencies = [
  "rattler_package_streaming",
  "rattler_redaction",
  "rayon",
- "reqwest 0.13.3",
+ "reqwest",
  "rstest",
  "serde_json",
  "simple_spawn_blocking",
@@ -5317,7 +5327,7 @@ dependencies = [
  "dunce",
  "fs-err",
  "rattler_prefix_guard",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "tempfile",
  "thiserror 2.0.18",
@@ -5350,7 +5360,7 @@ dependencies = [
  "rattler_networking",
  "rattler_package_streaming",
  "rattler_s3",
- "reqwest 0.13.3",
+ "reqwest",
  "retry-policies",
  "rmp-serde",
  "serde",
@@ -5473,7 +5483,7 @@ dependencies = [
  "keyring",
  "netrc-rs",
  "rattler_config",
- "reqwest 0.13.3",
+ "reqwest",
  "retry-policies",
  "rstest",
  "serde",
@@ -5514,7 +5524,7 @@ dependencies = [
  "rattler_digest",
  "rattler_networking",
  "rattler_redaction",
- "reqwest 0.13.3",
+ "reqwest",
  "rstest",
  "rstest_reuse",
  "serde_json",
@@ -5560,7 +5570,7 @@ name = "rattler_redaction"
 version = "0.1.15"
 dependencies = [
  "astral-reqwest-middleware",
- "reqwest 0.13.3",
+ "reqwest",
  "url",
 ]
 
@@ -5612,7 +5622,7 @@ dependencies = [
  "rattler_package_streaming",
  "rattler_redaction",
  "regex",
- "reqwest 0.13.3",
+ "reqwest",
  "retry-policies",
  "rmp-serde",
  "rstest",
@@ -5735,7 +5745,7 @@ dependencies = [
  "rattler_redaction",
  "rattler_s3",
  "rattler_solve",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5940,38 +5950,6 @@ dependencies = [
  "anyhow",
  "reqsign-core",
  "tokio",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -6812,7 +6790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c60b95ecc87b2e279705e4a617cfb2d668bb9dfb15b3a99322524b6f44a4201b"
 dependencies = [
  "base64 0.22.1",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -6844,7 +6822,7 @@ dependencies = [
  "ambient-id",
  "base64 0.22.1",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -6862,7 +6840,7 @@ checksum = "641fdaaa40d0cd6e249cf1671c2240beff1a3ece578062cf43e750779e8db2b3"
 dependencies = [
  "base64 0.22.1",
  "hex",
- "reqwest 0.13.3",
+ "reqwest",
  "serde",
  "serde_json",
  "sigstore-crypto",
@@ -6925,7 +6903,7 @@ dependencies = [
  "der 0.7.10",
  "hex",
  "rand 0.10.1",
- "reqwest 0.13.3",
+ "reqwest",
  "rustls-pki-types",
  "rustls-webpki",
  "sigstore-crypto",
@@ -7617,7 +7595,7 @@ dependencies = [
  "fs-err",
  "fslock",
  "rattler_digest",
- "reqwest 0.13.3",
+ "reqwest",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ netrc-rs = "0.1.2"
 nom = "8.0.0"
 nom-language = "0.1.0"
 num_cpus = "1.16.0"
-opendal = { version = "0.55.0", default-features = false }
+opendal = { version = "0.56.0", default-features = false }
 once_cell = "1.21.3"
 open = "5"
 openidconnect = { version = "4", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,9 +119,8 @@ num_cpus = "1.16.0"
 opendal = { version = "0.56.0", default-features = false }
 once_cell = "1.21.3"
 open = "5"
-openidconnect = { version = "4", default-features = false, features = [
-  "reqwest",
-] }
+openidconnect = { version = "4", default-features = false }
+oauth2-reqwest = { version = "0.1.0-alpha.3", default-features = false }
 parking_lot = "0.12.4"
 pathdiff = "0.2.3"
 pep440_rs = { version = "0.7.3" }

--- a/crates/rattler-bin/Cargo.toml
+++ b/crates/rattler-bin/Cargo.toml
@@ -16,7 +16,7 @@ name = "rattler"
 path = "src/main.rs"
 
 [features]
-default = ["rustls-tls", "s3", "gcs", "oauth"]
+default = ["rustls", "s3", "gcs", "oauth"]
 native-tls = [
   "reqwest/native-tls",
   "rattler/native-tls",
@@ -24,12 +24,12 @@ native-tls = [
   "rattler_networking/native-tls",
   "rattler_cache/native-tls",
 ]
-rustls-tls = [
+rustls = [
   "reqwest/rustls",
-  "rattler/rustls-tls",
-  "rattler_repodata_gateway/rustls-tls",
-  "rattler_networking/rustls-tls",
-  "rattler_cache/rustls-tls",
+  "rattler/rustls",
+  "rattler_repodata_gateway/rustls",
+  "rattler_networking/rustls",
+  "rattler_cache/rustls",
 ]
 s3 = ["rattler_networking/s3", "rattler_upload/s3"]
 gcs = ["rattler_networking/gcs"]

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -11,9 +11,9 @@ license.workspace = true
 readme.workspace = true
 
 [features]
-default = ['rustls-tls']
+default = ['rustls']
 native-tls = ['reqwest/native-tls', 'rattler_package_streaming/native-tls', 'rattler_cache/native-tls', 'rattler_networking/native-tls']
-rustls-tls = ['reqwest/rustls', 'rattler_package_streaming/rustls-tls', 'rattler_cache/rustls-tls', 'rattler_networking/rustls-tls']
+rustls = ['reqwest/rustls', 'rattler_package_streaming/rustls', 'rattler_cache/rustls', 'rattler_networking/rustls']
 oauth = ["dep:openidconnect", "dep:open"]
 cli-tools = ['dep:clap', 'oauth']
 indicatif = ['dep:indicatif', 'dep:console']

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 default = ['rustls']
 native-tls = ['reqwest/native-tls', 'rattler_package_streaming/native-tls', 'rattler_cache/native-tls', 'rattler_networking/native-tls']
 rustls = ['reqwest/rustls', 'rattler_package_streaming/rustls', 'rattler_cache/rustls', 'rattler_networking/rustls']
-oauth = ["dep:openidconnect", "dep:open"]
+oauth = ["dep:openidconnect", "dep:oauth2-reqwest", "dep:open"]
 cli-tools = ['dep:clap', 'oauth']
 indicatif = ['dep:indicatif', 'dep:console']
 
@@ -61,6 +61,7 @@ uuid = { workspace = true, features = ["v4", "fast-rng"] }
 console = { workspace = true, optional = true }
 open = { workspace = true, optional = true }
 openidconnect = { workspace = true, optional = true }
+oauth2-reqwest = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 

--- a/crates/rattler/src/cli/auth/oauth.rs
+++ b/crates/rattler/src/cli/auth/oauth.rs
@@ -9,6 +9,7 @@ use std::{
     time::Duration,
 };
 
+use oauth2_reqwest::ReqwestClient;
 use openidconnect::{
     core::{
         CoreAuthDisplay, CoreClaimName, CoreClaimType, CoreClient, CoreClientAuthMethod,
@@ -125,10 +126,6 @@ pub enum OAuthError {
     #[error(transparent)]
     Network(#[from] reqwest::Error),
 
-    /// A network error occurred during the OIDC flow.
-    #[error(transparent)]
-    OidcNetwork(#[from] openidconnect::reqwest::Error),
-
     /// An I/O error occurred.
     #[error(transparent)]
     Io(#[from] std::io::Error),
@@ -175,11 +172,12 @@ pub async fn perform_oauth_login(config: OAuthConfig) -> Result<Authentication, 
 
     let user_agent = config.user_agent.as_deref().unwrap_or(DEFAULT_USER_AGENT);
 
-    let http_client = openidconnect::reqwest::Client::builder()
-        .redirect(openidconnect::reqwest::redirect::Policy::none())
+    let reqwest_client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
         .user_agent(user_agent)
         .build()
-        .map_err(OAuthError::OidcNetwork)?;
+        .map_err(OAuthError::Network)?;
+    let http_client = ReqwestClient::from(reqwest_client);
 
     // 1. OIDC Discovery
     let endpoints = discover_endpoints(&http_client, &config.issuer_url).await?;
@@ -271,7 +269,7 @@ pub async fn perform_oauth_login(config: OAuthConfig) -> Result<Authentication, 
 /// `revocation_endpoint` and `device_authorization_endpoint` fields are
 /// deserialized from the discovery document in a single request.
 async fn discover_endpoints(
-    http_client: &openidconnect::reqwest::Client,
+    http_client: &ReqwestClient,
     issuer_url: &str,
 ) -> Result<DiscoveredEndpoints, OAuthError> {
     let oidc_issuer =
@@ -312,7 +310,7 @@ async fn auth_code_flow(
     client_secret: Option<&str>,
     scopes: &HashSet<String>,
     redirect_uri: Option<&str>,
-    http_client: &openidconnect::reqwest::Client,
+    http_client: &ReqwestClient,
 ) -> Result<OAuthTokens, OAuthError> {
     // If the caller pinned a redirect URI (because the IdP requires an
     // exact match against what was registered), bind there. Otherwise
@@ -534,7 +532,7 @@ async fn device_code_flow(
     client_id: &str,
     client_secret: Option<&str>,
     scopes: &HashSet<String>,
-    http_client: &openidconnect::reqwest::Client,
+    http_client: &ReqwestClient,
 ) -> Result<OAuthTokens, OAuthError> {
     let device_auth_url = endpoints
         .device_authorization_endpoint

--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -10,8 +10,8 @@ edition = { workspace = true }
 readme.workspace = true
 
 [features]
-default = ["rustls-tls"]
-rustls-tls = ["reqwest/rustls", "reqwest-middleware/rustls", "rattler_networking/rustls-tls", "rattler_package_streaming/rustls-tls"]
+default = ["rustls"]
+rustls = ["reqwest/rustls", "reqwest-middleware/rustls", "rattler_networking/rustls", "rattler_package_streaming/rustls"]
 native-tls = ["reqwest/native-tls", "rattler_networking/native-tls", "rattler_package_streaming/native-tls"]
 
 [dependencies]

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -72,7 +72,7 @@ insta = { workspace = true, features = [
   "filters",
 ] }
 rattler_package_streaming = { path = "../rattler_package_streaming", default-features = false, features = [
-  "rustls-tls",
+  "rustls",
 ] }
 rstest = { workspace = true }
 assert_matches = { workspace = true }

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -24,6 +24,7 @@ rustls = [
   "rattler_package_streaming/rustls",
   "rattler_networking/rustls",
   "rattler_s3?/rustls",
+  "opendal/reqwest-rustls-tls",
 ]
 s3 = ["opendal/services-s3", "dep:rattler_s3"]
 rattler_config = ["dep:rattler_config"]
@@ -47,7 +48,6 @@ futures = { workspace = true }
 indicatif = { workspace = true }
 opendal = { workspace = true, features = [
   "services-fs",
-  "reqwest-rustls-tls",
   "layers-retry",
 ], default-features = false }
 rattler_config = { workspace = true, optional = true }

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -39,7 +39,7 @@ ahash = { workspace = true }
 anyhow = { workspace = true }
 bytes = { workspace = true }
 indexmap = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["clock"] }
 clap = { workspace = true, features = ["derive", "env"] }
 clap-verbosity-flag = { workspace = true, features = ["tracing"] }
 console = { workspace = true }

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -47,6 +47,8 @@ futures = { workspace = true }
 indicatif = { workspace = true }
 opendal = { workspace = true, features = [
   "services-fs",
+  "reqwest-rustls-tls",
+  "layers-retry",
 ], default-features = false }
 rattler_config = { workspace = true, optional = true }
 rattler_networking = { workspace = true, default-features = false, features = [

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -12,18 +12,18 @@ readme.workspace = true
 default-run = "rattler-index"
 
 [features]
-default = ["rustls-tls", "s3", "rattler_config"]
+default = ["rustls", "s3", "rattler_config"]
 native-tls = [
   "reqwest/native-tls",
   "rattler_package_streaming/native-tls",
   "rattler_networking/native-tls",
   "rattler_s3?/native-tls",
 ]
-rustls-tls = [
+rustls = [
   "reqwest/rustls",
-  "rattler_package_streaming/rustls-tls",
-  "rattler_networking/rustls-tls",
-  "rattler_s3?/rustls-tls",
+  "rattler_package_streaming/rustls",
+  "rattler_networking/rustls",
+  "rattler_s3?/rustls",
 ]
 s3 = ["opendal/services-s3", "dep:rattler_s3"]
 rattler_config = ["dep:rattler_config"]

--- a/crates/rattler_index/tests/integration/etag_memory_backend.rs
+++ b/crates/rattler_index/tests/integration/etag_memory_backend.rs
@@ -428,7 +428,7 @@ impl Access for ETagMemoryBackend {
             Some(format!("{prefix}/"))
         };
 
-        let mut entries: Vec<(String, bool)> = Vec::new();
+        let mut entries: Vec<ListEntry> = Vec::new();
         let mut seen = HashSet::new();
 
         // Add direct child directories
@@ -437,7 +437,7 @@ impl Access for ETagMemoryBackend {
                 // List root level directories
                 if let Some(first) = dir.split('/').next() {
                     if !first.is_empty() && seen.insert(first) {
-                        entries.push((format!("{first}/"), true));
+                        entries.push(ListEntry::dir(format!("{first}/")));
                     }
                 }
             } else if let Some(ps) = &prefix_slash {
@@ -445,7 +445,7 @@ impl Access for ETagMemoryBackend {
                     // List subdirectories under prefix
                     if let Some(first) = stripped.split('/').next() {
                         if !first.is_empty() && seen.insert(first) {
-                            entries.push((format!("{first}/"), true));
+                            entries.push(ListEntry::dir(format!("{first}/")));
                         }
                     }
                 }
@@ -453,20 +453,29 @@ impl Access for ETagMemoryBackend {
         }
 
         // Add direct child files
-        for key in storage.keys() {
-            if prefix.is_empty() {
-                // List root level files (no / in path)
-                if !key.contains('/') {
-                    entries.push((key.clone(), false));
+        for (key, entry_lock) in storage.iter() {
+            let name = if prefix.is_empty() {
+                if key.contains('/') {
+                    continue;
                 }
-            } else if let Some(ps) = &prefix_slash {
-                if let Some(stripped) = key.strip_prefix(ps) {
-                    // List files directly under prefix (no further / in stripped path)
-                    if !stripped.contains('/') {
-                        entries.push((stripped.to_owned(), false));
-                    }
+                key.clone()
+            } else if let Some(stripped) =
+                prefix_slash.as_deref().and_then(|ps| key.strip_prefix(ps))
+            {
+                if stripped.contains('/') {
+                    continue;
                 }
-            }
+                stripped.to_owned()
+            } else {
+                continue;
+            };
+
+            let content_length = entry_lock.read().await.content_length;
+            entries.push(ListEntry {
+                path: name,
+                is_dir: false,
+                content_length,
+            });
         }
 
         drop(storage);
@@ -476,6 +485,24 @@ impl Access for ETagMemoryBackend {
             RpList::default(),
             oio::HierarchyLister::new(ETagMemoryLister { entries, index: 0 }, "/", false),
         ))
+    }
+}
+
+/// A single entry produced by the listing helpers, carrying the metadata that
+/// opendal's `CompleteLister` requires for file entries.
+struct ListEntry {
+    path: String,
+    is_dir: bool,
+    content_length: u64,
+}
+
+impl ListEntry {
+    fn dir(path: String) -> Self {
+        Self {
+            path,
+            is_dir: true,
+            content_length: 0,
+        }
     }
 }
 
@@ -533,7 +560,7 @@ impl oio::OneShotDelete for ETagMemoryDeleter {
 
 /// Lister for `ETag` memory backend
 pub struct ETagMemoryLister {
-    entries: Vec<(String, bool)>, // (path, is_dir)
+    entries: Vec<ListEntry>,
     index: usize,
 }
 
@@ -543,16 +570,18 @@ impl oio::List for ETagMemoryLister {
             return Ok(None);
         }
 
-        let (path, is_dir) = self.entries[self.index].clone();
+        let entry = &self.entries[self.index];
         self.index += 1;
 
-        let mode = if is_dir {
-            EntryMode::DIR
+        // opendal 0.56's CompleteLister silently drops file entries whose
+        // content_length isn't set by issuing an extra stat() that may miss in
+        // this stripped-path lister, so we populate it inline.
+        let metadata = if entry.is_dir {
+            Metadata::new(EntryMode::DIR)
         } else {
-            EntryMode::FILE
+            Metadata::new(EntryMode::FILE).with_content_length(entry.content_length)
         };
-        let entry = oio::Entry::new(&path, Metadata::new(mode));
-        Ok(Some(entry))
+        Ok(Some(oio::Entry::new(&entry.path, metadata)))
     }
 }
 

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -11,9 +11,9 @@ license.workspace = true
 readme.workspace = true
 
 [features]
-default = ["rustls-tls", "system-integration"]
+default = ["rustls", "system-integration"]
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls"]
+rustls = ["reqwest/rustls"]
 gcs = ["google-cloud-auth", "tokio/sync"]
 s3 = ["aws-config", "aws-sdk-s3", "aws-smithy-http-client"]
 system-integration = ["keyring", "netrc-rs", "dirs"]

--- a/crates/rattler_networking/src/oci_middleware.rs
+++ b/crates/rattler_networking/src/oci_middleware.rs
@@ -332,7 +332,7 @@ mod tests {
     use crate::OciMiddleware;
 
     // test pulling an image from OCI registry
-    #[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     #[tokio::test]
     async fn test_oci_middleware() {
         let client = reqwest::Client::new();
@@ -365,7 +365,7 @@ mod tests {
     }
 
     // test pulling an image from OCI registry
-    #[cfg(any(feature = "rustls-tls", feature = "native-tls"))]
+    #[cfg(any(feature = "rustls", feature = "native-tls"))]
     #[tokio::test]
     async fn test_oci_middleware_repodata() {
         let client = reqwest::Client::new();

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -61,9 +61,9 @@ getrandom = { workspace = true, features = ["wasm_js"] }
 getrandom_v02 = { package = "getrandom", version = "0.2", features = ["js"] }
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["rattler_networking/native-tls", "rattler_redaction/native-tls"]
-rustls-tls = ["rattler_networking/rustls-tls", "rattler_redaction/rustls-tls"]
+rustls = ["rattler_networking/rustls", "rattler_redaction/rustls"]
 reqwest = [
   "dep:reqwest-middleware",
   "dep:reqwest",

--- a/crates/rattler_redaction/Cargo.toml
+++ b/crates/rattler_redaction/Cargo.toml
@@ -11,9 +11,9 @@ license.workspace = true
 readme.workspace = true
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls"]
+rustls = ["reqwest/rustls"]
 
 [dependencies]
 url = { workspace = true }

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -103,9 +103,9 @@ tracing-test = { workspace = true }
 url = { workspace = true }
 
 [features]
-default = ['rustls-tls']
+default = ['rustls']
 native-tls = ['reqwest/native-tls', 'rattler_networking/native-tls', 'rattler_cache/native-tls', 'rattler_redaction/native-tls']
-rustls-tls = ['reqwest/rustls', 'rattler_networking/rustls-tls', 'rattler_cache/rustls-tls', 'rattler_redaction/rustls-tls']
+rustls = ['reqwest/rustls', 'rattler_networking/rustls', 'rattler_cache/rustls', 'rattler_redaction/rustls']
 sparse = ["rattler_conda_types", "memmap2", "self_cell", "superslice", "itertools", "serde_json/raw_value"]
 gateway = ["sparse", "http", "http-cache-semantics", "parking_lot", "async-trait", "rattler_package_streaming"]
 

--- a/crates/rattler_s3/Cargo.toml
+++ b/crates/rattler_s3/Cargo.toml
@@ -10,12 +10,12 @@ edition.workspace = true
 readme.workspace = true
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 # Note: aws-smithy-http-client does not support native-tls, only rustls variants.
 # This feature is provided for API compatibility with other rattler crates but
 # will use rustls under the hood.
-native-tls = ["rustls-tls"]
-rustls-tls = ["aws-smithy-http-client/rustls-aws-lc"]
+native-tls = ["rustls"]
+rustls = ["aws-smithy-http-client/rustls-aws-lc"]
 
 [dependencies]
 clap = { workspace = true, optional = true }

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -14,11 +14,11 @@ license.workspace = true
 readme.workspace = true
 
 [features]
-default = ["rustls-tls", "s3", "sigstore-sign"]
-rustls-tls = [
+default = ["rustls", "s3", "sigstore-sign"]
+rustls = [
   "reqwest/rustls",
-  "rattler_networking/rustls-tls",
-  "rattler_package_streaming/rustls-tls",
+  "rattler_networking/rustls",
+  "rattler_package_streaming/rustls",
   "sigstore-sign?/rustls",
 ]
 native-tls = [

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -49,6 +49,7 @@ futures = { workspace = true }
 indicatif = { workspace = true }
 opendal = { workspace = true, optional = true, default-features = false, features = [
   "services-s3",
+  "reqwest-rustls-tls",
 ] }
 reqwest-retry = { workspace = true }
 tokio-util = { workspace = true, features = ["codec", "compat"] }

--- a/crates/rattler_upload/Cargo.toml
+++ b/crates/rattler_upload/Cargo.toml
@@ -20,6 +20,7 @@ rustls = [
   "rattler_networking/rustls",
   "rattler_package_streaming/rustls",
   "sigstore-sign?/rustls",
+  "opendal?/reqwest-rustls-tls",
 ]
 native-tls = [
   "reqwest/native-tls",
@@ -49,7 +50,6 @@ futures = { workspace = true }
 indicatif = { workspace = true }
 opendal = { workspace = true, optional = true, default-features = false, features = [
   "services-s3",
-  "reqwest-rustls-tls",
 ] }
 reqwest-retry = { workspace = true }
 tokio-util = { workspace = true, features = ["codec", "compat"] }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = ["reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls"]
+rustls = ["reqwest/rustls"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -10,14 +10,14 @@ name = "rattler"
 crate-type = ["cdylib"]
 
 [features]
-default = ["rustls-tls"]
+default = ["rustls"]
 native-tls = [
     "rattler_networking/native-tls",
     "rattler_repodata_gateway/native-tls",
 ]
-rustls-tls = [
-    "rattler_networking/rustls-tls",
-    "rattler_repodata_gateway/rustls-tls",
+rustls = [
+    "rattler_networking/rustls",
+    "rattler_repodata_gateway/rustls",
     "reqwest/rustls",
 ]
 vendored-openssl = ["openssl", "openssl/vendored"]

--- a/scripts/check-native-tls.sh
+++ b/scripts/check-native-tls.sh
@@ -14,7 +14,7 @@ FORBIDDEN_CRATE="rustls"
 # Features to exclude when testing (space-separated)
 # These features will NOT be enabled during the check
 # Note: Auto-generated features for optional deps (dep:X) are automatically excluded
-EXCLUDE_FEATURES="rustls-tls default s3 gcs"
+EXCLUDE_FEATURES="rustls default s3 gcs"
 
 # Packages to skip entirely (space-separated)
 # Use this for packages that are known to require the forbidden crate

--- a/scripts/check-native-tls.sh
+++ b/scripts/check-native-tls.sh
@@ -18,7 +18,7 @@ EXCLUDE_FEATURES="rustls default s3 gcs"
 
 # Packages to skip entirely (space-separated)
 # Use this for packages that are known to require the forbidden crate
-SKIP_PACKAGES="rattler_s3 rattler_index create-resolvo-snapshot"
+SKIP_PACKAGES="rattler_s3 create-resolvo-snapshot"
 
 # =============================================================================
 # Script logic - typically no changes needed below

--- a/scripts/check-native-tls.sh
+++ b/scripts/check-native-tls.sh
@@ -18,7 +18,7 @@ EXCLUDE_FEATURES="rustls default s3 gcs"
 
 # Packages to skip entirely (space-separated)
 # Use this for packages that are known to require the forbidden crate
-SKIP_PACKAGES="rattler_s3 create-resolvo-snapshot"
+SKIP_PACKAGES="rattler_s3 rattler_index create-resolvo-snapshot"
 
 # =============================================================================
 # Script logic - typically no changes needed below


### PR DESCRIPTION
### Description
I found a bunch more references to reqwest 0.12. Also renamed `rustls-tls` to match reqwest.

- Renames the `rustls-tls` feature to `rustls` across all workspace crates to match reqwest 0.13's feature naming. Inter-crate references and CI workflows updated accordingly.
- Bumps opendal `0.55.0` to `0.56.0` and enables `reqwest-rustls-tls` explicitly. opendal 0.56 internally uses reqwest 0.13 as a separate dependency, so cargo feature unification no longer propagates TLS from our crates; this caused S3 uploads to fail with `invalid URL, scheme is not http`. Also adds `layers-retry` since opendal 0.56 feature-gated its built-in layers.
- Drops openidconnect's bundled `reqwest` feature (which pins reqwest 0.12) and wraps the workspace's reqwest 0.13 client with `oauth2_reqwest::ReqwestClient`. The redundant `OidcNetwork` error variant collapses back into `Network`.

After this change, `cargo tree -i reqwest@0.12.28` reports no matches: the workspace builds on reqwest 0.13 only.

### How Has This Been Tested?

- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p rattler --no-default-features --features rustls,oauth,cli-tools`

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.