### PR TITLE
feat: only walk active extras when fetching repodata

### DIFF
--- a/crates/rattler_conda_types/src/package_name.rs
+++ b/crates/rattler_conda_types/src/package_name.rs
@@ -175,7 +175,12 @@ impl PackageName {
         let options = crate::ParseMatchSpecOptions::default().with_experimental_extras(true);
         match crate::MatchSpec::from_str(spec, options) {
             Ok(parsed) => (name, parsed.extras.unwrap_or_default()),
-            Err(_) => (name, Vec::new()),
+            Err(err) => {
+                // Failure mode is silent under-fetching of an extra's deps;
+                // log so it shows up under RUST_LOG=debug when investigating.
+                tracing::debug!("failed to parse matchspec '{spec}' for extras extraction: {err}",);
+                (name, Vec::new())
+            }
         }
     }
 }
@@ -561,6 +566,17 @@ mod test {
     // Malformed bracket section falls back to empty extras but still extracts name.
     #[case("numpy[", "numpy", &[])]
     #[case("foo[extras=[", "foo", &[])]
+    // Empty extras list is rejected by the parser; we fall back gracefully.
+    #[case("foo[extras=[]]", "foo", &[])]
+    // Trailing comma is rejected by the parser; we fall back gracefully.
+    #[case("foo[extras=[a,]]", "foo", &[])]
+    // Multiple bracket sections are rejected by the parser; extras silently
+    // dropped. Documented limitation, captured here so future changes notice.
+    #[case(
+        r#"aiohttp[extras=[a]] [build="py*"]"#,
+        "aiohttp",
+        &[],
+    )]
     fn test_name_and_extras_from_matchspec_str(
         #[case] spec: &str,
         #[case] expected_name: &str,

--- a/crates/rattler_conda_types/src/package_name.rs
+++ b/crates/rattler_conda_types/src/package_name.rs
@@ -137,6 +137,47 @@ impl PackageName {
             Cow::Borrowed(name)
         }
     }
+
+    /// Extracts the normalized package name and the optional features (extras)
+    /// from a matchspec string.
+    ///
+    /// When the spec contains no `[` bracket section, this is the fast path:
+    /// equivalent to [`Self::normalized_name_from_matchspec_str`] with no
+    /// allocation for the extras `Vec`.
+    ///
+    /// When brackets are present, the full matchspec is parsed (with
+    /// experimental extras enabled) to correctly distinguish extras from other
+    /// bracket keys like `build`, `version` or `when`. If parsing fails, the
+    /// name is still extracted with the cheap scan and the extras list is
+    /// empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rattler_conda_types::PackageName;
+    ///
+    /// let (name, extras) = PackageName::name_and_extras_from_matchspec_str("numpy >=1.0");
+    /// assert_eq!(name, "numpy");
+    /// assert!(extras.is_empty());
+    ///
+    /// let (name, extras) =
+    ///     PackageName::name_and_extras_from_matchspec_str("numpy[extras=[gpu, mkl]]");
+    /// assert_eq!(name, "numpy");
+    /// assert_eq!(extras, vec!["gpu".to_string(), "mkl".to_string()]);
+    /// ```
+    pub fn name_and_extras_from_matchspec_str(spec: &str) -> (Cow<'_, str>, Vec<String>) {
+        if !spec.contains('[') {
+            return (Self::normalized_name_from_matchspec_str(spec), Vec::new());
+        }
+
+        let name = Self::normalized_name_from_matchspec_str(spec);
+
+        let options = crate::ParseMatchSpecOptions::default().with_experimental_extras(true);
+        match crate::MatchSpec::from_str(spec, options) {
+            Ok(parsed) => (name, parsed.extras.unwrap_or_default()),
+            Err(_) => (name, Vec::new()),
+        }
+    }
 }
 
 /// Returns `true` if the byte is a matchspec delimiter (whitespace or version
