### PR TITLE
fix: make sdist PEP 625 conformant and trim test data

### DIFF
--- a/crates/path_resolver/Cargo.toml
+++ b/crates/path_resolver/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["benches/**"]
 name = "path_resolver"
 version = "0.2.10"
 categories.workspace = true

--- a/crates/rattler/Cargo.toml
+++ b/crates/rattler/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["**/snapshots/**"]
 name = "rattler"
 version = "0.43.2"
 edition.workspace = true

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["**/snapshots/**", "benches/**"]
 name = "rattler_conda_types"
 version = "0.46.4"
 edition.workspace = true

--- a/crates/rattler_config/Cargo.toml
+++ b/crates/rattler_config/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["**/snapshots/**", "test-data/**"]
 name = "rattler_config"
 version = "0.4.1"
 edition.workspace = true

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["tests/**"]
 name = "rattler_index"
 version = "0.30.1"
 edition.workspace = true

--- a/crates/rattler_lock/Cargo.toml
+++ b/crates/rattler_lock/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["**/snapshots/**"]
 name = "rattler_lock"
 version = "0.30.3"
 edition.workspace = true

--- a/crates/rattler_macros/Cargo.toml
+++ b/crates/rattler_macros/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["tests/**"]
 name = "rattler_macros"
 version = "1.1.0"
 edition.workspace = true

--- a/crates/rattler_menuinst/Cargo.toml
+++ b/crates/rattler_menuinst/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["**/snapshots/**", "test-data/**"]
 name = "rattler_menuinst"
 version = "0.2.62"
 edition.workspace = true

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["tests/**", "**/snapshots/**"]
 name = "rattler_networking"
 version = "0.27.2"
 edition.workspace = true

--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["tests/**", "benches/**", "**/snapshots/**"]
 name = "rattler_package_streaming"
 version = "0.26.2"
 edition.workspace = true

--- a/crates/rattler_pty/Cargo.toml
+++ b/crates/rattler_pty/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["tests/**"]
 name = "rattler_pty"
 version = "0.2.12"
 description = "A crate to create pty"

--- a/crates/rattler_repodata_gateway/Cargo.toml
+++ b/crates/rattler_repodata_gateway/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["benches/**", "**/snapshots/**"]
 name = "rattler_repodata_gateway"
 version = "0.29.2"
 edition.workspace = true

--- a/crates/rattler_sandbox/Cargo.toml
+++ b/crates/rattler_sandbox/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["tests/**"]
 name = "rattler_sandbox"
 version = "0.2.19"
 description = "A crate to run executables in a sandbox"

--- a/crates/rattler_shell/Cargo.toml
+++ b/crates/rattler_shell/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["**/snapshots/**"]
 name = "rattler_shell"
 version = "0.27.2"
 edition.workspace = true

--- a/crates/rattler_solve/Cargo.toml
+++ b/crates/rattler_solve/Cargo.toml
@@ -1,4 +1,5 @@
 [package]
+exclude = ["tests/**", "benches/**"]
 name = "rattler_solve"
 version = "7.1.1"
 edition.workspace = true

--- a/py-rattler/pixi.lock
+++ b/py-rattler/pixi.lock
@@ -893,10 +893,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-he9a06e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.10.1-py310hb4e1661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.13.3-py310h2b5ca13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.17.1-py39hd399759_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.4-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.0.0-py39h8cd3c5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.9.23-hc30ae73_0_cpython.conda
@@ -1010,10 +1010,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.50.4-h39a8b3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-hd23fc13_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.10.1-py310h646694a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.13.3-py310h655e229_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.17.1-py39hb1cfd32_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h0622a9a_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.5.4-h230baf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.0.0-py39h80efdc8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.9.23-h8a7f3fd_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h7cca4af_2.conda
@@ -1082,10 +1082,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.4-h4237e3c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.10.1-py310ha114163_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.13.3-py310hc7c2786_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.17.1-py39he7485ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.4-h5503f6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.0.0-py39hf3bc14e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.9.23-h7139b31_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
@@ -1153,7 +1153,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.4-hf5d6505_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/maturin-1.10.1-py310h24db72e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/maturin-1.13.3-py310h6f63dbe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.17.1-py39h0802e32_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.4-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.0.0-py39ha55e580_0.conda
@@ -1691,24 +1691,24 @@ packages:
   purls: []
   size: 63629
   timestamp: 1774072609062
-- conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.10.1-py310hb4e1661_0.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.13.3-py310h2b5ca13_0.conda
   noarch: python
-  sha256: 63d03ae27c55fab0c4418515a7892190727199bf645da88f05c145727a8f0f7b
-  md5: 009038a194f410d216a7f15a741a15e0
+  sha256: 091d0f742e4fa9bab01f9b642795a84884ee6bfc6b8aa426e97c7213fa0fda6e
+  md5: b1e4804b025e3acee6e93f413c551d0c
   depends:
   - python
   - tomli >=1.1.0
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - openssl >=3.5.4,<4.0a0
+  - openssl >=3.5.6,<4.0a0
   constrains:
   - __glibc >=2.17
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/maturin?source=hash-mapping
-  size: 7424019
-  timestamp: 1762870656364
+  size: 9793377
+  timestamp: 1778496710620
 - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.17.1-py39hd399759_0.conda
   sha256: d9ff8dba35773b6b7ea464cfea50bceecbe143b6095dfdd2f8a2d7b2da578876
   md5: 174d1517c168b462c94ad8886706a9b4
@@ -1764,6 +1764,18 @@ packages:
   purls: []
   size: 3119624
   timestamp: 1759324353651
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  sha256: c0ef482280e38c71a08ad6d71448194b719630345b0c9c60744a2010e8a8e0cb
+  md5: da1b85b6a87e141f5140bb9924cecab0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - ca-certificates
+  - libgcc >=14
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3167099
+  timestamp: 1775587756857
 - conda: https://conda.anaconda.org/conda-forge/linux-64/patchelf-0.17.2-h58526e2_0.conda
   sha256: eb355ac225be2f698e19dba4dcab7cb0748225677a9799e9cc8e4cadc3cb738f
   md5: ba76a6a448819560b5f8b08a9c74f415
@@ -3945,23 +3957,23 @@ packages:
   purls: []
   size: 57133
   timestamp: 1727963183990
-- conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.10.1-py310h646694a_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.13.3-py310h655e229_0.conda
   noarch: python
-  sha256: 8ac4a38e064796431f3ca96e71a5868e39a22e3d6f6b8305957bbad4374629ea
-  md5: 6afd92ed40c7a2835ad0247377d54a67
+  sha256: dbf34f81ecf78b6c1b655a1a7ee5d6963acf3167ee19147e9b30a2ce486d59d8
+  md5: 5e8d3098089c56eafcfd11d40fc53642
   depends:
   - python
   - tomli >=1.1.0
-  - __osx >=10.13
-  - openssl >=3.5.4,<4.0a0
+  - __osx >=11.0
+  - openssl >=3.5.6,<4.0a0
   constrains:
   - __osx >=10.13
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/maturin?source=hash-mapping
-  size: 7126524
-  timestamp: 1762870862048
+  size: 9399549
+  timestamp: 1778496942402
 - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.17.1-py39hb1cfd32_0.conda
   sha256: 88047bacbb6d4e9ac5adf75c1547f5aba5f2d0f129466a550dbb6a744b18a34b
   md5: bc932df9ffccd43312ebb8668fe154ae
@@ -4013,6 +4025,17 @@ packages:
   purls: []
   size: 2747108
   timestamp: 1759326402264
+- conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
+  sha256: 334fd49ea31b99114f5afb1ec44555dc8c90640648302a4f8f838ee345d1ec50
+  md5: 5cf0ece4375c73d7a5765e83565a69c7
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 2776564
+  timestamp: 1775589970694
 - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.46-ha3e7e28_0.conda
   sha256: cb262b7f369431d1086445ddd1f21d40003bb03229dfc1d687e3a808de2663a6
   md5: 3b504da3a4f6d8b2b1f969686a0bf0c0
@@ -4674,23 +4697,23 @@ packages:
   purls: []
   size: 46438
   timestamp: 1727963202283
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.10.1-py310ha114163_0.conda
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.13.3-py310hc7c2786_0.conda
   noarch: python
