### PR TITLE
feat: support conda-pypi channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5262,6 +5262,7 @@ dependencies = [
  "rmp-serde",
  "rstest",
  "serde",
+ "serde-untagged",
  "serde_bytes",
  "serde_json",
  "serde_with",

--- a/crates/rattler-bin/src/commands/client.rs
+++ b/crates/rattler-bin/src/commands/client.rs
@@ -4,10 +4,13 @@ use miette::{Context, IntoDiagnostic};
 use rattler_networking::{AuthenticationMiddleware, AuthenticationStorage};
 use reqwest::Client;
 
+pub const USER_AGENT: &str = concat!("rattler/", env!("CARGO_PKG_VERSION"));
+
 /// Creates an HTTP client with the middleware stack used by the CLI for remote fetches.
 pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
     let download_client = Client::builder()
         .no_gzip()
+        .user_agent(USER_AGENT)
         .build()
         .into_diagnostic()
         .context("failed to create HTTP client")?;

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -5,7 +5,6 @@ use std::{
     future::IntoFuture,
     path::PathBuf,
     str::FromStr,
-    sync::Arc,
     time::{Duration, Instant},
 };
 
@@ -22,15 +21,11 @@ use rattler_conda_types::{
     Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, Matches, PackageName,
     ParseMatchSpecOptions, Platform, PrefixRecord, RepoDataRecord, Version,
 };
-use rattler_networking::AuthenticationMiddleware;
-#[cfg(feature = "s3")]
-use rattler_networking::AuthenticationStorage;
 use rattler_repodata_gateway::{Gateway, RepoData, SourceConfig};
 use rattler_solve::{
     libsolv_c::{self},
     resolvo, SolverImpl, SolverTask,
 };
-use reqwest::Client;
 
 use crate::{exclude_newer::ExcludeNewer, global_multi_progress};
 
@@ -183,24 +178,7 @@ pub async fn create(opt: Opt) -> miette::Result<()> {
     // `repodata.json` that should be available from the corresponding Url. The
     // code below also displays a nice CLI progress-bar to give users some more
     // information about what is going on.
-    let download_client = Client::builder()
-        .no_gzip()
-        .build()
-        .expect("failed to create client");
-
-    let download_client = reqwest_middleware::ClientBuilder::new(download_client.clone())
-        .with_arc(Arc::new(
-            AuthenticationMiddleware::from_env_and_defaults().into_diagnostic()?,
-        ))
-        .with(rattler_networking::OciMiddleware::new(download_client));
-    #[cfg(feature = "s3")]
-    let download_client = download_client.with(rattler_networking::S3Middleware::new(
-        HashMap::new(),
-        AuthenticationStorage::from_env_and_defaults().into_diagnostic()?,
-    ));
-    #[cfg(feature = "gcs")]
-    let download_client = download_client.with(rattler_networking::GCSMiddleware::default());
-    let download_client = download_client.build();
+    let download_client = super::client::create_client_with_middleware()?;
 
     // Get the package names from the matchspecs so we can only load the package
     // records that we need.

--- a/crates/rattler-bin/src/commands/fetch_file.rs
+++ b/crates/rattler-bin/src/commands/fetch_file.rs
@@ -1,11 +1,8 @@
 use std::io::Write;
 use std::path::Path;
-use std::sync::Arc;
 
 use miette::{Context, IntoDiagnostic};
-use rattler_networking::{AuthenticationMiddleware, AuthenticationStorage};
 use rattler_package_streaming::reqwest::fetch::fetch_file_from_remote_url;
-use reqwest::Client;
 use url::Url;
 
 /// Read a file from inside a remote conda package.
@@ -23,20 +20,7 @@ pub struct Opt {
 pub async fn fetch_file(opt: Opt) -> miette::Result<()> {
     let Opt { url, path } = opt;
 
-    let download_client = Client::builder()
-        .no_gzip()
-        .build()
-        .into_diagnostic()
-        .context("failed to create HTTP client")?;
-
-    let authentication_storage =
-        AuthenticationStorage::from_env_and_defaults().into_diagnostic()?;
-
-    let client = reqwest_middleware::ClientBuilder::new(download_client)
-        .with_arc(Arc::new(AuthenticationMiddleware::from_auth_storage(
-            authentication_storage,
-        )))
-        .build();
+    let client = super::client::create_client_with_middleware()?;
 
     let target_path = Path::new(&path);
 

--- a/crates/rattler-bin/src/commands/inspect.rs
+++ b/crates/rattler-bin/src/commands/inspect.rs
@@ -1,10 +1,6 @@
-use std::sync::Arc;
-
 use miette::{Context, IntoDiagnostic};
 use rattler_conda_types::package::{IndexJson, PathsJson};
-use rattler_networking::{AuthenticationMiddleware, AuthenticationStorage};
 use rattler_package_streaming::reqwest::fetch::fetch_package_file_from_remote_url;
-use reqwest::Client;
 use url::Url;
 
 /// Inspect package metadata from a remote conda package.
@@ -16,20 +12,7 @@ pub struct Opt {
 }
 
 pub async fn inspect(opt: Opt) -> miette::Result<()> {
-    let download_client = Client::builder()
-        .no_gzip()
-        .build()
-        .into_diagnostic()
-        .context("failed to create HTTP client")?;
-
-    let authentication_storage =
-        AuthenticationStorage::from_env_and_defaults().into_diagnostic()?;
-
-    let client = reqwest_middleware::ClientBuilder::new(download_client.clone())
-        .with_arc(Arc::new(AuthenticationMiddleware::from_auth_storage(
-            authentication_storage,
-        )))
-        .build();
+    let client = super::client::create_client_with_middleware()?;
 
     let index_json: IndexJson = fetch_package_file_from_remote_url(client.clone(), opt.url.clone())
         .await

--- a/crates/rattler-bin/src/commands/search.rs
+++ b/crates/rattler-bin/src/commands/search.rs
@@ -1,14 +1,10 @@
-use std::{collections::HashMap, env, sync::Arc, time::Instant};
+use std::{collections::HashMap, env, time::Instant};
 
 use indicatif::{ProgressBar, ProgressStyle};
 use itertools::Itertools;
 use miette::{Context, IntoDiagnostic};
 use rattler_conda_types::{Channel, ChannelConfig, MatchSpec, ParseMatchSpecOptions, Platform};
-use rattler_networking::AuthenticationMiddleware;
-#[cfg(feature = "s3")]
-use rattler_networking::AuthenticationStorage;
 use rattler_repodata_gateway::{Gateway, RepoData, SourceConfig};
-use reqwest::Client;
 
 /// Search for packages in conda channels using glob or regex patterns.
 #[derive(Debug, clap::Parser)]
@@ -80,24 +76,7 @@ pub async fn search(opt: Opt) -> miette::Result<()> {
     );
 
     // Create HTTP client
-    let download_client = Client::builder()
-        .no_gzip()
-        .build()
-        .expect("failed to create client");
-
-    let download_client = reqwest_middleware::ClientBuilder::new(download_client.clone())
-        .with_arc(Arc::new(
-            AuthenticationMiddleware::from_env_and_defaults().into_diagnostic()?,
-        ))
-        .with(rattler_networking::OciMiddleware::new(download_client));
-    #[cfg(feature = "s3")]
-    let download_client = download_client.with(rattler_networking::S3Middleware::new(
-        HashMap::new(),
-        AuthenticationStorage::from_env_and_defaults().into_diagnostic()?,
-    ));
-    #[cfg(feature = "gcs")]
-    let download_client = download_client.with(rattler_networking::GCSMiddleware::default());
-    let download_client = download_client.build();
+    let download_client = super::client::create_client_with_middleware()?;
 
     // Create gateway
     let gateway = Gateway::builder()

--- a/crates/rattler_digest/Cargo.toml
+++ b/crates/rattler_digest/Cargo.toml
@@ -17,6 +17,7 @@ hex = { workspace = true }
 md-5 = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_bytes = { workspace = true }
+serde-untagged = { workspace = true, optional = true }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = ["io-util"], optional = true }
@@ -25,7 +26,7 @@ generic-array = { workspace = true, optional = true }
 
 [features]
 tokio = ["dep:tokio"]
-serde = ["dep:serde", "generic-array/serde"]
+serde = ["dep:serde", "dep:serde-untagged", "generic-array/serde"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/rattler_digest/src/serde.rs
+++ b/crates/rattler_digest/src/serde.rs
@@ -11,34 +11,46 @@ use digest::{Digest, Output, OutputSizeUser};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{DeserializeAs, SerializeAs};
-use std::borrow::Cow;
 use std::fmt::LowerHex;
 use std::ops::Deref;
 
 /// Deserialize the [`Output`] of a [`Digest`].
 ///
-/// If the deserializer is human-readable, it will parse the digest from a hex
-/// string. Otherwise, it will deserialize raw bytes.
+/// Accepts either a hex-encoded string (for human-readable formats like JSON)
+/// or raw bytes (for binary formats like MessagePack). The format is detected
+/// per-value rather than by branching on `deserializer.is_human_readable()`,
+/// because serde's internal `Content` deserializer (used for
+/// `#[serde(flatten)]` and friends) hardcodes `is_human_readable() == true`
+/// regardless of the underlying format, so a flattened digest field reached
+/// via a binary deserializer would otherwise be asked for a hex string.
 pub fn deserialize<'de, D, Dig: Digest>(deserializer: D) -> Result<Output<Dig>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    if deserializer.is_human_readable() {
-        let str = Cow::<'de, str>::deserialize(deserializer)?;
-        super::parse_digest_from_hex::<Dig>(str.as_ref())
-            .ok_or_else(|| Error::custom("failed to parse digest"))
-    } else {
-        let bytes = Cow::<'de, [u8]>::deserialize(deserializer)?;
-        let len = <Dig as OutputSizeUser>::output_size();
-        if bytes.len() != len {
-            return Err(Error::custom(format!(
-                "invalid length, expected {}, got {}",
-                len,
+    let expected_len = <Dig as OutputSizeUser>::output_size();
+    let check_len = |bytes: &[u8]| -> Result<Output<Dig>, String> {
+        if bytes.len() == expected_len {
+            Ok(Output::<Dig>::clone_from_slice(bytes))
+        } else {
+            Err(format!(
+                "invalid length, expected {expected_len}, got {}",
                 bytes.len()
-            )));
+            ))
         }
-        Ok(Output::<Dig>::clone_from_slice(&bytes))
-    }
+    };
+
+    serde_untagged::UntaggedEnumVisitor::new()
+        .expecting("a hex-encoded digest string or raw digest bytes")
+        .string(|s| {
+            super::parse_digest_from_hex::<Dig>(s)
+                .ok_or_else(|| Error::custom("failed to parse digest"))
+        })
+        .bytes(|b| check_len(b).map_err(Error::custom))
+        .seq(|seq| {
+            let bytes: Vec<u8> = seq.deserialize()?;
+            check_len(&bytes).map_err(Error::custom)
+        })
+        .deserialize(deserializer)
 }
 
 /// Serializes the [`Output`] of a [`Digest`].
@@ -246,6 +258,43 @@ mod test {
         let deserialized_array: SerializableHash<sha2::Sha256> =
             rmp_serde::from_slice(&msgpack_array).unwrap();
         assert_eq!(&expected_hash.0, &deserialized_array.0);
+    }
+
+    #[test]
+    pub fn test_deserialize_messagepack_under_flatten() {
+        // Regression test: when SerializableHash is inside a struct that uses
+        // `#[serde(flatten)]`, serde buffers fields through its internal Content
+        // representation. That Content deserializer hardcodes
+        // `is_human_readable() == true`, which previously broke the bin/hex
+        // dispatch and surfaced as "byte array, expected a string" for shards
+        // produced for conda-pypi-style channels.
+        use serde::{Deserialize, Serialize};
+
+        #[serde_with::serde_as]
+        #[derive(Deserialize, Serialize)]
+        struct Inner {
+            #[serde_as(as = "SerializableHash::<sha2::Sha256>")]
+            sha256: sha2::digest::Output<sha2::Sha256>,
+        }
+
+        #[derive(Deserialize, Serialize)]
+        struct Outer {
+            #[serde(flatten)]
+            inner: Inner,
+            extra: String,
+        }
+
+        let expected = crate::parse_digest_from_hex::<sha2::Sha256>(
+            "fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726",
+        )
+        .unwrap();
+        let outer = Outer {
+            inner: Inner { sha256: expected },
+            extra: "hi".into(),
+        };
+        let bytes = rmp_serde::to_vec(&outer).unwrap();
+        let parsed: Outer = rmp_serde::from_slice(&bytes).unwrap();
+        assert_eq!(parsed.inner.sha256, expected);
     }
 
     #[test]


### PR DESCRIPTION
### Description

Two fixes needed to consume the `conda-pypi` sharded channel from `rattler`:

1. **`rattler_digest`**: `SerializableHash::deserialize` no longer branches on `Deserializer::is_human_readable()` to pick hex vs raw bytes. Under `#[serde(flatten)]` serde buffers fields through its internal `Content` deserializer, which hardcodes `is_human_readable() == true`. The `WhlPackageRecord` in sharded `v3.whl` shards uses `flatten`, so the embedded `md5` / `sha256` were being asked for a hex string while the wire format actually carried raw `bin` bytes, surfacing as `invalid value: byte array, expected a string`. Replaced with a `serde-untagged` `UntaggedEnumVisitor` that accepts hex string, raw bytes, or byte array per value.
2. **`rattler-bin`**: every CLI client now sends `User-Agent: rattler/<version>` and routes through a single `create_client_with_middleware()` helper. Channels behind Cloudflare/WAFs (including `conda-pypi`) reject the empty UA that `reqwest` defaults to with a 403.

### How Has This Been Tested?

- New `rattler_digest` regression test `test_deserialize_messagepack_under_flatten` covers the `SerializableHash`-inside-`#[serde(flatten)]` round-trip.
- Manual: `cargo run --bin rattler -- create --dry-run -c conda-pypi black` now reaches the solver (`Loaded 506099 records`); previously failed at repodata parse.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
