### PR TITLE
fix: abbreviate long version lists in unsolvable errors

### DIFF
--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -635,15 +635,40 @@ impl Interner for CondaDependencyProvider<'_> {
     }
 
     fn display_merged_solvables(&self, solvables: &[SolvableId]) -> impl Display + '_ {
+        // When abbreviating, the number of versions shown at the start and end of
+        // the list around the ellipsis.
+        const HEAD: usize = 2;
+        const TAIL: usize = 1;
+
         if solvables.is_empty() {
             return String::new();
         }
 
+        // Collect the distinct versions in sorted order. The same version can
+        // appear multiple times when there are several builds of it.
         let versions = solvables
             .iter()
             .filter_map(|&id| self.pool.resolve_solvable(id).record.version())
             .sorted()
-            .format(" | ");
+            .dedup()
+            .collect::<Vec<_>>();
+
+        // Abbreviate long lists with an ellipsis so a package with many versions
+        // does not flood the error message, similar to micromamba.
+        let versions = if versions.len() > HEAD + TAIL + 1 {
+            versions[..HEAD]
+                .iter()
+                .map(ToString::to_string)
+                .chain(std::iter::once("...".to_string()))
+                .chain(
+                    versions[versions.len() - TAIL..]
+                        .iter()
+                        .map(ToString::to_string),
+                )
+                .join(" | ")
+        } else {
+            versions.iter().map(ToString::to_string).join(" | ")
+        };
 
         let name = self.display_solvable_name(solvables[0]);
         let result = format!("{name} {versions}");

--- a/crates/rattler_solve/tests/backends/main.rs
+++ b/crates/rattler_solve/tests/backends/main.rs
@@ -795,11 +795,44 @@ mod resolvo {
 
     use super::dummy_channel_with_optional_dependencies_json_path;
     use super::{
-        FromStr, GenericVirtualPackage, SimpleSolveTask, SolveError, Version,
+        FromStr, GenericVirtualPackage, PackageBuilder, SimpleSolveTask, SolveError, Version,
         dummy_channel_json_path, installed_package, solve, solve_real_world,
     };
 
     solver_backend_tests!(rattler_solve::resolvo::Solver);
+
+    /// When a single node in the conflict merges many versions, the version list
+    /// is abbreviated with an ellipsis instead of printing every version.
+    #[test]
+    fn test_unsat_merged_versions_are_abbreviated() {
+        // Eight versions of `foo`, all depending on a `bar` that does not exist.
+        // They merge into a single node in the conflict graph.
+        let repo_data: Vec<RepoDataRecord> = (1..=8)
+            .map(|major| {
+                let version = format!("{major}.0");
+                let mut record = PackageBuilder::new("foo")
+                    .version(&version)
+                    .depends(["bar ==1.0"])
+                    .build();
+                // Give each build a unique identifier so they are not deduplicated.
+                record.identifier.identifier.version = version;
+                record.identifier.identifier.build_string = format!("h{major}_0");
+                record
+            })
+            .collect();
+
+        let task = SolverTask {
+            specs: vec![MatchSpec::from_str("foo", ParseStrictness::Lenient).unwrap()],
+            ..SolverTask::from_iter([&repo_data])
+        };
+
+        let err = rattler_solve::resolvo::Solver.solve(task).unwrap_err();
+        insta::assert_snapshot!(err, @r###"
+        Cannot solve the request because of: foo * cannot be installed because there are no viable options:
+        └─ foo 1.0 | 2.0 | ... | 8.0 would require
+           └─ bar ==1.0, for which no candidates were found.
+        "###);
+    }
 
     #[test]
     fn test_flags_select_matching_variant() {


### PR DESCRIPTION
### Description

When an environment cannot be solved, the error sometimes listed every version of a package, including the same version repeated once per build. For a package with many versions this produced a very long, noisy line.

This change makes that output shorter: repeated versions are removed and long version lists are abbreviated with an ellipsis, showing only the first and last few versions. This is similar to how micromamba reports the same situation.

Before:

```
r-ggpmisc * cannot be installed because there are no viable options:
└─ r-ggpmisc 0.3.0 | 0.3.1 | 0.3.1 | 0.3.1 | ... (many more) ... | 0.7.0 | 0.7.0 would require
   └─ r-base >=3.5.1,<3.5.2.0a0, for which no candidates were found.
```

After:

```
foo * cannot be installed because there are no viable options:
└─ foo 1.0 | 2.0 | ... | 8.0 would require
   └─ bar ==1.0, for which no candidates were found.
```

Related to #2476.

### How Has This Been Tested?

Added a test that requests a package with many versions whose dependency is unavailable, and asserts the abbreviated error message. The full `rattler_solve` backend test suite passes.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.