### PR TITLE
fix: match repodata records by file name

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -830,6 +830,10 @@ impl Matches<GenericVirtualPackage> for MatchSpec {
 }
 
 fn file_name_matches(spec_file_name: &str, record_file_name: &str) -> bool {
+    // Conda matches MatchSpec `fn` against PackageRecord.fn, which is the
+    // archive file name. RepoDataRecord stores the same value in its archive
+    // identifier, so callers should pass identifier.to_file_name() instead of
+    // deriving it from the record URL.
     spec_file_name_basename(spec_file_name) == record_file_name
 }
 
@@ -1255,6 +1259,8 @@ mod tests {
             channel: None,
         };
 
+        // Match against the archive identifier, mirroring conda's PackageRecord.fn
+        // semantics without parsing the record URL during matching.
         let match_spec = MatchSpec::from_str("mamba[fn=mamba-1.0-py37_0.conda]", Strict).unwrap();
         let nameless_spec = match_spec.clone().into_nameless().1;
         assert!(match_spec.matches(&repodata_record));

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -10,6 +10,7 @@ use rattler_digest::{Md5, Sha256, parse_digest_from_hex};
 use rattler_digest::{Md5Hash, Sha256Hash, serde::SerializableHash};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
+use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 use std::sync::Arc;
@@ -770,6 +771,12 @@ impl Matches<RepoDataRecord> for MatchSpec {
             return false;
         }
 
+        if let Some(file_name) = self.file_name.as_ref()
+            && !file_name_matches(file_name, &other.identifier.to_file_name())
+        {
+            return false;
+        }
+
         if !self.matches(&other.package_record) {
             return false;
         }
@@ -783,6 +790,12 @@ impl Matches<RepoDataRecord> for NamelessMatchSpec {
     fn matches(&self, other: &RepoDataRecord) -> bool {
         if let Some(url_spec) = self.url.as_ref()
             && url_spec != &other.url
+        {
+            return false;
+        }
+
+        if let Some(file_name) = self.file_name.as_ref()
+            && !file_name_matches(file_name, &other.identifier.to_file_name())
         {
             return false;
         }
@@ -814,6 +827,28 @@ impl Matches<GenericVirtualPackage> for MatchSpec {
             return false;
         }
         true
+    }
+}
+
+fn file_name_matches(spec_file_name: &str, record_file_name: &str) -> bool {
+    spec_file_name_basename(spec_file_name) == record_file_name
+}
+
+fn spec_file_name_basename(value: &str) -> Cow<'_, str> {
+    if let Ok(url) = Url::parse(value)
+        && let Some(segment) = url
+            .path_segments()
+            .and_then(Iterator::last)
+            .filter(|segment| !segment.is_empty())
+    {
+        return Cow::Owned(segment.to_string());
+    }
+
+    let value = value.trim_end_matches(['/', '\\']);
+    if let Some(index) = value.rfind(['/', '\\']) {
+        Cow::Borrowed(&value[index + 1..])
+    } else {
+        Cow::Borrowed(value)
     }
 }
 
