### PR TITLE
fix: render condition as defined in the CEP

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/condition.rs
+++ b/crates/rattler_conda_types/src/match_spec/condition.rs
@@ -25,7 +25,7 @@ pub enum MatchSpecCondition {
 impl Display for MatchSpecCondition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            MatchSpecCondition::MatchSpec(ms) => write!(f, "{ms}"),
+            MatchSpecCondition::MatchSpec(ms) => ms.fmt_in_condition(f),
             MatchSpecCondition::And(lhs, rhs) => write!(f, "({lhs} and {rhs})"),
             MatchSpecCondition::Or(lhs, rhs) => write!(f, "({lhs} or {rhs})"),
         }

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -275,18 +275,6 @@ impl MatchSpec {
             "MatchSpec inside a `when=` condition must not itself carry a `when` clause",
         );
 
-        if let Some(channel) = &self.channel {
-            write!(f, "{}", channel.name())?;
-            if let Some(subdir) = &self.subdir {
-                write!(f, "/{subdir}")?;
-            }
-        }
-        if let Some(namespace) = &self.namespace {
-            write!(f, ":{namespace}:")?;
-        } else if self.channel.is_some() || self.subdir.is_some() {
-            write!(f, "::")?;
-        }
-
         write!(f, "{}", self.name)?;
 
         if self.is_simple_for_condition() {
@@ -314,6 +302,18 @@ impl MatchSpec {
 
         if let Some(build_number) = &self.build_number {
             keys.push(format!("build_number=\"{build_number}\""));
+        }
+
+        if let Some(channel) = &self.channel {
+            keys.push(format!("channel=\"{}\"", channel.name()));
+        }
+
+        if let Some(subdir) = &self.subdir {
+            keys.push(format!("subdir=\"{subdir}\""));
+        }
+
+        if let Some(namespace) = &self.namespace {
+            keys.push(format!("namespace=\"{namespace}\""));
         }
 
         if let Some(extras) = &self.extras {

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -262,6 +262,143 @@ impl Display for MatchSpec {
 }
 
 impl MatchSpec {
+    /// Renders this match spec for inclusion inside a `when=` condition value.
+    ///
+    /// Uses the compact `{name}{operator}{version}` form when this is a simple
+    /// name+version query (and the version's rendering starts with one of the
+    /// version-constraint operator characters). Otherwise emits all constraints
+    /// using the bracket syntax `name[key="value", ...]`. Never emits a `when=`
+    /// key — nested conditions are not allowed.
+    pub(crate) fn fmt_in_condition(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        debug_assert!(
+            self.condition.is_none(),
+            "MatchSpec inside a `when=` condition must not itself carry a `when` clause",
+        );
+
+        if let Some(channel) = &self.channel {
+            write!(f, "{}", channel.name())?;
+            if let Some(subdir) = &self.subdir {
+                write!(f, "/{subdir}")?;
+            }
+        }
+        if let Some(namespace) = &self.namespace {
+            write!(f, ":{namespace}:")?;
+        } else if self.channel.is_some() || self.subdir.is_some() {
+            write!(f, "::")?;
+        }
+
+        write!(f, "{}", self.name)?;
+
+        if self.is_simple_for_condition() {
+            if let Some(version) = &self.version {
+                write!(f, "{version}")?;
+            }
+            return Ok(());
+        }
+
+        let mut keys = Vec::new();
+
+        if let Some(version) = &self.version {
+            keys.push(format!(
+                "version=\"{}\"",
+                escape_bracket_value(&version.to_string())
+            ));
+        }
+
+        if let Some(build) = &self.build {
+            keys.push(format!(
+                "build=\"{}\"",
+                escape_bracket_value(&build.to_string())
+            ));
+        }
+
+        if let Some(build_number) = &self.build_number {
+            keys.push(format!("build_number=\"{build_number}\""));
+        }
+
+        if let Some(extras) = &self.extras {
+            keys.push(format!("extras=[{}]", extras.iter().format(", ")));
+        }
+
+        if let Some(flags) = &self.flags {
+            keys.push(format!("flags=[{}]", flags.iter().format(", ")));
+        }
+
+        if let Some(md5) = &self.md5 {
+            keys.push(format!("md5=\"{md5:x}\""));
+        }
+
+        if let Some(sha256) = &self.sha256 {
+            keys.push(format!("sha256=\"{sha256:x}\""));
+        }
+
+        if let Some(file_name) = &self.file_name {
+            keys.push(format!("fn=\"{file_name}\""));
+        }
+
+        if let Some(url) = &self.url {
+            keys.push(format!("url=\"{url}\""));
+        }
+
+        if let Some(license) = &self.license {
+            keys.push(format!("license=\"{license}\""));
+        }
+
+        if let Some(license_family) = &self.license_family {
+            keys.push(format!("license_family=\"{license_family}\""));
+        }
+
+        if let Some(track_features) = &self.track_features {
+            keys.push(format!(
+                "track_features=\"{}\"",
+                track_features.iter().format(" ")
+            ));
+        }
+
+        if !keys.is_empty() {
+            write!(f, "[{}]", keys.join(", "))?;
+        }
+
+        Ok(())
+    }
+
+    /// Returns true if this match spec can be emitted as the compact
+    /// `{name}{operator}{version}` form inside a `when=` condition.
+    fn is_simple_for_condition(&self) -> bool {
+        if !matches!(self.name, PackageNameMatcher::Exact(_)) {
+            return false;
+        }
+        if self.build.is_some()
+            || self.build_number.is_some()
+            || self.file_name.is_some()
+            || self.extras.is_some()
+            || self.flags.is_some()
+            || self.channel.is_some()
+            || self.subdir.is_some()
+            || self.namespace.is_some()
+            || self.md5.is_some()
+            || self.sha256.is_some()
+            || self.url.is_some()
+            || self.license.is_some()
+            || self.license_family.is_some()
+            || self.track_features.is_some()
+        {
+            return false;
+        }
+        match &self.version {
+            None => true,
+            // The compact form requires the rendered version to start with a
+            // version-constraint operator character so the parser can split
+            // `{name}` from `{version}`. This excludes e.g. `StartsWith`
+            // (renders `1.2.*`) and the wildcard `Any` (`*`).
+            Some(v) => v
+                .to_string()
+                .chars()
+                .next()
+                .is_some_and(|c| matches!(c, '>' | '<' | '=' | '!' | '~')),
+        }
+    }
+
     /// Returns the repodata revision required to represent this matchspec.
     pub fn required_repodata_revision(&self) -> RepodataRevision {
         if self.extras.is_some() || self.condition.is_some() || self.flags.is_some() {

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -2110,6 +2110,73 @@ mod tests {
     }
 
     #[test]
+    fn test_conditional_render_bracket_form_with_build() {
+        // A leaf with a build constraint cannot use the compact `name op version`
+        // form, so the renderer falls back to the bracket syntax.
+        let spec = parse_conditional(r#"foo[when="python >=3.8[build=\"py39*\"]"]"#).unwrap();
+        let condition = spec.condition.as_ref().unwrap().to_string();
+        assert_eq!(condition, r#"python[version=">=3.8", build="py39*"]"#);
+
+        // Round-trip: the rendered MatchSpec parses back to the same value.
+        let reparsed = parse_conditional(&spec.to_string()).unwrap();
+        assert_eq!(spec, reparsed);
+    }
+
+    #[test]
+    fn test_conditional_render_bracket_form_startswith_version() {
+        // Bare `3.9.*` parses to StrictRange(StartsWith, ...) which renders as
+        // `3.9.*` — no leading operator char. The compact form `python3.9.*`
+        // would not parse back, so we must fall back to the bracket form.
+        let spec = parse_conditional(r#"foo[when="python 3.9.*"]"#).unwrap();
+        let condition = spec.condition.as_ref().unwrap().to_string();
+        assert_eq!(condition, r#"python[version="3.9.*"]"#);
+
+        let reparsed = parse_conditional(&spec.to_string()).unwrap();
+        assert_eq!(spec, reparsed);
+    }
+
+    #[test]
+    fn test_conditional_render_bracket_form_extra_keys() {
+        // Each non-version bracket key forces the bracket form. Round-trip
+        // every supported key to keep `fmt_in_condition` aligned with the
+        // parser's accepted set.
+        let cases = [
+            r#"foo[when="python[md5=\"8b1a9953c4611296a827abf8c47804d7\"]"]"#,
+            r#"foo[when="python[sha256=\"315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3\"]"]"#,
+            r#"foo[when="python >=3.8[build_number=\">=6\"]"]"#,
+            r#"foo[when="python[fn=\"python-3.9-0.tar.bz2\"]"]"#,
+            r#"foo[when="python[license=\"MIT\"]"]"#,
+            r#"foo[when="python[license_family=\"MIT\"]"]"#,
+            r#"foo[when="python[track_features=\"feat1 feat2\"]"]"#,
+        ];
+        for input in cases {
+            let spec = parse_conditional(input).expect(input);
+            let reparsed = parse_conditional(&spec.to_string()).expect(input);
+            assert_eq!(spec, reparsed, "round-trip failed for {input}");
+        }
+    }
+
+    #[test]
+    fn test_conditional_render_compound_with_bracket_leaf() {
+        // A compound expression where one leaf must use the bracket form.
+        // Confirms that inner double quotes get escaped at the outer
+        // `when="..."` boundary and the whole thing parses back.
+        let spec = parse_conditional(
+            r#"foo[when="(python >=3.8[build=\"py39*\"] and __linux) or __win"]"#,
+        )
+        .unwrap();
+        let condition = spec.condition.as_ref().unwrap().to_string();
+        assert_eq!(
+            condition,
+            r#"((python[version=">=3.8", build="py39*"] and __linux) or __win)"#
+        );
+
+        let rendered = spec.to_string();
+        let reparsed = parse_conditional(&rendered).unwrap();
+        assert_eq!(spec, reparsed);
+    }
+
+    #[test]
     fn test_nameless_match_spec_with_when() {
         // NamelessMatchSpec with when should work
         let spec = NamelessMatchSpec::from_str(

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -566,6 +566,7 @@ fn parse_bracket_vec_into_components(
                 }
             }
             "license_family" => match_spec.license_family = Some(value.to_string()),
+            "namespace" => match_spec.namespace = Some(value.to_string()),
             _ => Err(ParseMatchSpecError::InvalidBracketKey(key.to_owned()))?,
         }
     }
@@ -2154,6 +2155,25 @@ mod tests {
             let reparsed = parse_conditional(&spec.to_string()).expect(input);
             assert_eq!(spec, reparsed, "round-trip failed for {input}");
         }
+    }
+
+    #[test]
+    fn test_conditional_render_bracket_form_channel_subdir_namespace() {
+        // Channel, subdir, and namespace must be expressed via bracket keys
+        // inside a `when=` condition (no `channel/subdir:namespace:name`
+        // prefix), since the spec mandates pure square-bracket syntax.
+        let spec = parse_conditional(
+            r#"foo[when="python[channel=\"conda-forge\", subdir=\"linux-64\", namespace=\"py\"]"]"#,
+        )
+        .unwrap();
+        let condition = spec.condition.as_ref().unwrap().to_string();
+        assert_eq!(
+            condition,
+            r#"python[channel="conda-forge", subdir="linux-64", namespace="py"]"#
+        );
+
+        let reparsed = parse_conditional(&spec.to_string()).unwrap();
+        assert_eq!(spec, reparsed);
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -1829,7 +1829,7 @@ mod tests {
         assert_eq!(spec.name, "foo".parse().unwrap());
         assert_eq!(
             spec.condition.unwrap().to_string(),
-            "python >=3.6".to_string()
+            "python>=3.6".to_string()
         );
     }
 
@@ -1848,7 +1848,7 @@ mod tests {
         );
         assert_eq!(
             spec.condition.unwrap().to_string(),
-            "python >=3.10".to_string()
+            "python>=3.10".to_string()
         );
     }
 
@@ -1863,7 +1863,7 @@ mod tests {
         assert_eq!(spec.name, "foo".parse().unwrap());
         assert_eq!(
             spec.condition.unwrap().to_string(),
-            "python >=3.6".to_string()
+            "python>=3.6".to_string()
         );
     }
 
@@ -1881,7 +1881,7 @@ mod tests {
         let spec = parse_conditional(r#"foo[when="python >=3.6 and linux"]"#).unwrap();
         assert_eq!(
             spec.condition.unwrap().to_string(),
-            "(python >=3.6 and linux)"
+            "(python>=3.6 and linux)"
         );
     }
 
@@ -1899,13 +1899,13 @@ mod tests {
     fn test_conditional_parsing_complex_version() {
         // Complex version constraints in condition
         let spec = parse_conditional(r#"foo[when="python >=3.6,<4.0"]"#).unwrap();
-        assert_eq!(spec.condition.unwrap().to_string(), "python >=3.6,<4.0");
+        assert_eq!(spec.condition.unwrap().to_string(), "python>=3.6,<4.0");
 
         // Multiple conditions with or
         let spec = parse_conditional(r#"foo[when="python >=3.6 or python <3.0"]"#).unwrap();
         assert_eq!(
             spec.condition.unwrap().to_string(),
-            "(python >=3.6 or python <3.0)"
+            "(python>=3.6 or python<3.0)"
         );
     }
 
@@ -1961,7 +1961,7 @@ mod tests {
             spec.version,
             Some(VersionSpec::from_str(">=1.0", Strict).unwrap())
         );
-        assert_eq!(spec.condition.unwrap().to_string(), "python >=3.6");
+        assert_eq!(spec.condition.unwrap().to_string(), "python>=3.6");
         assert_eq!(spec.build.unwrap().to_string(), "py*");
     }
 
@@ -2084,7 +2084,7 @@ mod tests {
     fn test_conditional_package_name_with_and_or_substring() {
         // Package names containing "and"/"or" substrings should not be split
         let spec = parse_conditional(r#"foo[when="pandoc >=2.0"]"#).unwrap();
-        assert_eq!(spec.condition.unwrap().to_string(), "pandoc >=2.0");
+        assert_eq!(spec.condition.unwrap().to_string(), "pandoc>=2.0");
     }
 
     #[test]
@@ -2121,7 +2121,7 @@ mod tests {
             spec.version,
             Some(VersionSpec::from_str(">=1.0", Strict).unwrap())
         );
-        assert_eq!(spec.condition.unwrap().to_string(), "python >=3.6");
+        assert_eq!(spec.condition.unwrap().to_string(), "python>=3.6");
     }
 
     #[test]

--- a/py-rattler/tests/unit/test_matchspec.py
+++ b/py-rattler/tests/unit/test_matchspec.py
@@ -110,24 +110,24 @@ def test_experimental_extras_multiple() -> None:
 
 def test_experimental_conditionals_enabled() -> None:
     """Test that conditionals syntax can be parsed when experimental_conditionals is enabled."""
-    m = MatchSpec('requests[when="python >=3.6"]', experimental_conditionals=True)
+    m = MatchSpec('requests[when="python>=3.6"]', experimental_conditionals=True)
     assert m.name is not None
     assert m.name.normalized == "requests"
-    assert m.condition == "python >=3.6"
+    assert m.condition == "python>=3.6"
 
 
 def test_experimental_conditionals_disabled() -> None:
     """Test that conditionals are rejected when experimental_conditionals is disabled."""
     # When disabled, the when key should be rejected as invalid
     with pytest.raises(Exception):
-        MatchSpec('requests[when="python >=3.6"]', experimental_conditionals=False)
+        MatchSpec('requests[when="python>=3.6"]', experimental_conditionals=False)
 
 
 def test_experimental_conditionals_default() -> None:
     """Test that conditionals are rejected by default (experimental_conditionals defaults to False)."""
     # When disabled, the when key should be rejected as invalid
     with pytest.raises(Exception):
-        MatchSpec('requests[when="python >=3.6"]')
+        MatchSpec('requests[when="python>=3.6"]')
 
 
 def test_deprecated_if_syntax_returns_error() -> None:
@@ -141,11 +141,11 @@ def test_deprecated_if_syntax_returns_error() -> None:
 
 def test_experimental_both_features() -> None:
     """Test using both experimental extras and conditionals together."""
-    m = MatchSpec('numpy[extras=[test], when="python >=3.7"]', experimental_extras=True, experimental_conditionals=True)
+    m = MatchSpec('numpy[extras=[test], when="python>=3.7"]', experimental_extras=True, experimental_conditionals=True)
     assert m.name is not None
     assert m.name.normalized == "numpy"
     assert m.extras == ["test"]
-    assert m.condition == "python >=3.7"
+    assert m.condition == "python>=3.7"
 
 
 def test_nameless_experimental_extras() -> None:


### PR DESCRIPTION
### Description

As per the CEP, matchspecs in conditions need slightly adjusted rendering: 

- no spaces
- only `{name}{op}{version}` allowed
- otherwise, need to use bracket syntax

This PR adjusts the rendering and adds more tests. This is required by `pixi` and when producing valid repodata.

### How Has This Been Tested?

Added more tests.

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
