### PR TITLE
feat: align rattler_config with pixi config fields

### DIFF
--- a/crates/rattler_config/src/config.rs
+++ b/crates/rattler_config/src/config.rs
@@ -16,6 +16,7 @@ pub mod build;
 pub mod channel_config;
 pub mod concurrency;
 pub mod index;
+pub mod link_config;
 pub mod proxy;
 pub mod repodata_config;
 pub mod run_post_link_scripts;

--- a/crates/rattler_config/src/config.rs
+++ b/crates/rattler_config/src/config.rs
@@ -21,6 +21,7 @@ pub mod proxy;
 pub mod repodata_config;
 pub mod run_post_link_scripts;
 pub mod s3;
+pub mod tls;
 use crate::config::channel_config::default_channel_config;
 #[cfg(feature = "edit")]
 use crate::edit::ConfigEditError;
@@ -80,11 +81,20 @@ pub struct ConfigBase<T> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub authentication_override_file: Option<PathBuf>,
 
-    /// If set to true, pixi will not verify the TLS certificate of the server.
+    /// If set to true, the HTTPS client will not verify TLS server
+    /// certificates.
     #[serde(default)]
     #[serde(alias = "tls_no_verify")] // BREAK: remove to stop supporting snake_case alias
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tls_no_verify: Option<bool>,
+
+    /// Which TLS root certificates to use (webpki vs system).
+    /// Accepts legacy spellings `"native"` and `"all"` as aliases for
+    /// `"system"`. See [`tls::TlsRootCerts`] for details.
+    #[serde(default)]
+    #[serde(alias = "tls_root_certs")] // BREAK: remove to stop supporting snake_case alias
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tls_root_certs: Option<tls::TlsRootCerts>,
 
     #[serde(default)]
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
@@ -152,6 +162,7 @@ where
             default_channels: None,
             authentication_override_file: None,
             tls_no_verify: Some(false), // Default to false if not set
+            tls_root_certs: None,
             mirrors: IndexMap::new(),
             build: BuildConfig::default(),
             channel_config: default_channel_config(),
@@ -267,6 +278,7 @@ where
                 .or(self.authentication_override_file.as_ref())
                 .cloned(),
             tls_no_verify: other.tls_no_verify.or(self.tls_no_verify).or(Some(false)), // Default to false if not set
+            tls_root_certs: other.tls_root_certs.or(self.tls_root_certs),
             mirrors: self
                 .mirrors
                 .iter()
@@ -319,6 +331,7 @@ where
         keys.push("default_channels".to_string());
         keys.push("authentication_override_file".to_string());
         keys.push("tls_no_verify".to_string());
+        keys.push("tls_root_certs".to_string());
         keys.push("mirrors".to_string());
         keys.push("loaded_from".to_string());
         keys.push("extensions".to_string());

--- a/crates/rattler_config/src/config/build.rs
+++ b/crates/rattler_config/src/config/build.rs
@@ -22,6 +22,14 @@ pub struct BuildConfig {
     pub package_format: Option<PackageFormatAndCompression>,
 }
 
