### PR TITLE
feat: add FreeBSD powerpc64* platform support

### DIFF
--- a/crates/rattler_conda_types/src/platform.rs
+++ b/crates/rattler_conda_types/src/platform.rs
@@ -35,6 +35,8 @@ pub enum Platform {
     FreeBsd32,
     FreeBsd64,
     FreeBsdArm64,
+    FreeBsdPpc64le,
+    FreeBsdPpc64,
 
     Osx64,
     OsxArm64,
@@ -154,7 +156,18 @@ impl Platform {
             #[cfg(target_arch = "aarch64")]
             return Platform::FreeBsdArm64;
 
-            #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
+            #[cfg(all(target_arch = "powerpc64", target_endian = "little"))]
+            return Platform::FreeBsdPpc64le;
+
+            #[cfg(all(target_arch = "powerpc64", target_endian = "big"))]
+            return Platform::FreeBsdPpc64;
+
+            #[cfg(not(any(
+                target_arch = "x86",
+                target_arch = "x86_64",
+                target_arch = "aarch64",
+                target_arch = "powerpc64"
+            )))]
             compile_error!("unsupported freebsd architecture");
         }
         #[cfg(windows)]
@@ -230,6 +243,8 @@ impl Platform {
                     | Platform::FreeBsd32
                     | Platform::FreeBsd64
                     | Platform::FreeBsdArm64
+                    | Platform::FreeBsdPpc64le
+                    | Platform::FreeBsdPpc64
             )
     }
 
