### PR TITLE
test(package-streaming): enable serde_json preserve_order for deterministic tests

### DIFF
--- a/crates/rattler_package_streaming/Cargo.toml
+++ b/crates/rattler_package_streaming/Cargo.toml
@@ -88,6 +88,7 @@ rstest_reuse = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true, features = ["fs"] }
 insta = { workspace = true, features = ["yaml"] }
+serde_json = { workspace = true, features = ["preserve_order"] }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 fs-err = { workspace = true }


### PR DESCRIPTION
The extract integration test asserts a json! snapshot with keys in insertion order (sha256, md5). That order only holds when serde_json's preserve_order feature is active, which previously happened by accident: rattler_shell enables it and Cargo unifies features across a workspace build. Testing rattler_package_streaming in isolation left the feature off, so json! fell back to alphabetical key order and the snapshot failed.

Enable preserve_order on the dev-dependency so the test is deterministic regardless of build scope, without changing production serialization.

### How Has This Been Tested?

By running the püackage-streaming tests in isolation

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

