### PR TITLE
fix: loop over completion files instead of using glob operator

### DIFF
--- a/crates/rattler_shell/src/shell/mod.rs
+++ b/crates/rattler_shell/src/shell/mod.rs
@@ -406,7 +406,10 @@ impl Shell for Bash {
             } else {
                 completions_dir.to_string_lossy().to_string()
             };
-            writeln!(f, "source {completions_dir_str}/*")?;
+            writeln!(f, "for _pixi_f in {completions_dir_str}/*; do")?;
+            writeln!(f, "    [ -r \"$_pixi_f\" ] && . \"$_pixi_f\"")?;
+            writeln!(f, "done")?;
+            writeln!(f, "unset _pixi_f")?;
         }
         Ok(())
     }


### PR DESCRIPTION
### Description

cc @Hofer-Julian

This PR fixes a bug in `Bash::source_completions` from `rattler_shell` where only the alphabetically-first file in a completion directory ends up sourced..

The current implementation emits:

```bash
source <completions_dir>/*`
```

The glob expands to all files in the directory, but bash's source builtin only treats its first argument as a file path. Any remaining arguments become positional parameters (`$1`, `$2`, ...) inside the sourced script, where they're typically ignored. The result: in a Conda/pixi environment with multiple files in `share/bash-completion/completions/`, only one gets sourced.

The fix replaces the broken glob source with an explicit for loop that sources each file individually (the same pattern `Fish::source_completions` already uses correctly a few lines below in the same file).

```bash
for f in <completions_dir>/*; do
    [ -r "$f" ] && . "$f"
done
unset f
```

Fixes #2472

### How Has This Been Tested?

Tested locally by patching pixi's Cargo.toml to use my local rattler fork:

```
[patch.crates-io]
rattler_shell = { path = "../rattler/crates/rattler_shell" }
rattler_conda_types = { path = "../rattler/crates/rattler_conda_types" }
rattler_repodata_gateway = { path = "../rattler/crates/rattler_repodata_gateway" }
rattler_networking = { path = "../rattler/crates/rattler_networking" }
rattler_cache = { path = "../rattler/crates/rattler_cache" }
rattler_index = { path = "../rattler/crates/rattler_index" }
rattler_menuinst = { path = "../rattler/crates/rattler_menuinst" }
rattler_digest = { path = "../rattler/crates/rattler_digest" }
rattler_lock = { path = "../rattler/crates/rattler_lock" }
rattler_package_streaming = { path = "../rattler/crates/rattler_package_streaming" }
rattler_s3 = { path = "../rattler/crates/rattler_s3" }
rattler_solve = { path = "../rattler/crates/rattler_solve" }
rattler_upload = { path = "../rattler/crates/rattler_upload" }
rattler_virtual_packages = { path = "../rattler/crates/rattler_virtual_packages" }
file_url = { path = "../rattler/crates/file_url" }
simple_spawn_blocking = { path = "../rattler/crates/simple_spawn_blocking" }
```

Then:
```bash
pixi run install-as pixid
cd <my-pixi-project>
pixid shell
complete -p   # all completions present
pixid shell-hook   # shows the `for` loop change instead of `source dir/*`
```

Note on testing setup: applying these changes directly on rattler `main` produces a build error against the latest pixi, because rattler main has dependencies (e.g. `sysinfo` 0.39.3) that require Rust 1.95, while the current pixi release is built with Rust 1.94. To work around this for local testing, I checked out rattler at the latest releases' commit `ec9cab3`  and applied this fix there. I guess this will be managed later in the pixi repo.

### AI Disclosure
- [x ] This PR contains AI-generated content.
  - [x ] I have tested any AI-generated content in my PR.
  - [ x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (claude.ai chat)
I used Claude to help diagnose this bug while investigating an unrelated symptom (Python argcomplete completions not registering in a pixi shell). The code change in this PR (four lines replacing the original writeln!) and this PR description were drafted with Claude's assistance. I fully understand the change.

### Checklist:
- [ x] I have performed a self-review of my own code