@@ -1206,6 +1241,38 @@ mod tests {
         assert!(match_spec.matches(&package_record));
         assert!(nameless_spec.matches(&repodata_record));
         assert!(nameless_spec.matches(&package_record));
+    }
+
+    #[test]
+    fn test_file_name_matches_repodata_identifier() {
+        let repodata_record = RepoDataRecord {
+            package_record: PackageRecord::new(
+                PackageName::new_unchecked("mamba"),
+                Version::from_str("1.0").unwrap(),
+                String::from(""),
+            ),
+            identifier: "mamba-1.0-py37_0.conda"
+                .parse::<DistArchiveIdentifier>()
+                .unwrap(),
+            url: url::Url::parse("file:///tmp/mamba-1.0-py37_0.conda").unwrap(),
+            channel: None,
+        };
+
+        let match_spec = MatchSpec::from_str("mamba[fn=mamba-1.0-py37_0.conda]", Strict).unwrap();
+        let nameless_spec = match_spec.clone().into_nameless().1;
+        assert!(match_spec.matches(&repodata_record));
+        assert!(nameless_spec.matches(&repodata_record));
+
+        let match_spec =
+            MatchSpec::from_str("mamba[fn=file:///tmp/mamba-1.0-py37_0.conda]", Strict).unwrap();
+        let nameless_spec = match_spec.clone().into_nameless().1;
+        assert!(match_spec.matches(&repodata_record));
+        assert!(nameless_spec.matches(&repodata_record));
+
+        let match_spec = MatchSpec::from_str("mamba[fn=other-1.0-py37_0.conda]", Strict).unwrap();
+        let nameless_spec = match_spec.clone().into_nameless().1;
+        assert!(!match_spec.matches(&repodata_record));
+        assert!(!nameless_spec.matches(&repodata_record));
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -10,7 +10,6 @@ use rattler_digest::{Md5, Sha256, parse_digest_from_hex};
 use rattler_digest::{Md5Hash, Sha256Hash, serde::SerializableHash};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{serde_as, skip_serializing_none};
-use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 use std::sync::Arc;
@@ -834,21 +833,16 @@ fn file_name_matches(spec_file_name: &str, record_file_name: &str) -> bool {
     spec_file_name_basename(spec_file_name) == record_file_name
 }
 
-fn spec_file_name_basename(value: &str) -> Cow<'_, str> {
-    if let Ok(url) = Url::parse(value)
-        && let Some(segment) = url
-            .path_segments()
-            .and_then(Iterator::last)
-            .filter(|segment| !segment.is_empty())
-    {
-        return Cow::Owned(segment.to_string());
-    }
-
+fn spec_file_name_basename(value: &str) -> &str {
+    let value = match value.find(['?', '#']) {
+        Some(index) => &value[..index],
+        None => value,
+    };
     let value = value.trim_end_matches(['/', '\\']);
     if let Some(index) = value.rfind(['/', '\\']) {
-        Cow::Borrowed(&value[index + 1..])
+        &value[index + 1..]
     } else {
-        Cow::Borrowed(value)
+        value
     }
 }
 
@@ -930,8 +924,11 @@ mod tests {
 
     use crate::{
         Flag, MatchSpec, NamelessMatchSpec, PackageName, PackageRecord, ParseMatchSpecError,
-        ParseMatchSpecOptions, ParseStrictness::*, RepoDataRecord, RepodataRevision, StringMatcher,
-        Version, match_spec::Matches, package::DistArchiveIdentifier,
+        ParseMatchSpecOptions,
+        ParseStrictness::*,
+        RepoDataRecord, RepodataRevision, StringMatcher, Version,
+        match_spec::{Matches, file_name_matches},
+        package::DistArchiveIdentifier,
         parse_mode::ParseStrictnessWithNameMatcher,
     };
     use insta::assert_snapshot;
@@ -1268,6 +1265,19 @@ mod tests {
         let nameless_spec = match_spec.clone().into_nameless().1;
         assert!(match_spec.matches(&repodata_record));
         assert!(nameless_spec.matches(&repodata_record));
+
+        assert!(file_name_matches(
+            "/tmp/mamba-1.0-py37_0.conda",
+            "mamba-1.0-py37_0.conda"
+        ));
+        assert!(file_name_matches(
+            r"C:\tmp\mamba-1.0-py37_0.conda",
+            "mamba-1.0-py37_0.conda"
+        ));
+        assert!(file_name_matches(
+            "file:///tmp/mamba-1.0-py37_0.conda?download=1#sha256:abc",
+            "mamba-1.0-py37_0.conda"
+        ));
 
         let match_spec = MatchSpec::from_str("mamba[fn=other-1.0-py37_0.conda]", Strict).unwrap();
         let nameless_spec = match_spec.clone().into_nameless().1;


### PR DESCRIPTION
### Description

Fixes #1721

`fn` constraints were parsed into `MatchSpec`, but were not checked when matching `MatchSpec` or `NamelessMatchSpec` against a `RepoDataRecord`. That allowed a path-style spec such as `fn=file:///.../package.conda` to behave like a name-only match instead of selecting by the record's archive filename.

This adds `RepoDataRecord` filename matching and treats URL/path `fn` values as their basename, so a local path dependency can match `package-...conda` while still rejecting a different archive filename.

### How Has This Been Tested?

Red check before implementation:
- `cargo test -p rattler_conda_types test_file_name_matches_repodata_identifier -- --nocapture` failed because `fn=other-1.0-py37_0.conda` still matched the record.

Green checks after implementation:
- `cargo test -p rattler_conda_types test_file_name_matches_repodata_identifier -- --nocapture`
- `cargo test -p rattler_conda_types --lib`
- `cargo fmt --all -- --check`
- `cargo clippy -p rattler_conda_types --all-targets -- -D warnings`
- `git diff --check`

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: OpenAI GPT-5.5 was used to inspect the matchspec/repodata matching path, add the regression test and implementation, and draft this PR text. The changes and tests were reviewed and run locally.

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.