@@ -273,7 +288,11 @@ impl Platform {
             | Platform::LinuxS390X
             | Platform::LinuxRiscv32
             | Platform::LinuxRiscv64 => Some("linux"),
-            Platform::FreeBsd32 | Platform::FreeBsd64 | Platform::FreeBsdArm64 => Some("freebsd"),
+            Platform::FreeBsd32
+            | Platform::FreeBsd64
+            | Platform::FreeBsdArm64
+            | Platform::FreeBsdPpc64le
+            | Platform::FreeBsdPpc64 => Some("freebsd"),
             Platform::Osx64 | Platform::OsxArm64 => Some("osx"),
             Platform::Win32 | Platform::Win64 | Platform::WinArm64 => Some("win"),
             Platform::EmscriptenWasm32 => Some("emscripten"),
@@ -322,6 +341,8 @@ impl FromStr for Platform {
             "freebsd-32" => Platform::FreeBsd32,
             "freebsd-64" => Platform::FreeBsd64,
             "freebsd-arm64" => Platform::FreeBsdArm64,
+            "freebsd-ppc64le" => Platform::FreeBsdPpc64le,
+            "freebsd-ppc64" => Platform::FreeBsdPpc64,
             "osx-64" => Platform::Osx64,
             "osx-arm64" => Platform::OsxArm64,
             "win-32" => Platform::Win32,
@@ -358,6 +379,8 @@ impl From<Platform> for &'static str {
             Platform::FreeBsd32 => "freebsd-32",
             Platform::FreeBsd64 => "freebsd-64",
             Platform::FreeBsdArm64 => "freebsd-arm64",
+            Platform::FreeBsdPpc64le => "freebsd-ppc64le",
+            Platform::FreeBsdPpc64 => "freebsd-ppc64",
             Platform::Osx64 => "osx-64",
             Platform::OsxArm64 => "osx-arm64",
             Platform::Win32 => "win-32",
@@ -382,8 +405,8 @@ impl Platform {
             Platform::LinuxArmV6l => Some(Arch::ArmV6l),
             Platform::LinuxArmV7l => Some(Arch::ArmV7l),
             Platform::LinuxLoongArch64 => Some(Arch::LoongArch64),
-            Platform::LinuxPpc64le => Some(Arch::Ppc64le),
-            Platform::LinuxPpc64 => Some(Arch::Ppc64),
+            Platform::LinuxPpc64le | Platform::FreeBsdPpc64le => Some(Arch::Ppc64le),
+            Platform::LinuxPpc64 | Platform::FreeBsdPpc64 => Some(Arch::Ppc64),
             Platform::LinuxPpc => Some(Arch::Ppc),
             Platform::LinuxS390X => Some(Arch::S390X),
             Platform::LinuxRiscv32 => Some(Arch::Riscv32),
@@ -552,6 +575,14 @@ mod tests {
             "freebsd-arm64".parse::<Platform>().unwrap(),
             Platform::FreeBsdArm64
         );
+        assert_eq!(
+            "freebsd-ppc64le".parse::<Platform>().unwrap(),
+            Platform::FreeBsdPpc64le
+        );
+        assert_eq!(
+            "freebsd-ppc64".parse::<Platform>().unwrap(),
+            Platform::FreeBsdPpc64
+        );
         assert_eq!("win-arm64".parse::<Platform>().unwrap(), Platform::WinArm64);
         assert_eq!(
             "emscripten-wasm32".parse::<Platform>().unwrap(),
@@ -596,6 +627,8 @@ mod tests {
         assert_eq!(Platform::FreeBsd32.arch(), Some(Arch::X86));
         assert_eq!(Platform::FreeBsd64.arch(), Some(Arch::X86_64));
         assert_eq!(Platform::FreeBsdArm64.arch(), Some(Arch::Arm64));
+        assert_eq!(Platform::FreeBsdPpc64le.arch(), Some(Arch::Ppc64le));
+        assert_eq!(Platform::FreeBsdPpc64.arch(), Some(Arch::Ppc64));
         assert_eq!(Platform::Osx64.arch(), Some(Arch::X86_64));
         assert_eq!(Platform::OsxArm64.arch(), Some(Arch::Arm64));
         assert_eq!(Platform::Win32.arch(), Some(Arch::X86));

--- a/js-rattler/js/platform.js
+++ b/js-rattler/js/platform.js
@@ -16,6 +16,8 @@ export const platformNames = [
     "freebsd-32",
     "freebsd-64",
     "freebsd-arm64",
+    "freebsd-ppc64le",
+    "freebsd-ppc64",
     "osx-64",
     "osx-arm64",
     "win-32",

--- a/js-rattler/src/Platform.ts
+++ b/js-rattler/src/Platform.ts
@@ -21,6 +21,8 @@ export const platformNames = [
     "freebsd-32",
     "freebsd-64",
     "freebsd-arm64",
+    "freebsd-ppc64le",
+    "freebsd-ppc64",
     "osx-64",
     "osx-arm64",
     "win-32",
@@ -133,6 +135,10 @@ export function platformArch(platform: Platform): Arch | null {
             return "x86_64";
         case "freebsd-arm64":
             return "arm64";
+        case "freebsd-ppc64le":
+            return "ppc64le";
+        case "freebsd-ppc64":
+            return "ppc64";
         case "osx-64":
             return "x86_64";
         case "osx-arm64":

--- a/py-rattler/rattler/platform/platform.py
+++ b/py-rattler/rattler/platform/platform.py
@@ -23,6 +23,8 @@ PlatformLiteral = Literal[
     "freebsd-32",
     "freebsd-64",
     "freebsd-arm64",
+    "freebsd-ppc64le",
+    "freebsd-ppc64",
     "osx-64",
     "osx-arm64",
     "win-32",
@@ -112,7 +114,7 @@ class Platform(metaclass=PlatformSingleton):
         >>> next(Platform.all())
         Platform(noarch)
         >>> len(list(Platform.all()))
-        25
+        27
         >>>
         """
         return (cls._from_py_platform(p) for p in PyPlatform.all())


### PR DESCRIPTION
### Description

This PR adds support for two additional FreeBSD platforms:

* FreeBsdPpc64 - FreeBSD on powerpc64,
* FreeBsdPpc64le - FreeBSD on powerpc64le,

These platforms are now recognized and properly handled across the codebase, including:

* Platform enum variants and string representations
* Architecture detection for each platform
* Runtime platform detection on FreeBSD systems
* Language bindings (TypeScript, Python, JavaScript)

The changes ensure that FreeBSD users on powerpc64* systems can properly specify their target platform when building or installing packages.
### How Has This Been Tested?

* Added unit tests for parsing "freebsd-32" and "freebsd-arm64" platform strings
* Added unit tests for architecture detection of the new platforms
* Existing platform tests continue to pass
* The platform count in Python bindings updated from 23 to 25 platforms

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

Mirrored after https://github.com/conda/rattler/pull/2227.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
