### PR TITLE
feat: nicer OAuth callback page with per-project override

### DIFF
--- a/crates/rattler/src/cli/auth.rs
+++ b/crates/rattler/src/cli/auth.rs
@@ -380,6 +380,7 @@ async fn login(
                 scopes,
                 redirect_uri,
                 user_agent: args.user_agent,
+                callback_page: None,
             };
 
             let auth = oauth::perform_oauth_login(config).await?;

--- a/crates/rattler/src/cli/auth/oauth.rs
+++ b/crates/rattler/src/cli/auth/oauth.rs
@@ -399,7 +399,12 @@ async fn auth_code_flow(
 
     // Verify CSRF state
     if callback.state != *csrf_token.secret() {
-        send_callback_response(&callback.stream, false, "CSRF state mismatch", callback_page);
+        send_callback_response(
+            &callback.stream,
+            false,
+            "CSRF state mismatch",
+            callback_page,
+        );
         return Err(OAuthError::CsrfMismatch);
     }
 

--- a/crates/rattler/src/cli/auth/oauth.rs
+++ b/crates/rattler/src/cli/auth/oauth.rs
@@ -60,6 +60,12 @@ use super::DEFAULT_USER_AGENT;
 /// Generic OIDC scopes used when no host-specific defaults apply.
 pub const DEFAULT_OAUTH_SCOPES: &[&str] = &["openid", "profile", "offline_access"];
 
+/// Renderer for the HTML page shown in the browser after the OAuth
+/// redirect. Receives whether the authentication succeeded and a
+/// human-readable error detail (not HTML-escaped — the renderer is
+/// responsible for escaping if it interpolates the detail into HTML).
+pub type CallbackPageRenderer = Box<dyn Fn(bool, &str) -> String + Send + Sync>;
+
 /// Configuration for an OAuth login flow.
 pub struct OAuthConfig {
     /// The OIDC issuer URL.
@@ -79,6 +85,10 @@ pub struct OAuthConfig {
     /// Override for the User-Agent header. When `None`, defaults to
     /// `rattler/<crate version>`.
     pub user_agent: Option<String>,
+    /// Override for the HTML page shown in the browser after the OAuth
+    /// redirect. When `None`, [`default_callback_page`] is used. Callers
+    /// (e.g. pixi, rattler-build) can supply their own branded page.
+    pub callback_page: Option<CallbackPageRenderer>,
 }
 
 /// Which OAuth flow to attempt.
@@ -185,6 +195,11 @@ pub async fn perform_oauth_login(config: OAuthConfig) -> Result<Authentication, 
     let client_secret = config.client_secret.as_deref();
     let redirect_uri = config.redirect_uri.as_deref();
 
+    let callback_page: CallbackPageRenderer = config
+        .callback_page
+        .unwrap_or_else(|| Box::new(default_callback_page));
+    let callback_page: &(dyn Fn(bool, &str) -> String + Send + Sync) = &*callback_page;
+
     // 2. Run the appropriate flow
     let tokens = match config.flow {
         OAuthFlow::AuthCode => {
@@ -195,6 +210,7 @@ pub async fn perform_oauth_login(config: OAuthConfig) -> Result<Authentication, 
                 &config.scopes,
                 redirect_uri,
                 &http_client,
+                callback_page,
             )
             .await?
         }
@@ -216,6 +232,7 @@ pub async fn perform_oauth_login(config: OAuthConfig) -> Result<Authentication, 
                 &config.scopes,
                 redirect_uri,
                 &http_client,
+                callback_page,
             )
             .await
             {
@@ -311,6 +328,7 @@ async fn auth_code_flow(
     scopes: &HashSet<String>,
     redirect_uri: Option<&str>,
     http_client: &ReqwestClient,
+    callback_page: &(dyn Fn(bool, &str) -> String + Send + Sync),
 ) -> Result<OAuthTokens, OAuthError> {
     // If the caller pinned a redirect URI (because the IdP requires an
     // exact match against what was registered), bind there. Otherwise
@@ -370,7 +388,7 @@ async fn auth_code_flow(
     eprintln!("Waiting for authentication in browser...");
     let callback = tokio::time::timeout(
         Duration::from_secs(300),
-        accept_redirect_callback(&listener),
+        accept_redirect_callback(&listener, callback_page),
     )
     .await
     .map_err(|_timeout| {
@@ -381,7 +399,7 @@ async fn auth_code_flow(
 
     // Verify CSRF state
     if callback.state != *csrf_token.secret() {
-        send_callback_response(&callback.stream, false, "CSRF state mismatch");
+        send_callback_response(&callback.stream, false, "CSRF state mismatch", callback_page);
         return Err(OAuthError::CsrfMismatch);
     }
 
@@ -394,12 +412,12 @@ async fn auth_code_flow(
         .await
     {
         Ok(response) => {
-            send_callback_response(&callback.stream, true, "");
+            send_callback_response(&callback.stream, true, "", callback_page);
             response
         }
         Err(e) => {
             let msg = e.to_string();
-            send_callback_response(&callback.stream, false, &msg);
+            send_callback_response(&callback.stream, false, &msg, callback_page);
             return Err(OAuthError::TokenExchange(msg));
         }
     };
@@ -428,7 +446,10 @@ async fn auth_code_flow(
 /// and returns them along with the stream. The caller is responsible for
 /// sending the browser response via [`send_callback_response`] after
 /// the token exchange completes.
-async fn accept_redirect_callback(listener: &TcpListener) -> Result<CallbackResult, OAuthError> {
+async fn accept_redirect_callback(
+    listener: &TcpListener,
+    callback_page: &(dyn Fn(bool, &str) -> String + Send + Sync),
+) -> Result<CallbackResult, OAuthError> {
     let (stream, _) = listener.accept().await?;
 
     // Convert to std TcpStream for synchronous I/O (simpler than async line
@@ -463,7 +484,7 @@ async fn accept_redirect_callback(listener: &TcpListener) -> Result<CallbackResu
 
         let msg = description.unwrap_or(error);
 
-        send_callback_response(&std_stream, false, &msg);
+        send_callback_response(&std_stream, false, &msg, callback_page);
         return Err(OAuthError::Authorization(msg));
     }
 
@@ -487,7 +508,7 @@ async fn accept_redirect_callback(listener: &TcpListener) -> Result<CallbackResu
 }
 
 /// Escape a string for safe interpolation into HTML.
-fn html_escape(s: &str) -> String {
+pub fn html_escape(s: &str) -> String {
     s.replace('&', "&amp;")
         .replace('<', "&lt;")
         .replace('>', "&gt;")
@@ -495,23 +516,20 @@ fn html_escape(s: &str) -> String {
         .replace('\'', "&#x27;")
 }
 
-/// Send an HTML response to the browser on the callback stream.
-fn send_callback_response(stream: &std::net::TcpStream, success: bool, detail: &str) {
-    let response_body = if success {
-        "<html><body><h1>Authentication successful!</h1>\
-            <p>You can close this window and return to the terminal.</p></body></html>"
-            .to_string()
-    } else {
-        let escaped = html_escape(detail);
-        format!(
-            "<html><body><h1>Authentication failed</h1><p>{escaped}</p>\
-                <p>Please return to the terminal and try again.</p></body></html>"
-        )
-    };
+/// Send an HTML response to the browser on the callback stream using the
+/// supplied page renderer.
+fn send_callback_response(
+    stream: &std::net::TcpStream,
+    success: bool,
+    detail: &str,
+    render: &(dyn Fn(bool, &str) -> String + Send + Sync),
+) {
+    let response_body = render(success, detail);
     let response = format!(
         "HTTP/1.1 200 OK\r\n\
-         Content-Type: text/html\r\n\
+         Content-Type: text/html; charset=utf-8\r\n\
          Content-Length: {}\r\n\
+         Cache-Control: no-store\r\n\
          Connection: close\r\n\
          \r\n\
          {response_body}",
@@ -521,6 +539,113 @@ fn send_callback_response(stream: &std::net::TcpStream, success: bool, detail: &
     let _ = writer
         .write_all(response.as_bytes())
         .and_then(|_| writer.flush());
+}
+
+/// Default HTML page shown in the browser after the OAuth redirect.
+///
+/// Callers can override this by setting [`OAuthConfig::callback_page`].
+/// The returned HTML is fully self-contained (inline CSS, inline SVG) so
+/// it works after the local callback server has shut down.
+///
+/// `detail` is treated as plain text and HTML-escaped before being
+/// interpolated, so it is safe to pass raw error messages from the
+/// identity provider.
+pub fn default_callback_page(success: bool, detail: &str) -> String {
+    const STYLES: &str = "\
+        :root{color-scheme:light dark;\
+        --bg:#f8fafc;--fg:#0f172a;--muted:#475569;\
+        --card:#ffffff;--border:#e2e8f0;\
+        --accent:#6366f1;--success:#10b981;--error:#ef4444;\
+        --success-bg:rgba(16,185,129,.12);--error-bg:rgba(239,68,68,.12);}\
+        @media (prefers-color-scheme:dark){:root{\
+        --bg:#0b1120;--fg:#f1f5f9;--muted:#94a3b8;\
+        --card:#111827;--border:#1f2937;\
+        --accent:#a5b4fc;}}\
+        *{box-sizing:border-box}\
+        html,body{margin:0;padding:0;height:100%}\
+        body{display:flex;align-items:center;justify-content:center;\
+        background:var(--bg);color:var(--fg);padding:24px;\
+        font-family:-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,\
+        \"Helvetica Neue\",Arial,sans-serif;\
+        font-feature-settings:\"ss01\",\"cv11\";-webkit-font-smoothing:antialiased}\
+        .card{width:100%;max-width:440px;background:var(--card);\
+        border:1px solid var(--border);border-radius:16px;\
+        padding:40px 32px 28px;text-align:center;\
+        box-shadow:0 1px 2px rgba(15,23,42,.04),0 12px 32px rgba(15,23,42,.08)}\
+        .icon{width:64px;height:64px;border-radius:50%;margin:0 auto 20px;\
+        display:flex;align-items:center;justify-content:center}\
+        .icon.success{background:var(--success-bg);color:var(--success)}\
+        .icon.error{background:var(--error-bg);color:var(--error)}\
+        h1{margin:0 0 8px;font-size:22px;font-weight:600;letter-spacing:-.01em}\
+        p{margin:0;color:var(--muted);font-size:15px;line-height:1.55}\
+        .detail{margin-top:16px;padding:12px 14px;\
+        background:var(--error-bg);border-radius:10px;\
+        color:var(--error);font-family:ui-monospace,SFMono-Regular,Menlo,\
+        Consolas,monospace;font-size:13px;text-align:left;\
+        word-break:break-word;white-space:pre-wrap}\
+        footer{margin-top:28px;padding-top:20px;border-top:1px solid var(--border);\
+        color:var(--muted);font-size:12px;letter-spacing:.02em}\
+        footer a{color:var(--accent);text-decoration:none;font-weight:500}\
+        footer a:hover{text-decoration:underline}";
+
+    const CHECK_SVG: &str = "<svg width=\"32\" height=\"32\" viewBox=\"0 0 24 24\" \
+        fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\" \
+        stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\">\
+        <polyline points=\"20 6 9 17 4 12\"/></svg>";
+
+    const CROSS_SVG: &str = "<svg width=\"32\" height=\"32\" viewBox=\"0 0 24 24\" \
+        fill=\"none\" stroke=\"currentColor\" stroke-width=\"2.5\" \
+        stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\">\
+        <line x1=\"18\" y1=\"6\" x2=\"6\" y2=\"18\"/>\
+        <line x1=\"6\" y1=\"6\" x2=\"18\" y2=\"18\"/></svg>";
+
+    let (title, kind, icon, heading, message, detail_block) = if success {
+        (
+            "Signed in",
+            "success",
+            CHECK_SVG,
+            "You're signed in",
+            "Authentication completed. You can close this window and return to your terminal.",
+            String::new(),
+        )
+    } else {
+        let escaped = html_escape(detail);
+        let detail_block = if escaped.is_empty() {
+            String::new()
+        } else {
+            format!("<div class=\"detail\">{escaped}</div>")
+        };
+        (
+            "Sign-in failed",
+            "error",
+            CROSS_SVG,
+            "Sign-in failed",
+            "Authentication did not complete. Please return to your terminal and try again.",
+            detail_block,
+        )
+    };
+
+    format!(
+        "<!doctype html>\
+<html lang=\"en\">\
+<head>\
+<meta charset=\"utf-8\">\
+<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\
+<meta name=\"robots\" content=\"noindex\">\
+<title>{title}</title>\
+<style>{STYLES}</style>\
+</head>\
+<body>\
+<main class=\"card\" role=\"status\" aria-live=\"polite\">\
+<div class=\"icon {kind}\">{icon}</div>\
+<h1>{heading}</h1>\
+<p>{message}</p>\
+{detail_block}\
+<footer>Powered by <a href=\"https://prefix.dev\" rel=\"noopener noreferrer\" target=\"_blank\">prefix.dev</a></footer>\
+</main>\
+</body>\
+</html>"
+    )
 }
 
 /// Device code flow for headless environments (RFC 8628).

--- a/crates/rattler/src/cli/auth/oauth.rs
+++ b/crates/rattler/src/cli/auth/oauth.rs
@@ -467,13 +467,28 @@ async fn accept_redirect_callback(
     reader.read_line(&mut request_line)?;
 
     // Parse the GET request line: "GET /?code=...&state=... HTTP/1.1"
-    let path = request_line
-        .split_whitespace()
-        .nth(1)
-        .ok_or(OAuthError::InvalidCallback)?;
+    let Some(path) = request_line.split_whitespace().nth(1) else {
+        send_callback_response(
+            &std_stream,
+            false,
+            "Invalid callback from identity provider",
+            callback_page,
+        );
+        return Err(OAuthError::InvalidCallback);
+    };
 
-    let callback_url = Url::parse(&format!("http://localhost{path}"))
-        .map_err(|_err| OAuthError::InvalidCallback)?;
+    let callback_url = match Url::parse(&format!("http://localhost{path}")) {
+        Ok(url) => url,
+        Err(_err) => {
+            send_callback_response(
+                &std_stream,
+                false,
+                "Invalid callback from identity provider",
+                callback_page,
+            );
+            return Err(OAuthError::InvalidCallback);
+        }
+    };
 
     // Check for an error response from the identity provider (RFC 6749 Section
     // 4.1.2.1)
@@ -493,17 +508,33 @@ async fn accept_redirect_callback(
         return Err(OAuthError::Authorization(msg));
     }
 
-    let code = callback_url
+    let Some(code) = callback_url
         .query_pairs()
         .find(|(k, _)| k == "code")
         .map(|(_, v)| v.to_string())
-        .ok_or(OAuthError::InvalidCallback)?;
+    else {
+        send_callback_response(
+            &std_stream,
+            false,
+            "Invalid callback from identity provider",
+            callback_page,
+        );
+        return Err(OAuthError::InvalidCallback);
+    };
 
-    let state = callback_url
+    let Some(state) = callback_url
         .query_pairs()
         .find(|(k, _)| k == "state")
         .map(|(_, v)| v.to_string())
-        .ok_or(OAuthError::InvalidCallback)?;
+    else {
+        send_callback_response(
+            &std_stream,
+            false,
+            "Invalid callback from identity provider",
+            callback_page,
+        );
+        return Err(OAuthError::InvalidCallback);
+    };
 
     Ok(CallbackResult {
         code,
@@ -817,5 +848,30 @@ pub async fn revoke_tokens(
         Err(e) => {
             tracing::warn!("Failed to revoke access token: {e}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{default_callback_page, html_escape};
+
+    #[test]
+    fn escapes_html_detail() {
+        assert_eq!(html_escape("<&>\"'"), "&lt;&amp;&gt;&quot;&#x27;");
+    }
+
+    #[test]
+    fn default_callback_page_escapes_error_detail() {
+        let page = default_callback_page(false, "<script>alert('x')</script>");
+
+        assert!(page.contains("&lt;script&gt;alert(&#x27;x&#x27;)&lt;/script&gt;"));
+        assert!(!page.contains("<script>alert"));
+    }
+
+    #[test]
+    fn default_callback_page_hides_empty_error_detail() {
+        let page = default_callback_page(false, "");
+
+        assert!(!page.contains("class=\"detail\""));
     }
 }

--- a/crates/rattler/src/cli/auth/oauth.rs
+++ b/crates/rattler/src/cli/auth/oauth.rs
@@ -66,6 +66,37 @@ pub const DEFAULT_OAUTH_SCOPES: &[&str] = &["openid", "profile", "offline_access
 /// responsible for escaping if it interpolates the detail into HTML).
 pub type CallbackPageRenderer = Box<dyn Fn(bool, &str) -> String + Send + Sync>;
 
+const DEFAULT_POWERED_BY: &str = "Powered by <a href=\"https://prefix.dev\" rel=\"noopener noreferrer\" target=\"_blank\">prefix.dev</a>";
+
+/// Text inserted into the default OAuth callback page.
+#[derive(Clone, Debug)]
+pub struct CallbackPageTemplate {
+    /// Program name shown in the title and status text.
+    pub application_name: String,
+    /// Raw HTML shown in the footer. When empty, a link to the issuer domain is used.
+    pub powered_by: String,
+}
+
+impl Default for CallbackPageTemplate {
+    fn default() -> Self {
+        Self {
+            application_name: "rattler".to_string(),
+            powered_by: String::new(),
+        }
+    }
+}
+
+/// Build a branded version of the default OAuth callback page renderer.
+pub fn callback_page_renderer(
+    template: CallbackPageTemplate,
+    issuer_url: &str,
+) -> CallbackPageRenderer {
+    let domain = callback_page_domain_from_issuer(issuer_url);
+    Box::new(move |success, detail| {
+        default_callback_page_with_template(success, detail, &template, &domain, DEFAULT_POWERED_BY)
+    })
+}
+
 /// Configuration for an OAuth login flow.
 pub struct OAuthConfig {
     /// The OIDC issuer URL.
@@ -195,9 +226,9 @@ pub async fn perform_oauth_login(config: OAuthConfig) -> Result<Authentication, 
     let client_secret = config.client_secret.as_deref();
     let redirect_uri = config.redirect_uri.as_deref();
 
-    let callback_page: CallbackPageRenderer = config
-        .callback_page
-        .unwrap_or_else(|| Box::new(default_callback_page));
+    let callback_page: CallbackPageRenderer = config.callback_page.unwrap_or_else(|| {
+        callback_page_renderer(CallbackPageTemplate::default(), &config.issuer_url)
+    });
     let callback_page: &(dyn Fn(bool, &str) -> String + Send + Sync) = &*callback_page;
 
     // 2. Run the appropriate flow
@@ -577,6 +608,13 @@ fn send_callback_response(
         .and_then(|_| writer.flush());
 }
 
+fn callback_page_domain_from_issuer(issuer_url: &str) -> String {
+    Url::parse(issuer_url)
+        .ok()
+        .and_then(|url| url.host_str().map(ToString::to_string))
+        .unwrap_or_else(|| "prefix.dev".to_string())
+}
+
 /// Default HTML page shown in the browser after the OAuth redirect.
 ///
 /// Callers can override this by setting [`OAuthConfig::callback_page`].
@@ -587,6 +625,23 @@ fn send_callback_response(
 /// interpolated, so it is safe to pass raw error messages from the
 /// identity provider.
 pub fn default_callback_page(success: bool, detail: &str) -> String {
+    default_callback_page_with_template(
+        success,
+        detail,
+        &CallbackPageTemplate::default(),
+        "prefix.dev",
+        DEFAULT_POWERED_BY,
+    )
+}
+
+/// Default OAuth callback page with caller-provided text.
+pub fn default_callback_page_with_template(
+    success: bool,
+    detail: &str,
+    template: &CallbackPageTemplate,
+    domain: &str,
+    default_powered_by: &str,
+) -> String {
     const STYLES: &str = "\
         :root{color-scheme:light dark;\
         --bg:#f8fafc;--fg:#0f172a;--muted:#475569;\
@@ -635,12 +690,20 @@ pub fn default_callback_page(success: bool, detail: &str) -> String {
         <line x1=\"18\" y1=\"6\" x2=\"6\" y2=\"18\"/>\
         <line x1=\"6\" y1=\"6\" x2=\"18\" y2=\"18\"/></svg>";
 
+    let application_name = html_escape(&template.application_name);
+    let domain = html_escape(domain);
+    let powered_by = if template.powered_by.is_empty() {
+        default_powered_by
+    } else {
+        &template.powered_by
+    };
+
     let (title, kind, icon, heading, message, detail_block) = if success {
         (
-            "Signed in",
+            format!("Signed in to {application_name}"),
             "success",
             CHECK_SVG,
-            "You're signed in",
+            format!("{application_name} is signed in to {domain}"),
             "Authentication completed. You can close this window and return to your terminal.",
             String::new(),
         )
@@ -652,10 +715,10 @@ pub fn default_callback_page(success: bool, detail: &str) -> String {
             format!("<div class=\"detail\">{escaped}</div>")
         };
         (
-            "Sign-in failed",
+            format!("{application_name} sign-in failed"),
             "error",
             CROSS_SVG,
-            "Sign-in failed",
+            format!("{application_name} sign-in failed"),
             "Authentication did not complete. Please return to your terminal and try again.",
             detail_block,
         )
@@ -677,7 +740,7 @@ pub fn default_callback_page(success: bool, detail: &str) -> String {
 <h1>{heading}</h1>\
 <p>{message}</p>\
 {detail_block}\
-<footer>Powered by <a href=\"https://prefix.dev\" rel=\"noopener noreferrer\" target=\"_blank\">prefix.dev</a></footer>\
+<footer>{powered_by}</footer>\
 </main>\
 </body>\
 </html>"
@@ -853,7 +916,10 @@ pub async fn revoke_tokens(
 
 #[cfg(test)]
 mod tests {
-    use super::{default_callback_page, html_escape};
+    use super::{
+        CallbackPageTemplate, DEFAULT_POWERED_BY, callback_page_domain_from_issuer,
+        default_callback_page, default_callback_page_with_template, html_escape,
+    };
 
     #[test]
     fn escapes_html_detail() {
@@ -873,5 +939,47 @@ mod tests {
         let page = default_callback_page(false, "");
 
         assert!(!page.contains("class=\"detail\""));
+    }
+
+    #[test]
+    fn default_callback_page_uses_template_text() {
+        let page = default_callback_page_with_template(
+            true,
+            "",
+            &CallbackPageTemplate {
+                application_name: "pixi".to_string(),
+                powered_by: "built by <strong>example</strong>".to_string(),
+            },
+            "example.com",
+            "Powered by example.com",
+        );
+
+        assert!(page.contains("pixi is signed in to example.com"));
+        assert!(page.contains("built by <strong>example</strong>"));
+    }
+
+    #[test]
+    fn callback_page_uses_issuer_domain() {
+        let domain = callback_page_domain_from_issuer("https://login.example.com/realms/prefix");
+
+        assert_eq!(domain, "login.example.com");
+    }
+
+    #[test]
+    fn empty_powered_by_uses_prefix_dev() {
+        let page = default_callback_page_with_template(
+            true,
+            "",
+            &CallbackPageTemplate {
+                application_name: "pixi".to_string(),
+                powered_by: String::new(),
+            },
+            "login.example.com",
+            DEFAULT_POWERED_BY,
+        );
+
+        assert!(page.contains("pixi is signed in to login.example.com"));
+        assert!(page.contains("https://prefix.dev"));
+        assert!(page.contains(">prefix.dev</a>"));
     }
 }


### PR DESCRIPTION
## Summary

<img width="1059" height="768" alt="Screenshot 2026-07-09 at 13 46 27" src="https://github.com/user-attachments/assets/eb30dc16-03d1-4414-a4e9-2e06b06fc175" />

- Replace the bare `<html><body><h1>…` browser response shown after the OAuth redirect with a self-contained card layout (light/dark aware via `prefers-color-scheme`, inline SVG icons, HTML-escaped error detail, `Cache-Control: no-store`, `noindex`).
- Add `OAuthConfig::callback_page: Option<CallbackPageRenderer>` so downstream tools (pixi, rattler-build) can supply their own branded page. The renderer is `Box<dyn Fn(bool, &str) -> String + Send + Sync>` and receives `(success, plain-text detail)`.
- Make `default_callback_page` and `html_escape` `pub` so overriders can reuse the default or safely interpolate the detail.

## Example override

```rust
let config = OAuthConfig {
    // ...
    callback_page: Some(Box::new(|success, detail| {
        if success {
            include_str!("pixi_success.html").to_string()
        } else {
            format!("<!doctype html>...<pre>{}</pre>...", html_escape(detail))
        }
    })),
};
```

When `None`, falls back to the new default page.