### PR TITLE
feat: add auth status command and update to keyring-core

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -73,9 +73,9 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1.0.7
+      - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # v1.15.2
         with:
-          profile: minimal
+          toolchain: "1.95"
 
       - name: Pre-docs-build
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "archspec"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,30 +278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,20 +288,6 @@ dependencies = [
  "futures-io",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
 ]
 
 [[package]]
@@ -333,97 +306,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.4",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.4",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "async-spooled-tempfile"
@@ -434,12 +320,6 @@ dependencies = [
  "tempfile",
  "tokio",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1164,19 +1044,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -1940,8 +1807,19 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
+ "openssl",
  "sha2 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
 ]
 
 [[package]]
@@ -2234,12 +2112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endi"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,27 +2130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -2325,16 +2176,6 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
  "pin-project-lite",
 ]
 
@@ -3584,20 +3425,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "byteorder",
- "dbus-secret-service",
  "log",
- "secret-service",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zbus",
- "zeroize",
 ]
 
 [[package]]
@@ -3665,6 +3498,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -3834,15 +3668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3952,7 +3777,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3962,19 +3787,6 @@ name = "netrc-rs"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836"
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
-]
 
 [[package]]
 name = "nix"
@@ -4414,6 +4226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4421,6 +4242,7 @@ checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4448,16 +4270,6 @@ checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -4714,17 +4526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4800,20 +4601,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5134,6 +4921,8 @@ dependencies = [
  "assert_matches",
  "astral-reqwest-middleware",
  "axum",
+ "base64 0.22.1",
+ "chrono",
  "clap",
  "console",
  "digest 0.11.3",
@@ -5503,6 +5292,7 @@ version = "0.27.2"
 dependencies = [
  "ambient-id",
  "anyhow",
+ "apple-native-keyring-store",
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "async-once-cell",
@@ -5512,6 +5302,7 @@ dependencies = [
  "aws-smithy-http-client",
  "axum",
  "base64 0.22.1",
+ "dbus-secret-service-keyring-store",
  "dirs",
  "fs-err",
  "getrandom 0.4.2",
@@ -5520,7 +5311,7 @@ dependencies = [
  "http 1.4.0",
  "insta",
  "itertools 0.14.0",
- "keyring",
+ "keyring-core",
  "netrc-rs",
  "rattler_config",
  "reqwest",
@@ -5536,6 +5327,7 @@ dependencies = [
  "tracing",
  "tracing-test",
  "url",
+ "windows-native-keyring-store",
 ]
 
 [[package]]
@@ -5601,7 +5393,7 @@ name = "rattler_pty"
 version = "0.2.12"
 dependencies = [
  "libc",
- "nix 0.30.1",
+ "nix",
  "signal-hook",
  "tokio",
 ]
@@ -6219,7 +6011,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6259,7 +6051,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -6287,7 +6079,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -6439,38 +6231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "secret-service"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
-dependencies = [
- "aes",
- "cbc",
- "futures-util",
- "generic-array",
- "hkdf",
- "num",
- "once_cell",
- "rand 0.8.6",
- "serde",
- "sha2 0.10.9",
- "zbus",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -7103,12 +6863,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -7814,17 +7568,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
-name = "uds_windows"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
-dependencies = [
- "memoffset",
- "tempfile",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8372,6 +8115,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8852,16 +8608,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8894,68 +8640,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zbus"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix 0.29.0",
- "ordered-stream",
- "rand 0.8.6",
- "serde",
- "serde_repr",
- "sha1 0.10.6",
- "static_assertions",
- "tracing",
- "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
-dependencies = [
- "serde",
- "static_assertions",
- "zvariant",
 ]
 
 [[package]]
@@ -9117,41 +8801,4 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "zvariant"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "zvariant_derive",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "archspec"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,30 +278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,20 +288,6 @@ dependencies = [
  "futures-io",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
 ]
 
 [[package]]
@@ -333,97 +306,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.4",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.4",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "async-spooled-tempfile"
@@ -434,12 +320,6 @@ dependencies = [
  "tempfile",
  "tokio",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1164,19 +1044,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -1940,8 +1807,19 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
+ "openssl",
  "sha2 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
 ]
 
 [[package]]
@@ -2234,12 +2112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endi"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,27 +2130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -2325,16 +2176,6 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
  "pin-project-lite",
 ]
 
@@ -3584,20 +3425,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "byteorder",
- "dbus-secret-service",
  "log",
- "secret-service",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zbus",
- "zeroize",
 ]
 
 [[package]]
@@ -3665,6 +3498,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -3834,15 +3668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miette"
 version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3952,7 +3777,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3962,19 +3787,6 @@ name = "netrc-rs"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836"
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
-]
 
 [[package]]
 name = "nix"
@@ -4414,6 +4226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.0+3.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4421,6 +4242,7 @@ checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -4448,16 +4270,6 @@ checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
  "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -4714,17 +4526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4800,20 +4601,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5134,6 +4921,7 @@ dependencies = [
  "assert_matches",
  "astral-reqwest-middleware",
  "axum",
+ "base64 0.22.1",
  "clap",
  "console",
  "digest 0.11.3",
@@ -5147,6 +4935,7 @@ dependencies = [
  "indicatif",
  "insta",
  "itertools 0.14.0",
+ "jiff",
  "memchr",
  "memmap2",
  "mockito",
@@ -5502,6 +5291,7 @@ version = "0.27.2"
 dependencies = [
  "ambient-id",
  "anyhow",
+ "apple-native-keyring-store",
  "astral-reqwest-middleware",
  "astral-reqwest-retry",
  "async-once-cell",
@@ -5511,6 +5301,7 @@ dependencies = [
  "aws-smithy-http-client",
  "axum",
  "base64 0.22.1",
+ "dbus-secret-service-keyring-store",
  "dirs",
  "fs-err",
  "getrandom 0.4.2",
@@ -5519,7 +5310,7 @@ dependencies = [
  "http 1.4.0",
  "insta",
  "itertools 0.14.0",
- "keyring",
+ "keyring-core",
  "netrc-rs",
  "rattler_config",
  "reqwest",
@@ -5535,6 +5326,7 @@ dependencies = [
  "tracing",
  "tracing-test",
  "url",
+ "windows-native-keyring-store",
 ]
 
 [[package]]
@@ -5600,7 +5392,7 @@ name = "rattler_pty"
 version = "0.2.12"
 dependencies = [
  "libc",
- "nix 0.30.1",
+ "nix",
  "signal-hook",
  "tokio",
 ]
@@ -6258,7 +6050,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.7.0",
+ "security-framework",
 ]
 
 [[package]]
@@ -6286,7 +6078,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
- "security-framework 3.7.0",
+ "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
@@ -6438,38 +6230,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
  "zeroize",
-]
-
-[[package]]
-name = "secret-service"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
-dependencies = [
- "aes",
- "cbc",
- "futures-util",
- "generic-array",
- "hkdf",
- "num",
- "once_cell",
- "rand 0.8.6",
- "serde",
- "sha2 0.10.9",
- "zbus",
-]
-
-[[package]]
-name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
 ]
 
 [[package]]
@@ -7102,12 +6862,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -7813,17 +7567,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
-name = "uds_windows"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
-dependencies = [
- "memoffset",
- "tempfile",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8371,6 +8114,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8851,16 +8607,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8893,68 +8639,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zbus"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix 0.29.0",
- "ordered-stream",
- "rand 0.8.6",
- "serde",
- "serde_repr",
- "sha1 0.10.6",
- "static_assertions",
- "tracing",
- "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
-dependencies = [
- "serde",
- "static_assertions",
- "zvariant",
 ]
 
 [[package]]
@@ -9116,41 +8800,4 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "zvariant"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "zvariant_derive",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ lto = true
 ahash = "0.8.12"
 ambient-id = { version = "0.0.11", default-features = false }
 anyhow = "1.0.98"
+apple-native-keyring-store = { version = "1.0.0", default-features = false }
 archspec = "0.2.0"
 assert_matches = "1.5.0"
 async-compression = { version = "0.4", features = [
@@ -72,6 +73,7 @@ dashmap = "6.1.0"
 difference = "2.0.0"
 digest = "0.11"
 dirs = "6.0.0"
+dbus-secret-service-keyring-store = { version = "1.0.0", default-features = false }
 dunce = "1.0.5"
 enum_dispatch = "0.3.13"
 fancy-regex = "0.18.0"
@@ -104,7 +106,7 @@ indicatif = "0.18.0"
 insta = { version = "1.44.3" }
 itertools = "0.14.0"
 json-patch = "4.0.0"
-keyring = "3.6.2"
+keyring-core = "1.0.0"
 lazy-regex = "3.4.1"
 libc = { version = "0.2" }
 libloading = "0.9.0"
@@ -194,6 +196,7 @@ walkdir = "2.5.0"
 wasmtimer = "0.4.1"
 which = "8.0.0"
 windows-sys = { version = "0.61.2", default-features = false }
+windows-native-keyring-store = "1.0.0"
 winver = { version = "1.0.0" }
 xxhash-rust = "0.8.15"
 zip = { version = "8.5.1", default-features = false }

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -15,7 +15,7 @@ default = ['rustls']
 native-tls = ['reqwest/native-tls', 'rattler_package_streaming/native-tls', 'rattler_cache/native-tls', 'rattler_networking/native-tls']
 rustls = ['reqwest/rustls', 'rattler_package_streaming/rustls', 'rattler_cache/rustls', 'rattler_networking/rustls']
 oauth = ["dep:openidconnect", "dep:oauth2-reqwest", "dep:open"]
-cli-tools = ['dep:clap', 'oauth']
+cli-tools = ['dep:clap', 'oauth', 'dep:console']
 indicatif = ['dep:indicatif', 'dep:console']
 
 [package.metadata.docs.rs]

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -23,6 +23,8 @@ features = ["cli-tools", "indicatif"]
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
+chrono = { workspace = true }
 clap = { workspace = true, optional = true }
 digest = { workspace = true }
 hex = { workspace = true }

--- a/crates/rattler/src/cli/auth.rs
+++ b/crates/rattler/src/cli/auth.rs
@@ -3,12 +3,18 @@
 #[cfg(feature = "oauth")]
 pub mod oauth;
 
+use base64::{
+    Engine as _,
+    engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
+};
+use chrono::{DateTime, Utc};
 use clap::Parser;
 use rattler_networking::{
     Authentication, AuthenticationStorage, authentication_storage::AuthenticationStorageError,
 };
 use reqwest::{Client, header::CONTENT_TYPE};
-use serde_json::json;
+use serde_json::{Value, json};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use thiserror;
 use url::Url;
 
@@ -107,12 +113,17 @@ struct LogoutArgs {
 }
 
 #[derive(Parser, Debug)]
+struct StatusArgs {}
+
+#[derive(Parser, Debug)]
 #[allow(clippy::large_enum_variant)]
 enum Subcommand {
     /// Store authentication information for a given host
     Login(LoginArgs),
     /// Remove authentication information for a given host
     Logout(LogoutArgs),
+    /// Show stored authentication entries and non-secret token metadata
+    Status(StatusArgs),
 }
 
 /// Login to prefix.dev or anaconda.org servers to access private channels
@@ -541,6 +552,218 @@ async fn logout(
     Ok(())
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TokenMetadata {
+    expires_at: Option<i64>,
+    scopes: Vec<String>,
+    issuer: Option<String>,
+    subject: Option<String>,
+    audience: Vec<String>,
+}
+
+fn jwt_claims(token: &str) -> Option<Value> {
+    let payload = token.split('.').nth(1)?;
+    let decoded = URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| URL_SAFE.decode(payload))
+        .ok()?;
+    serde_json::from_slice(&decoded).ok()
+}
+
+fn string_or_string_array(value: &Value) -> Vec<String> {
+    match value {
+        Value::String(value) => vec![value.clone()],
+        Value::Array(values) => values
+            .iter()
+            .filter_map(|value| value.as_str().map(ToString::to_string))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn token_metadata(token: &str) -> Option<TokenMetadata> {
+    let claims = jwt_claims(token)?;
+
+    let mut scopes = claims
+        .get("scope")
+        .and_then(Value::as_str)
+        .map(|scope| {
+            scope
+                .split_whitespace()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    scopes.extend(
+        claims
+            .get("scp")
+            .map(string_or_string_array)
+            .unwrap_or_default(),
+    );
+    scopes.sort();
+    scopes.dedup();
+
+    Some(TokenMetadata {
+        expires_at: claims.get("exp").and_then(Value::as_i64),
+        scopes,
+        issuer: claims
+            .get("iss")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        subject: claims
+            .get("sub")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        audience: claims
+            .get("aud")
+            .map(string_or_string_array)
+            .unwrap_or_default(),
+    })
+}
+
+fn now_unix_timestamp() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+fn format_timestamp(timestamp: i64) -> String {
+    DateTime::<Utc>::from_timestamp(timestamp, 0)
+        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+        .unwrap_or_else(|| format!("unix timestamp {timestamp}"))
+}
+
+fn format_validity(expires_at: Option<i64>, now: i64) -> String {
+    let Some(expires_at) = expires_at else {
+        return "unknown (no expiry metadata)".to_string();
+    };
+
+    let timestamp = format_timestamp(expires_at);
+    if expires_at <= now {
+        let elapsed = Duration::from_secs((now - expires_at) as u64);
+        format!(
+            "expired at {timestamp} ({} ago)",
+            humantime::format_duration(elapsed)
+        )
+    } else {
+        let remaining = Duration::from_secs((expires_at - now) as u64);
+        format!(
+            "valid until {timestamp} (in {})",
+            humantime::format_duration(remaining)
+        )
+    }
+}
+
+fn print_token_metadata(metadata: Option<&TokenMetadata>) {
+    let Some(metadata) = metadata else {
+        return;
+    };
+
+    if !metadata.scopes.is_empty() {
+        println!("  scopes: {}", metadata.scopes.join(", "));
+    }
+    if let Some(issuer) = &metadata.issuer {
+        println!("  issuer: {issuer}");
+    }
+    if !metadata.audience.is_empty() {
+        println!("  audience: {}", metadata.audience.join(", "));
+    }
+    if let Some(subject) = &metadata.subject {
+        println!("  subject: {subject}");
+    }
+}
+
+fn print_authentication_status(host: &str, auth: &Authentication, now: i64) {
+    println!("{host}");
+    println!("  method: {}", auth.method());
+
+    match auth {
+        Authentication::BearerToken(token) => {
+            let metadata = token_metadata(token);
+            println!(
+                "  validity: {}",
+                format_validity(
+                    metadata.as_ref().and_then(|metadata| metadata.expires_at),
+                    now
+                )
+            );
+            print_token_metadata(metadata.as_ref());
+        }
+        Authentication::CondaToken(token) => {
+            let metadata = token_metadata(token);
+            println!(
+                "  validity: {}",
+                format_validity(
+                    metadata.as_ref().and_then(|metadata| metadata.expires_at),
+                    now
+                )
+            );
+            print_token_metadata(metadata.as_ref());
+        }
+        Authentication::OAuth {
+            access_token,
+            refresh_token,
+            expires_at,
+            token_endpoint,
+            revocation_endpoint,
+            client_id,
+        } => {
+            let metadata = token_metadata(access_token);
+            println!(
+                "  validity: {}",
+                format_validity(
+                    expires_at
+                        .or_else(|| metadata.as_ref().and_then(|metadata| metadata.expires_at)),
+                    now,
+                )
+            );
+            println!("  client id: {client_id}");
+            println!(
+                "  refresh token: {}",
+                if refresh_token.is_some() { "yes" } else { "no" }
+            );
+            println!("  token endpoint: {token_endpoint}");
+            if let Some(revocation_endpoint) = revocation_endpoint {
+                println!("  revocation endpoint: {revocation_endpoint}");
+            }
+            print_token_metadata(metadata.as_ref());
+        }
+        Authentication::BasicHTTP { username, .. } => {
+            println!("  validity: unknown (basic authentication)");
+            println!("  username: {username}");
+        }
+        Authentication::S3Credentials { session_token, .. } => {
+            println!("  validity: unknown (S3 credentials)");
+            println!(
+                "  session token: {}",
+                if session_token.is_some() { "yes" } else { "no" }
+            );
+        }
+    }
+}
+
+fn status(_args: StatusArgs, storage: AuthenticationStorage) -> Result<(), AuthenticationCLIError> {
+    let entries = storage.list()?;
+
+    if entries.is_empty() {
+        println!("No stored authentication entries found.");
+        return Ok(());
+    }
+
+    println!("Stored authentication entries:");
+    let now = now_unix_timestamp();
+    for (index, (host, auth)) in entries.iter().enumerate() {
+        if index > 0 {
+            println!();
+        }
+        print_authentication_status(host, auth, now);
+    }
+
+    Ok(())
+}
+
 /// CLI entrypoint for authentication
 pub async fn execute(args: Args) -> Result<(), AuthenticationCLIError> {
     let storage = AuthenticationStorage::from_env_and_defaults()?;
@@ -548,6 +771,7 @@ pub async fn execute(args: Args) -> Result<(), AuthenticationCLIError> {
     match args.subcommand {
         Subcommand::Login(args) => login(args, storage).await,
         Subcommand::Logout(args) => logout(args, storage).await,
+        Subcommand::Status(args) => status(args, storage),
     }
 }
 
@@ -598,6 +822,43 @@ mod tests {
             oauth_redirect_uri: None,
             user_agent: None,
         }
+    }
+
+    fn unsigned_jwt(payload: Value) -> String {
+        let header = json!({ "alg": "none" });
+        format!(
+            "{}.{}.",
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap()),
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap())
+        )
+    }
+
+    #[test]
+    fn token_metadata_extracts_expiry_scopes_and_claims() {
+        let token = unsigned_jwt(json!({
+            "exp": 1_900_000_000_i64,
+            "scope": "channel:read channel:upload",
+            "scp": ["openid", "profile"],
+            "iss": "https://prefix.dev",
+            "sub": "user-123",
+            "aud": ["rattler", "prefix"]
+        }));
+
+        assert_eq!(
+            token_metadata(&token),
+            Some(TokenMetadata {
+                expires_at: Some(1_900_000_000),
+                scopes: vec![
+                    "channel:read".to_string(),
+                    "channel:upload".to_string(),
+                    "openid".to_string(),
+                    "profile".to_string()
+                ],
+                issuer: Some("https://prefix.dev".to_string()),
+                subject: Some("user-123".to_string()),
+                audience: vec!["rattler".to_string(), "prefix".to_string()],
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/rattler/src/cli/auth.rs
+++ b/crates/rattler/src/cli/auth.rs
@@ -687,10 +687,18 @@ fn print_authentication_status(
     host: &str,
     auth: &Authentication,
     source: &str,
+    active: bool,
     account: Option<&str>,
     now: i64,
 ) {
-    println!("{host}");
+    if active {
+        println!("{host}");
+    } else {
+        // Shadowed entry — `get()` would return a different backend's copy
+        // for this host. Dim the heading so it's visually subordinate but
+        // still useful for cleanup.
+        println!("{} {}", host, style("(shadowed)").dim());
+    }
 
     // Header line. For verified prefix.dev entries (account known) we mirror
     // `gh auth status` and lead with a "✓ Logged in to ..." line. For
@@ -804,21 +812,31 @@ async fn status(
         return Ok(());
     }
 
-    let accounts = futures::future::join_all(
-        entries
-            .iter()
-            .map(|(host, auth, _)| lookup_prefix_dev_account(host, auth)),
-    )
+    // Only call prefix.dev's API for entries that `get()` would actually
+    // return — there's no point validating shadowed copies.
+    let accounts = futures::future::join_all(entries.iter().map(|entry| async {
+        if entry.active {
+            lookup_prefix_dev_account(&entry.host, &entry.auth).await
+        } else {
+            None
+        }
+    }))
     .await;
 
     println!("Stored authentication entries:");
     let now = now_unix_timestamp();
-    for (index, ((host, auth, source), account)) in entries.iter().zip(accounts.iter()).enumerate()
-    {
+    for (index, (entry, account)) in entries.iter().zip(accounts.iter()).enumerate() {
         if index > 0 {
             println!();
         }
-        print_authentication_status(host, auth, source, account.as_deref(), now);
+        print_authentication_status(
+            &entry.host,
+            &entry.auth,
+            &entry.source,
+            entry.active,
+            account.as_deref(),
+            now,
+        );
     }
 
     Ok(())

--- a/crates/rattler/src/cli/auth.rs
+++ b/crates/rattler/src/cli/auth.rs
@@ -9,6 +9,7 @@ use base64::{
 };
 use chrono::{DateTime, Utc};
 use clap::Parser;
+use console::style;
 use rattler_networking::{
     Authentication, AuthenticationStorage, authentication_storage::AuthenticationStorageError,
 };
@@ -682,19 +683,6 @@ fn print_token_metadata(metadata: Option<&TokenMetadata>) {
     }
 }
 
-/// Render a secret token in a redacted, gh-style form: keep a short visible
-/// prefix and pad with asterisks so the user can recognize the token without
-/// the secret material appearing on screen.
-fn redact_token(token: &str) -> String {
-    const VISIBLE_PREFIX: usize = 4;
-    const TOTAL_LEN: usize = 40;
-
-    let visible_len = token.chars().count().min(VISIBLE_PREFIX);
-    let visible: String = token.chars().take(visible_len).collect();
-    let mask_len = TOTAL_LEN.saturating_sub(visible_len);
-    format!("{visible}{}", "*".repeat(mask_len))
-}
-
 fn print_authentication_status(
     host: &str,
     auth: &Authentication,
@@ -708,27 +696,17 @@ fn print_authentication_status(
     // `gh auth status` and lead with a "✓ Logged in to ..." line. For
     // anything else we just report where the entry came from.
     match account {
-        Some(account) => println!("  ✓ Logged in to {host} account {account} ({source})"),
+        Some(account) => println!(
+            "  {} Logged in to {host} account {account} ({source})",
+            style("✓").green()
+        ),
         None => println!("  - Source: {source}"),
     }
     println!("  - Method: {}", auth.method());
 
     match auth {
-        Authentication::BearerToken(token) => {
+        Authentication::BearerToken(token) | Authentication::CondaToken(token) => {
             let metadata = token_metadata(token);
-            println!("  - Token: {}", redact_token(token));
-            println!(
-                "  - Token validity: {}",
-                format_validity(
-                    metadata.as_ref().and_then(|metadata| metadata.expires_at),
-                    now
-                )
-            );
-            print_token_metadata(metadata.as_ref());
-        }
-        Authentication::CondaToken(token) => {
-            let metadata = token_metadata(token);
-            println!("  - Token: {}", redact_token(token));
             println!(
                 "  - Token validity: {}",
                 format_validity(
@@ -747,7 +725,6 @@ fn print_authentication_status(
             client_id,
         } => {
             let metadata = token_metadata(access_token);
-            println!("  - Token: {}", redact_token(access_token));
             println!(
                 "  - Token validity: {}",
                 format_validity(
@@ -769,15 +746,8 @@ fn print_authentication_status(
         }
         Authentication::BasicHTTP { username, .. } => {
             println!("  - Username: {username}");
-            println!("  - Password: {}", "*".repeat(12));
         }
-        Authentication::S3Credentials {
-            access_key_id,
-            session_token,
-            ..
-        } => {
-            println!("  - Access key ID: {}", redact_token(access_key_id));
-            println!("  - Secret access key: {}", "*".repeat(40));
+        Authentication::S3Credentials { session_token, .. } => {
             println!(
                 "  - Session token: {}",
                 if session_token.is_some() {

--- a/crates/rattler/src/cli/auth.rs
+++ b/crates/rattler/src/cli/auth.rs
@@ -630,9 +630,10 @@ fn now_unix_timestamp() -> i64 {
 }
 
 fn format_timestamp(timestamp: i64) -> String {
-    DateTime::<Utc>::from_timestamp(timestamp, 0)
-        .map(|dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string())
-        .unwrap_or_else(|| format!("unix timestamp {timestamp}"))
+    DateTime::<Utc>::from_timestamp(timestamp, 0).map_or_else(
+        || format!("unix timestamp {timestamp}"),
+        |dt| dt.format("%Y-%m-%d %H:%M:%S UTC").to_string(),
+    )
 }
 
 fn format_validity(expires_at: Option<i64>, now: i64) -> String {
@@ -675,9 +676,19 @@ fn print_token_metadata(metadata: Option<&TokenMetadata>) {
     }
 }
 
-fn print_authentication_status(host: &str, auth: &Authentication, now: i64) {
+fn print_authentication_status(
+    host: &str,
+    auth: &Authentication,
+    source: &str,
+    account: Option<&str>,
+    now: i64,
+) {
     println!("{host}");
+    println!("  source: {source}");
     println!("  method: {}", auth.method());
+    if let Some(account) = account {
+        println!("  account: {account}");
+    }
 
     match auth {
         Authentication::BearerToken(token) => {
@@ -744,21 +755,65 @@ fn print_authentication_status(host: &str, auth: &Authentication, now: i64) {
     }
 }
 
-fn status(_args: StatusArgs, storage: AuthenticationStorage) -> Result<(), AuthenticationCLIError> {
-    let entries = storage.list()?;
+/// Returns true if `host` belongs to the prefix.dev family (e.g. `prefix.dev`,
+/// `repo.prefix.dev`, `*.prefix.dev`). Used to decide whether the status
+/// command should look up the account name via prefix.dev's GraphQL API.
+fn is_prefix_dev_host(host: &str) -> bool {
+    let normalized = normalize_login_host(host);
+    normalized == "prefix.dev" || normalized.ends_with(".prefix.dev")
+}
+
+/// Extract a bearer-style token from an authentication entry if one is
+/// available — i.e. something that can be sent as `Authorization: Bearer …`
+/// to prefix.dev's GraphQL API.
+fn bearer_for_prefix_dev(auth: &Authentication) -> Option<&str> {
+    match auth {
+        Authentication::BearerToken(token) => Some(token.as_str()),
+        Authentication::OAuth { access_token, .. } => Some(access_token.as_str()),
+        _ => None,
+    }
+}
+
+/// Best-effort lookup of the prefix.dev account name for an entry. Returns
+/// `None` on any failure (network error, invalid token, non-prefix.dev host)
+/// since this is a display-only enrichment for `auth status`.
+async fn lookup_prefix_dev_account(host: &str, auth: &Authentication) -> Option<String> {
+    if !is_prefix_dev_host(host) {
+        return None;
+    }
+    let token = bearer_for_prefix_dev(auth)?;
+    match validate_prefix_dev_token(token, host, None).await {
+        Ok(ValidationResult::Valid(username, _)) => Some(username),
+        _ => None,
+    }
+}
+
+async fn status(
+    _args: StatusArgs,
+    storage: AuthenticationStorage,
+) -> Result<(), AuthenticationCLIError> {
+    let entries = storage.list_with_sources()?;
 
     if entries.is_empty() {
         println!("No stored authentication entries found.");
         return Ok(());
     }
 
+    let accounts = futures::future::join_all(
+        entries
+            .iter()
+            .map(|(host, auth, _)| lookup_prefix_dev_account(host, auth)),
+    )
+    .await;
+
     println!("Stored authentication entries:");
     let now = now_unix_timestamp();
-    for (index, (host, auth)) in entries.iter().enumerate() {
+    for (index, ((host, auth, source), account)) in entries.iter().zip(accounts.iter()).enumerate()
+    {
         if index > 0 {
             println!();
         }
-        print_authentication_status(host, auth, now);
+        print_authentication_status(host, auth, source, account.as_deref(), now);
     }
 
     Ok(())
@@ -771,7 +826,7 @@ pub async fn execute(args: Args) -> Result<(), AuthenticationCLIError> {
     match args.subcommand {
         Subcommand::Login(args) => login(args, storage).await,
         Subcommand::Logout(args) => logout(args, storage).await,
-        Subcommand::Status(args) => status(args, storage),
+        Subcommand::Status(args) => status(args, storage).await,
     }
 }
 

--- a/crates/rattler/src/cli/auth.rs
+++ b/crates/rattler/src/cli/auth.rs
@@ -663,17 +663,36 @@ fn print_token_metadata(metadata: Option<&TokenMetadata>) {
     };
 
     if !metadata.scopes.is_empty() {
-        println!("  scopes: {}", metadata.scopes.join(", "));
+        let scopes = metadata
+            .scopes
+            .iter()
+            .map(|s| format!("'{s}'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        println!("  - Token scopes: {scopes}");
     }
     if let Some(issuer) = &metadata.issuer {
-        println!("  issuer: {issuer}");
+        println!("  - Issuer: {issuer}");
     }
     if !metadata.audience.is_empty() {
-        println!("  audience: {}", metadata.audience.join(", "));
+        println!("  - Audience: {}", metadata.audience.join(", "));
     }
     if let Some(subject) = &metadata.subject {
-        println!("  subject: {subject}");
+        println!("  - Subject: {subject}");
     }
+}
+
+/// Render a secret token in a redacted, gh-style form: keep a short visible
+/// prefix and pad with asterisks so the user can recognize the token without
+/// the secret material appearing on screen.
+fn redact_token(token: &str) -> String {
+    const VISIBLE_PREFIX: usize = 4;
+    const TOTAL_LEN: usize = 40;
+
+    let visible_len = token.chars().count().min(VISIBLE_PREFIX);
+    let visible: String = token.chars().take(visible_len).collect();
+    let mask_len = TOTAL_LEN.saturating_sub(visible_len);
+    format!("{visible}{}", "*".repeat(mask_len))
 }
 
 fn print_authentication_status(
@@ -684,17 +703,22 @@ fn print_authentication_status(
     now: i64,
 ) {
     println!("{host}");
-    println!("  source: {source}");
-    println!("  method: {}", auth.method());
-    if let Some(account) = account {
-        println!("  account: {account}");
+
+    // Header line. For verified prefix.dev entries (account known) we mirror
+    // `gh auth status` and lead with a "✓ Logged in to ..." line. For
+    // anything else we just report where the entry came from.
+    match account {
+        Some(account) => println!("  ✓ Logged in to {host} account {account} ({source})"),
+        None => println!("  - Source: {source}"),
     }
+    println!("  - Method: {}", auth.method());
 
     match auth {
         Authentication::BearerToken(token) => {
             let metadata = token_metadata(token);
+            println!("  - Token: {}", redact_token(token));
             println!(
-                "  validity: {}",
+                "  - Token validity: {}",
                 format_validity(
                     metadata.as_ref().and_then(|metadata| metadata.expires_at),
                     now
@@ -704,8 +728,9 @@ fn print_authentication_status(
         }
         Authentication::CondaToken(token) => {
             let metadata = token_metadata(token);
+            println!("  - Token: {}", redact_token(token));
             println!(
-                "  validity: {}",
+                "  - Token validity: {}",
                 format_validity(
                     metadata.as_ref().and_then(|metadata| metadata.expires_at),
                     now
@@ -722,34 +747,44 @@ fn print_authentication_status(
             client_id,
         } => {
             let metadata = token_metadata(access_token);
+            println!("  - Token: {}", redact_token(access_token));
             println!(
-                "  validity: {}",
+                "  - Token validity: {}",
                 format_validity(
                     expires_at
                         .or_else(|| metadata.as_ref().and_then(|metadata| metadata.expires_at)),
                     now,
                 )
             );
-            println!("  client id: {client_id}");
+            println!("  - Client ID: {client_id}");
             println!(
-                "  refresh token: {}",
+                "  - Refresh token: {}",
                 if refresh_token.is_some() { "yes" } else { "no" }
             );
-            println!("  token endpoint: {token_endpoint}");
+            println!("  - Token endpoint: {token_endpoint}");
             if let Some(revocation_endpoint) = revocation_endpoint {
-                println!("  revocation endpoint: {revocation_endpoint}");
+                println!("  - Revocation endpoint: {revocation_endpoint}");
             }
             print_token_metadata(metadata.as_ref());
         }
         Authentication::BasicHTTP { username, .. } => {
-            println!("  validity: unknown (basic authentication)");
-            println!("  username: {username}");
+            println!("  - Username: {username}");
+            println!("  - Password: {}", "*".repeat(12));
         }
-        Authentication::S3Credentials { session_token, .. } => {
-            println!("  validity: unknown (S3 credentials)");
+        Authentication::S3Credentials {
+            access_key_id,
+            session_token,
+            ..
+        } => {
+            println!("  - Access key ID: {}", redact_token(access_key_id));
+            println!("  - Secret access key: {}", "*".repeat(40));
             println!(
-                "  session token: {}",
-                if session_token.is_some() { "yes" } else { "no" }
+                "  - Session token: {}",
+                if session_token.is_some() {
+                    "present"
+                } else {
+                    "none"
+                }
             );
         }
     }

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -17,6 +17,12 @@ rustls = ["reqwest/rustls", "ambient-id/rustls"]
 gcs = ["google-cloud-auth", "tokio/sync"]
 s3 = ["aws-config", "aws-sdk-s3", "aws-smithy-http-client"]
 system-integration = ["keyring", "netrc-rs", "dirs"]
+keyring = [
+    "keyring-core",
+    "dep:apple-native-keyring-store",
+    "dep:dbus-secret-service-keyring-store",
+    "dep:windows-native-keyring-store",
+]
 
 [package.metadata.docs.rs]
 features = ["gcs", "s3"]
@@ -45,13 +51,7 @@ aws-sdk-s3 = { workspace = true, optional = true, features = [
 aws-smithy-http-client = { workspace = true, optional = true, features = ["rustls-aws-lc"] }
 http = { workspace = true }
 itertools = { workspace = true }
-keyring = { workspace = true, optional = true, features = [
-    "apple-native",
-    "windows-native",
-    "async-secret-service",
-    "async-io",
-    "crypto-rust",
-] }
+keyring-core = { workspace = true, optional = true }
 netrc-rs = { workspace = true, optional = true }
 reqwest = { workspace = true, features = ["json", "form"] }
 reqwest-middleware = { workspace = true, features = ["json"] }
@@ -67,6 +67,18 @@ rattler_config = { workspace = true, optional = true }
 
 [target.'cfg( target_arch = "wasm32" )'.dependencies]
 getrandom = { workspace = true, features = ["wasm_js"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+apple-native-keyring-store = { workspace = true, optional = true, features = ["keychain"] }
+
+[target.'cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))'.dependencies]
+dbus-secret-service-keyring-store = { workspace = true, optional = true, features = [
+    "crypto-rust",
+    "vendored",
+] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows-native-keyring-store = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/rattler_networking/src/authentication_middleware.rs
+++ b/crates/rattler_networking/src/authentication_middleware.rs
@@ -251,7 +251,7 @@ mod tests {
         let host = "conda.example.com";
 
         // Make sure the keyring is empty
-        if let Ok(entry) = keyring::Entry::new("rattler_test", host) {
+        if let Ok(entry) = keyring_core::Entry::new("rattler_test", host) {
             let _ = entry.delete_credential();
         }
 
@@ -306,7 +306,7 @@ mod tests {
         let host = "bearer.example.com";
 
         // Make sure the keyring is empty
-        if let Ok(entry) = keyring::Entry::new("rattler_test", host) {
+        if let Ok(entry) = keyring_core::Entry::new("rattler_test", host) {
             let _ = entry.delete_credential();
         }
 
@@ -367,7 +367,7 @@ mod tests {
         let host = "basic.example.com";
 
         // Make sure the keyring is empty
-        if let Ok(entry) = keyring::Entry::new("rattler_test", host) {
+        if let Ok(entry) = keyring_core::Entry::new("rattler_test", host) {
             let _ = entry.delete_credential();
         }
 

--- a/crates/rattler_networking/src/authentication_storage/backends/file.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/file.rs
@@ -148,6 +148,15 @@ impl StorageBackend for FileStorage {
         Ok(cache.content.get(host).cloned())
     }
 
+    fn list(&self) -> Result<Vec<(String, crate::Authentication)>, AuthenticationStorageError> {
+        let cache = self.cache.read().unwrap();
+        Ok(cache
+            .content
+            .iter()
+            .map(|(host, auth)| (host.clone(), auth.clone()))
+            .collect())
+    }
+
     fn delete(&self, host: &str) -> Result<(), AuthenticationStorageError> {
         let mut dict = self.read_json()?;
         if dict.remove(host).is_some() {

--- a/crates/rattler_networking/src/authentication_storage/backends/file.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/file.rs
@@ -133,6 +133,10 @@ impl FileStorage {
 }
 
 impl StorageBackend for FileStorage {
+    fn name(&self) -> String {
+        format!("file ({})", self.path.display())
+    }
+
     fn store(
         &self,
         host: &str,

--- a/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
@@ -1,28 +1,19 @@
 //! Backend to store credentials in the operating system's keyring
 
-use keyring_core::Entry;
-use std::str::FromStr;
+use keyring_core::{Entry, api::CredentialStore};
+use std::{collections::HashMap, str::FromStr, sync::Arc};
 
 use crate::{
     Authentication,
     authentication_storage::{AuthenticationStorageError, StorageBackend},
 };
 
-const INDEX_ACCOUNT: &str = "__rattler_authentication_hosts";
-
-/// Hosts that rattler historically stored credentials for under the keyring
-/// `rattler` service name, before the `__rattler_authentication_hosts` index
-/// was introduced. Probed during [`list`](StorageBackend::list) so that
-/// `auth status` can still surface legacy keychain entries written by older
-/// rattler / pixi versions. New stores are tracked via the index and don't
-/// need to appear here.
-const LEGACY_FALLBACK_HOSTS: &[&str] = &[
-    "prefix.dev",
-    "*.prefix.dev",
-    "repo.prefix.dev",
-    "anaconda.org",
-    "*.anaconda.org",
-];
+/// Account name used by older rattler/pixi versions to store a JSON-encoded
+/// list of hosts under the `rattler` service. Newer rattler versions enumerate
+/// entries via `CredentialStore::search`, so this entry is no longer written
+/// — but we still filter it out of `list()` results and opportunistically
+/// delete it during `store`/`delete` so it doesn't linger in users' keychains.
+const LEGACY_INDEX_ACCOUNT: &str = "__rattler_authentication_hosts";
 
 fn configure_default_store() -> Result<(), KeyringAuthenticationStorageError> {
     if keyring_core::get_default_store().is_some() {
@@ -61,6 +52,39 @@ fn configure_platform_default_store() -> Result<(), KeyringAuthenticationStorage
     })
 }
 
+/// Build the platform-specific [`CredentialStore::search`] spec that enumerates
+/// every entry written by this storage instance.
+///
+/// macOS and the dbus secret service filter on the `service` attribute
+/// directly. Windows has no notion of a "service" field — the keyring-core
+/// store encodes `service` into the credential target as `{user}.{service}`
+/// (default delimiters) and exposes a `pattern` (regex) filter, so we match on
+/// the suffix.
+#[cfg(any(
+    target_os = "macos",
+    all(unix, not(any(target_os = "macos", target_os = "ios")))
+))]
+fn search_spec(store_key: &str) -> HashMap<String, String> {
+    HashMap::from([("service".to_string(), store_key.to_string())])
+}
+
+#[cfg(target_os = "windows")]
+fn search_spec(store_key: &str) -> HashMap<String, String> {
+    // `\Q...\E` quotes the store_key as a literal so any future caller using a
+    // custom (possibly regex-meaningful) store key still gets the expected
+    // entries back.
+    HashMap::from([("pattern".to_string(), format!(r"\.\Q{store_key}\E\z"))])
+}
+
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "windows",
+    all(unix, not(any(target_os = "macos", target_os = "ios")))
+)))]
+fn search_spec(_store_key: &str) -> HashMap<String, String> {
+    HashMap::new()
+}
+
 #[derive(Clone, Debug)]
 /// A storage backend that stores credentials in the operating system's keyring
 pub struct KeyringAuthenticationStorage {
@@ -82,47 +106,26 @@ impl KeyringAuthenticationStorage {
         Entry::new(&self.store_key, host).map_err(KeyringAuthenticationStorageError::from)
     }
 
-    fn index_entry(&self) -> Result<Entry, KeyringAuthenticationStorageError> {
-        self.entry(INDEX_ACCOUNT)
+    fn credential_store(&self) -> Result<Arc<CredentialStore>, KeyringAuthenticationStorageError> {
+        configure_default_store()?;
+        keyring_core::get_default_store().ok_or_else(|| {
+            KeyringAuthenticationStorageError::UnsupportedTarget {
+                target: std::env::consts::OS.to_string(),
+            }
+        })
     }
 
-    fn read_index(&self) -> Result<Vec<String>, KeyringAuthenticationStorageError> {
-        let entry = self.index_entry()?;
-        let password = match entry.get_password() {
-            Ok(password) => password,
-            Err(keyring_core::Error::NoEntry) => return Ok(Vec::new()),
-            Err(err) => return Err(KeyringAuthenticationStorageError::from(err)),
+    /// Delete the legacy index entry written by older rattler/pixi versions if
+    /// it's still around. Failures are logged but don't propagate — this is a
+    /// best-effort cleanup.
+    fn purge_legacy_index(&self) {
+        let Ok(entry) = self.entry(LEGACY_INDEX_ACCOUNT) else {
+            return;
         };
-
-        serde_json::from_str(&password).map_err(KeyringAuthenticationStorageError::from)
-    }
-
-    fn write_index(&self, hosts: &[String]) -> Result<(), KeyringAuthenticationStorageError> {
-        let password =
-            serde_json::to_string(hosts).map_err(KeyringAuthenticationStorageError::from)?;
-        self.index_entry()?
-            .set_password(&password)
-            .map_err(KeyringAuthenticationStorageError::from)
-    }
-
-    fn add_to_index(&self, host: &str) -> Result<(), KeyringAuthenticationStorageError> {
-        let mut hosts = self.read_index()?;
-        if !hosts.iter().any(|existing| existing == host) {
-            hosts.push(host.to_string());
-            hosts.sort();
-            self.write_index(&hosts)?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring_core::Error::NoEntry) => {}
+            Err(err) => tracing::debug!("Could not remove legacy keyring index entry: {err}"),
         }
-        Ok(())
-    }
-
-    fn remove_from_index(&self, host: &str) -> Result<(), KeyringAuthenticationStorageError> {
-        let mut hosts = self.read_index()?;
-        let previous_len = hosts.len();
-        hosts.retain(|existing| existing != host);
-        if hosts.len() != previous_len {
-            self.write_index(&hosts)?;
-        }
-        Ok(())
     }
 }
 
@@ -196,9 +199,7 @@ impl StorageBackend for KeyringAuthenticationStorage {
             .set_password(&password)
             .map_err(KeyringAuthenticationStorageError::from)?;
 
-        if let Err(err) = self.add_to_index(host) {
-            tracing::debug!("Error updating keyring credential index: {err}");
-        }
+        self.purge_legacy_index();
 
         Ok(())
     }
@@ -226,18 +227,45 @@ impl StorageBackend for KeyringAuthenticationStorage {
     }
 
     fn list(&self) -> Result<Vec<(String, Authentication)>, AuthenticationStorageError> {
-        let mut hosts = self.read_index()?;
-        hosts.extend(LEGACY_FALLBACK_HOSTS.iter().map(ToString::to_string));
-        hosts.sort();
-        hosts.dedup();
+        let store = self.credential_store()?;
+        let spec = search_spec(&self.store_key);
+        let spec_refs: HashMap<&str, &str> =
+            spec.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
 
-        let mut entries = Vec::new();
-        for host in hosts {
-            if let Some(auth) = self.get(&host)? {
-                entries.push((host, auth));
+        let entries = store
+            .search(&spec_refs)
+            .map_err(KeyringAuthenticationStorageError::from)?;
+
+        let mut results = Vec::new();
+        for entry in entries {
+            let Some((service, account)) = entry.get_specifiers() else {
+                continue;
+            };
+            // Defensive: on Windows the regex may match credentials whose
+            // service component coincidentally ends in our store_key.
+            if service != self.store_key {
+                continue;
+            }
+            if account == LEGACY_INDEX_ACCOUNT {
+                continue;
+            }
+
+            let password = match entry.get_password() {
+                Ok(password) => password,
+                Err(keyring_core::Error::NoEntry) => continue,
+                Err(err) => return Err(KeyringAuthenticationStorageError::from(err).into()),
+            };
+
+            match Authentication::from_str(&password) {
+                Ok(auth) => results.push((account, auth)),
+                Err(err) => {
+                    tracing::warn!("Error parsing credentials for {account}: {err:?}");
+                }
             }
         }
-        Ok(entries)
+
+        results.sort_by(|a, b| a.0.cmp(&b.0));
+        Ok(results)
     }
 
     fn delete(&self, host: &str) -> Result<(), AuthenticationStorageError> {
@@ -248,9 +276,7 @@ impl StorageBackend for KeyringAuthenticationStorage {
             Err(err) => return Err(KeyringAuthenticationStorageError::from(err).into()),
         }
 
-        if let Err(err) = self.remove_from_index(host) {
-            tracing::debug!("Error updating keyring credential index: {err}");
-        }
+        self.purge_legacy_index();
 
         Ok(())
     }

--- a/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
@@ -1,6 +1,6 @@
 //! Backend to store credentials in the operating system's keyring
 
-use keyring::Entry;
+use keyring_core::Entry;
 use std::str::FromStr;
 
 use crate::{
@@ -16,6 +16,43 @@ const WELL_KNOWN_HOSTS: &[&str] = &[
     "anaconda.org",
     "*.anaconda.org",
 ];
+
+fn configure_default_store() -> Result<(), KeyringAuthenticationStorageError> {
+    if keyring_core::get_default_store().is_some() {
+        Ok(())
+    } else {
+        configure_platform_default_store()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn configure_platform_default_store() -> Result<(), KeyringAuthenticationStorageError> {
+    keyring_core::set_default_store(apple_native_keyring_store::keychain::Store::new()?);
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn configure_platform_default_store() -> Result<(), KeyringAuthenticationStorageError> {
+    keyring_core::set_default_store(windows_native_keyring_store::Store::new()?);
+    Ok(())
+}
+
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+fn configure_platform_default_store() -> Result<(), KeyringAuthenticationStorageError> {
+    keyring_core::set_default_store(dbus_secret_service_keyring_store::Store::new()?);
+    Ok(())
+}
+
+#[cfg(not(any(
+    target_os = "macos",
+    target_os = "windows",
+    all(unix, not(any(target_os = "macos", target_os = "ios")))
+)))]
+fn configure_platform_default_store() -> Result<(), KeyringAuthenticationStorageError> {
+    Err(KeyringAuthenticationStorageError::UnsupportedTarget {
+        target: std::env::consts::OS.to_string(),
+    })
+}
 
 #[derive(Clone, Debug)]
 /// A storage backend that stores credentials in the operating system's keyring
@@ -33,15 +70,20 @@ impl KeyringAuthenticationStorage {
         }
     }
 
+    fn entry(&self, host: &str) -> Result<Entry, KeyringAuthenticationStorageError> {
+        configure_default_store()?;
+        Entry::new(&self.store_key, host).map_err(KeyringAuthenticationStorageError::from)
+    }
+
     fn index_entry(&self) -> Result<Entry, KeyringAuthenticationStorageError> {
-        Entry::new(&self.store_key, INDEX_ACCOUNT).map_err(KeyringAuthenticationStorageError::from)
+        self.entry(INDEX_ACCOUNT)
     }
 
     fn read_index(&self) -> Result<Vec<String>, KeyringAuthenticationStorageError> {
         let entry = self.index_entry()?;
         let password = match entry.get_password() {
             Ok(password) => password,
-            Err(keyring::Error::NoEntry) => return Ok(Vec::new()),
+            Err(keyring_core::Error::NoEntry) => return Ok(Vec::new()),
             Err(err) => return Err(KeyringAuthenticationStorageError::from(err)),
         };
 
@@ -83,7 +125,14 @@ pub enum KeyringAuthenticationStorageError {
     // TODO: make this more fine-grained
     /// An error occurred when accessing the authentication storage
     #[error("Could not retrieve credentials from authentication storage: {0}")]
-    StorageError(#[from] keyring::Error),
+    StorageError(#[from] keyring_core::Error),
+
+    /// The current target does not have a configured keyring-core store.
+    #[error("No keyring-core credential store is configured for {target}")]
+    UnsupportedTarget {
+        /// Target OS without a configured keyring-core store.
+        target: String,
+    },
 
     /// An error occurred when serializing the credentials
     #[error("Could not serialize credentials {0}")]
@@ -111,8 +160,7 @@ impl StorageBackend for KeyringAuthenticationStorage {
     ) -> Result<(), AuthenticationStorageError> {
         let password = serde_json::to_string(authentication)
             .map_err(KeyringAuthenticationStorageError::from)?;
-        let entry =
-            Entry::new(&self.store_key, host).map_err(KeyringAuthenticationStorageError::from)?;
+        let entry = self.entry(host)?;
 
         entry
             .set_password(&password)
@@ -126,13 +174,12 @@ impl StorageBackend for KeyringAuthenticationStorage {
     }
 
     fn get(&self, host: &str) -> Result<Option<Authentication>, AuthenticationStorageError> {
-        let entry =
-            Entry::new(&self.store_key, host).map_err(KeyringAuthenticationStorageError::from)?;
+        let entry = self.entry(host)?;
         let password = entry.get_password();
 
         let p_string = match password {
             Ok(password) => password,
-            Err(keyring::Error::NoEntry) => return Ok(None),
+            Err(keyring_core::Error::NoEntry) => return Ok(None),
             Err(e) => return Err(KeyringAuthenticationStorageError::from(e))?,
         };
 
@@ -151,7 +198,7 @@ impl StorageBackend for KeyringAuthenticationStorage {
     fn list(&self) -> Result<Vec<(String, Authentication)>, AuthenticationStorageError> {
         let mut entries = Vec::new();
         let mut hosts = self.read_index()?;
-        hosts.extend(WELL_KNOWN_HOSTS.iter().map(|host| host.to_string()));
+        hosts.extend(WELL_KNOWN_HOSTS.iter().map(ToString::to_string));
         hosts.sort();
         hosts.dedup();
 
@@ -164,11 +211,10 @@ impl StorageBackend for KeyringAuthenticationStorage {
     }
 
     fn delete(&self, host: &str) -> Result<(), AuthenticationStorageError> {
-        let entry =
-            Entry::new(&self.store_key, host).map_err(KeyringAuthenticationStorageError::from)?;
+        let entry = self.entry(host)?;
 
         match entry.delete_credential() {
-            Ok(()) | Err(keyring::Error::NoEntry) => {}
+            Ok(()) | Err(keyring_core::Error::NoEntry) => {}
             Err(err) => return Err(KeyringAuthenticationStorageError::from(err).into()),
         }
 

--- a/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
@@ -98,15 +98,15 @@ impl KeyringAuthenticationStorage {
         configure_default_store()?;
         Entry::new(&self.store_key, host).map_err(KeyringAuthenticationStorageError::from)
     }
+}
 
-    fn credential_store(&self) -> Result<Arc<CredentialStore>, KeyringAuthenticationStorageError> {
-        configure_default_store()?;
-        keyring_core::get_default_store().ok_or_else(|| {
-            KeyringAuthenticationStorageError::UnsupportedTarget {
-                target: std::env::consts::OS.to_string(),
-            }
-        })
-    }
+fn credential_store() -> Result<Arc<CredentialStore>, KeyringAuthenticationStorageError> {
+    configure_default_store()?;
+    keyring_core::get_default_store().ok_or_else(|| {
+        KeyringAuthenticationStorageError::UnsupportedTarget {
+            target: std::env::consts::OS.to_string(),
+        }
+    })
 }
 
 /// An error that can occur when accessing the authentication storage
@@ -205,7 +205,7 @@ impl StorageBackend for KeyringAuthenticationStorage {
     }
 
     fn list(&self) -> Result<Vec<(String, Authentication)>, AuthenticationStorageError> {
-        let store = self.credential_store()?;
+        let store = credential_store()?;
         let spec = search_spec(&self.store_key);
         let spec_refs: HashMap<&str, &str> =
             spec.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();

--- a/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
@@ -153,6 +153,29 @@ impl Default for KeyringAuthenticationStorage {
 }
 
 impl StorageBackend for KeyringAuthenticationStorage {
+    fn name(&self) -> String {
+        #[cfg(target_os = "macos")]
+        {
+            "macOS keychain".to_string()
+        }
+        #[cfg(target_os = "windows")]
+        {
+            "Windows credential manager".to_string()
+        }
+        #[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
+        {
+            "secret service (keyring)".to_string()
+        }
+        #[cfg(not(any(
+            target_os = "macos",
+            target_os = "windows",
+            all(unix, not(any(target_os = "macos", target_os = "ios")))
+        )))]
+        {
+            "keyring".to_string()
+        }
+    }
+
     fn store(
         &self,
         host: &str,

--- a/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
@@ -10,6 +10,20 @@ use crate::{
 
 const INDEX_ACCOUNT: &str = "__rattler_authentication_hosts";
 
+/// Hosts that rattler historically stored credentials for under the keyring
+/// `rattler` service name, before the `__rattler_authentication_hosts` index
+/// was introduced. Probed during [`list`](StorageBackend::list) so that
+/// `auth status` can still surface legacy keychain entries written by older
+/// rattler / pixi versions. New stores are tracked via the index and don't
+/// need to appear here.
+const LEGACY_FALLBACK_HOSTS: &[&str] = &[
+    "prefix.dev",
+    "*.prefix.dev",
+    "repo.prefix.dev",
+    "anaconda.org",
+    "*.anaconda.org",
+];
+
 fn configure_default_store() -> Result<(), KeyringAuthenticationStorageError> {
     if keyring_core::get_default_store().is_some() {
         Ok(())
@@ -212,8 +226,13 @@ impl StorageBackend for KeyringAuthenticationStorage {
     }
 
     fn list(&self) -> Result<Vec<(String, Authentication)>, AuthenticationStorageError> {
+        let mut hosts = self.read_index()?;
+        hosts.extend(LEGACY_FALLBACK_HOSTS.iter().map(ToString::to_string));
+        hosts.sort();
+        hosts.dedup();
+
         let mut entries = Vec::new();
-        for host in self.read_index()? {
+        for host in hosts {
             if let Some(auth) = self.get(&host)? {
                 entries.push((host, auth));
             }

--- a/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
@@ -8,13 +8,6 @@ use crate::{
     authentication_storage::{AuthenticationStorageError, StorageBackend},
 };
 
-/// Account name used by older rattler/pixi versions to store a JSON-encoded
-/// list of hosts under the `rattler` service. Newer rattler versions enumerate
-/// entries via `CredentialStore::search`, so this entry is no longer written
-/// — but we still filter it out of `list()` results and opportunistically
-/// delete it during `store`/`delete` so it doesn't linger in users' keychains.
-const LEGACY_INDEX_ACCOUNT: &str = "__rattler_authentication_hosts";
-
 fn configure_default_store() -> Result<(), KeyringAuthenticationStorageError> {
     if keyring_core::get_default_store().is_some() {
         Ok(())
@@ -114,19 +107,6 @@ impl KeyringAuthenticationStorage {
             }
         })
     }
-
-    /// Delete the legacy index entry written by older rattler/pixi versions if
-    /// it's still around. Failures are logged but don't propagate — this is a
-    /// best-effort cleanup.
-    fn purge_legacy_index(&self) {
-        let Ok(entry) = self.entry(LEGACY_INDEX_ACCOUNT) else {
-            return;
-        };
-        match entry.delete_credential() {
-            Ok(()) | Err(keyring_core::Error::NoEntry) => {}
-            Err(err) => tracing::debug!("Could not remove legacy keyring index entry: {err}"),
-        }
-    }
 }
 
 /// An error that can occur when accessing the authentication storage
@@ -199,8 +179,6 @@ impl StorageBackend for KeyringAuthenticationStorage {
             .set_password(&password)
             .map_err(KeyringAuthenticationStorageError::from)?;
 
-        self.purge_legacy_index();
-
         Ok(())
     }
 
@@ -246,9 +224,6 @@ impl StorageBackend for KeyringAuthenticationStorage {
             if service != self.store_key {
                 continue;
             }
-            if account == LEGACY_INDEX_ACCOUNT {
-                continue;
-            }
 
             let password = match entry.get_password() {
                 Ok(password) => password,
@@ -275,8 +250,6 @@ impl StorageBackend for KeyringAuthenticationStorage {
             Ok(()) | Err(keyring_core::Error::NoEntry) => {}
             Err(err) => return Err(KeyringAuthenticationStorageError::from(err).into()),
         }
-
-        self.purge_legacy_index();
 
         Ok(())
     }

--- a/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
@@ -8,6 +8,15 @@ use crate::{
     authentication_storage::{AuthenticationStorageError, StorageBackend},
 };
 
+const INDEX_ACCOUNT: &str = "__rattler_authentication_hosts";
+const WELL_KNOWN_HOSTS: &[&str] = &[
+    "prefix.dev",
+    "*.prefix.dev",
+    "repo.prefix.dev",
+    "anaconda.org",
+    "*.anaconda.org",
+];
+
 #[derive(Clone, Debug)]
 /// A storage backend that stores credentials in the operating system's keyring
 pub struct KeyringAuthenticationStorage {
@@ -22,6 +31,49 @@ impl KeyringAuthenticationStorage {
         Self {
             store_key: store_key.to_string(),
         }
+    }
+
+    fn index_entry(&self) -> Result<Entry, KeyringAuthenticationStorageError> {
+        Entry::new(&self.store_key, INDEX_ACCOUNT).map_err(KeyringAuthenticationStorageError::from)
+    }
+
+    fn read_index(&self) -> Result<Vec<String>, KeyringAuthenticationStorageError> {
+        let entry = self.index_entry()?;
+        let password = match entry.get_password() {
+            Ok(password) => password,
+            Err(keyring::Error::NoEntry) => return Ok(Vec::new()),
+            Err(err) => return Err(KeyringAuthenticationStorageError::from(err)),
+        };
+
+        serde_json::from_str(&password).map_err(KeyringAuthenticationStorageError::from)
+    }
+
+    fn write_index(&self, hosts: &[String]) -> Result<(), KeyringAuthenticationStorageError> {
+        let password =
+            serde_json::to_string(hosts).map_err(KeyringAuthenticationStorageError::from)?;
+        self.index_entry()?
+            .set_password(&password)
+            .map_err(KeyringAuthenticationStorageError::from)
+    }
+
+    fn add_to_index(&self, host: &str) -> Result<(), KeyringAuthenticationStorageError> {
+        let mut hosts = self.read_index()?;
+        if !hosts.iter().any(|existing| existing == host) {
+            hosts.push(host.to_string());
+            hosts.sort();
+            self.write_index(&hosts)?;
+        }
+        Ok(())
+    }
+
+    fn remove_from_index(&self, host: &str) -> Result<(), KeyringAuthenticationStorageError> {
+        let mut hosts = self.read_index()?;
+        let previous_len = hosts.len();
+        hosts.retain(|existing| existing != host);
+        if hosts.len() != previous_len {
+            self.write_index(&hosts)?;
+        }
+        Ok(())
     }
 }
 
@@ -66,6 +118,10 @@ impl StorageBackend for KeyringAuthenticationStorage {
             .set_password(&password)
             .map_err(KeyringAuthenticationStorageError::from)?;
 
+        if let Err(err) = self.add_to_index(host) {
+            tracing::debug!("Error updating keyring credential index: {err}");
+        }
+
         Ok(())
     }
 
@@ -92,12 +148,33 @@ impl StorageBackend for KeyringAuthenticationStorage {
         }
     }
 
+    fn list(&self) -> Result<Vec<(String, Authentication)>, AuthenticationStorageError> {
+        let mut entries = Vec::new();
+        let mut hosts = self.read_index()?;
+        hosts.extend(WELL_KNOWN_HOSTS.iter().map(|host| host.to_string()));
+        hosts.sort();
+        hosts.dedup();
+
+        for host in hosts {
+            if let Some(auth) = self.get(&host)? {
+                entries.push((host, auth));
+            }
+        }
+        Ok(entries)
+    }
+
     fn delete(&self, host: &str) -> Result<(), AuthenticationStorageError> {
         let entry =
             Entry::new(&self.store_key, host).map_err(KeyringAuthenticationStorageError::from)?;
-        entry
-            .delete_credential()
-            .map_err(KeyringAuthenticationStorageError::from)?;
+
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => {}
+            Err(err) => return Err(KeyringAuthenticationStorageError::from(err).into()),
+        }
+
+        if let Err(err) = self.remove_from_index(host) {
+            tracing::debug!("Error updating keyring credential index: {err}");
+        }
 
         Ok(())
     }

--- a/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
@@ -9,13 +9,6 @@ use crate::{
 };
 
 const INDEX_ACCOUNT: &str = "__rattler_authentication_hosts";
-const WELL_KNOWN_HOSTS: &[&str] = &[
-    "prefix.dev",
-    "*.prefix.dev",
-    "repo.prefix.dev",
-    "anaconda.org",
-    "*.anaconda.org",
-];
 
 fn configure_default_store() -> Result<(), KeyringAuthenticationStorageError> {
     if keyring_core::get_default_store().is_some() {
@@ -220,12 +213,7 @@ impl StorageBackend for KeyringAuthenticationStorage {
 
     fn list(&self) -> Result<Vec<(String, Authentication)>, AuthenticationStorageError> {
         let mut entries = Vec::new();
-        let mut hosts = self.read_index()?;
-        hosts.extend(WELL_KNOWN_HOSTS.iter().map(ToString::to_string));
-        hosts.sort();
-        hosts.dedup();
-
-        for host in hosts {
+        for host in self.read_index()? {
             if let Some(auth) = self.get(&host)? {
                 entries.push((host, auth));
             }

--- a/crates/rattler_networking/src/authentication_storage/backends/memory.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/memory.rs
@@ -58,6 +58,17 @@ impl StorageBackend for MemoryStorage {
         Ok(store.get(host).cloned())
     }
 
+    fn list(&self) -> Result<Vec<(String, crate::Authentication)>, AuthenticationStorageError> {
+        let store = self
+            .store
+            .lock()
+            .map_err(|_err| MemoryStorageError::LockError)?;
+        Ok(store
+            .iter()
+            .map(|(host, auth)| (host.clone(), auth.clone()))
+            .collect())
+    }
+
     fn delete(&self, host: &str) -> Result<(), AuthenticationStorageError> {
         let mut store = self
             .store

--- a/crates/rattler_networking/src/authentication_storage/backends/memory.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/memory.rs
@@ -37,6 +37,10 @@ pub enum MemoryStorageError {
 }
 
 impl StorageBackend for MemoryStorage {
+    fn name(&self) -> String {
+        "memory".to_string()
+    }
+
     fn store(
         &self,
         host: &str,

--- a/crates/rattler_networking/src/authentication_storage/backends/netrc.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/netrc.rs
@@ -130,6 +130,18 @@ impl StorageBackend for NetRcStorage {
             Err(err) => Err(err.into()),
         }
     }
+
+    fn list(&self) -> Result<Vec<(String, Authentication)>, AuthenticationStorageError> {
+        self.machines
+            .keys()
+            .map(|host| {
+                self.get_password(host)
+                    .map(|auth| auth.map(|auth| (host.clone(), auth)))
+                    .map_err(AuthenticationStorageError::from)
+            })
+            .filter_map(Result::transpose)
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/crates/rattler_networking/src/authentication_storage/backends/netrc.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/netrc.rs
@@ -25,6 +25,11 @@ fn default_netrc_path() -> PathBuf {
 /// information backed by a on-disk JSON file
 #[derive(Debug, Clone, Default)]
 pub struct NetRcStorage {
+    /// The path to the netrc file that was loaded, if any. Surfaced via
+    /// [`StorageBackend::name`] so that `auth status` can show users which
+    /// file the credentials came from.
+    path: Option<PathBuf>,
+
     /// The netrc file contents
     machines: HashMap<String, Machine>,
 }
@@ -74,7 +79,10 @@ impl NetRcStorage {
             Err(NetRcStorageError::IOError(err))
                 if err.kind() == ErrorKind::NotFound && !explicit =>
             {
-                Ok(Self::default())
+                Ok(Self {
+                    path: Some(path),
+                    machines: HashMap::new(),
+                })
             }
             Err(err) => Err((path, err)),
         }
@@ -91,7 +99,10 @@ impl NetRcStorage {
             .map(|m| (m.name.clone(), m))
             .filter_map(|(name, value)| name.map(|n| (n, value)))
             .collect();
-        Ok(Self { machines })
+        Ok(Self {
+            path: Some(path.to_path_buf()),
+            machines,
+        })
     }
 
     /// Retrieve the authentication information for the given host
@@ -107,6 +118,13 @@ impl NetRcStorage {
 }
 
 impl StorageBackend for NetRcStorage {
+    fn name(&self) -> String {
+        match &self.path {
+            Some(path) => format!("netrc ({})", path.display()),
+            None => "netrc".to_string(),
+        }
+    }
+
     fn store(
         &self,
         _host: &str,

--- a/crates/rattler_networking/src/authentication_storage/mod.rs
+++ b/crates/rattler_networking/src/authentication_storage/mod.rs
@@ -28,6 +28,11 @@ pub enum AuthenticationStorageError {
 
 /// A trait that defines the interface for authentication storage backends
 pub trait StorageBackend: std::fmt::Debug {
+    /// A short human-readable description identifying this backend (and any
+    /// relevant location, like a file path). Surfaced to users by the
+    /// `auth status` CLI so they can tell where each credential lives.
+    fn name(&self) -> String;
+
     /// Store the given authentication information for the given host
     fn store(
         &self,

--- a/crates/rattler_networking/src/authentication_storage/mod.rs
+++ b/crates/rattler_networking/src/authentication_storage/mod.rs
@@ -38,6 +38,15 @@ pub trait StorageBackend: std::fmt::Debug {
     /// Retrieve the authentication information for the given host
     fn get(&self, host: &str) -> Result<Option<Authentication>, AuthenticationStorageError>;
 
+    /// List all authentication entries known to this backend.
+    ///
+    /// Some backends, such as platform keyrings, cannot enumerate arbitrary
+    /// legacy entries. They may return only entries that were stored with an
+    /// index maintained by this crate.
+    fn list(&self) -> Result<Vec<(String, Authentication)>, AuthenticationStorageError> {
+        Ok(Vec::new())
+    }
+
     /// Delete the authentication information for the given host
     fn delete(&self, host: &str) -> Result<(), AuthenticationStorageError>;
 }

--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -3,7 +3,7 @@
 use anyhow::{Result, anyhow};
 use reqwest::IntoUrl;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     sync::{Arc, Mutex},
 };
 use url::Url;
@@ -146,6 +146,29 @@ impl AuthenticationStorage {
         cache.insert(host.to_string(), None);
 
         Ok(None)
+    }
+
+    /// List authentication entries known to the configured backends.
+    ///
+    /// Entries are deduplicated by host using backend priority, matching the
+    /// lookup behavior of [`get`](Self::get).
+    pub fn list(&self) -> Result<Vec<(String, Authentication)>> {
+        let mut entries = BTreeMap::new();
+
+        for backend in &self.backends {
+            match backend.list() {
+                Ok(backend_entries) => {
+                    for (host, auth) in backend_entries {
+                        entries.entry(host).or_insert(auth);
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!("Error listing credentials from backend: {}", error);
+                }
+            }
+        }
+
+        Ok(entries.into_iter().collect())
     }
 
     /// Retrieve the authentication information for the given URL, along with the
@@ -340,5 +363,25 @@ mod tests {
                 .unwrap();
             assert_eq!(retrieved, Some(auth));
         }
+    }
+
+    #[test]
+    fn list_returns_entries_from_backends() {
+        let mut storage = AuthenticationStorage::empty();
+        storage.add_backend(Arc::new(MemoryStorage::new()));
+        storage
+            .store(
+                "example.com",
+                &Authentication::BearerToken("token".to_string()),
+            )
+            .unwrap();
+
+        assert_eq!(
+            storage.list().unwrap(),
+            vec![(
+                "example.com".to_string(),
+                Authentication::BearerToken("token".to_string())
+            )]
+        );
     }
 }

--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -20,6 +20,26 @@ use crate::authentication_storage::backends::keyring::KeyringAuthenticationStora
 
 #[cfg(feature = "keyring")]
 use super::backends::keyring::KeyringAuthenticationStorage;
+
+/// A single entry returned by [`AuthenticationStorage::list_with_sources`].
+/// Carries the host and credential along with the backend's display name and
+/// a flag indicating whether this is the entry [`get`](AuthenticationStorage::get)
+/// would actually return (the first backend that knows the host wins).
+#[derive(Debug, Clone)]
+pub struct ListedEntry {
+    /// The host this credential is stored under.
+    pub host: String,
+    /// The credential itself.
+    pub auth: Authentication,
+    /// Human-readable name of the backend the entry came from (see
+    /// [`StorageBackend::name`]).
+    pub source: String,
+    /// `true` if this is the entry `get(host)` would return — i.e. the first
+    /// backend (in priority order) that holds credentials for `host`. Later
+    /// backends with the same host are "shadowed" and have `active = false`.
+    pub active: bool,
+}
+
 #[derive(Debug, Clone)]
 /// This struct implements storage and access of authentication
 /// information backed by multiple storage backends
@@ -159,28 +179,13 @@ impl AuthenticationStorage {
     /// Entries are deduplicated by host using backend priority, matching the
     /// lookup behavior of [`get`](Self::get).
     pub fn list(&self) -> Result<Vec<(String, Authentication)>> {
-        Ok(self
-            .list_with_sources()?
-            .into_iter()
-            .map(|(host, auth, _source)| (host, auth))
-            .collect())
-    }
-
-    /// Like [`list`](Self::list), but also reports the human-readable name of
-    /// the backend each entry was loaded from (see [`StorageBackend::name`]).
-    /// Entries are deduplicated by host using backend priority — the first
-    /// backend to surface a given host wins, matching [`get`](Self::get).
-    pub fn list_with_sources(&self) -> Result<Vec<(String, Authentication, String)>> {
-        let mut entries: BTreeMap<String, (Authentication, String)> = BTreeMap::new();
+        let mut entries: BTreeMap<String, Authentication> = BTreeMap::new();
 
         for backend in &self.backends {
             match backend.list() {
                 Ok(backend_entries) => {
-                    let source = backend.name();
                     for (host, auth) in backend_entries {
-                        entries
-                            .entry(host)
-                            .or_insert_with(|| (auth, source.clone()));
+                        entries.entry(host).or_insert(auth);
                     }
                 }
                 Err(error) => {
@@ -189,10 +194,40 @@ impl AuthenticationStorage {
             }
         }
 
-        Ok(entries
-            .into_iter()
-            .map(|(host, (auth, source))| (host, auth, source))
-            .collect())
+        Ok(entries.into_iter().collect())
+    }
+
+    /// Like [`list`](Self::list), but reports every entry from every backend
+    /// (not deduplicated) along with the backend's human-readable name (see
+    /// [`StorageBackend::name`]) and whether it's the entry that `get()` would
+    /// return for that host. Used by `auth status` so users can see what's
+    /// stored where, including shadowed entries.
+    pub fn list_with_sources(&self) -> Result<Vec<ListedEntry>> {
+        let mut entries: Vec<ListedEntry> = Vec::new();
+        let mut seen_hosts: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+        for backend in &self.backends {
+            match backend.list() {
+                Ok(backend_entries) => {
+                    let source = backend.name();
+                    for (host, auth) in backend_entries {
+                        let active = seen_hosts.insert(host.clone());
+                        entries.push(ListedEntry {
+                            host,
+                            auth,
+                            source: source.clone(),
+                            active,
+                        });
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!("Error listing credentials from backend: {}", error);
+                }
+            }
+        }
+
+        entries.sort_by(|a, b| a.host.cmp(&b.host));
+        Ok(entries)
     }
 
     /// Retrieve the authentication information for the given URL, along with the

--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -90,10 +90,13 @@ impl AuthenticationStorage {
             #[allow(unused_variables)]
             if let Err(error) = backend.store(host, authentication) {
                 #[cfg(feature = "keyring")]
-                if let AuthenticationStorageError::KeyringStorageError(
-                    KeyringAuthenticationStorageError::StorageError(_),
-                ) = error
-                {
+                if matches!(
+                    error,
+                    AuthenticationStorageError::KeyringStorageError(
+                        KeyringAuthenticationStorageError::StorageError(_)
+                            | KeyringAuthenticationStorageError::UnsupportedTarget { .. }
+                    )
+                ) {
                     tracing::debug!("Error storing credentials in keyring: {}", error);
                 } else {
                     tracing::warn!("Error storing credentials from backend: {}", error);
@@ -128,10 +131,13 @@ impl AuthenticationStorage {
                 Ok(None) => {}
                 Err(_e) => {
                     #[cfg(feature = "keyring")]
-                    if let AuthenticationStorageError::KeyringStorageError(
-                        KeyringAuthenticationStorageError::StorageError(_),
-                    ) = _e
-                    {
+                    if matches!(
+                        _e,
+                        AuthenticationStorageError::KeyringStorageError(
+                            KeyringAuthenticationStorageError::StorageError(_)
+                                | KeyringAuthenticationStorageError::UnsupportedTarget { .. }
+                        )
+                    ) {
                         tracing::trace!("Error storing credentials in keyring: {}", _e);
                     } else {
                         tracing::warn!("Error retrieving credentials from backend: {}", _e);
@@ -302,10 +308,13 @@ impl AuthenticationStorage {
             #[allow(unused_variables)]
             if let Err(error) = backend.delete(host) {
                 #[cfg(feature = "keyring")]
-                if let AuthenticationStorageError::KeyringStorageError(
-                    KeyringAuthenticationStorageError::StorageError(_),
-                ) = error
-                {
+                if matches!(
+                    error,
+                    AuthenticationStorageError::KeyringStorageError(
+                        KeyringAuthenticationStorageError::StorageError(_)
+                            | KeyringAuthenticationStorageError::UnsupportedTarget { .. }
+                    )
+                ) {
                     tracing::debug!("Error deleting credentials in keyring: {}", error);
                 } else {
                     tracing::warn!("Error deleting credentials from backend: {}", error);

--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -159,13 +159,28 @@ impl AuthenticationStorage {
     /// Entries are deduplicated by host using backend priority, matching the
     /// lookup behavior of [`get`](Self::get).
     pub fn list(&self) -> Result<Vec<(String, Authentication)>> {
-        let mut entries = BTreeMap::new();
+        Ok(self
+            .list_with_sources()?
+            .into_iter()
+            .map(|(host, auth, _source)| (host, auth))
+            .collect())
+    }
+
+    /// Like [`list`](Self::list), but also reports the human-readable name of
+    /// the backend each entry was loaded from (see [`StorageBackend::name`]).
+    /// Entries are deduplicated by host using backend priority — the first
+    /// backend to surface a given host wins, matching [`get`](Self::get).
+    pub fn list_with_sources(&self) -> Result<Vec<(String, Authentication, String)>> {
+        let mut entries: BTreeMap<String, (Authentication, String)> = BTreeMap::new();
 
         for backend in &self.backends {
             match backend.list() {
                 Ok(backend_entries) => {
+                    let source = backend.name();
                     for (host, auth) in backend_entries {
-                        entries.entry(host).or_insert(auth);
+                        entries
+                            .entry(host)
+                            .or_insert_with(|| (auth, source.clone()));
                     }
                 }
                 Err(error) => {
@@ -174,7 +189,10 @@ impl AuthenticationStorage {
             }
         }
 
-        Ok(entries.into_iter().collect())
+        Ok(entries
+            .into_iter()
+            .map(|(host, (auth, source))| (host, auth, source))
+            .collect())
     }
 
     /// Retrieve the authentication information for the given URL, along with the

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -106,7 +106,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -125,6 +125,17 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework 3.7.0",
+]
 
 [[package]]
 name = "archspec"
@@ -227,30 +238,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-compression"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,20 +248,6 @@ dependencies = [
  "futures-io",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
 ]
 
 [[package]]
@@ -293,97 +266,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.3",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
 name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix 1.1.3",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.3",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "async-spooled-tempfile"
@@ -394,12 +280,6 @@ dependencies = [
  "tempfile",
  "tokio",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -943,9 +823,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitvec"
@@ -993,19 +873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -1117,12 +984,6 @@ dependencies = [
  "libc",
  "shlex 1.3.0",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1576,8 +1437,19 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
+ "openssl",
  "sha2 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
 ]
 
 [[package]]
@@ -1653,7 +1525,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1785,12 +1657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endi"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,27 +1675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -1865,7 +1710,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1885,16 +1730,6 @@ checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
  "pin-project-lite",
 ]
 
@@ -2909,7 +2744,7 @@ dependencies = [
  "portable-atomic-util",
  "serde_core",
  "wasm-bindgen",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2940,25 +2775,52 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
+ "jni-macros",
  "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -3005,20 +2867,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "byteorder",
- "dbus-secret-service",
  "log",
- "secret-service",
- "security-framework 2.11.1",
- "security-framework 3.5.1",
- "windows-sys 0.60.2",
- "zbus",
- "zeroize",
 ]
 
 [[package]]
@@ -3027,7 +2881,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d463f34ca3c400fde3a054da0e0b8c6ffa21e4590922f3e18281bb5eeef4cbdc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3083,6 +2937,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
+ "cc",
  "pkg-config",
 ]
 
@@ -3272,19 +3127,6 @@ name = "netrc-rs"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2970fbbc8c785e8246234a7bd004ed66cd1ed1a35ec73669a92545e419b836"
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
-]
 
 [[package]]
 name = "nix"
@@ -3588,16 +3430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3763,17 +3595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3810,20 +3631,6 @@ dependencies = [
  "quick-xml 0.38.4",
  "serde",
  "time",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.3",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3882,15 +3689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve 0.13.8",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
-dependencies = [
- "toml_edit",
 ]
 
 [[package]]
@@ -3955,7 +3753,7 @@ dependencies = [
  "chrono",
  "futures",
  "http 1.4.0",
- "nix 0.30.1",
+ "nix",
  "openssl",
  "parking_lot",
  "pep440_rs",
@@ -4271,10 +4069,12 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
+ "base64",
+ "chrono",
  "console",
  "digest 0.11.3",
  "dirs",
@@ -4316,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4348,7 +4148,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.46.3"
+version = "0.46.4"
 dependencies = [
  "ahash",
  "chrono",
@@ -4388,7 +4188,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "console",
  "fs-err",
@@ -4422,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4460,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.30.2"
+version = "0.30.3"
 dependencies = [
  "ahash",
  "chrono",
@@ -4495,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.61"
+version = "0.2.62"
 dependencies = [
  "chrono",
  "configparser",
@@ -4525,10 +4325,11 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "ambient-id",
  "anyhow",
+ "apple-native-keyring-store",
  "astral-reqwest-middleware",
  "async-once-cell",
  "async-trait",
@@ -4536,13 +4337,14 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http-client",
  "base64",
+ "dbus-secret-service-keyring-store",
  "dirs",
  "fs-err",
  "getrandom 0.4.2",
  "google-cloud-auth",
  "http 1.4.0",
  "itertools 0.14.0",
- "keyring",
+ "keyring-core",
  "netrc-rs",
  "reqwest",
  "retry-policies",
@@ -4553,11 +4355,12 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "windows-native-keyring-store",
 ]
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -4598,7 +4401,7 @@ name = "rattler_pty"
 version = "0.2.12"
 dependencies = [
  "libc",
- "nix 0.30.1",
+ "nix",
  "signal-hook",
  "tokio",
 ]
@@ -4614,7 +4417,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.29.1"
+version = "0.29.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4676,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4692,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.1"
+version = "0.27.2"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4711,7 +4514,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "7.1.0"
+version = "7.1.1"
 dependencies = [
  "chrono",
  "futures",
@@ -4729,7 +4532,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "archspec",
  "libloading",
@@ -5076,7 +4879,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5089,7 +4892,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5116,7 +4919,7 @@ dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -5131,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -5144,10 +4947,10 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework 3.5.1",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5278,25 +5081,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "secret-service"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
-dependencies = [
- "aes",
- "cbc",
- "futures-util",
- "generic-array",
- "hkdf",
- "num",
- "once_cell",
- "rand 0.8.5",
- "serde",
- "sha2 0.10.9",
- "zbus",
-]
-
-[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5311,9 +5095,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",
@@ -5324,9 +5108,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5615,6 +5399,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5698,12 +5492,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -5843,7 +5631,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6044,19 +5832,10 @@ dependencies = [
  "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
+ "winnow",
 ]
 
 [[package]]
@@ -6069,24 +5848,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
-dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "winnow 0.7.14",
-]
-
-[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -6215,17 +5982,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "uds_windows"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
-dependencies = [
- "memoffset",
- "tempfile",
- "winapi",
-]
 
 [[package]]
 name = "unarray"
@@ -6615,7 +6371,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6759,6 +6515,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5fd986f648459dd29aa252ed3a5ad11a60c0b1251bf81625fb03a86c69d274e"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6838,15 +6607,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6879,21 +6639,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6964,12 +6709,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6988,12 +6727,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -7009,12 +6742,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7048,12 +6775,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -7069,12 +6790,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7096,12 +6811,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -7120,12 +6829,6 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -7141,15 +6844,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -7286,16 +6980,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7328,68 +7012,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zbus"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-fs",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix 0.29.0",
- "ordered-stream",
- "rand 0.8.5",
- "serde",
- "serde_repr",
- "sha1",
- "static_assertions",
- "tracing",
- "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
-dependencies = [
- "serde",
- "static_assertions",
- "zvariant",
 ]
 
 [[package]]
@@ -7551,41 +7173,4 @@ checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",
-]
-
-[[package]]
-name = "zvariant"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "zvariant_derive",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]


### PR DESCRIPTION
## Summary

- add `rattler auth status` to list stored authentication entries
- surface non-secret token metadata such as validity, scopes, issuer, audience, subject, and OAuth endpoints
- add auth-storage listing support across file, memory, netrc, and keyring backends
- migrate the keyring backend from deprecated `keyring` to `keyring-core` with platform credential stores

This is what it looks like on macOS now: 

<img width="636" height="440" alt="Screenshot 2026-05-21 at 08 36 15" src="https://github.com/user-attachments/assets/73d85229-5329-47a6-97e9-f6732f59a0cb" />


## Notes

The status command derives validity from local expiry metadata only. It does not call remote services to validate opaque tokens.

The public `rattler_networking` feature remains named `keyring`; internally it now configures a `keyring-core` default store for macOS, Windows, and Unix Secret Service targets. The Linux Secret Service store enables vendored D-Bus so CI/build environments do not need a system `dbus-1.pc` package.

## Validation

- `pixi run cargo-fmt`
- `pixi run -- cargo check -p rattler_networking --features system-integration`
- `pixi run -- cargo test -p rattler_networking list_returns_entries_from_backends`
- `pixi run -- cargo test -p rattler --features cli-tools token_metadata_extracts_expiry_scopes_and_claims`
- `pixi run -- cargo check -p rattler-bin`
- `pixi run -- cargo tree --manifest-path py-rattler/Cargo.toml --features pty --target x86_64-unknown-linux-gnu -e features -i libdbus-sys`
- `pixi run -- cargo metadata --manifest-path py-rattler/Cargo.toml --features pty --format-version 1`
- `cd py-rattler && pixi run build`
- `git diff --check`
