### PR TITLE
fix: avoid runtime import of typing_extensions in index module

### DIFF
--- a/py-rattler/rattler/index/index.py
+++ b/py-rattler/rattler/index/index.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 import os
-from typing import Any, Literal, Mapping, Optional, Sequence, Union
-from typing_extensions import TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, Mapping, Optional, Sequence, Union
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 from rattler.platform import Platform
 from rattler.rattler import py_index_fs, py_index_s3

--- a/py-rattler/rattler/index/index.py
+++ b/py-rattler/rattler/index/index.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 import os
+import sys
 from typing import TYPE_CHECKING, Any, Literal, Mapping, Optional, Sequence, Union
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
 
 from rattler.platform import Platform
 from rattler.rattler import py_index_fs, py_index_s3


### PR DESCRIPTION
Fixes an issue with importing `typing_extensions`.