@@ -489,5 +530,45 @@ mod test {
         let name = PackageName::normalized_name_from_matchspec_str(spec);
         assert_eq!(&*name, expected);
         assert_eq!(matches!(name, Cow::Borrowed(_)), is_borrowed);
+    }
+
+    #[rstest]
+    // No brackets: fast path, no extras.
+    #[case("numpy", "numpy", &[])]
+    #[case("numpy>=1.0", "numpy", &[])]
+    #[case("numpy >=1.0,<2.0", "numpy", &[])]
+    #[case("NumPy>=1.0", "numpy", &[])]
+    // Brackets but no extras key.
+    #[case(r#"numpy[build="py37*"]"#, "numpy", &[])]
+    #[case(r#"numpy[when="python >=3.6"]"#, "numpy", &[])]
+    #[case(r#"foo[version=">=1.0", build="py*"]"#, "foo", &[])]
+    // Extras present.
+    #[case("numpy[extras=[gpu]]", "numpy", &["gpu"])]
+    #[case("numpy[extras=[gpu, mkl]]", "numpy", &["gpu", "mkl"])]
+    #[case("Numpy[extras=[GPU]]", "numpy", &["GPU"])]
+    // Extras combined with other bracket keys.
+    #[case(
+        r#"aiohttp[extras=[speedups], build="py*"]"#,
+        "aiohttp",
+        &["speedups"],
+    )]
+    // Extras combined with a version constraint outside the bracket.
+    #[case(
+        "aiohttp >=3.7.4 [extras=[speedups]]",
+        "aiohttp",
+        &["speedups"],
+    )]
+    // Malformed bracket section falls back to empty extras but still extracts name.
+    #[case("numpy[", "numpy", &[])]
+    #[case("foo[extras=[", "foo", &[])]
+    fn test_name_and_extras_from_matchspec_str(
+        #[case] spec: &str,
+        #[case] expected_name: &str,
+        #[case] expected_extras: &[&str],
+    ) {
+        let (name, extras) = PackageName::name_and_extras_from_matchspec_str(spec);
+        assert_eq!(&*name, expected_name);
+        let expected: Vec<String> = expected_extras.iter().map(|s| (*s).to_string()).collect();
+        assert_eq!(extras, expected);
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/local_subdir.rs
@@ -7,7 +7,7 @@ use crate::{
     gateway::{
         GatewayError,
         error::SubdirNotFoundError,
-        subdir::{PackageRecords, SubdirClient, extract_unique_deps},
+        subdir::{PackageRecords, SubdirClient, extract_unique_deps_split},
     },
     sparse::{PackageFormatSelection, SparseRepoData},
 };
@@ -81,10 +81,11 @@ impl SubdirClient for LocalSubdirClient {
             .load_records(&name, PackageFormatSelection::PreferConda)
         {
             Ok(records) => {
-                let unique_deps = extract_unique_deps(&records);
+                let (unique_base_deps, unique_extra_deps) = extract_unique_deps_split(&records);
                 Ok(PackageRecords {
                     records: records.into_iter().map(Arc::new).collect(),
-                    unique_deps,
+                    unique_base_deps,
+                    unique_extra_deps,
                 })
             }
             Err(err) => Err(GatewayError::IoError(

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -1450,9 +1450,28 @@ mod test {
     }
 
     fn make_test_record(name: &str, version: &str, subdir: &str) -> RepoDataRecord {
+        make_test_record_full(name, version, subdir, &[], &[])
+    }
+
+    fn make_test_record_full(
+        name: &str,
+        version: &str,
+        subdir: &str,
+        depends: &[&str],
+        extra_depends: &[(&str, &[&str])],
+    ) -> RepoDataRecord {
         use rattler_conda_types::{
             PackageRecord, VersionWithSource, package::DistArchiveIdentifier,
         };
+
+        let mut experimental_extra_depends: std::collections::BTreeMap<String, Vec<String>> =
+            std::collections::BTreeMap::default();
+        for (extra, items) in extra_depends {
+            experimental_extra_depends.insert(
+                (*extra).to_string(),
+                items.iter().map(|s| (*s).to_string()).collect(),
+            );
+        }
 
         let package_record = PackageRecord {
             name: PackageName::from_str(name).unwrap(),
@@ -1465,7 +1484,7 @@ mod test {
             size: Some(1000),
             arch: None,
             platform: None,
-            depends: vec![],
+            depends: depends.iter().map(|s| (*s).to_string()).collect(),
             constrains: vec![],
             track_features: vec![],
             features: None,
@@ -1479,7 +1498,7 @@ mod test {
             purls: None,
             run_exports: None,
             python_site_packages_path: None,
-            experimental_extra_depends: std::collections::BTreeMap::default(),
+            experimental_extra_depends,
         };
 
         RepoDataRecord {
@@ -1892,6 +1911,193 @@ mod test {
                 .map(String::from)
                 .collect::<std::collections::BTreeSet<_>>(),
             "glob should find all lib-* packages across both sources and both subdirs"
+        );
+    }
+
+    /// Mock source that records every name it has been asked to fetch.
+    struct RecordingSource {
+        inner: MockRepoDataSource,
+        fetched: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    impl RecordingSource {
+        fn new() -> (Self, Arc<std::sync::Mutex<Vec<String>>>) {
+            let fetched = Arc::new(std::sync::Mutex::new(Vec::new()));
+            (
+                Self {
+                    inner: MockRepoDataSource::new(),
+                    fetched: fetched.clone(),
+                },
+                fetched,
+            )
+        }
+
+        fn add(&mut self, platform: Platform, rec: RepoDataRecord) {
+            self.inner.add_record(platform, rec);
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl super::RepoDataSource for RecordingSource {
+        async fn fetch_package_records(
+            &self,
+            platform: Platform,
+            name: &PackageName,
+        ) -> Result<Vec<Arc<RepoDataRecord>>, GatewayError> {
+            self.fetched
+                .lock()
+                .unwrap()
+                .push(name.as_normalized().to_string());
+            self.inner.fetch_package_records(platform, name).await
+        }
+
+        fn package_names(&self, platform: Platform) -> Vec<String> {
+            self.inner.package_names(platform)
+        }
+    }
+
+    /// `outer` depends on `black` (no extras). Black is reached via the
+    /// transitive walk; aiohttp lives in black's [d] extra. Since [d] was
+    /// never activated, aiohttp must not be fetched.
+    #[tokio::test]
+    async fn extras_skipped_when_inactive_transitive() {
+        let gateway = Gateway::new();
+        let (mut src, fetched) = RecordingSource::new();
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("outer", "1.0.0", "linux-64", &["black"], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "black",
+                "25.0.0",
+                "linux-64",
+                &["click >=8"],
+                &[("d", &["aiohttp >=3"])],
+            ),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("click", "8.0.0", "linux-64", &[], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("aiohttp", "3.0.0", "linux-64", &[], &[]),
+        );
+        let source: Arc<dyn super::RepoDataSource> = Arc::new(src);
+
+        gateway
+            .query(
+                vec![super::Source::Custom(source)],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("outer", Lenient).unwrap()].into_iter(),
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+
+        let names = fetched.lock().unwrap().clone();
+        assert!(names.contains(&"outer".to_string()));
+        assert!(names.contains(&"black".to_string()));
+        assert!(names.contains(&"click".to_string()));
+        assert!(
+            !names.contains(&"aiohttp".to_string()),
+            "aiohttp should not be fetched when black's [d] extra is inactive; got {names:?}",
+        );
+    }
+
+    /// A transitive package can introduce an extra on another package. Here
+    /// `helper` has a base dep `black[extras=[d]]`. Asking for `helper`
+    /// should pull both black and aiohttp.
+    #[tokio::test]
+    async fn extras_walk_followed_when_active_via_transitive() {
+        let gateway = Gateway::new();
+        let (mut src, fetched) = RecordingSource::new();
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("helper", "1.0.0", "linux-64", &["black[extras=[d]]"], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "black",
+                "25.0.0",
+                "linux-64",
+                &[],
+                &[("d", &["aiohttp >=3"])],
+            ),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("aiohttp", "3.0.0", "linux-64", &[], &[]),
+        );
+        let source: Arc<dyn super::RepoDataSource> = Arc::new(src);
+
+        gateway
+            .query(
+                vec![super::Source::Custom(source)],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("helper", Lenient).unwrap()].into_iter(),
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+
+        let names = fetched.lock().unwrap().clone();
+        assert!(names.contains(&"helper".to_string()));
+        assert!(names.contains(&"black".to_string()));
+        assert!(
+            names.contains(&"aiohttp".to_string()),
+            "aiohttp should be fetched via the transitive [d] activation; got {names:?}",
+        );
+    }
+
+    /// Black has two extras `d` and `jupyter`. A transitive activation of [d]
+    /// must fetch aiohttp but not ipython.
+    #[tokio::test]
+    async fn extras_walk_only_requested_extra_transitive() {
+        let gateway = Gateway::new();
+        let (mut src, fetched) = RecordingSource::new();
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("helper", "1.0.0", "linux-64", &["black[extras=[d]]"], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "black",
+                "25.0.0",
+                "linux-64",
+                &[],
+                &[("d", &["aiohttp >=3"]), ("jupyter", &["ipython >=8"])],
+            ),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("aiohttp", "3.0.0", "linux-64", &[], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("ipython", "8.0.0", "linux-64", &[], &[]),
+        );
+        let source: Arc<dyn super::RepoDataSource> = Arc::new(src);
+
+        gateway
+            .query(
+                vec![super::Source::Custom(source)],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("helper", Lenient).unwrap()].into_iter(),
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+
+        let names = fetched.lock().unwrap().clone();
+        assert!(names.contains(&"aiohttp".to_string()));
+        assert!(
+            !names.contains(&"ipython".to_string()),
+            "ipython must not be fetched when only [d] is active; got {names:?}",
         );
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -2168,6 +2168,177 @@ mod test {
         );
     }
 
+    fn extras_options() -> rattler_conda_types::ParseMatchSpecOptions {
+        rattler_conda_types::ParseMatchSpecOptions::default().with_experimental_extras(true)
+    }
+
+    /// User asks for `black` directly (Input). Black has extras `d` and
+    /// `jupyter`, neither requested. Neither aiohttp nor ipython must be
+    /// fetched.
+    #[tokio::test]
+    async fn extras_input_skipped_when_none_active() {
+        let gateway = Gateway::new();
+        let (mut src, fetched) = RecordingSource::new();
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "black",
+                "25.0.0",
+                "linux-64",
+                &["click >=8"],
+                &[("d", &["aiohttp >=3"]), ("jupyter", &["ipython >=8"])],
+            ),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("click", "8.0.0", "linux-64", &[], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("aiohttp", "3.0.0", "linux-64", &[], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("ipython", "8.0.0", "linux-64", &[], &[]),
+        );
+        let source: Arc<dyn super::RepoDataSource> = Arc::new(src);
+
+        gateway
+            .query(
+                vec![super::Source::Custom(source)],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("black", Lenient).unwrap()].into_iter(),
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+
+        let names = fetched.lock().unwrap().clone();
+        assert!(names.contains(&"black".to_string()));
+        assert!(names.contains(&"click".to_string()));
+        assert!(
+            !names.contains(&"aiohttp".to_string()),
+            "aiohttp must not be fetched when black has no active extras; got {names:?}",
+        );
+        assert!(
+            !names.contains(&"ipython".to_string()),
+            "ipython must not be fetched when black has no active extras; got {names:?}",
+        );
+    }
+
+    /// User asks for `black[extras=[d]]`. aiohttp must be fetched; the other
+    /// extra's deps must not.
+    #[tokio::test]
+    async fn extras_input_walks_only_requested() {
+        let gateway = Gateway::new();
+        let (mut src, fetched) = RecordingSource::new();
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "black",
+                "25.0.0",
+                "linux-64",
+                &[],
+                &[("d", &["aiohttp >=3"]), ("jupyter", &["ipython >=8"])],
+            ),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("aiohttp", "3.0.0", "linux-64", &[], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("ipython", "8.0.0", "linux-64", &[], &[]),
+        );
+        let source: Arc<dyn super::RepoDataSource> = Arc::new(src);
+
+        gateway
+            .query(
+                vec![super::Source::Custom(source)],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("black[extras=[d]]", extras_options()).unwrap()]
+                    .into_iter(),
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+
+        let names = fetched.lock().unwrap().clone();
+        assert!(names.contains(&"aiohttp".to_string()));
+        assert!(
+            !names.contains(&"ipython".to_string()),
+            "ipython must not be fetched when only [d] is active; got {names:?}",
+        );
+    }
+
+    /// User asks for `pkg >=2` (Input with version constraint). A transitive
+    /// dep later activates `pkg[extras=[d]]`. The extra's deps must only be
+    /// walked from records that match the original version constraint.
+    #[tokio::test]
+    async fn extras_input_late_activation_respects_spec_filter() {
+        let gateway = Gateway::new();
+        let (mut src, fetched) = RecordingSource::new();
+        // Two versions of pkg with different deps in the [d] extra.
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "pkg",
+                "1.0.0",
+                "linux-64",
+                &[],
+                &[("d", &["dep_for_v1 >=1"])],
+            ),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "pkg",
+                "2.0.0",
+                "linux-64",
+                &[],
+                &[("d", &["dep_for_v2 >=1"])],
+            ),
+        );
+        // Transitive activator: introduced via a separate top-level package.
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("activator", "1.0.0", "linux-64", &["pkg[extras=[d]]"], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("dep_for_v1", "1.0.0", "linux-64", &[], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("dep_for_v2", "1.0.0", "linux-64", &[], &[]),
+        );
+        let source: Arc<dyn super::RepoDataSource> = Arc::new(src);
+
+        gateway
+            .query(
+                vec![super::Source::Custom(source)],
+                vec![Platform::Linux64],
+                vec![
+                    MatchSpec::from_str("pkg >=2", Lenient).unwrap(),
+                    MatchSpec::from_str("activator", Lenient).unwrap(),
+                ]
+                .into_iter(),
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+
+        let names = fetched.lock().unwrap().clone();
+        assert!(
+            names.contains(&"dep_for_v2".to_string()),
+            "dep from matching pkg record must be fetched; got {names:?}",
+        );
+        assert!(
+            !names.contains(&"dep_for_v1".to_string()),
+            "dep from non-matching pkg record must not be fetched; got {names:?}",
+        );
+    }
+
     /// Black has two extras `d` and `jupyter`. A transitive activation of [d]
     /// must fetch aiohttp but not ipython.
     #[tokio::test]

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -2271,6 +2271,120 @@ mod test {
         );
     }
 
+    /// Pattern-expanded specs must still merge extras when another input spec
+    /// already queued the same exact package name.
+    #[tokio::test]
+    async fn extras_pattern_merges_with_existing_input() {
+        use rattler_conda_types::ParseMatchSpecOptions;
+
+        let gateway = Gateway::new();
+        let (mut src, fetched) = RecordingSource::new();
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "black",
+                "25.0.0",
+                "linux-64",
+                &["click >=8"],
+                &[("d", &["aiohttp >=3"])],
+            ),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("click", "8.0.0", "linux-64", &[], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("aiohttp", "3.0.0", "linux-64", &[], &[]),
+        );
+        let source: Arc<dyn super::RepoDataSource> = Arc::new(src);
+
+        let pattern = MatchSpec::from_str(
+            "bla*[extras=[d]]",
+            ParseMatchSpecOptions::strict()
+                .with_exact_names_only(false)
+                .with_experimental_extras(true),
+        )
+        .unwrap();
+
+        gateway
+            .query(
+                vec![super::Source::Custom(source)],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("black", Lenient).unwrap(), pattern].into_iter(),
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+
+        let names = fetched.lock().unwrap().clone();
+        assert!(
+            names.contains(&"aiohttp".to_string()),
+            "pattern extras should activate [d] even when black was already queued; got {names:?}",
+        );
+    }
+
+    /// Pattern-expanded specs should activate extras even when the pattern is
+    /// the only user input.
+    #[tokio::test]
+    async fn extras_pattern_only_walks_requested_extra() {
+        use rattler_conda_types::ParseMatchSpecOptions;
+
+        let gateway = Gateway::new();
+        let (mut src, fetched) = RecordingSource::new();
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "black",
+                "25.0.0",
+                "linux-64",
+                &["click >=8"],
+                &[("d", &["aiohttp >=3"]), ("jupyter", &["ipython >=8"])],
+            ),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("click", "8.0.0", "linux-64", &[], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("aiohttp", "3.0.0", "linux-64", &[], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("ipython", "8.0.0", "linux-64", &[], &[]),
+        );
+        let source: Arc<dyn super::RepoDataSource> = Arc::new(src);
+
+        let pattern = MatchSpec::from_str(
+            "bla*[extras=[d]]",
+            ParseMatchSpecOptions::strict()
+                .with_exact_names_only(false)
+                .with_experimental_extras(true),
+        )
+        .unwrap();
+
+        gateway
+            .query(
+                vec![super::Source::Custom(source)],
+                vec![Platform::Linux64],
+                vec![pattern].into_iter(),
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+
+        let names = fetched.lock().unwrap().clone();
+        assert!(
+            names.contains(&"aiohttp".to_string()),
+            "pattern extras should fetch deps from the requested [d] extra; got {names:?}",
+        );
+        assert!(
+            !names.contains(&"ipython".to_string()),
+            "pattern extras should not fetch inactive [jupyter] deps; got {names:?}",
+        );
+    }
+
     /// User asks for `pkg >=2` (Input with version constraint). A transitive
     /// dep later activates `pkg[extras=[d]]`. The extra's deps must only be
     /// walked from records that match the original version constraint.
@@ -2384,6 +2498,77 @@ mod test {
         assert!(
             !names.contains(&"ipython".to_string()),
             "ipython must not be fetched when only [d] is active; got {names:?}",
+        );
+    }
+
+    /// Late activation must walk cached records for a package across every
+    /// source/subdir that already returned records for that package.
+    #[tokio::test]
+    async fn extras_late_activation_walks_cached_records_across_sources() {
+        let gateway = Gateway::new();
+        let (mut source_a, fetched_a) = RecordingSource::new();
+        let (mut source_b, fetched_b) = RecordingSource::new();
+
+        source_a.add(
+            Platform::Linux64,
+            make_test_record_full("driver", "1.0.0", "linux-64", &["pkg", "activator"], &[]),
+        );
+        source_a.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "pkg",
+                "1.0.0",
+                "linux-64",
+                &[],
+                &[("d", &["dep_from_source_a >=1"])],
+            ),
+        );
+        source_a.add(
+            Platform::Linux64,
+            make_test_record_full("dep_from_source_a", "1.0.0", "linux-64", &[], &[]),
+        );
+
+        source_b.add(
+            Platform::Linux64,
+            make_test_record_full("activator", "1.0.0", "linux-64", &["pkg[extras=[d]]"], &[]),
+        );
+        source_b.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "pkg",
+                "2.0.0",
+                "linux-64",
+                &[],
+                &[("d", &["dep_from_source_b >=1"])],
+            ),
+        );
+        source_b.add(
+            Platform::Linux64,
+            make_test_record_full("dep_from_source_b", "1.0.0", "linux-64", &[], &[]),
+        );
+
+        gateway
+            .query(
+                vec![
+                    super::Source::Custom(Arc::new(source_a)),
+                    super::Source::Custom(Arc::new(source_b)),
+                ],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("driver", Lenient).unwrap()].into_iter(),
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+
+        let mut names = fetched_a.lock().unwrap().clone();
+        names.extend(fetched_b.lock().unwrap().clone());
+        assert!(
+            names.contains(&"dep_from_source_a".to_string()),
+            "late activation should walk cached pkg records from source A; got {names:?}",
+        );
+        assert!(
+            names.contains(&"dep_from_source_b".to_string()),
+            "late activation should walk cached pkg records from source B; got {names:?}",
         );
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -2053,6 +2053,121 @@ mod test {
         );
     }
 
+    /// `helper` depends on `aiohttp` (base) and on `tornado`, and `tornado`
+    /// in turn depends on `aiohttp[extras=[speedups]]`. The [speedups] extra
+    /// may activate after aiohttp's records have already arrived; when that
+    /// happens we must still walk it. `speedups_helper` is gated by the
+    /// speedups extra and must end up fetched.
+    #[tokio::test]
+    async fn extras_late_activation_walks_cached_records() {
+        let gateway = Gateway::new();
+        let (mut src, fetched) = RecordingSource::new();
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("helper", "1.0.0", "linux-64", &["aiohttp", "tornado"], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "aiohttp",
+                "3.0.0",
+                "linux-64",
+                &[],
+                &[("speedups", &["speedups_helper >=1"])],
+            ),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "tornado",
+                "6.0.0",
+                "linux-64",
+                &["aiohttp[extras=[speedups]]"],
+                &[],
+            ),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("speedups_helper", "1.0.0", "linux-64", &[], &[]),
+        );
+        let source: Arc<dyn super::RepoDataSource> = Arc::new(src);
+
+        gateway
+            .query(
+                vec![super::Source::Custom(source)],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("helper", Lenient).unwrap()].into_iter(),
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+
+        let names = fetched.lock().unwrap().clone();
+        assert!(names.contains(&"helper".to_string()));
+        assert!(names.contains(&"aiohttp".to_string()));
+        assert!(names.contains(&"tornado".to_string()));
+        assert!(
+            names.contains(&"speedups_helper".to_string()),
+            "late activation of aiohttp[speedups] should walk the extra's deps; got {names:?}",
+        );
+    }
+
+    /// `pkg[full]` activates `pkg[a]` and `pkg[b]`, both of which add their
+    /// own deps. Chained activation on the same package must terminate and
+    /// fetch all of the involved deps.
+    #[tokio::test]
+    async fn extras_chained_activation_same_package() {
+        let gateway = Gateway::new();
+        let (mut src, fetched) = RecordingSource::new();
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("driver", "1.0.0", "linux-64", &["pkg[extras=[full]]"], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full(
+                "pkg",
+                "1.0.0",
+                "linux-64",
+                &[],
+                &[
+                    ("full", &["pkg[extras=[a]]", "pkg[extras=[b]]"]),
+                    ("a", &["dep_a >=1"]),
+                    ("b", &["dep_b >=1"]),
+                ],
+            ),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("dep_a", "1.0.0", "linux-64", &[], &[]),
+        );
+        src.add(
+            Platform::Linux64,
+            make_test_record_full("dep_b", "1.0.0", "linux-64", &[], &[]),
+        );
+        let source: Arc<dyn super::RepoDataSource> = Arc::new(src);
+
+        gateway
+            .query(
+                vec![super::Source::Custom(source)],
+                vec![Platform::Linux64],
+                vec![MatchSpec::from_str("driver", Lenient).unwrap()].into_iter(),
+            )
+            .recursive(true)
+            .await
+            .unwrap();
+
+        let names = fetched.lock().unwrap().clone();
+        assert!(
+            names.contains(&"dep_a".to_string()),
+            "[full] should chain to [a]; got {names:?}",
+        );
+        assert!(
+            names.contains(&"dep_b".to_string()),
+            "[full] should chain to [b]; got {names:?}",
+        );
+    }
+
     /// Black has two extras `d` and `jupyter`. A transitive activation of [d]
     /// must fetch aiohttp but not ipython.
     #[tokio::test]

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -176,9 +176,6 @@ struct QueryExecutor {
     /// Records cached by name across subdirs. Used to re-walk a name's
     /// records when an extra activates after the first arrival.
     fetched: ahash::HashMap<PackageName, FetchedEntry>,
-    /// Per-name set of extras whose deps have already been queued. Used to
-    /// avoid re-walking an extra during late activation.
-    walked_extras: ahash::HashMap<PackageName, ahash::HashSet<String>>,
 
     // Subdir management
     subdir_handles: Vec<SubdirHandle>,
@@ -319,7 +316,6 @@ impl QueryExecutor {
             pending_package_specs,
             active_extras,
             fetched: ahash::HashMap::default(),
-            walked_extras: ahash::HashMap::default(),
             subdir_handles,
             pending_subdirs,
             pending_records: FuturesUnordered::new(),
@@ -414,31 +410,22 @@ impl QueryExecutor {
         }
     }
 
-    /// Extract dependencies from records and queue them if not seen. Base
-    /// deps are walked every arrival; `queue_dependency` dedupes by name so
-    /// re-walking is harmless. Extra deps are walked at most once per
-    /// (name, extra) pair so the late-walk path can pick up only newly
-    /// activated extras.
+    /// Extract dependencies from records and queue them if not seen.
+    /// `queue_dependency` dedupes by name so re-walking the same deps on
+    /// multi-subdir arrivals is harmless.
     fn queue_dependencies(&mut self, pkg: &PackageRecords, request: &PendingRequest) {
-        let to_walk_extras: Vec<String> = {
-            let active = self
-                .active_extras
-                .get(&request.name)
-                .cloned()
-                .unwrap_or_default();
-            let walked = self.walked_extras.entry(request.name.clone()).or_default();
-            active
-                .into_iter()
-                .filter(|e| walked.insert(e.clone()))
-                .collect()
-        };
+        let active: Vec<String> = self
+            .active_extras
+            .get(&request.name)
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default();
 
         match &request.specs {
             SourceSpecs::Transitive => {
                 for dep in pkg.unique_base_deps.iter() {
                     self.queue_dependency(dep);
                 }
-                for extra in &to_walk_extras {
+                for extra in &active {
                     if let Some(deps) = pkg.unique_extra_deps.get(extra) {
                         for dep in deps.iter() {
                             self.queue_dependency(dep);
@@ -447,8 +434,6 @@ impl QueryExecutor {
                 }
             }
             SourceSpecs::Input(specs) => {
-                // Input mode still walks every extra of matching records. A
-                // follow-up commit narrows this to the active set.
                 for record in &pkg.records {
                     if !specs.iter().any(|s| s.matches(record.as_ref())) {
                         continue;
@@ -456,10 +441,13 @@ impl QueryExecutor {
                     for dependency in &record.package_record.depends {
                         self.queue_dependency(dependency);
                     }
-                    for (_, dependencies) in record.package_record.experimental_extra_depends.iter()
-                    {
-                        for dependency in dependencies {
-                            self.queue_dependency(dependency);
+                    for extra in &active {
+                        if let Some(deps) =
+                            record.package_record.experimental_extra_depends.get(extra)
+                        {
+                            for dependency in deps {
+                                self.queue_dependency(dependency);
+                            }
                         }
                     }
                 }
@@ -470,38 +458,50 @@ impl QueryExecutor {
     /// Walk the deps of newly-active extras against records that have
     /// already been fetched for `name`. Called when [`Self::queue_dependency`]
     /// activates one or more extras for a name whose records have already
-    /// arrived. Input-mode names are skipped here; they are handled by a
-    /// follow-up commit.
+    /// arrived. For Input-mode names, only deps from records matching the
+    /// stored specs are walked.
     fn late_walk(&mut self, name: &PackageName, new_extras: &[String]) {
-        // Collect deps to walk so the borrow on `self.fetched` is released
-        // before we recurse into queue_dependency.
+        // Collect deps so the borrow on `self.fetched` is released before
+        // recursing into queue_dependency.
         let deps_to_walk: Vec<String> = {
             let Some(entry) = self.fetched.get(name) else {
                 return;
             };
-            if !matches!(entry.source, SourceSpecs::Transitive) {
-                return;
-            }
-            entry
-                .pkgs
-                .iter()
-                .flat_map(|pkg| {
-                    new_extras.iter().filter_map(move |ext| {
-                        pkg.unique_extra_deps
-                            .get(ext)
-                            .map(|deps| deps.iter().cloned())
+            match &entry.source {
+                SourceSpecs::Transitive => entry
+                    .pkgs
+                    .iter()
+                    .flat_map(|pkg| {
+                        new_extras.iter().filter_map(move |ext| {
+                            pkg.unique_extra_deps
+                                .get(ext)
+                                .map(|deps| deps.iter().cloned())
+                        })
                     })
-                })
-                .flatten()
-                .collect()
-        };
-
-        {
-            let walked = self.walked_extras.entry(name.clone()).or_default();
-            for ext in new_extras {
-                walked.insert(ext.clone());
+                    .flatten()
+                    .collect(),
+                SourceSpecs::Input(specs) => entry
+                    .pkgs
+                    .iter()
+                    .flat_map(|pkg| {
+                        pkg.records.iter().filter_map(move |record| {
+                            if !specs.iter().any(|s| s.matches(record.as_ref())) {
+                                return None;
+                            }
+                            Some(new_extras.iter().filter_map(move |ext| {
+                                record
+                                    .package_record
+                                    .experimental_extra_depends
+                                    .get(ext)
+                                    .map(|deps| deps.iter().cloned())
+                            }))
+                        })
+                    })
+                    .flatten()
+                    .flatten()
+                    .collect(),
             }
-        }
+        };
 
         for dep in &deps_to_walk {
             self.queue_dependency(dep);

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -60,13 +60,14 @@ enum SourceSpecs {
     Transitive,
 }
 
-/// A request to fetch records for a single package name, together with the
-/// extras that should be activated for that name. `extras` is informational
-/// for now; later increments use it to scope the dep walk.
+/// A request to fetch records for a single package name. The active extras
+/// set for the name lives on `QueryExecutor::active_extras`; this struct only
+/// carries the spec source and the name (so the executor can look extras up
+/// when records arrive).
 #[derive(Clone)]
 struct PendingRequest {
+    name: PackageName,
     specs: SourceSpecs,
-    extras: ahash::HashSet<String>,
 }
 
 /// A spec that references a package by direct URL.
@@ -224,15 +225,12 @@ impl QueryExecutor {
                             pending_package_specs
                                 .entry(name.clone())
                                 .or_insert_with(|| PendingRequest {
+                                    name: name.clone(),
                                     specs: SourceSpecs::Input(vec![]),
-                                    extras: ahash::HashSet::default(),
                                 });
                         let SourceSpecs::Input(input_specs) = &mut pending.specs else {
                             panic!("SourceSpecs::Input was overwritten by SourceSpecs::Transitive");
                         };
-                        if let Some(extras) = spec.extras.as_ref() {
-                            pending.extras.extend(extras.iter().cloned());
-                        }
                         input_specs.push(spec);
                     }
                     matcher @ (PackageNameMatcher::Glob(_) | PackageNameMatcher::Regex(_)) => {
@@ -344,16 +342,11 @@ impl QueryExecutor {
                 // Push the direct url in the first subdir result for channel priority logic
                 let (unique_base_deps, unique_extra_deps) =
                     super::subdir::extract_unique_deps_split(records.iter().map(|r| &**r));
-                let extras: ahash::HashSet<String> = spec
-                    .extras
-                    .as_ref()
-                    .map(|e| e.iter().cloned().collect())
-                    .unwrap_or_default();
                 Ok((
                     0,
                     PendingRequest {
+                        name: name.clone(),
                         specs: SourceSpecs::Input(vec![spec]),
-                        extras,
                     },
                     PackageRecords {
                         records,
@@ -404,22 +397,32 @@ impl QueryExecutor {
 
     /// Extract dependencies from records and queue them if not seen.
     fn queue_dependencies(&mut self, pkg: &PackageRecords, request: &PendingRequest) {
+        // Snapshot the set of active extras for this name so we walk only the
+        // deps the solver could actually pull in.
+        let active: Vec<String> = self
+            .active_extras
+            .get(&request.name)
+            .map(|set| set.iter().cloned().collect())
+            .unwrap_or_default();
+
         match &request.specs {
             SourceSpecs::Transitive => {
-                // Use precomputed unique deps. Walk base deps and every extra's
-                // deps; a later increment will restrict the extras walked to
-                // those actually active for this name.
+                // Use precomputed unique deps: base + only the active extras.
                 for dep in pkg.unique_base_deps.iter() {
                     self.queue_dependency(dep);
                 }
-                for deps in pkg.unique_extra_deps.values() {
-                    for dep in deps.iter() {
-                        self.queue_dependency(dep);
+                for extra in &active {
+                    if let Some(deps) = pkg.unique_extra_deps.get(extra) {
+                        for dep in deps.iter() {
+                            self.queue_dependency(dep);
+                        }
                     }
                 }
             }
             SourceSpecs::Input(specs) => {
                 // For input specs, only process deps from matching records.
+                // A later increment scopes the per-extra walk here as well; for
+                // now we still iterate every extra on matching records.
                 for record in &pkg.records {
                     if !specs.iter().any(|s| s.matches(record.as_ref())) {
                         continue;
@@ -443,18 +446,39 @@ impl QueryExecutor {
     /// Uses `entry_ref` for a single hash lookup. Only allocates when the
     /// name is genuinely new (~500 unique names vs ~1M+ dependency strings).
     fn queue_dependency(&mut self, dependency: &str) {
-        let normalized = PackageName::normalized_name_from_matchspec_str(dependency);
+        let (normalized, extras) = PackageName::name_and_extras_from_matchspec_str(dependency);
         let normalized_str: &str = &normalized;
-        if let hashbrown::hash_map::EntryRef::Vacant(entry) = self.seen.entry_ref(normalized_str) {
-            entry.insert(());
+        let is_new = matches!(
+            self.seen.entry_ref(normalized_str),
+            hashbrown::hash_map::EntryRef::Vacant(_)
+        );
+
+        if is_new {
+            self.seen.insert(normalized.to_string(), ());
             let dependency_name = PackageName::from_matchspec_str_unchecked(dependency);
+            if !extras.is_empty() {
+                self.active_extras
+                    .entry(dependency_name.clone())
+                    .or_default()
+                    .extend(extras);
+            }
             self.pending_package_specs.insert(
-                dependency_name,
+                dependency_name.clone(),
                 PendingRequest {
+                    name: dependency_name,
                     specs: SourceSpecs::Transitive,
-                    extras: ahash::HashSet::default(),
                 },
             );
+        } else if !extras.is_empty() {
+            // Name has been seen, but the dep may activate new extras. Merge
+            // into the active set so any pending fetch picks them up when its
+            // records arrive. Late activation against already-fetched records
+            // is handled by a later increment.
+            let dependency_name = PackageName::from_matchspec_str_unchecked(dependency);
+            self.active_extras
+                .entry(dependency_name)
+                .or_default()
+                .extend(extras);
         }
     }
 
@@ -518,14 +542,11 @@ impl QueryExecutor {
                             .pending_package_specs
                             .entry(name.clone())
                             .or_insert_with(|| PendingRequest {
+                                name: name.clone(),
                                 specs: SourceSpecs::Input(vec![]),
-                                extras: ahash::HashSet::default(),
                             });
                         if let SourceSpecs::Input(input_specs) = &mut pending.specs {
                             input_specs.push(spec.clone());
-                        }
-                        if let Some(extras) = spec.extras.as_ref() {
-                            pending.extras.extend(extras.iter().cloned());
                         }
                     }
                     break;

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -605,27 +605,22 @@ impl QueryExecutor {
 
             for (matcher, spec) in &self.pending_pattern_specs {
                 if matcher.matches(&name) {
-                    if self
-                        .seen
-                        .insert(name.as_normalized().to_string(), ())
-                        .is_none()
-                    {
-                        if let Some(extras) = spec.extras.as_ref() {
-                            self.active_extras
-                                .entry(name.clone())
-                                .or_default()
-                                .extend(extras.iter().cloned());
-                        }
-                        let pending = self
-                            .pending_package_specs
+                    self.seen.insert(name.as_normalized().to_string(), ());
+                    if let Some(extras) = spec.extras.as_ref() {
+                        self.active_extras
                             .entry(name.clone())
-                            .or_insert_with(|| PendingRequest {
-                                name: name.clone(),
-                                specs: SourceSpecs::Input(vec![]),
-                            });
-                        if let SourceSpecs::Input(input_specs) = &mut pending.specs {
-                            input_specs.push(spec.clone());
-                        }
+                            .or_default()
+                            .extend(extras.iter().cloned());
+                    }
+                    let pending = self
+                        .pending_package_specs
+                        .entry(name.clone())
+                        .or_insert_with(|| PendingRequest {
+                            name: name.clone(),
+                            specs: SourceSpecs::Input(vec![]),
+                        });
+                    if let SourceSpecs::Input(input_specs) = &mut pending.specs {
+                        input_specs.push(spec.clone());
                     }
                     break;
                 }

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -508,20 +508,24 @@ impl QueryExecutor {
         }
     }
 
-    /// Queue a single dependency if not already seen.
-    ///
-    /// Uses `entry_ref` for a single hash lookup. Only allocates when the
-    /// name is genuinely new (~500 unique names vs ~1M+ dependency strings).
+    /// Queue a single dependency if not already seen. Allocates the name
+    /// only when it is genuinely new (~500 unique names vs ~1M+ dependency
+    /// strings on a large query).
     fn queue_dependency(&mut self, dependency: &str) {
         let (normalized, extras) = PackageName::name_and_extras_from_matchspec_str(dependency);
         let normalized_str: &str = &normalized;
-        let is_new = matches!(
-            self.seen.entry_ref(normalized_str),
-            hashbrown::hash_map::EntryRef::Vacant(_)
-        );
+
+        // Single hash lookup via EntryRef: either insert for a new name, or
+        // observe and fall through to the merge-extras path for a known one.
+        let is_new = match self.seen.entry_ref(normalized_str) {
+            hashbrown::hash_map::EntryRef::Vacant(entry) => {
+                entry.insert(());
+                true
+            }
+            hashbrown::hash_map::EntryRef::Occupied(_) => false,
+        };
 
         if is_new {
-            self.seen.insert(normalized.to_string(), ());
             let dependency_name = PackageName::from_matchspec_str_unchecked(dependency);
             if !extras.is_empty() {
                 self.active_extras
@@ -537,9 +541,8 @@ impl QueryExecutor {
                 },
             );
         } else if !extras.is_empty() {
-            // Name has been seen. Merge any extras the dep activates into the
-            // active set; if records already arrived, walk the new extras
-            // against them.
+            // Merge any extras the dep activates into the active set; if
+            // records already arrived, walk the new extras against them.
             let dependency_name = PackageName::from_matchspec_str_unchecked(dependency);
             let newly_added: Vec<String> = {
                 let existing = self

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -70,6 +70,17 @@ struct PendingRequest {
     specs: SourceSpecs,
 }
 
+/// Records cached for a single package name across one or more subdirs.
+/// Used to re-walk extras whose activation happens after the first arrival
+/// of records for the name.
+struct FetchedEntry {
+    pkgs: Vec<PackageRecords>,
+    /// Spec source captured on first arrival. Used by the late-walk path so
+    /// Transitive and Input names follow the same filtering rules they did on
+    /// initial walk.
+    source: SourceSpecs,
+}
+
 /// A spec that references a package by direct URL.
 struct DirectUrlSpec {
     #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
@@ -162,6 +173,12 @@ struct QueryExecutor {
     /// Per-name set of extras that are currently active. Grows monotonically
     /// as new extras are discovered via top-level specs and dep parsing.
     active_extras: ahash::HashMap<PackageName, ahash::HashSet<String>>,
+    /// Records cached by name across subdirs. Used to re-walk a name's
+    /// records when an extra activates after the first arrival.
+    fetched: ahash::HashMap<PackageName, FetchedEntry>,
+    /// Per-name set of extras whose deps have already been queued. Used to
+    /// avoid re-walking an extra during late activation.
+    walked_extras: ahash::HashMap<PackageName, ahash::HashSet<String>>,
 
     // Subdir management
     subdir_handles: Vec<SubdirHandle>,
@@ -301,6 +318,8 @@ impl QueryExecutor {
             seen,
             pending_package_specs,
             active_extras,
+            fetched: ahash::HashMap::default(),
+            walked_extras: ahash::HashMap::default(),
             subdir_handles,
             pending_subdirs,
             pending_records: FuturesUnordered::new(),
@@ -395,23 +414,31 @@ impl QueryExecutor {
         }
     }
 
-    /// Extract dependencies from records and queue them if not seen.
+    /// Extract dependencies from records and queue them if not seen. Base
+    /// deps are walked every arrival; `queue_dependency` dedupes by name so
+    /// re-walking is harmless. Extra deps are walked at most once per
+    /// (name, extra) pair so the late-walk path can pick up only newly
+    /// activated extras.
     fn queue_dependencies(&mut self, pkg: &PackageRecords, request: &PendingRequest) {
-        // Snapshot the set of active extras for this name so we walk only the
-        // deps the solver could actually pull in.
-        let active: Vec<String> = self
-            .active_extras
-            .get(&request.name)
-            .map(|set| set.iter().cloned().collect())
-            .unwrap_or_default();
+        let to_walk_extras: Vec<String> = {
+            let active = self
+                .active_extras
+                .get(&request.name)
+                .cloned()
+                .unwrap_or_default();
+            let walked = self.walked_extras.entry(request.name.clone()).or_default();
+            active
+                .into_iter()
+                .filter(|e| walked.insert(e.clone()))
+                .collect()
+        };
 
         match &request.specs {
             SourceSpecs::Transitive => {
-                // Use precomputed unique deps: base + only the active extras.
                 for dep in pkg.unique_base_deps.iter() {
                     self.queue_dependency(dep);
                 }
-                for extra in &active {
+                for extra in &to_walk_extras {
                     if let Some(deps) = pkg.unique_extra_deps.get(extra) {
                         for dep in deps.iter() {
                             self.queue_dependency(dep);
@@ -420,9 +447,8 @@ impl QueryExecutor {
                 }
             }
             SourceSpecs::Input(specs) => {
-                // For input specs, only process deps from matching records.
-                // A later increment scopes the per-extra walk here as well; for
-                // now we still iterate every extra on matching records.
+                // Input mode still walks every extra of matching records. A
+                // follow-up commit narrows this to the active set.
                 for record in &pkg.records {
                     if !specs.iter().any(|s| s.matches(record.as_ref())) {
                         continue;
@@ -438,6 +464,47 @@ impl QueryExecutor {
                     }
                 }
             }
+        }
+    }
+
+    /// Walk the deps of newly-active extras against records that have
+    /// already been fetched for `name`. Called when [`Self::queue_dependency`]
+    /// activates one or more extras for a name whose records have already
+    /// arrived. Input-mode names are skipped here; they are handled by a
+    /// follow-up commit.
+    fn late_walk(&mut self, name: &PackageName, new_extras: &[String]) {
+        // Collect deps to walk so the borrow on `self.fetched` is released
+        // before we recurse into queue_dependency.
+        let deps_to_walk: Vec<String> = {
+            let Some(entry) = self.fetched.get(name) else {
+                return;
+            };
+            if !matches!(entry.source, SourceSpecs::Transitive) {
+                return;
+            }
+            entry
+                .pkgs
+                .iter()
+                .flat_map(|pkg| {
+                    new_extras.iter().filter_map(move |ext| {
+                        pkg.unique_extra_deps
+                            .get(ext)
+                            .map(|deps| deps.iter().cloned())
+                    })
+                })
+                .flatten()
+                .collect()
+        };
+
+        {
+            let walked = self.walked_extras.entry(name.clone()).or_default();
+            for ext in new_extras {
+                walked.insert(ext.clone());
+            }
+        }
+
+        for dep in &deps_to_walk {
+            self.queue_dependency(dep);
         }
     }
 
@@ -470,15 +537,23 @@ impl QueryExecutor {
                 },
             );
         } else if !extras.is_empty() {
-            // Name has been seen, but the dep may activate new extras. Merge
-            // into the active set so any pending fetch picks them up when its
-            // records arrive. Late activation against already-fetched records
-            // is handled by a later increment.
+            // Name has been seen. Merge any extras the dep activates into the
+            // active set; if records already arrived, walk the new extras
+            // against them.
             let dependency_name = PackageName::from_matchspec_str_unchecked(dependency);
-            self.active_extras
-                .entry(dependency_name)
-                .or_default()
-                .extend(extras);
+            let newly_added: Vec<String> = {
+                let existing = self
+                    .active_extras
+                    .entry(dependency_name.clone())
+                    .or_default();
+                extras
+                    .into_iter()
+                    .filter(|e| existing.insert(e.clone()))
+                    .collect()
+            };
+            if !newly_added.is_empty() && self.fetched.contains_key(&dependency_name) {
+                self.late_walk(&dependency_name, &newly_added);
+            }
         }
     }
 
@@ -578,6 +653,16 @@ impl QueryExecutor {
                     let (result_idx, request, pkg) = records?;
 
                     if self.recursive {
+                        // Cache for late activations, then walk deps.
+                        let entry =
+                            self.fetched.entry(request.name.clone()).or_insert_with(|| {
+                                FetchedEntry {
+                                    pkgs: Vec::new(),
+                                    source: request.specs.clone(),
+                                }
+                            });
+                        entry.pkgs.push(pkg.clone());
+
                         self.queue_dependencies(&pkg, &request);
                     }
 

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -60,6 +60,15 @@ enum SourceSpecs {
     Transitive,
 }
 
+/// A request to fetch records for a single package name, together with the
+/// extras that should be activated for that name. `extras` is informational
+/// for now; later increments use it to scope the dep walk.
+#[derive(Clone)]
+struct PendingRequest {
+    specs: SourceSpecs,
+    extras: ahash::HashSet<String>,
+}
+
 /// A spec that references a package by direct URL.
 struct DirectUrlSpec {
     #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
@@ -148,7 +157,10 @@ struct QueryExecutor {
     // Mutable state during execution
     /// Normalized (lowercase) package names we've already queued.
     seen: hashbrown::HashMap<String, (), ahash::RandomState>,
-    pending_package_specs: ahash::HashMap<PackageName, SourceSpecs>,
+    pending_package_specs: ahash::HashMap<PackageName, PendingRequest>,
+    /// Per-name set of extras that are currently active. Grows monotonically
+    /// as new extras are discovered via top-level specs and dep parsing.
+    active_extras: ahash::HashMap<PackageName, ahash::HashSet<String>>,
 
     // Subdir management
     subdir_handles: Vec<SubdirHandle>,
@@ -175,7 +187,10 @@ impl QueryExecutor {
         } = query;
 
         let mut seen = hashbrown::HashMap::with_hasher(ahash::RandomState::new());
-        let mut pending_package_specs = ahash::HashMap::default();
+        let mut pending_package_specs: ahash::HashMap<PackageName, PendingRequest> =
+            ahash::HashMap::default();
+        let mut active_extras: ahash::HashMap<PackageName, ahash::HashSet<String>> =
+            ahash::HashMap::default();
         let mut direct_url_specs = Vec::new();
         let mut pending_pattern_specs = Vec::new();
         let pattern_names_seen = HashSet::new();
@@ -188,17 +203,36 @@ impl QueryExecutor {
                     GatewayError::MatchSpecWithoutExactName(Box::new(spec.clone())),
                 )?;
                 seen.insert(name.as_normalized().to_string(), ());
+                if let Some(extras) = spec.extras.as_ref() {
+                    active_extras
+                        .entry(name.clone())
+                        .or_default()
+                        .extend(extras.iter().cloned());
+                }
                 direct_url_specs.push(DirectUrlSpec { spec, url, name });
             } else {
                 match &spec.name {
                     PackageNameMatcher::Exact(name) => {
                         seen.insert(name.as_normalized().to_string(), ());
-                        let pending = pending_package_specs
-                            .entry(name.clone())
-                            .or_insert_with(|| SourceSpecs::Input(vec![]));
-                        let SourceSpecs::Input(input_specs) = pending else {
+                        if let Some(extras) = spec.extras.as_ref() {
+                            active_extras
+                                .entry(name.clone())
+                                .or_default()
+                                .extend(extras.iter().cloned());
+                        }
+                        let pending =
+                            pending_package_specs
+                                .entry(name.clone())
+                                .or_insert_with(|| PendingRequest {
+                                    specs: SourceSpecs::Input(vec![]),
+                                    extras: ahash::HashSet::default(),
+                                });
+                        let SourceSpecs::Input(input_specs) = &mut pending.specs else {
                             panic!("SourceSpecs::Input was overwritten by SourceSpecs::Transitive");
                         };
+                        if let Some(extras) = spec.extras.as_ref() {
+                            pending.extras.extend(extras.iter().cloned());
+                        }
                         input_specs.push(spec);
                     }
                     matcher @ (PackageNameMatcher::Glob(_) | PackageNameMatcher::Regex(_)) => {
@@ -268,6 +302,7 @@ impl QueryExecutor {
             pattern_names_seen,
             seen,
             pending_package_specs,
+            active_extras,
             subdir_handles,
             pending_subdirs,
             pending_records: FuturesUnordered::new(),
@@ -309,9 +344,17 @@ impl QueryExecutor {
                 // Push the direct url in the first subdir result for channel priority logic
                 let (unique_base_deps, unique_extra_deps) =
                     super::subdir::extract_unique_deps_split(records.iter().map(|r| &**r));
+                let extras: ahash::HashSet<String> = spec
+                    .extras
+                    .as_ref()
+                    .map(|e| e.iter().cloned().collect())
+                    .unwrap_or_default();
                 Ok((
                     0,
-                    SourceSpecs::Input(vec![spec]),
+                    PendingRequest {
+                        specs: SourceSpecs::Input(vec![spec]),
+                        extras,
+                    },
                     PackageRecords {
                         records,
                         unique_base_deps,
@@ -337,9 +380,9 @@ impl QueryExecutor {
 
     /// Drain `pending_package_specs` and spawn fetch futures for each.
     fn spawn_package_fetches(&mut self) {
-        for (package_name, specs) in self.pending_package_specs.drain() {
+        for (package_name, request) in self.pending_package_specs.drain() {
             for handle in &self.subdir_handles {
-                let specs = specs.clone();
+                let request = request.clone();
                 let package_name = package_name.clone();
                 let reporter = self.reporter.clone();
                 let result_index = handle.result_index;
@@ -351,8 +394,8 @@ impl QueryExecutor {
                         Subdir::Found(subdir) => subdir
                             .get_or_fetch_package_records(&package_name, reporter)
                             .await
-                            .map(|pkg| (result_index, specs, pkg)),
-                        Subdir::NotFound => Ok((result_index, specs, PackageRecords::default())),
+                            .map(|pkg| (result_index, request, pkg)),
+                        Subdir::NotFound => Ok((result_index, request, PackageRecords::default())),
                     }
                 }));
             }
@@ -360,8 +403,8 @@ impl QueryExecutor {
     }
 
     /// Extract dependencies from records and queue them if not seen.
-    fn queue_dependencies(&mut self, pkg: &PackageRecords, request_specs: &SourceSpecs) {
-        match request_specs {
+    fn queue_dependencies(&mut self, pkg: &PackageRecords, request: &PendingRequest) {
+        match &request.specs {
             SourceSpecs::Transitive => {
                 // Use precomputed unique deps. Walk base deps and every extra's
                 // deps; a later increment will restrict the extras walked to
@@ -405,8 +448,13 @@ impl QueryExecutor {
         if let hashbrown::hash_map::EntryRef::Vacant(entry) = self.seen.entry_ref(normalized_str) {
             entry.insert(());
             let dependency_name = PackageName::from_matchspec_str_unchecked(dependency);
-            self.pending_package_specs
-                .insert(dependency_name, SourceSpecs::Transitive);
+            self.pending_package_specs.insert(
+                dependency_name,
+                PendingRequest {
+                    specs: SourceSpecs::Transitive,
+                    extras: ahash::HashSet::default(),
+                },
+            );
         }
     }
 
@@ -415,11 +463,11 @@ impl QueryExecutor {
         &mut self,
         result_idx: usize,
         records: Vec<Arc<RepoDataRecord>>,
-        request_specs: &SourceSpecs,
+        request: &PendingRequest,
     ) {
         let result = &mut self.result[result_idx];
 
-        match request_specs {
+        match &request.specs {
             SourceSpecs::Transitive => {
                 // All records match — extend with Arc clones (cheap refcount bumps).
                 result.records.extend(records);
@@ -460,12 +508,24 @@ impl QueryExecutor {
                         .insert(name.as_normalized().to_string(), ())
                         .is_none()
                     {
+                        if let Some(extras) = spec.extras.as_ref() {
+                            self.active_extras
+                                .entry(name.clone())
+                                .or_default()
+                                .extend(extras.iter().cloned());
+                        }
                         let pending = self
                             .pending_package_specs
                             .entry(name.clone())
-                            .or_insert_with(|| SourceSpecs::Input(vec![]));
-                        if let SourceSpecs::Input(input_specs) = pending {
+                            .or_insert_with(|| PendingRequest {
+                                specs: SourceSpecs::Input(vec![]),
+                                extras: ahash::HashSet::default(),
+                            });
+                        if let SourceSpecs::Input(input_specs) = &mut pending.specs {
                             input_specs.push(spec.clone());
+                        }
+                        if let Some(extras) = spec.extras.as_ref() {
+                            pending.extras.extend(extras.iter().cloned());
                         }
                     }
                     break;
@@ -494,13 +554,13 @@ impl QueryExecutor {
 
                 // Handle any records that were fetched
                 records = self.pending_records.select_next_some() => {
-                    let (result_idx, request_specs, pkg) = records?;
+                    let (result_idx, request, pkg) = records?;
 
                     if self.recursive {
-                        self.queue_dependencies(&pkg, &request_specs);
+                        self.queue_dependencies(&pkg, &request);
                     }
 
-                    self.accumulate_records(result_idx, pkg.records, &request_specs);
+                    self.accumulate_records(result_idx, pkg.records, &request);
                 }
 
                 // All futures have been handled, all subdirectories have been loaded and all
@@ -533,7 +593,7 @@ fn box_future<T, F: Future<Output = T> + Send + 'static>(future: F) -> BoxFuture
 
 /// Result type for pending record fetches.
 type PendingSubdirResult = Result<Arc<Subdir>, GatewayError>;
-type PendingRecordsResult = Result<(usize, SourceSpecs, PackageRecords), GatewayError>;
+type PendingRecordsResult = Result<(usize, PendingRequest, PackageRecords), GatewayError>;
 
 impl IntoFuture for RepoDataQuery {
     type Output = Result<Vec<RepoData>, GatewayError>;

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -307,13 +307,15 @@ impl QueryExecutor {
                 }
 
                 // Push the direct url in the first subdir result for channel priority logic
-                let unique_deps = super::subdir::extract_unique_deps(records.iter().map(|r| &**r));
+                let (unique_base_deps, unique_extra_deps) =
+                    super::subdir::extract_unique_deps_split(records.iter().map(|r| &**r));
                 Ok((
                     0,
                     SourceSpecs::Input(vec![spec]),
                     PackageRecords {
                         records,
-                        unique_deps,
+                        unique_base_deps,
+                        unique_extra_deps,
                     },
                 ))
             }));
@@ -361,10 +363,16 @@ impl QueryExecutor {
     fn queue_dependencies(&mut self, pkg: &PackageRecords, request_specs: &SourceSpecs) {
         match request_specs {
             SourceSpecs::Transitive => {
-                // Use precomputed unique deps — typically ~50-100 strings
-                // instead of iterating all records (~20,000 dep strings).
-                for dep in pkg.unique_deps.iter() {
+                // Use precomputed unique deps. Walk base deps and every extra's
+                // deps; a later increment will restrict the extras walked to
+                // those actually active for this name.
+                for dep in pkg.unique_base_deps.iter() {
                     self.queue_dependency(dep);
+                }
+                for deps in pkg.unique_extra_deps.values() {
+                    for dep in deps.iter() {
+                        self.queue_dependency(dep);
+                    }
                 }
             }
             SourceSpecs::Input(specs) => {

--- a/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/sharded_subdir/mod.rs
@@ -13,7 +13,7 @@ use url::Url;
 use crate::{
     GatewayError,
     fetch::FetchRepoDataError,
-    gateway::subdir::{PackageRecords, extract_unique_deps},
+    gateway::subdir::{PackageRecords, extract_unique_deps_split},
 };
 
 /// Returns `true` if the HTTP status indicates that the server does not expose
@@ -154,10 +154,12 @@ async fn parse_records<R: AsRef<[u8]> + Send + 'static>(
                 }));
             }
 
-            let unique_deps = extract_unique_deps(records.iter().map(|r| &**r));
+            let (unique_base_deps, unique_extra_deps) =
+                extract_unique_deps_split(records.iter().map(|r| &**r));
             Ok(PackageRecords {
                 records,
-                unique_deps,
+                unique_base_deps,
+                unique_extra_deps,
             })
         };
 

--- a/crates/rattler_repodata_gateway/src/gateway/source.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/source.rs
@@ -6,7 +6,7 @@ use rattler_conda_types::{Channel, PackageName, Platform, RepoDataRecord};
 
 use super::{
     GatewayError,
-    subdir::{PackageRecords, SubdirClient, extract_unique_deps},
+    subdir::{PackageRecords, SubdirClient, extract_unique_deps_split},
 };
 use crate::Reporter;
 
@@ -90,10 +90,12 @@ impl SubdirClient for CustomSourceClient {
             .source
             .fetch_package_records(self.platform, name)
             .await?;
-        let unique_deps = extract_unique_deps(records.iter().map(|r| &**r));
+        let (unique_base_deps, unique_extra_deps) =
+            extract_unique_deps_split(records.iter().map(|r| &**r));
         Ok(PackageRecords {
             records,
-            unique_deps,
+            unique_base_deps,
+            unique_extra_deps,
         })
     }
 

--- a/crates/rattler_repodata_gateway/src/gateway/subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir.rs
@@ -31,8 +31,10 @@ pub struct PackageRecords {
 pub type ExtraDeps = Arc<HashMap<String, Arc<[String]>>>;
 
 /// Extract the unique dependency strings from a set of records, split into
-/// base deps and per-extra deps. Each output list is deduplicated and a dep
-/// that appears in the base list is not repeated in any extra list.
+/// base deps and per-extra deps. Each output list is deduplicated, and a dep
+/// that appears in any record's base list is removed from every extra list
+/// (a base requirement is unconditional, so the solver does not need it gated
+/// on an extra).
 pub(crate) fn extract_unique_deps_split<'a>(
     records: impl IntoIterator<Item = &'a RepoDataRecord>,
 ) -> (Arc<[String]>, ExtraDeps) {
@@ -49,9 +51,6 @@ pub(crate) fn extract_unique_deps_split<'a>(
         for (extra, extra_deps) in record.package_record.experimental_extra_depends.iter() {
             let entry = per_extra.entry(extra.clone()).or_default();
             for dep in extra_deps {
-                if base_seen.contains(dep) {
-                    continue;
-                }
                 if entry.0.insert(dep.clone()) {
                     entry.1.push(dep.clone());
                 }
@@ -59,9 +58,21 @@ pub(crate) fn extract_unique_deps_split<'a>(
         }
     }
 
+    // Final pass: a dep that ended up in base must not appear in any extra
+    // list, regardless of the order records were visited.
     let per_extra: HashMap<String, Arc<[String]>> = per_extra
         .into_iter()
-        .map(|(extra, (_, deps))| (extra, Arc::from(deps)))
+        .filter_map(|(extra, (_, deps))| {
+            let filtered: Vec<String> = deps
+                .into_iter()
+                .filter(|d| !base_seen.contains(d))
+                .collect();
+            if filtered.is_empty() {
+                None
+            } else {
+                Some((extra, Arc::from(filtered)))
+            }
+        })
         .collect();
 
     (Arc::from(base), Arc::new(per_extra))
@@ -171,8 +182,8 @@ mod tests {
     use std::str::FromStr;
 
     use rattler_conda_types::{
-        package::DistArchiveIdentifier, NoArchType, PackageRecord, RepoDataRecord,
-        VersionWithSource,
+        NoArchType, PackageRecord, RepoDataRecord, VersionWithSource,
+        package::DistArchiveIdentifier,
     };
     use url::Url;
 
@@ -282,6 +293,29 @@ mod tests {
         let (base, per_extra) = extract_unique_deps_split([&rec_a, &rec_b]);
         assert_eq!(&*base, &["aiohttp".to_string()]);
         assert_eq!(&*per_extra["d"], &["aiosignal".to_string()]);
+    }
+
+    /// Same as `extract_unique_deps_split_base_wins_across_records` but with
+    /// the records visited in the opposite order. The base-wins invariant
+    /// must hold regardless of iteration order.
+    #[test]
+    fn extract_unique_deps_split_base_wins_reversed_order() {
+        let rec_extra_first = make_record("black", &[], &[("d", &["aiohttp", "aiosignal"])]);
+        let rec_base_after = make_record("black", &["aiohttp"], &[]);
+        let (base, per_extra) = extract_unique_deps_split([&rec_extra_first, &rec_base_after]);
+        assert_eq!(&*base, &["aiohttp".to_string()]);
+        assert_eq!(&*per_extra["d"], &["aiosignal".to_string()]);
+    }
+
+    /// An extra whose only dep also appears in some record's base list must
+    /// not produce an empty entry in the per-extra map.
+    #[test]
+    fn extract_unique_deps_split_extra_fully_subsumed_is_dropped() {
+        let rec_extra_first = make_record("black", &[], &[("d", &["aiohttp"])]);
+        let rec_base_after = make_record("black", &["aiohttp"], &[]);
+        let (base, per_extra) = extract_unique_deps_split([&rec_extra_first, &rec_base_after]);
+        assert_eq!(&*base, &["aiohttp".to_string()]);
+        assert!(per_extra.is_empty());
     }
 
     #[test]

--- a/crates/rattler_repodata_gateway/src/gateway/subdir.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/subdir.rs
@@ -1,47 +1,70 @@
 use std::sync::Arc;
 
+use ahash::HashMap;
 use rattler_conda_types::{PackageName, RepoDataRecord, RepodataRevisionInfo};
 
 use super::GatewayError;
 use crate::Reporter;
 use coalesced_map::{CoalescedGetError, CoalescedMap};
 
-/// Records for a single package, with precomputed unique dependency strings.
+/// Records for a single package, with precomputed unique dependency strings
+/// split between unconditional (base) deps and per-extra deps.
 ///
-/// The `unique_deps` field contains the deduplicated set of dependency strings
-/// across all versions of the package. This avoids iterating all records
-/// during dependency resolution (e.g. 2000 numpy versions × 10 deps = 20,000
-/// strings reduced to ~50 unique ones).
+/// The split lets the gateway walk only the extras that are actually active
+/// for a name instead of cascading through every extra's dependencies. For
+/// packages without any extras (the common case), `unique_extra_deps` is
+/// empty.
 #[derive(Clone, Debug, Default)]
 pub struct PackageRecords {
     /// All repodata records for this package.
     pub records: Vec<Arc<RepoDataRecord>>,
 
-    /// Unique dependency strings across all records.
-    pub unique_deps: Arc<[String]>,
+    /// Unique base dependency strings across all records.
+    pub unique_base_deps: Arc<[String]>,
+
+    /// Unique dependency strings per extra, deduplicated across all records.
+    pub unique_extra_deps: ExtraDeps,
 }
 
-/// Extract the unique dependency strings from a set of records.
-pub(crate) fn extract_unique_deps<'a>(
+/// Per-extra deduplicated dependency strings. Empty for packages without any
+/// extras (the common case).
+pub type ExtraDeps = Arc<HashMap<String, Arc<[String]>>>;
+
+/// Extract the unique dependency strings from a set of records, split into
+/// base deps and per-extra deps. Each output list is deduplicated and a dep
+/// that appears in the base list is not repeated in any extra list.
+pub(crate) fn extract_unique_deps_split<'a>(
     records: impl IntoIterator<Item = &'a RepoDataRecord>,
-) -> Arc<[String]> {
-    let mut seen = ahash::HashSet::<String>::default();
-    let mut deps = Vec::new();
+) -> (Arc<[String]>, ExtraDeps) {
+    let mut base_seen = ahash::HashSet::<String>::default();
+    let mut base = Vec::new();
+    let mut per_extra: HashMap<String, (ahash::HashSet<String>, Vec<String>)> = HashMap::default();
+
     for record in records {
         for dep in &record.package_record.depends {
-            if seen.insert(dep.clone()) {
-                deps.push(dep.clone());
+            if base_seen.insert(dep.clone()) {
+                base.push(dep.clone());
             }
         }
-        for (_, extra_deps) in record.package_record.experimental_extra_depends.iter() {
+        for (extra, extra_deps) in record.package_record.experimental_extra_depends.iter() {
+            let entry = per_extra.entry(extra.clone()).or_default();
             for dep in extra_deps {
-                if seen.insert(dep.clone()) {
-                    deps.push(dep.clone());
+                if base_seen.contains(dep) {
+                    continue;
+                }
+                if entry.0.insert(dep.clone()) {
+                    entry.1.push(dep.clone());
                 }
             }
         }
     }
-    Arc::from(deps)
+
+    let per_extra: HashMap<String, Arc<[String]>> = per_extra
+        .into_iter()
+        .map(|(extra, (_, deps))| (extra, Arc::from(deps)))
+        .collect();
+
+    (Arc::from(base), Arc::new(per_extra))
 }
 
 pub enum Subdir {
@@ -139,5 +162,133 @@ pub trait SubdirClient: Send + Sync {
     /// Returns repodata revisions advertised by the subdirectory.
     fn repodata_revisions(&self) -> &[RepodataRevisionInfo] {
         &[]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::str::FromStr;
+
+    use rattler_conda_types::{
+        package::DistArchiveIdentifier, NoArchType, PackageRecord, RepoDataRecord,
+        VersionWithSource,
+    };
+    use url::Url;
+
+    use super::extract_unique_deps_split;
+
+    fn make_record(name: &str, deps: &[&str], extra_deps: &[(&str, &[&str])]) -> RepoDataRecord {
+        let mut experimental_extra_depends: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for (extra, items) in extra_deps {
+            experimental_extra_depends.insert(
+                (*extra).to_string(),
+                items.iter().map(|s| (*s).to_string()).collect(),
+            );
+        }
+
+        let package_record = PackageRecord {
+            arch: None,
+            build: "0".to_string(),
+            build_number: 0,
+            constrains: Vec::new(),
+            depends: deps.iter().map(|s| (*s).to_string()).collect(),
+            features: None,
+            flags: Vec::new(),
+            legacy_bz2_md5: None,
+            legacy_bz2_size: None,
+            license: None,
+            license_family: None,
+            md5: None,
+            name: name.parse().unwrap(),
+            noarch: NoArchType::default(),
+            platform: None,
+            python_site_packages_path: None,
+            experimental_extra_depends,
+            sha256: None,
+            size: None,
+            subdir: "linux-64".to_string(),
+            timestamp: None,
+            track_features: Vec::new(),
+            version: VersionWithSource::from_str("1.0").unwrap(),
+            purls: None,
+            run_exports: None,
+        };
+
+        RepoDataRecord {
+            url: Url::parse(&format!("https://example.com/{name}-1.0-0.conda")).unwrap(),
+            channel: None,
+            package_record,
+            identifier: format!("{name}-1.0-0.conda")
+                .parse::<DistArchiveIdentifier>()
+                .unwrap(),
+        }
+    }
+
+    #[test]
+    fn extract_unique_deps_split_base_only() {
+        let rec = make_record("foo", &["bar >=1", "baz"], &[]);
+        let (base, per_extra) = extract_unique_deps_split([&rec]);
+        assert_eq!(&*base, &["bar >=1".to_string(), "baz".to_string()]);
+        assert!(per_extra.is_empty());
+    }
+
+    #[test]
+    fn extract_unique_deps_split_dedupes_across_records() {
+        let rec_a = make_record("foo", &["bar >=1", "baz"], &[]);
+        let rec_b = make_record("foo", &["bar >=1", "qux"], &[]);
+        let (base, per_extra) = extract_unique_deps_split([&rec_a, &rec_b]);
+        assert_eq!(
+            &*base,
+            &["bar >=1".to_string(), "baz".to_string(), "qux".to_string()]
+        );
+        assert!(per_extra.is_empty());
+    }
+
+    #[test]
+    fn extract_unique_deps_split_per_extra() {
+        let rec = make_record(
+            "black",
+            &["click >=8"],
+            &[
+                ("d", &["aiohttp >=3"]),
+                ("jupyter", &["ipython", "qtconsole"]),
+            ],
+        );
+        let (base, per_extra) = extract_unique_deps_split([&rec]);
+        assert_eq!(&*base, &["click >=8".to_string()]);
+        assert_eq!(per_extra.len(), 2);
+        assert_eq!(&*per_extra["d"], &["aiohttp >=3".to_string()]);
+        assert_eq!(
+            &*per_extra["jupyter"],
+            &["ipython".to_string(), "qtconsole".to_string()]
+        );
+    }
+
+    #[test]
+    fn extract_unique_deps_split_skips_extra_dep_already_in_base() {
+        let rec = make_record("black", &["aiohttp"], &[("d", &["aiohttp", "aiosignal"])]);
+        let (base, per_extra) = extract_unique_deps_split([&rec]);
+        assert_eq!(&*base, &["aiohttp".to_string()]);
+        assert_eq!(&*per_extra["d"], &["aiosignal".to_string()]);
+    }
+
+    /// A dep that appears in the base set of one record and in an extra of
+    /// another must not be repeated in the extra (base wins).
+    #[test]
+    fn extract_unique_deps_split_base_wins_across_records() {
+        let rec_a = make_record("black", &["aiohttp"], &[]);
+        let rec_b = make_record("black", &[], &[("d", &["aiohttp", "aiosignal"])]);
+        let (base, per_extra) = extract_unique_deps_split([&rec_a, &rec_b]);
+        assert_eq!(&*base, &["aiohttp".to_string()]);
+        assert_eq!(&*per_extra["d"], &["aiosignal".to_string()]);
+    }
+
+    #[test]
+    fn extract_unique_deps_split_empty_records() {
+        let records: Vec<&RepoDataRecord> = Vec::new();
+        let (base, per_extra) = extract_unique_deps_split(records);
+        assert!(base.is_empty());
+        assert!(per_extra.is_empty());
     }
 }


### PR DESCRIPTION
### Description

The gateway used to walk every extra of every package it pulled in, which made even small solves (e.g. `black` from conda-pypi) cascade through ~500k records. This PR scopes extra traversal to the extras that are actually activated by the top-level specs, while still handling the case where a deeply nested package activates a new extra on an already-fetched package.

Changes:
- `PackageName::name_and_extras_from_matchspec_str` parses `pkg[extras=[a,b]]` and returns the activated extras alongside the normalized name.
- `PackageRecords` now splits unique deps into `unique_base_deps` and `unique_extra_deps` (per extra), so the gateway can pick which lists to walk.
- The query executor tracks active extras per package, walks only base deps plus active extras when queueing, and re-walks cached records when an extra is activated late. Works for both Input and Transitive paths and respects the existing spec filter on Input.

Effect: `rattler create --dry-run -c conda-pypi black` drops from ~500k to ~1.5k records (327x reduction). Multi-channel solve with conda-forge still picks the right `black` version.

### How Has This Been Tested?

- New unit tests in `subdir.rs` for `extract_unique_deps_split` covering base/extra dedup, base-wins across records (both orders), fully-subsumed extras, and the empty-records case.
- New rstest cases in `package_name.rs` for `name_and_extras_from_matchspec_str` including empty extras list, trailing comma, multiple bracket sections, and malformed input.
- New gateway integration tests in `mod.rs` exercising inactive vs active extras, late activation via Transitive, chained activation on the same package, Input scoping, and Input late activation with spec filter.
- End-to-end verified with `rattler create --dry-run -c conda-pypi black` and `-c conda-pypi -c conda-forge black`.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.