-  sha256: 9bbac59acb9b09581bcb12fb760e9aa9228ab7e46b5e2f5011a4923acd1ed1a2
-  md5: 668d23addd9f1e3c382933bff2533478
+  sha256: 4d91d10209712aff4406754adf3ae2162005d38085410fba9705dd5d5ccf82d2
+  md5: f6d00cdd97a48d336f7d8fdcd630a537
   depends:
   - python
   - tomli >=1.1.0
   - __osx >=11.0
-  - openssl >=3.5.4,<4.0a0
+  - openssl >=3.5.6,<4.0a0
   constrains:
   - __osx >=11.0
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/maturin?source=hash-mapping
-  size: 6716977
-  timestamp: 1762870858035
+  size: 8794005
+  timestamp: 1778496841913
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.17.1-py39he7485ab_0.conda
   sha256: 1a907c11f0700c6564d288d8894c74da57822bbc74b0ed667cc0dca999255b2e
   md5: a37b3c332e81e0096cca2a747464c489
@@ -4743,6 +4766,17 @@ packages:
   purls: []
   size: 3067808
   timestamp: 1759324763146
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+  sha256: c91bf510c130a1ea1b6ff023e28bac0ccaef869446acd805e2016f69ebdc49ea
+  md5: 25dcccd4f80f1638428613e0d7c9b4e1
+  depends:
+  - __osx >=11.0
+  - ca-certificates
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 3106008
+  timestamp: 1775587972483
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.46-h7125dd6_0.conda
   sha256: 5bf2eeaa57aab6e8e95bea6bd6bb2a739f52eb10572d8ed259d25864d3528240
   md5: 0e6e82c3cc3835f4692022e9b9cd5df8
@@ -5453,16 +5487,13 @@ packages:
   purls: []
   size: 55476
   timestamp: 1727963768015
-- conda: https://conda.anaconda.org/conda-forge/win-64/maturin-1.10.1-py310h24db72e_0.conda
+- conda: https://conda.anaconda.org/conda-forge/win-64/maturin-1.13.3-py310h6f63dbe_0.conda
   noarch: python
-  sha256: fb1884b19eacea1f68e5ff9d1b19a99f993fa374265113caf805f1eeab8721d1
-  md5: 92ac49a39dad8e393b762acd8d37f055
+  sha256: 6ff2d3eb93a3f5331aae70d7ecb132d9f5f13403f6759ed481707e0a10ac0422
+  md5: a9093a51d0a9edaf9b3d451fd3f8a2b3
   depends:
   - python
   - tomli >=1.1.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
@@ -5470,8 +5501,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/maturin?source=hash-mapping
-  size: 6742892
-  timestamp: 1762870671533
+  size: 8814348
+  timestamp: 1778496765901
 - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.17.1-py39h0802e32_0.conda
   sha256: 3ff904d227fb80f884a7fc169d93742ad1c1faa1328a98f2f4934d76b335ebaa
   md5: 4f19cbaad159262265f7cd185bc7f7ca

--- a/py-rattler/pixi.toml
+++ b/py-rattler/pixi.toml
@@ -9,7 +9,7 @@ platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
 license = "BSD-3-Clause"
 
 [feature.build.dependencies]
-maturin = "~=1.10.1"
+maturin = "~=1.13.3"
 pip = "~=23.2.1"
 rust = "~=1.95.0"
 

--- a/py-rattler/pyproject.toml
+++ b/py-rattler/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin>=1.10,<2.0"]
+requires = ["maturin>=1.13.3,<2.0"]
 build-backend = "maturin"
 
 [project]

--- a/py-rattler/pyproject.toml
+++ b/py-rattler/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin~=1.9.0"]
+requires = ["maturin>=1.10,<2.0"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
### Description

Makes the py-rattler source distribution conformant with PEP 625. The published sdist was using a tar format that strict tooling cannot read.

This also trims the sdist down to what is actually needed to build and install py-rattler. Previously, it bundled a large amount of test data from the workspace crates, which roughly halves the download size once removed.

Fixes #2464

### How Has This Been Tested?

Built the sdist locally, confirmed it no longer contains the non-conformant entry or the bundled test data, and verified it still installs and imports successfully.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code