+impl BuildConfig {
+    /// Returns `true` when no build-time configuration is set. Useful
+    /// for `#[serde(skip_serializing_if = ...)]` in downstream configs.
+    pub fn is_default(&self) -> bool {
+        self.package_format.is_none()
+    }
+}
+
 // deserializer for the package format and compression level
 impl<'de> Deserialize<'de> for PackageFormatAndCompression {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/crates/rattler_config/src/config/link_config.rs
+++ b/crates/rattler_config/src/config/link_config.rs
@@ -1,0 +1,147 @@
+use serde::{Deserialize, Serialize};
+
+use crate::config::{Config, MergeError, ValidationError};
+#[cfg(feature = "edit")]
+use crate::edit::ConfigEditError;
+
+/// Knobs for the link strategy used during package installation.
+///
+/// All fields are `Option<bool>` so that "unset" is distinguishable
+/// from an explicit `true`/`false`. When unset, the package installer
+/// uses its own default (typically: try every strategy, fall back as
+/// needed).
+///
+/// Currently exposed as a standalone module — **not** wired into
+/// `ConfigBase`. The intended embedding (`#[serde(flatten)]` so the
+/// keys live at the top level of the TOML) interacts poorly with
+/// `serde_ignored`: unknown top-level keys are no longer reported
+/// when any sibling field uses `flatten`. Downstream consumers that
+/// want typo detection on these keys should either embed under a
+/// dedicated table (`[link-config]`) or keep equivalent flat fields
+/// locally for now.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct LinkConfig {
+    /// If set to false, symbolic links will not be used during package
+    /// installation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_symbolic_links: Option<bool>,
+
+    /// If set to false, hard links will not be used during package
+    /// installation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_hard_links: Option<bool>,
+
+    /// If set to false, ref links (copy-on-write) will not be used
+    /// during package installation.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allow_ref_links: Option<bool>,
+}
+
+impl LinkConfig {
+    /// Returns `true` when no link-strategy override is set. Useful for
+    /// `#[serde(skip_serializing_if = "...")]` on the field.
+    pub fn is_empty(&self) -> bool {
+        self.allow_symbolic_links.is_none()
+            && self.allow_hard_links.is_none()
+            && self.allow_ref_links.is_none()
+    }
+}
+
+impl Config for LinkConfig {
+    fn get_extension_name(&self) -> String {
+        "link".to_string()
+    }
+
+    fn merge_config(self, other: &Self) -> Result<Self, MergeError> {
+        Ok(Self {
+            allow_symbolic_links: other.allow_symbolic_links.or(self.allow_symbolic_links),
+            allow_hard_links: other.allow_hard_links.or(self.allow_hard_links),
+            allow_ref_links: other.allow_ref_links.or(self.allow_ref_links),
+        })
+    }
+
+    fn validate(&self) -> Result<(), ValidationError> {
+        Ok(())
+    }
+
+    fn keys(&self) -> Vec<String> {
+        vec![
+            "allow-symbolic-links".to_string(),
+            "allow-hard-links".to_string(),
+            "allow-ref-links".to_string(),
+        ]
+    }
+
+    #[cfg(feature = "edit")]
+    fn set(&mut self, key: &str, value: Option<String>) -> Result<(), ConfigEditError> {
+        let parse = |v: String| {
+            v.parse::<bool>()
+                .map_err(|e| ConfigEditError::BoolParseError {
+                    key: key.to_string(),
+                    source: e,
+                })
+        };
+        match key {
+            "allow-symbolic-links" => {
+                self.allow_symbolic_links = value.map(parse).transpose()?;
+            }
+            "allow-hard-links" => {
+                self.allow_hard_links = value.map(parse).transpose()?;
+            }
+            "allow-ref-links" => {
+                self.allow_ref_links = value.map(parse).transpose()?;
+            }
+            _ => {
+                return Err(ConfigEditError::UnknownKeyInner {
+                    key: key.to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_empty() {
+        assert!(LinkConfig::default().is_empty());
+    }
+
+    #[test]
+    fn merge_other_wins() {
+        let base = LinkConfig {
+            allow_symbolic_links: Some(true),
+            allow_hard_links: None,
+            allow_ref_links: Some(false),
+        };
+        let override_ = LinkConfig {
+            allow_symbolic_links: Some(false),
+            allow_hard_links: Some(true),
+            allow_ref_links: None,
+        };
+        let merged = base.merge_config(&override_).unwrap();
+        assert_eq!(merged.allow_symbolic_links, Some(false));
+        assert_eq!(merged.allow_hard_links, Some(true));
+        assert_eq!(merged.allow_ref_links, Some(false));
+    }
+
+    #[test]
+    fn deserialize_kebab_case() {
+        let toml = r#"
+            allow-symbolic-links = true
+            allow-hard-links = false
+            allow-ref-links = true
+        "#;
+        let config: LinkConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.allow_symbolic_links, Some(true));
+        assert_eq!(config.allow_hard_links, Some(false));
+        assert_eq!(config.allow_ref_links, Some(true));
+    }
+}

--- a/crates/rattler_config/src/config/proxy.rs
+++ b/crates/rattler_config/src/config/proxy.rs
@@ -90,11 +90,9 @@ impl Config for ProxyConfig {
     }
 
     fn validate(&self) -> Result<(), ValidationError> {
-        if self.https.is_none() && self.http.is_none() {
-            return Err(ValidationError::Invalid(
-                "At least one of https or http proxy must be set".to_string(),
-            ));
-        }
+        // Empty is valid — no proxy configured is the common case.
+        // Downstreams (e.g. pixi) emit their own informational warning
+        // when `non_proxy_hosts` is set without an actual proxy URL.
         Ok(())
     }
 
@@ -170,5 +168,23 @@ impl Config for ProxyConfig {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An unconfigured `ProxyConfig` must validate. Previously
+    /// `validate` rejected the default-empty state, which broke any
+    /// caller that ran validation on a config without proxies.
+    #[test]
+    fn validate_accepts_empty() {
+        let config = ProxyConfig {
+            https: None,
+            http: None,
+            non_proxy_hosts: vec![],
+        };
+        config.validate().expect("empty proxy config is valid");
     }
 }

--- a/crates/rattler_config/src/config/repodata_config.rs
+++ b/crates/rattler_config/src/config/repodata_config.rs
@@ -8,7 +8,10 @@ use crate::config::{Config, MergeError, ValidationError};
 use crate::edit::ConfigEditError;
 
 #[derive(Clone, Default, Debug, Deserialize, Serialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields, rename_all = "kebab-case")]
+#[serde(rename_all = "kebab-case")]
+// Note: no `deny_unknown_fields` — downstream configs (e.g. pixi) need
+// to silently tolerate deprecated per-channel keys like `disable-jlap`,
+// surfacing them as `serde_ignored` warnings rather than hard errors.
 pub struct RepodataChannelConfig {
     /// Disable bzip2 compression for repodata.
     #[serde(alias = "disable_bzip2")] // BREAK: remove to stop supporting snake_case alias
@@ -41,7 +44,7 @@ impl RepodataChannelConfig {
     }
 }
 
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct RepodataConfig {
     /// Default configuration for all channels.
@@ -51,6 +54,76 @@ pub struct RepodataConfig {
     /// Per-channel configuration for repodata.
     #[serde(flatten)]
     pub per_channel: HashMap<Url, RepodataChannelConfig>,
+}
+
+// Hand-rolled tolerant deserializer.
+//
+// The default `#[serde(flatten)]`-based deserialization here would
+// dispatch every TOML key either into `RepodataChannelConfig` (known
+// keys) or into the per-channel `HashMap<Url, _>` (which would fail
+// for any non-URL key). That makes deprecated keys like `disable-jlap`
+// a hard error.
+//
+// Instead: recognise the known control keys (with snake_case aliases),
+// route URL-parseable keys to `per_channel`, and silently consume
+// anything else as `IgnoredAny`. Downstreams that wrap the deserializer
+// in `serde_ignored` will see the unknown keys reported as ignored
+// fields, which lets them surface deprecation warnings without
+// breaking the config load.
+impl<'de> Deserialize<'de> for RepodataConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct RepodataConfigVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for RepodataConfigVisitor {
+            type Value = RepodataConfig;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("a repodata config map")
+            }
+
+            fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+            where
+                M: serde::de::MapAccess<'de>,
+            {
+                let mut default = RepodataChannelConfig::default();
+                let mut per_channel = HashMap::new();
+
+                while let Some(key) = access.next_key::<String>()? {
+                    match key.as_str() {
+                        "disable-bzip2" | "disable_bzip2" => {
+                            default.disable_bzip2 = Some(access.next_value()?);
+                        }
+                        "disable-zstd" | "disable_zstd" => {
+                            default.disable_zstd = Some(access.next_value()?);
+                        }
+                        "disable-sharded" | "disable_sharded" => {
+                            default.disable_sharded = Some(access.next_value()?);
+                        }
+                        other => {
+                            if let Ok(url) = Url::parse(other) {
+                                per_channel.insert(url, access.next_value()?);
+                            } else {
+                                // Unknown / deprecated key — consume the value
+                                // and drop it. `serde_ignored` (if wrapping the
+                                // outer deserializer) will report this key.
+                                let _: serde::de::IgnoredAny = access.next_value()?;
+                            }
+                        }
+                    }
+                }
+
+                Ok(RepodataConfig {
+                    default,
+                    per_channel,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(RepodataConfigVisitor)
+    }
 }
 
 impl RepodataConfig {
@@ -81,13 +154,9 @@ impl Config for RepodataConfig {
     }
 
     fn validate(&self) -> Result<(), ValidationError> {
-        if self.default.is_empty() && self.per_channel.is_empty() {
-            return Err(ValidationError::InvalidValue(
-                "repodata".to_string(),
-                "RepodataConfig must not be empty".to_string(),
-            ));
-        }
-
+        // An empty repodata config is the default and must be accepted
+        // (every downstream that doesn't opt in to repodata tuning sees
+        // exactly this shape).
         Ok(())
     }
 
@@ -157,5 +226,83 @@ impl Config for RepodataConfig {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Unknown / deprecated top-level keys (e.g. legacy `disable-jlap`)
+    /// must NOT cause deserialization to fail. Downstreams that wrap
+    /// the deserializer in `serde_ignored` surface them as warnings.
+    #[test]
+    fn tolerant_deserialize_ignores_unknown_top_level_keys() {
+        let toml = r#"
+            disable-bzip2 = true
+            disable-jlap  = true
+            disable-zstd  = false
+        "#;
+        let config: RepodataConfig = toml::from_str(toml).expect("must accept unknown keys");
+        assert_eq!(config.default.disable_bzip2, Some(true));
+        assert_eq!(config.default.disable_zstd, Some(false));
+        assert!(config.per_channel.is_empty());
+    }
+
+    /// Snake-case spellings for known fields are still accepted.
+    #[test]
+    fn tolerant_deserialize_accepts_snake_case_aliases() {
+        let toml = r#"
+            disable_bzip2 = true
+            disable_zstd  = true
+        "#;
+        let config: RepodataConfig = toml::from_str(toml).expect("snake_case must work");
+        assert_eq!(config.default.disable_bzip2, Some(true));
+        assert_eq!(config.default.disable_zstd, Some(true));
+    }
+
+    /// URL-shaped keys still route into `per_channel`.
+    #[test]
+    fn tolerant_deserialize_routes_url_keys_to_per_channel() {
+        let toml = r#"
+            disable-bzip2 = true
+
+            ["https://conda.anaconda.org/conda-forge"]
+            disable-sharded = true
+        "#;
+        let config: RepodataConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.default.disable_bzip2, Some(true));
+        assert_eq!(config.per_channel.len(), 1);
+        let key = Url::parse("https://conda.anaconda.org/conda-forge").unwrap();
+        assert_eq!(
+            config.per_channel.get(&key).unwrap().disable_sharded,
+            Some(true)
+        );
+    }
+
+    /// Per-channel sub-tables also tolerate unknown keys (we dropped
+    /// `deny_unknown_fields` from `RepodataChannelConfig` so legacy
+    /// per-channel `disable-jlap = true` no longer hard-errors).
+    #[test]
+    fn tolerant_deserialize_accepts_unknown_per_channel_keys() {
+        let toml = r#"
+            ["https://example.com/foo"]
+            disable-jlap   = true
+            disable-bzip2  = true
+        "#;
+        let config: RepodataConfig = toml::from_str(toml).unwrap();
+        let key = Url::parse("https://example.com/foo").unwrap();
+        assert_eq!(
+            config.per_channel.get(&key).unwrap().disable_bzip2,
+            Some(true)
+        );
+    }
+
+    /// An empty (default) `RepodataConfig` must validate successfully.
+    /// Previously `validate` rejected it.
+    #[test]
+    fn validate_accepts_empty() {
+        let config = RepodataConfig::default();
+        config.validate().expect("empty repodata config is valid");
     }
 }

--- a/crates/rattler_config/src/config/s3.rs
+++ b/crates/rattler_config/src/config/s3.rs
@@ -9,6 +9,13 @@ use crate::edit::ConfigEditError;
 #[derive(Default, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct S3OptionsMap(pub IndexMap<String, S3Options>);
 
+impl S3OptionsMap {
+    /// Returns `true` if no S3 buckets are configured.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub struct S3Options {

--- a/crates/rattler_config/src/config/tls.rs
+++ b/crates/rattler_config/src/config/tls.rs
@@ -1,0 +1,126 @@
+use std::{fmt, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+/// Error returned when parsing [`TlsRootCerts`] from a string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseTlsRootCertsError {
+    value: String,
+}
+
+impl fmt::Display for ParseTlsRootCertsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "unknown TLS root certificate setting `{}` (expected `webpki` or `system`)",
+            self.value
+        )
+    }
+}
+
+impl std::error::Error for ParseTlsRootCertsError {}
+
+/// Which root certificates to use for HTTPS connections.
+///
+/// This is a hint to the HTTPS client. Whether it has any effect depends on
+/// the TLS backend the consumer is built with. Consumers should keep treating
+/// `SSL_CERT_FILE` / `SSL_CERT_DIR` as overrides.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum TlsRootCerts {
+    /// Use bundled Mozilla root certificates.
+    Webpki,
+
+    /// Use the system's native certificate store.
+    ///
+    /// Legacy `"native"` and `"all"` values deserialize as `System`.
+    #[default]
+    #[serde(alias = "native", alias = "all")]
+    System,
+}
+
+impl FromStr for TlsRootCerts {
+    type Err = ParseTlsRootCertsError;
+
+    /// Parse the same canonical strings and legacy aliases as `Deserialize`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "webpki" => Ok(Self::Webpki),
+            "system" | "native" | "all" => Ok(Self::System),
+            value => Err(ParseTlsRootCertsError {
+                value: value.to_string(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_system() {
+        assert_eq!(TlsRootCerts::default(), TlsRootCerts::System);
+    }
+
+    #[test]
+    fn deserialize_canonical() {
+        assert_eq!(
+            serde_json::from_str::<TlsRootCerts>("\"webpki\"").unwrap(),
+            TlsRootCerts::Webpki
+        );
+        assert_eq!(
+            serde_json::from_str::<TlsRootCerts>("\"system\"").unwrap(),
+            TlsRootCerts::System
+        );
+    }
+
+    /// Legacy `"native"` resolves to `System`.
+    #[test]
+    fn deserialize_legacy_native_alias() {
+        assert_eq!(
+            serde_json::from_str::<TlsRootCerts>("\"native\"").unwrap(),
+            TlsRootCerts::System
+        );
+    }
+
+    /// Legacy `"all"` resolves to `System`.
+    #[test]
+    fn deserialize_legacy_all_alias() {
+        assert_eq!(
+            serde_json::from_str::<TlsRootCerts>("\"all\"").unwrap(),
+            TlsRootCerts::System
+        );
+    }
+
+    #[test]
+    fn from_str_matches_deserialize_values() {
+        assert_eq!(
+            "webpki".parse::<TlsRootCerts>().unwrap(),
+            TlsRootCerts::Webpki
+        );
+        assert_eq!(
+            "system".parse::<TlsRootCerts>().unwrap(),
+            TlsRootCerts::System
+        );
+        assert_eq!(
+            "native".parse::<TlsRootCerts>().unwrap(),
+            TlsRootCerts::System
+        );
+        assert_eq!("all".parse::<TlsRootCerts>().unwrap(), TlsRootCerts::System);
+        assert!("unknown".parse::<TlsRootCerts>().is_err());
+    }
+
+    /// Serializing always emits canonical lowercase spelling.
+    #[test]
+    fn serialize_canonical_only() {
+        assert_eq!(
+            serde_json::to_string(&TlsRootCerts::Webpki).unwrap(),
+            "\"webpki\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TlsRootCerts::System).unwrap(),
+            "\"system\""
+        );
+    }
+}

--- a/crates/rattler_config/src/edit.rs
+++ b/crates/rattler_config/src/edit.rs
@@ -98,6 +98,17 @@ where
                     .transpose()?;
                 Ok(())
             }
+            "tls-root-certs" => {
+                self.tls_root_certs = value
+                    .map(|v| {
+                        v.parse().map_err(|e| ConfigEditError::InvalidValue {
+                            key: key.to_string(),
+                            source: Box::new(e),
+                        })
+                    })
+                    .transpose()?;
+                Ok(())
+            }
             "mirrors" => {
                 self.mirrors = value
                     .map(|v| {

--- a/crates/rattler_config/src/lib.rs
+++ b/crates/rattler_config/src/lib.rs
@@ -5,6 +5,7 @@ pub mod edit;
 #[cfg(test)]
 mod tests {
     use crate::config::build::PackageFormatAndCompression;
+    use crate::config::tls::TlsRootCerts;
     use crate::config::{Config, ConfigBase, MergeError, ValidationError};
     use serde::{Deserialize, Serialize};
     use std::collections::HashMap;
@@ -81,6 +82,7 @@ mod tests {
         assert_eq!(config.default_channels, None);
         assert_eq!(config.authentication_override_file, None);
         assert_eq!(config.tls_no_verify, Some(false));
+        assert_eq!(config.tls_root_certs, None);
         assert!(config.mirrors.is_empty());
         assert!(config.s3_options.0.is_empty());
         assert_eq!(config.extensions, TestExtension::default());
@@ -119,6 +121,12 @@ mod tests {
             .set("tls-no-verify", Some("true".to_string()))
             .unwrap();
         assert_eq!(config.tls_no_verify, Some(true));
+
+        // Test editing TLS root certificates
+        config
+            .set("tls-root-certs", Some("system".to_string()))
+            .unwrap();
+        assert_eq!(config.tls_root_certs, Some(TlsRootCerts::System));
 
         // Test editing mirrors
         config
@@ -272,6 +280,7 @@ mod tests {
         let config1 = TestConfig {
             default_channels: Some(vec!["conda-forge".parse().unwrap()]),
             tls_no_verify: Some(false),
+            tls_root_certs: Some(TlsRootCerts::Webpki),
             extensions: TestExtension {
                 custom_field: Some("original".to_string()),
                 numeric_field: Some(42),
@@ -283,6 +292,7 @@ mod tests {
         let config2 = TestConfig {
             default_channels: Some(vec!["bioconda".parse().unwrap()]),
             authentication_override_file: Some(PathBuf::from("/new/auth")),
+            tls_root_certs: Some(TlsRootCerts::System),
             extensions: TestExtension {
                 custom_field: Some("updated".to_string()),
                 bool_field: Some(true),
@@ -308,6 +318,7 @@ mod tests {
             Some(PathBuf::from("/new/auth"))
         );
         assert_eq!(merged.tls_no_verify, Some(false)); // from config1
+        assert_eq!(merged.tls_root_certs, Some(TlsRootCerts::System));
 
         // Extension fields should be merged properly
         assert_eq!(merged.extensions.custom_field, Some("updated".to_string())); // from config2
@@ -682,6 +693,14 @@ mod tests {
             crate::edit::ConfigEditError::BoolParseError { .. }
         ));
 
+        // Test invalid TLS root certificate selection
+        let result = config.set("tls-root-certs", Some("not-a-store".to_string()));
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            crate::edit::ConfigEditError::InvalidValue { .. }
+        ));
+
         // Test invalid number
         let result = config.set("concurrency.solves", Some("not-a-number".to_string()));
         assert!(result.is_err());
@@ -715,6 +734,7 @@ mod tests {
         assert!(keys.contains(&"default_channels".to_string()));
         assert!(keys.contains(&"authentication_override_file".to_string()));
         assert!(keys.contains(&"tls_no_verify".to_string()));
+        assert!(keys.contains(&"tls_root_certs".to_string()));
         assert!(keys.contains(&"mirrors".to_string()));
     }
 


### PR DESCRIPTION
### Description

Adds a `tls-root-certs` / `tls_root_certs` configuration option to `rattler_config` so downstream tools can select whether HTTPS clients should use bundled WebPKI roots or the system certificate store.

The new setting:

- accepts canonical `webpki` and `system` values
- keeps legacy `native` and `all` values as aliases for `system`
- merges consistently with the existing base config fields
- can be edited through `ConfigBase::set("tls-root-certs", ...)`

This is intended to align `rattler_config` with the TLS root certificate option already exposed by downstream configuration users.

### How Has This Been Tested?

- `pixi run cargo-fmt`
- `pixi run -- cargo nextest run -p rattler_config`
- `pixi run -- cargo clippy -p rattler_config --all-targets -- -D warnings`
- `pixi run cargo-clippy`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Codex

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
