### PR TITLE
feat: use semaphore for concurrent downloads

### DIFF
--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -69,6 +69,7 @@ pub struct Installer {
     downloader: Option<LazyClient>,
     execute_link_scripts: bool,
     io_semaphore: Option<Arc<Semaphore>>,
+    concurrent_requests_semaphore: Option<Arc<Semaphore>>,
     reporter: Option<Arc<dyn Reporter>>,
     target_platform: Option<Platform>,
     apple_code_sign_behavior: AppleCodeSignBehavior,
@@ -142,6 +143,43 @@ impl Installer {
     /// modifies an existing instance.
     pub fn set_io_concurrency_semaphore(&mut self, limit: usize) -> &mut Self {
         self.io_semaphore = Some(Arc::new(Semaphore::new(limit)));
+        self
+    }
+
+    /// Sets a limit on the number of concurrent package downloads and extractions. This
+    /// is used to avoid overwhelming a server or saturating the network.
+    #[must_use]
+    pub fn with_max_concurrent_requests(self, limit: usize) -> Self {
+        Self {
+            concurrent_requests_semaphore: Some(Arc::new(Semaphore::new(limit))),
+            ..self
+        }
+    }
+
+    /// Sets a limit on the number of concurrent package downloads and extractions.
+    ///
+    /// This function is similar to [`Self::with_max_concurrent_requests`],
+    /// but modifies an existing instance.
+    pub fn set_max_concurrent_requests(&mut self, limit: usize) -> &mut Self {
+        self.concurrent_requests_semaphore = Some(Arc::new(Semaphore::new(limit)));
+        self
+    }
+
+    /// Sets a semaphore that limits concurrent package downloads and extractions.
+    #[must_use]
+    pub fn with_concurrent_requests_semaphore(self, semaphore: Arc<Semaphore>) -> Self {
+        Self {
+            concurrent_requests_semaphore: Some(semaphore),
+            ..self
+        }
+    }
+
+    /// Sets a semaphore that limits concurrent package downloads and extractions.
+    ///
+    /// This function is similar to [`Self::with_concurrent_requests_semaphore`],
+    /// but modifies an existing instance.
+    pub fn set_concurrent_requests_semaphore(&mut self, semaphore: Arc<Semaphore>) -> &mut Self {
+        self.concurrent_requests_semaphore = Some(semaphore);
         self
     }
 
@@ -552,6 +590,10 @@ impl Installer {
             .await
             .map_err(InstallerError::FailedToAcquireCacheLock)?;
 
+        // Semaphore that limits concurrent package downloads and extractions. The permit
+        // is held for the duration of both. When None, concurrency is unlimited.
+        let concurrent_requests_semaphore = self.concurrent_requests_semaphore;
+
         // Construct a driver.
         let driver = InstallDriver::builder()
             .execute_link_scripts(self.execute_link_scripts)
@@ -643,6 +685,7 @@ impl Installer {
             let base_install_options = &base_install_options;
             let driver = &driver;
             let prefix = &prefix;
+            let concurrent_requests_semaphore = &concurrent_requests_semaphore;
             let spec_mapping_ref = spec_mapping.clone();
             let operation_future = async move {
                 if let Some(reporter) = &reporter
@@ -657,6 +700,7 @@ impl Installer {
                     let downloader = downloader.clone();
                     let reporter = reporter.clone();
                     let package_cache = package_cache.clone();
+                    let concurrent_requests_semaphore = concurrent_requests_semaphore.clone();
                     tokio::spawn(async move {
                         let populate_cache_report = reporter.clone().map(|r| {
                             let cache_index = r.on_populate_cache_start(operation_idx, &record);
@@ -667,6 +711,7 @@ impl Installer {
                             downloader,
                             &package_cache,
                             populate_cache_report.clone(),
+                            concurrent_requests_semaphore,
                         )
                         .await?;
                         if let Some((reporter, index)) = populate_cache_report {
@@ -831,6 +876,7 @@ async fn populate_cache(
     downloader: LazyClient,
     cache: &PackageCache,
     reporter: Option<(Arc<dyn Reporter>, usize)>,
+    concurrent_requests_semaphore: Option<Arc<Semaphore>>,
 ) -> Result<CacheMetadata, InstallerError> {
     struct CacheReporterBridge {
         reporter: Arc<dyn Reporter>,
@@ -889,6 +935,7 @@ async fn populate_cache(
                 downloader,
                 default_retry_policy(),
                 reporter,
+                concurrent_requests_semaphore,
             )
             .await
             .map_err(|e| InstallerError::FailedToFetch(record.identifier.to_string(), e))

--- a/crates/rattler/src/install/mod.rs
+++ b/crates/rattler/src/install/mod.rs
@@ -1427,6 +1427,7 @@ mod test {
                             package_url.clone(),
                             client.clone(),
                             None,
+                            None,
                         )
                         .await
                         .unwrap();

--- a/crates/rattler/src/install/test_utils.rs
+++ b/crates/rattler/src/install/test_utils.rs
@@ -93,6 +93,7 @@ pub async fn execute_operation(
                 download_client.clone(),
                 default_retry_policy(),
                 None,
+                None,
             )
             .map_ok(|cache_lock| Some((install_record.clone(), cache_lock)))
             .map_err(anyhow::Error::from)

--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -419,9 +419,17 @@ impl PackageCache {
         url: Url,
         client: LazyClient,
         reporter: Option<Arc<dyn CacheReporter>>,
+        concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
     ) -> Result<CacheMetadata, PackageCacheError> {
-        self.get_or_fetch_from_url_with_retry(pkg, url, client, DoNotRetryPolicy, reporter)
-            .await
+        self.get_or_fetch_from_url_with_retry(
+            pkg,
+            url,
+            client,
+            DoNotRetryPolicy,
+            reporter,
+            concurrent_requests_semaphore,
+        )
+        .await
     }
 
     /// Returns the directory that contains the specified package.
@@ -478,6 +486,11 @@ impl PackageCache {
     /// uses the passed in `retry_policy` if, after the request has been sent
     /// and the response is successful, streaming of the package data fails
     /// and the whole request must be retried.
+    ///
+    /// The optional `concurrent_requests_semaphore` limits the number of
+    /// simultaneous downloads. A permit is acquired only when a download is
+    /// actually started (i.e. the package is not already cached), and is held
+    /// for the duration of the download and extraction.
     #[instrument(skip_all, fields(url=%url))]
     pub async fn get_or_fetch_from_url_with_retry(
         &self,
@@ -486,6 +499,7 @@ impl PackageCache {
         client: LazyClient,
         retry_policy: impl RetryPolicy + Send + 'static + Clone,
         reporter: Option<Arc<dyn CacheReporter>>,
+        concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
     ) -> Result<CacheMetadata, PackageCacheError> {
         let request_start = SystemTime::now();
         // Convert into cache key
@@ -503,7 +517,21 @@ impl PackageCache {
             let client = client.clone();
             let retry_policy = retry_policy.clone();
             let download_reporter = download_reporter.clone();
+            let concurrent_requests_semaphore = concurrent_requests_semaphore.clone();
             async move {
+                // Acquire a permit to limit the number of concurrent download
+                // and extraction operations. The permit is held until the
+                // closure returns and is released automatically when dropped.
+                let _permit = match concurrent_requests_semaphore {
+                    Some(semaphore) => Some(
+                        semaphore
+                            .acquire_owned()
+                            .await
+                            .expect("semaphore should not be closed"),
+                    ),
+                    None => None,
+                };
+
                 let mut current_try = 0;
                 // Retry until the retry policy says to stop
                 loop {
@@ -1434,6 +1462,7 @@ mod test {
                 client.clone().into(),
                 DoNotRetryPolicy,
                 None,
+                None,
             )
             .await;
 
@@ -1451,7 +1480,14 @@ mod test {
 
         // The second one should fail after the 2nd try
         let result = cache
-            .get_or_fetch_from_url_with_retry(identifier, url, client.into(), retry_policy, None)
+            .get_or_fetch_from_url_with_retry(
+                identifier,
+                url,
+                client.into(),
+                retry_policy,
+                None,
+                None,
+            )
             .await;
 
         assert!(result.is_ok());
@@ -1985,5 +2021,52 @@ mod test {
         .unwrap();
         assert_eq!(lock_contents.len(), 40);
         assert_eq!(&lock_contents[8..], pypy_record.sha256.unwrap().as_slice());
+    }
+
+    /// Verify that a fully-exhausted semaphore does not block a cache hit.
+    ///
+    /// The semaphore permit is only acquired inside the fetch closure, which is
+    /// never called when the package is already cached. So even with zero
+    /// available permits the call must return immediately.
+    #[tokio::test]
+    async fn test_semaphore_not_acquired_on_cache_hit() {
+        let package_path = get_test_data_dir().join("clobber/clobber-python-0.1.0-cpython.conda");
+
+        let packages_dir = tempdir().unwrap();
+        let cache = PackageCache::new(packages_dir.path());
+
+        // Populate the cache from disk first.
+        cache
+            .get_or_fetch_from_path(&package_path, None, None)
+            .await
+            .unwrap();
+
+        // A semaphore with 0 permits — any attempt to acquire it would block
+        // forever.
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(0));
+
+        // A fake URL; it will never be contacted because the package is cached.
+        let url = Url::parse("https://example.com/clobber-python-0.1.0-cpython.conda").unwrap();
+        let identifier = CondaArchiveIdentifier::try_from_path(&package_path).unwrap();
+        let client = rattler_networking::LazyClient::default();
+
+        // This must complete without blocking even though the semaphore is empty.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            cache.get_or_fetch_from_url_with_retry(
+                identifier,
+                url,
+                client,
+                rattler_networking::retry_policies::DoNotRetryPolicy,
+                None,
+                Some(semaphore.clone()),
+            ),
+        )
+        .await
+        .expect("timed out — semaphore was incorrectly acquired on a cache hit");
+
+        assert!(result.is_ok(), "expected cache hit, got {result:?}");
+        // The semaphore should still have 0 permits — nothing was acquired.
+        assert_eq!(semaphore.available_permits(), 0);
     }
 }

--- a/crates/rattler_repodata_gateway/src/gateway/direct_url_query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/direct_url_query.rs
@@ -23,6 +23,8 @@ pub(crate) struct DirectUrlQuery {
     client: LazyClient,
     /// The cache to use for storing the package
     package_cache: PackageCache,
+    /// An optional semaphore to limit the number of concurrent downloads and extractions.
+    concurrent_requests_semaphore: Option<Arc<tokio::sync::Semaphore>>,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -51,7 +53,17 @@ impl DirectUrlQuery {
             md5,
             client,
             package_cache,
+            concurrent_requests_semaphore: None,
         }
+    }
+
+    /// Sets a semaphore to limit the number of concurrent package downloads and extractions.
+    pub(crate) fn with_concurrent_requests_semaphore(
+        mut self,
+        semaphore: Option<Arc<tokio::sync::Semaphore>>,
+    ) -> Self {
+        self.concurrent_requests_semaphore = semaphore;
+        self
     }
 
     /// Execute the Repodata query using the cache as a source for the
@@ -106,6 +118,7 @@ impl DirectUrlQuery {
                     self.client.clone(),
                     // Should we add a reporter?
                     None,
+                    self.concurrent_requests_semaphore,
                 )
                 .await?;
 

--- a/crates/rattler_repodata_gateway/src/gateway/query.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/query.rs
@@ -337,7 +337,8 @@ impl QueryExecutor {
                     gateway.client.clone(),
                     spec.sha256,
                     spec.md5,
-                );
+                )
+                .with_concurrent_requests_semaphore(gateway.concurrent_requests_semaphore.clone());
 
                 let records = query
                     .execute()

--- a/crates/rattler_repodata_gateway/src/gateway/run_exports_extractor.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/run_exports_extractor.rs
@@ -341,9 +341,6 @@ impl RunExportExtractor {
             .and_then(|reporter| reporter.create_package_download_reporter(record))
             .map(Arc::from);
 
-        // Wait for a permit from the semaphore to limit concurrent requests.
-        let _permit = self.acquire_request_permit().await;
-
         match package_cache
             .get_or_fetch_from_url_with_retry(
                 cache_key,
@@ -351,6 +348,7 @@ impl RunExportExtractor {
                 client.clone(),
                 rattler_networking::retry_policies::default_retry_policy(),
                 reporter,
+                self.max_concurrent_requests.clone(),
             )
             .await
         {


### PR DESCRIPTION
### Description

Use a semaphore during the package fetching phase. Web servers (hosting conda channels) can limit the maximum number of concurrent streams per HTTP2 request, and on a machine with 100+ cores, this limit can be easily breached with rattler-build, leading to issues like:

```
 ⚠ warning 3c661_0TLYula: an io error occurred: background task failed. Retry #1, Sleeping 1.074016416s until the next attempt...
 ⚠ warning failed to download and extract https://conda.mydomain.com/channels/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda to /spare/local/nehal/tmp/.tmp3n5ZsZ/.xorg-libxrandr
 ⚠ warning -1.5.5-hb03c661_0IRuJ9d: an io error occurred: background task failed. Retry #1, Sleeping 1.276796573s until the next attempt...
 ⚠ warning failed to download and extract https://conda.mydomain.com/channels/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda to /spare/local/nehal/tmp/.tmp3n5ZsZ/.xorg-libxfixes
 ⚠ warning -6.0.2-hb03c661_0EEhDv5: an io error occurred: background task failed. Retry #1, Sleeping 652.365217ms until the next attempt...
 ⚠ warning failed to download and extract https://conda.mydomain.com/channels/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda to /spare/local/nehal/tmp/.tmp3n5ZsZ/.uriparser-0.9.8-hac
 ⚠ warning 33072_0jnlfuM: an io error occurred: background task failed. Retry #1, Sleeping 1.416194794s until the next attempt...
 ⚠ warning failed to download and extract https://conda.mydomain.com/channels/conda-forge/linux-64/libpciaccess-0.19-hb03c661_0.conda to /spare/local/nehal/tmp/.tmp3n5ZsZ/.libpciaccess-0.19
 ⚠ warning -hb03c661_072hDHC: an io error occurred: background task failed. Retry #1, Sleeping 1.770080294s until the next attempt...
 ⚠ warning failed to download and extract https://conda.mydomain.com/channels/conda-forge/linux-64/xorg-libxi-1.8.3-hb03c661_0.conda to /spare/local/nehal/tmp/.tmp3n5ZsZ/.xorg-libxi-1.8.3-h
 ⚠ warning b03c661_0RO4xpW: an io error occurred: background task failed. Retry #1, Sleeping 305.761819ms until the next attempt...
 ⚠ warning failed to download and extract https://conda.mydomain.com/channels/conda-forge/linux-64/libopentelemetry-cpp-1.27.0-h9692893_0.conda to /spare/local/nehal/tmp/.tmp3n5ZsZ/.libopen
 ⚠ warning telemetry-cpp-1.27.0-h9692893_0T7jh4o: an io error occurred: failed to unpack `/spare/local/nehal/tmp/.tmp3n5ZsZ/.libopentelemetry-cpp-1.27.0-h9692893_0T7jh4o/lib/libopentelemetry_common.so`. Retry #
 ⚠ warning 1, Sleeping 1.444153262s until the next attempt...
 ⚠ warning failed to download and extract https://conda.mydomain.com/channels/conda-forge/linux-64/lcms2-2.19.1-h0c24ade_1.conda to /spare/local/nehal/tmp/.tmp3n5ZsZ/.lcms2-2.19.1-h0c24ade_
 ⚠ warning 1aYU4Dv: an io error occurred: background task failed. Retry #1, Sleeping 1.756179219s until the next attempt...
 ⚠ warning failed to download and extract https://conda.mydomain.com/channels/conda-forge/linux-64/azure-identity-cpp-1.13.3-hed0cdb0_1.conda to /spare/local/nehal/tmp/.tmp3n5ZsZ/.azure-ide
 ⚠ warning ntity-cpp-1.13.3-hed0cdb0_1rXcvOm: an io error occurred: failed to unpack `/spare/local/nehal/tmp/.tmp3n5ZsZ/.azure-identity-cpp-1.13.3-hed0cdb0_1rXcvOm/lib/libazure-identity.so.1.13.3`. Retry #1, Sl
 ⚠ warning eeping 1.113816042s until the next attempt...
 ⚠ warning failed to download and extract https://conda.mydomain.com/channels/conda-forge/linux-64/libgl-devel-1.7.0-ha4b6fd6_3.conda to /spare/local/nehal/tmp/.tmp3n5ZsZ/.libgl-devel-1.7.0
 ⚠ warning -ha4b6fd6_3xMZHPP: an io error occurred: failed to unpack `/spare/local/nehal/tmp/.tmp3n5ZsZ/.libgl-devel-1.7.0-ha4b6fd6_3xMZHPP/include/GL/glcorearb.h`. Retry #1, Sleeping 384.609048ms until the nex
 ⚠ warning t attempt...
 │ │ │   download & extract   [00:00:00] [━━━━━━━━━━━━━━━━━━━━] 476.81 MiB @ 4.71 GiB/s python_abi (+237)
 │ │ │   installing packages  [00:00:00] [━━━━━━━━━━━━━━━━━━━━]   254/254
Error:   × Test failed: failed to setup test environment:   × failed to fetch munkres-1.1.4-pyhd8ed1ab_1.conda
  │   ├─▶ failed to interact with the package cache layer.
  │   ├─▶ error sending request for url (https://conda.mydomain.com/channels/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda)
  │   ├─▶ client error (SendRequest)
  │   ├─▶ dispatch task is gone
  │   ╰─▶ runtime dropped the dispatch task
  │
```

<!--- Add visual representation of the effect of the change when possible, e.g. before and after screenshots, code snippets, etc. --->

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: GitHub Copilot (Claude Sonnet 4.6)

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (n/a)
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
