### PR TITLE
feat: allow setting alternative target prefix on Installer

### DIFF
--- a/crates/rattler/src/install/installer/mod.rs
+++ b/crates/rattler/src/install/installer/mod.rs
@@ -323,6 +323,33 @@ impl Installer {
         self
     }
 
+    /// Sets an alternative prefix to use when patching hardcoded paths in
+    /// installed files.
+    ///
+    /// When files are linked into the target directory, hardcoded paths in
+    /// those files are "patched" by replacing the placeholder prefix with the
+    /// full path of the target directory. In exceptional cases you might want
+    /// to patch in a different prefix than the directory that is actually being
+    /// installed to. When set, this prefix is used instead of the target
+    /// directory.
+    #[must_use]
+    pub fn with_alternative_target_prefix(self, prefix: impl Into<PathBuf>) -> Self {
+        Self {
+            alternative_target_prefix: Some(prefix.into()),
+            ..self
+        }
+    }
+
+    /// Sets an alternative prefix to use when patching hardcoded paths in
+    /// installed files.
+    ///
+    /// This function is similar to [`Self::with_alternative_target_prefix`],
+    /// but modifies an existing instance.
+    pub fn set_alternative_target_prefix(&mut self, prefix: impl Into<PathBuf>) -> &mut Self {
+        self.alternative_target_prefix = Some(prefix.into());
+        self
+    }
+
     /// Sets the link options for the installer.
     pub fn with_link_options(self, options: LinkOptions) -> Self {
         Self {
@@ -1551,6 +1578,33 @@ mod tests {
             Some(LinkType::Copy),
             "link_type should be Copy when hard links are disabled"
         );
+    }
+
+    #[test]
+    fn test_alternative_target_prefix_setters() {
+        let prefix = Path::new("/some/other/prefix");
+
+        // The builder-style setter should store the prefix.
+        let installer = Installer::new().with_alternative_target_prefix(prefix);
+        assert_eq!(installer.alternative_target_prefix.as_deref(), Some(prefix));
+
+        // The mutable setter should store the prefix as well.
+        let mut installer = Installer::new();
+        installer.set_alternative_target_prefix(prefix);
+        assert_eq!(installer.alternative_target_prefix.as_deref(), Some(prefix));
+    }
+
+    #[tokio::test]
+    async fn test_install_with_alternative_target_prefix() {
+        let (_temp_dir, target_prefix) = create_test_environment();
+        let repo_record = create_dummy_repo_record();
+
+        // Installing with an alternative target prefix set should still succeed.
+        let installer = Installer::new().with_alternative_target_prefix("/some/other/prefix");
+        install_and_verify_success(installer, &target_prefix, repo_record.clone()).await;
+
+        let meta_file_path = get_meta_file_path(&target_prefix, &repo_record);
+        assert!(meta_file_path.exists(), "conda-meta file should exist");
     }
 
     /// Test that when hard links are explicitly forced on

--- a/py-rattler/rattler/install/installer.py
+++ b/py-rattler/rattler/install/installer.py
@@ -288,6 +288,7 @@ async def install(
     client: Optional[Client] = None,
     requested_specs: Optional[List[MatchSpec]] = None,
     reporter: Optional[InstallerReporter] = None,
+    alternative_target_prefix: Optional[str | os.PathLike[str]] = None,
 ) -> None:
     """
     Create an environment by downloading and linking the `dependencies` in
@@ -348,6 +349,11 @@ async def install(
         reporter: An optional :class:`InstallerReporter` instance that receives progress
                 callbacks during installation. When provided, `show_progress` is ignored.
                 Subclass :class:`InstallerReporter` and override the methods you need.
+        alternative_target_prefix: An alternative prefix to patch into the hardcoded paths of
+                installed files instead of `target_prefix`. The environment is still created in
+                `target_prefix`; only the prefix written into the linked files differs. This is
+                only needed in exceptional cases, for example when the environment will later be
+                relocated to or used from a different path.
     """
 
     await py_install(
@@ -363,4 +369,7 @@ async def install(
         show_progress=show_progress,
         requested_specs=requested_specs,
         reporter=reporter,
+        alternative_target_prefix=str(alternative_target_prefix)
+        if alternative_target_prefix is not None
+        else None,
     )

--- a/py-rattler/rattler/install/installer.py
+++ b/py-rattler/rattler/install/installer.py
@@ -369,7 +369,5 @@ async def install(
         show_progress=show_progress,
         requested_specs=requested_specs,
         reporter=reporter,
-        alternative_target_prefix=str(alternative_target_prefix)
-        if alternative_target_prefix is not None
-        else None,
+        alternative_target_prefix=str(alternative_target_prefix) if alternative_target_prefix is not None else None,
     )

--- a/py-rattler/src/installer.rs
+++ b/py-rattler/src/installer.rs
@@ -214,7 +214,7 @@ impl Reporter for PyReporter {
 
 #[pyfunction]
 #[allow(clippy::too_many_arguments)]
-#[pyo3(signature = (records, target_prefix, execute_link_scripts=false, show_progress=false, platform=None, client=None, cache_dir=None, installed_packages=None, reinstall_packages=None, ignored_packages=None, requested_specs=None, reporter=None))]
+#[pyo3(signature = (records, target_prefix, execute_link_scripts=false, show_progress=false, platform=None, client=None, cache_dir=None, installed_packages=None, reinstall_packages=None, ignored_packages=None, requested_specs=None, reporter=None, alternative_target_prefix=None))]
 pub fn py_install<'a>(
     py: Python<'a>,
     records: Vec<Bound<'a, PyAny>>,
@@ -229,6 +229,7 @@ pub fn py_install<'a>(
     ignored_packages: Option<HashSet<String>>,
     requested_specs: Option<Vec<PyMatchSpec>>,
     reporter: Option<PyObject>,
+    alternative_target_prefix: Option<PathBuf>,
 ) -> PyResult<Bound<'a, PyAny>> {
     let dependencies = records
         .into_iter()
@@ -302,6 +303,10 @@ pub fn py_install<'a>(
         if let Some(requested_specs) = requested_specs {
             installer
                 .set_requested_specs(requested_specs.into_iter().map(|spec| spec.inner).collect());
+        }
+
+        if let Some(alternative_target_prefix) = alternative_target_prefix {
+            installer.set_alternative_target_prefix(alternative_target_prefix);
         }
 
         // TODO: Return the installation result to python


### PR DESCRIPTION
### Description

The installer supports installing into a prefix while patching files with a different "alternative" prefix, but this option could not actually be configured on the `Installer`. The setting existed internally with no way to provide it.

This change exposes the alternative target prefix as a configurable option on the `Installer`, so callers can finally make use of it.

### How Has This Been Tested?

Added tests covering both the new configuration methods and an installation run with an alternative target prefix set. All tests pass alongside formatting and lint checks.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.