### PR TITLE
ci: build py-rattler wheels with cargo-auditable

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -80,12 +80,16 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: ${{ matrix.platform.arch }}
+      - name: "Install cargo-auditable"
+        uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
+        with:
+          tool: cargo-auditable
       - name: "Build wheels"
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --no-default-features --features rustls
+          args: --release --auditable --out dist --no-default-features --features rustls
       - name: "Test wheel"
         if: ${{ !startsWith(matrix.platform.target, 'aarch64') }}
         shell: bash
@@ -121,7 +125,8 @@ jobs:
           working-directory: py-rattler
           target: ${{ matrix.target }}
           manylinux: auto
-          args: --release --out dist --no-default-features --features rustls,pty
+          before-script-linux: cargo install cargo-auditable --locked
+          args: --release --auditable --out dist --no-default-features --features rustls,pty
       - name: "Test wheel"
         if: ${{ startsWith(matrix.target, 'x86_64') }}
         run: |
@@ -158,7 +163,8 @@ jobs:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
           manylinux: "2_28"
-          args: --release --out dist  --no-default-features --features rustls,pty
+          before-script-linux: cargo install cargo-auditable --locked
+          args: --release --auditable --out dist  --no-default-features --features rustls,pty
       - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
         if: matrix.platform.arch != 'ppc64'
         name: Test wheel
@@ -206,7 +212,8 @@ jobs:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
           manylinux: auto
-          args: --release --out dist --no-default-features --features native-tls,vendored-openssl,pty
+          before-script-linux: cargo install cargo-auditable --locked
+          args: --release --auditable --out dist --no-default-features --features native-tls,vendored-openssl,pty
       - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
         if: matrix.platform.arch != 'ppc64'
         name: Test wheel
@@ -251,7 +258,8 @@ jobs:
           working-directory: py-rattler
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
-          args: --release --out dist --no-default-features --features rustls,pty
+          before-script-linux: cargo install cargo-auditable --locked
+          args: --release --auditable --out dist --no-default-features --features rustls,pty
       - name: "Build wheels (native-tls)"
         if: matrix.target != 'x86_64-unknown-linux-musl'
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
@@ -259,7 +267,8 @@ jobs:
           working-directory: py-rattler
           target: ${{ matrix.target }}
           manylinux: musllinux_1_2
-          args: --release --out dist --no-default-features --features native-tls,vendored-openssl,pty
+          before-script-linux: cargo install cargo-auditable --locked
+          args: --release --auditable --out dist --no-default-features --features native-tls,vendored-openssl,pty
       - name: "Test wheel"
         if: matrix.target == 'x86_64-unknown-linux-musl'
         uses: addnab/docker-run-action@4f65fabd2431ebc8d299f8e5a018d79a769ae185 # v3
@@ -301,7 +310,8 @@ jobs:
           working-directory: py-rattler
           target: ${{ matrix.platform.target }}
           manylinux: musllinux_1_2
-          args: --release --out dist --no-default-features --features rustls,pty
+          before-script-linux: cargo install cargo-auditable --locked
+          args: --release --auditable --out dist --no-default-features --features rustls,pty
       - uses: uraimo/run-on-arch-action@d94c13912ea685de38fccc1109385b83fd79427d # v3.0.1
         name: Test wheel
         with:
@@ -330,12 +340,16 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
+      - name: "Install cargo-auditable"
+        uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
+        with:
+          tool: cargo-auditable
       - name: "Build wheels - x86_64"
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:
           working-directory: py-rattler
           target: x86_64
-          args: --release --out dist --no-default-features --features rustls,pty
+          args: --release --auditable --out dist --no-default-features --features rustls,pty
       - name: "Test wheel - x86_64"
         run: |
           pip install py-rattler/dist/${{ env.PACKAGE_NAME }}-*.whl --force-reinstall
@@ -357,10 +371,14 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: x64
+      - name: "Install cargo-auditable"
+        uses: taiki-e/install-action@5939f3337e40968c39aa70f5ecb1417a92fb25a0 # v2.75.15
+        with:
+          tool: cargo-auditable
       - name: "Build wheels - universal2"
         uses: PyO3/maturin-action@86b9d133d34bc1b40018696f782949dac11bd380 # v1.49.4
         with:
-          args: --release --target universal2-apple-darwin --out dist --no-default-features --features rustls,pty
+          args: --release --auditable --target universal2-apple-darwin --out dist --no-default-features --features rustls,pty
           working-directory: py-rattler
       - name: "Test wheel - universal2"
         run: |


### PR DESCRIPTION
### Description

Builds the py-rattler wheels with `cargo-auditable` so the published wheels embed an SBOM of their Rust dependencies. This lets vulnerability scanners like `cargo audit bin`, `syft`, and `trivy` read the dependency graph directly from the installed binary instead of inferring it.

### How Has This Been Tested?

The `release-python.yml` workflow runs on PRs that modify it, so CI on this PR exercises every wheel build.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code