### PR TITLE
test: prefix.dev OIDC end-to-end test and channel auth wiring (stacked on #2504)

### DIFF
--- a/.github/workflows/e2e-prefix-dev-tests.yml
+++ b/.github/workflows/e2e-prefix-dev-tests.yml
@@ -10,6 +10,11 @@ on:
       - pixi.lock
       - .github/workflows/e2e-prefix-dev-tests.yml
   workflow_dispatch:
+    inputs:
+      skip_upload:
+        description: "Skip the upload steps (bring-up: package already in the channel / upload 403 under investigation)"
+        type: boolean
+        default: false
 
 name: E2E prefix.dev OIDC Tests
 
@@ -40,6 +45,8 @@ jobs:
     env:
       # Enable sccache (picked up by pixi build).
       SCCACHE_GHA_ENABLED: "true"
+      # 'true' only when dispatched with the skip_upload input; empty on push.
+      PREFIX_DEV_E2E_SKIP_UPLOAD: ${{ inputs.skip_upload }}
 
     steps:
       - name: Checkout source code

--- a/.github/workflows/e2e-prefix-dev-tests.yml
+++ b/.github/workflows/e2e-prefix-dev-tests.yml
@@ -1,0 +1,51 @@
+on:
+  push:
+    branches: [main]
+    paths:
+      - crates/rattler-bin/**
+      - crates/rattler_networking/**
+      - crates/rattler_upload/**
+      - scripts/e2e/prefix-dev-oidc.nu
+      - pixi.toml
+      - pixi.lock
+      - .github/workflows/e2e-prefix-dev-tests.yml
+  workflow_dispatch:
+
+name: E2E prefix.dev OIDC Tests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  RUST_LOG: rattler_networking=debug,info
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+
+jobs:
+  e2e-prefix-dev-oidc:
+    name: E2E Upload/Challenged-Read [beta.prefix.dev]
+    runs-on: ubuntu-latest
+    # The OIDC identity is only authorized (via the server-side repository
+    # access config) for this repository; manual dispatch allows bring-up
+    # runs from a branch.
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    permissions:
+      id-token: write
+      contents: read
+
+    env:
+      # Enable sccache (picked up by pixi build).
+      SCCACHE_GHA_ENABLED: "true"
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          submodules: recursive
+
+      - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
+        with:
+          environments: prefix-dev-e2e
+
+      - run: pixi run -vv e2e-prefix-dev

--- a/.github/workflows/e2e-prefix-dev-tests.yml
+++ b/.github/workflows/e2e-prefix-dev-tests.yml
@@ -13,8 +13,10 @@ on:
 
 name: E2E prefix.dev OIDC Tests
 
+# All runs share one beta.prefix.dev channel; serialize across refs so a
+# dispatch run cannot race a main run's delete/upload/read cycle.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 env:

--- a/.github/workflows/e2e-prefix-dev-tests.yml
+++ b/.github/workflows/e2e-prefix-dev-tests.yml
@@ -26,6 +26,7 @@ jobs:
   e2e-prefix-dev-oidc:
     name: E2E Upload/Challenged-Read [beta.prefix.dev]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # The OIDC identity is only authorized (via the server-side repository
     # access config) for this repository; manual dispatch allows bring-up
     # runs from a branch.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,8 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
  "sync_wrapper",
  "tokio",
  "tower",

--- a/crates/rattler-bin/src/commands/client.rs
+++ b/crates/rattler-bin/src/commands/client.rs
@@ -70,7 +70,7 @@ pub fn create_client_with_middleware_for_channels(
         {
             continue;
         }
-        let Some(options) = TrustedPublishingOptions::for_host(url) else {
+        let Some(options) = TrustedPublishingOptions::for_server(url) else {
             continue;
         };
         let mut server = url.clone();

--- a/crates/rattler-bin/src/commands/client.rs
+++ b/crates/rattler-bin/src/commands/client.rs
@@ -1,13 +1,39 @@
 use std::{collections::HashMap, sync::Arc};
 
 use miette::{Context, IntoDiagnostic};
-use rattler_networking::{AuthenticationMiddleware, AuthenticationStorage};
+use rattler_conda_types::Channel;
+use rattler_networking::{
+    AuthChallengeMiddleware, AuthenticationMiddleware, AuthenticationStorage,
+    trusted_publishing::{TrustedPublishingFlow, TrustedPublishingOptions},
+};
 use reqwest::Client;
+use url::Url;
 
 pub const USER_AGENT: &str = concat!("rattler/", env!("CARGO_PKG_VERSION"));
 
+/// Hosts for which the CLI is willing to perform CI OIDC trusted publishing.
+/// Restricting this keeps the CLI from volunteering CI identity tokens to
+/// arbitrary channel hosts.
+fn is_prefix_dev_host(host: &str) -> bool {
+    host == "prefix.dev" || host.ends_with(".prefix.dev")
+}
+
 /// Creates an HTTP client with the middleware stack used by the CLI for remote fetches.
 pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
+    create_client_with_middleware_for_channels(&[])
+}
+
+/// Like [`create_client_with_middleware`], but additionally layers one
+/// [`AuthChallengeMiddleware`] per unique `https` channel host that matches
+/// the prefix.dev host policy. On a `WWW-Authenticate` challenge from such a
+/// host, the middleware acquires a token via CI OIDC trusted publishing
+/// (audience = the channel host) and replays the request.
+///
+/// This is the reference wiring for challenge-reactive private-channel
+/// reads (see prefix-dev/pixi#6318).
+pub fn create_client_with_middleware_for_channels(
+    channels: &[Channel],
+) -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
     let download_client = Client::builder()
         .no_gzip()
         .user_agent(USER_AGENT)
@@ -18,11 +44,40 @@ pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::Cli
     let authentication_storage =
         AuthenticationStorage::from_env_and_defaults().into_diagnostic()?;
 
-    let client = reqwest_middleware::ClientBuilder::new(download_client.clone())
-        .with_arc(Arc::new(AuthenticationMiddleware::from_auth_storage(
-            authentication_storage.clone(),
-        )))
-        .with(rattler_networking::OciMiddleware::new(download_client));
+    let mut client =
+        reqwest_middleware::ClientBuilder::new(download_client.clone()).with_arc(Arc::new(
+            AuthenticationMiddleware::from_auth_storage(authentication_storage.clone()),
+        ));
+
+    // The mint exchange must not itself go through AuthChallengeMiddleware
+    // (it would recurse), so it uses a plain client.
+    let mint_client = reqwest_middleware::ClientBuilder::new(download_client.clone()).build();
+
+    let mut seen_hosts = std::collections::HashSet::new();
+    for channel in channels {
+        let url: &Url = channel.base_url.as_ref();
+        if url.scheme() != "https" {
+            continue;
+        }
+        let Some(host) = url.host_str() else {
+            continue;
+        };
+        if !is_prefix_dev_host(host) || !seen_hosts.insert(host.to_string()) {
+            continue;
+        }
+        let Some(options) = TrustedPublishingOptions::for_host(url) else {
+            continue;
+        };
+        let mut server = url.clone();
+        server.set_path("/");
+        server.set_query(None);
+        client = client.with_arc(Arc::new(AuthChallengeMiddleware::new(
+            server,
+            Arc::new(TrustedPublishingFlow::new(options, mint_client.clone())),
+        )));
+    }
+
+    let client = client.with(rattler_networking::OciMiddleware::new(download_client));
     #[cfg(feature = "s3")]
     let client = client.with(rattler_networking::S3Middleware::new(
         HashMap::new(),
@@ -32,4 +87,20 @@ pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::Cli
     let client = client.with(rattler_networking::GCSMiddleware::default());
 
     Ok(client.build())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_dev_host_policy() {
+        assert!(is_prefix_dev_host("prefix.dev"));
+        assert!(is_prefix_dev_host("beta.prefix.dev"));
+        assert!(is_prefix_dev_host("staging.beta.prefix.dev"));
+        // not subdomains of prefix.dev:
+        assert!(!is_prefix_dev_host("evil-prefix.dev"));
+        assert!(!is_prefix_dev_host("prefix.dev.evil.com"));
+        assert!(!is_prefix_dev_host("conda.anaconda.org"));
+    }
 }

--- a/crates/rattler-bin/src/commands/client.rs
+++ b/crates/rattler-bin/src/commands/client.rs
@@ -19,6 +19,9 @@ fn is_prefix_dev_host(host: &str) -> bool {
 }
 
 /// Creates an HTTP client with the middleware stack used by the CLI for remote fetches.
+///
+/// This stack performs no challenge/trusted-publishing auth; commands that
+/// read channels should prefer [`create_client_with_middleware_for_channels`].
 pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
     create_client_with_middleware_for_channels(&[])
 }
@@ -62,13 +65,17 @@ pub fn create_client_with_middleware_for_channels(
         let Some(host) = url.host_str() else {
             continue;
         };
-        if !is_prefix_dev_host(host) || !seen_hosts.insert(host.to_string()) {
+        if !is_prefix_dev_host(host)
+            || !seen_hosts.insert((host.to_string(), url.port_or_known_default()))
+        {
             continue;
         }
         let Some(options) = TrustedPublishingOptions::for_host(url) else {
             continue;
         };
         let mut server = url.clone();
+        // Cosmetic: the middleware scopes on scheme+host+port and ignores
+        // path/query; normalizing just keeps Debug output tidy.
         server.set_path("/");
         server.set_query(None);
         client = client.with_arc(Arc::new(AuthChallengeMiddleware::new(
@@ -102,5 +109,8 @@ mod tests {
         assert!(!is_prefix_dev_host("evil-prefix.dev"));
         assert!(!is_prefix_dev_host("prefix.dev.evil.com"));
         assert!(!is_prefix_dev_host("conda.anaconda.org"));
+        // trailing-dot (DNS absolute) hosts are deliberately not matched:
+        // url::Url preserves the dot, so this fails closed.
+        assert!(!is_prefix_dev_host("beta.prefix.dev."));
     }
 }

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -179,7 +179,7 @@ pub async fn create(opt: Opt) -> miette::Result<()> {
     // `repodata.json` that should be available from the corresponding Url. The
     // code below also displays a nice CLI progress-bar to give users some more
     // information about what is going on.
-    let download_client = super::client::create_client_with_middleware()?;
+    let download_client = super::client::create_client_with_middleware_for_channels(&channels)?;
 
     // Get the package names from the matchspecs so we can only load the package
     // records that we need.

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -86,7 +86,7 @@ anyhow = { workspace = true }
 insta = { workspace = true, features = ["json"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
-axum = { workspace = true }
+axum = { workspace = true, features = ["json"] }
 reqwest-retry = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -1,8 +1,8 @@
 //! Host-scoped middleware that reacts to `WWW-Authenticate` challenges by
-//! acquiring a bearer token from a pluggable `AuthFlow` and replaying the
+//! acquiring a bearer token from a pluggable [`AuthFlow`] and replaying the
 //! request once.
 //!
-//! The first `AuthFlow` implementation will be
+//! The first [`AuthFlow`] implementation will be
 //! `crate::trusted_publishing::TrustedPublishingFlow` (added in a later task).
 
 use std::{
@@ -16,6 +16,8 @@ use base64::{
     engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
 };
 use serde::Deserialize;
+use thiserror::Error;
+use url::Url;
 
 /// One parsed challenge from a `WWW-Authenticate` response header.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -132,7 +134,7 @@ fn split_commas_respecting_quotes(s: &str) -> Vec<&str> {
 #[allow(dead_code)]
 const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
 
-/// A short-lived bearer token acquired by an auth flow (trait added in a later task).
+/// A short-lived bearer token acquired by an [`AuthFlow`] implementation.
 ///
 /// `Deserialize`-transparent (a raw JSON string body deserializes directly
 /// into it) and `Clone` so it can be shared between the cache and requests.
@@ -156,6 +158,45 @@ impl fmt::Debug for BearerToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("BearerToken").field(&"<redacted>").finish()
     }
+}
+
+/// Error produced by an [`AuthFlow`] implementation.
+///
+/// Boxed so custom flows can surface arbitrary failures. The middleware only
+/// logs this error and disables further attempts — it never propagates it,
+/// so the caller always observes the server's original response.
+#[derive(Debug, Error)]
+#[error("authentication flow failed: {source}")]
+pub struct AuthFlowError {
+    #[source]
+    source: Box<dyn std::error::Error + Send + Sync + 'static>,
+}
+
+impl AuthFlowError {
+    /// Wrap any error produced by an [`AuthFlow`] implementation.
+    pub fn new(err: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>) -> Self {
+        Self { source: err.into() }
+    }
+}
+
+/// A pluggable strategy that turns a `WWW-Authenticate` challenge into a
+/// bearer token.
+///
+/// Implementations decide which challenges they support (e.g. only scheme
+/// `Bearer`) and how to acquire the token (OIDC exchange, device flow, ...).
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+pub trait AuthFlow: Send + Sync + fmt::Debug {
+    /// Respond to `challenges` received from `url`.
+    ///
+    /// Return `Ok(None)` when this flow does not apply (e.g. unsupported
+    /// scheme, or not running in a CI environment) — the middleware caches
+    /// that negatively and stops asking for the lifetime of the process.
+    async fn acquire_token(
+        &self,
+        url: &Url,
+        challenges: &[Challenge],
+    ) -> Result<Option<BearerToken>, AuthFlowError>;
 }
 
 #[allow(dead_code)]

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -5,7 +5,17 @@
 //! The first `AuthFlow` implementation will be
 //! `crate::trusted_publishing::TrustedPublishingFlow` (added in a later task).
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    fmt,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use base64::{
+    Engine as _,
+    engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
+};
+use serde::Deserialize;
 
 /// One parsed challenge from a `WWW-Authenticate` response header.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -117,8 +127,104 @@ fn split_commas_respecting_quotes(s: &str) -> Vec<&str> {
     parts
 }
 
+/// Refresh tokens this long before their `exp` so a token does not become
+/// invalid while a request is in flight.
+#[allow(dead_code)]
+const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
+
+/// A short-lived bearer token acquired by an auth flow (trait added in a later task).
+///
+/// `Deserialize`-transparent (a raw JSON string body deserializes directly
+/// into it) and `Clone` so it can be shared between the cache and requests.
+#[derive(Clone, Deserialize)]
+#[serde(transparent)]
+pub struct BearerToken(String);
+
+impl BearerToken {
+    /// Wrap an existing token string.
+    pub fn new(token: String) -> Self {
+        Self(token)
+    }
+
+    /// The raw bearer token. Treat as sensitive; don't log it.
+    pub fn secret(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for BearerToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("BearerToken").field(&"<redacted>").finish()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct JwtClaims {
+    exp: Option<u64>,
+}
+
+/// Best-effort extraction of the `exp` claim from a JWT-shaped token.
+/// Returns `None` for opaque tokens, which are then cached without expiry.
+#[allow(dead_code)]
+fn jwt_expiration(token: &str) -> Option<SystemTime> {
+    let mut parts = token.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    let _signature = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+
+    let payload = URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| URL_SAFE.decode(payload))
+        .ok()?;
+    let claims: JwtClaims = serde_json::from_slice(&payload).ok()?;
+    claims
+        .exp
+        .and_then(|exp| UNIX_EPOCH.checked_add(Duration::from_secs(exp)))
+}
+
+#[derive(Debug)]
+struct CachedToken {
+    #[allow(dead_code)]
+    token: BearerToken,
+    #[allow(dead_code)]
+    expires_at: Option<SystemTime>,
+}
+
+impl CachedToken {
+    #[allow(dead_code)]
+    fn new(token: BearerToken) -> Self {
+        let expires_at = jwt_expiration(token.secret());
+        Self { token, expires_at }
+    }
+
+    #[allow(dead_code)]
+    fn is_fresh(&self, now: SystemTime) -> bool {
+        self.expires_at
+            .is_none_or(|expires_at| now + TOKEN_REFRESH_MARGIN < expires_at)
+    }
+}
+
+/// Cache state shared by all clones of one middleware instance.
+#[derive(Debug, Default)]
+#[allow(dead_code)]
+enum TokenCache {
+    /// No acquisition attempted yet.
+    #[default]
+    Empty,
+    /// The flow reported "not applicable" or failed — stop asking.
+    Disabled,
+    /// A previously acquired token.
+    Token(CachedToken),
+}
+
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, UNIX_EPOCH};
+
     use super::*;
 
     fn header_map(values: &[&str]) -> http::HeaderMap {
@@ -192,5 +298,44 @@ mod tests {
         assert!(parse_challenges(&header_map(&[""])).is_empty());
         assert!(parse_challenges(&header_map(&["%%% ###"])).is_empty());
         assert!(parse_challenges(&http::HeaderMap::new()).is_empty());
+    }
+
+    #[test]
+    fn bearer_token_debug_is_redacted() {
+        let token = BearerToken::new("supersecret".to_string());
+        let formatted = format!("{token:?}");
+        assert!(!formatted.contains("supersecret"));
+        assert!(formatted.contains("redacted"));
+    }
+
+    fn unsigned_jwt_with_exp(exp: u64) -> String {
+        use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
+        format!("{header}.{payload}.")
+    }
+
+    #[test]
+    fn jwt_expiration_reads_exp_claim() {
+        let token = unsigned_jwt_with_exp(1_700_000_000);
+        assert_eq!(
+            jwt_expiration(&token),
+            UNIX_EPOCH.checked_add(Duration::from_secs(1_700_000_000))
+        );
+    }
+
+    #[test]
+    fn opaque_token_has_no_expiration() {
+        assert_eq!(jwt_expiration("not-a-jwt"), None);
+    }
+
+    #[test]
+    fn cached_jwt_is_stale_inside_refresh_margin() {
+        let token = BearerToken::new(unsigned_jwt_with_exp(1_700_000_000));
+        let cached = CachedToken::new(token);
+        let now = UNIX_EPOCH + Duration::from_secs(1_700_000_000 - 30);
+        assert!(!cached.is_fresh(now));
+        let earlier = UNIX_EPOCH + Duration::from_secs(1_700_000_000 - 3600);
+        assert!(cached.is_fresh(earlier));
     }
 }

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -730,7 +730,12 @@ mod tests {
             _challenges: &[Challenge],
         ) -> Result<Option<BearerToken>, AuthFlowError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
-            let token = self.tokens.lock().unwrap().remove(0);
+            let mut tokens = self.tokens.lock().unwrap();
+            assert!(
+                !tokens.is_empty(),
+                "SequenceFlow exhausted: middleware called acquire_token more times than expected"
+            );
+            let token = tokens.remove(0);
             Ok(Some(BearerToken::new(token.to_string())))
         }
     }
@@ -769,6 +774,7 @@ mod tests {
 
         assert_eq!(response.status(), 401);
         assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -789,6 +795,7 @@ mod tests {
 
         assert_eq!(response.status(), 401);
         assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -839,8 +846,40 @@ mod tests {
 
     #[tokio::test]
     async fn stale_cached_token_is_cleared_and_reacquired() {
-        let hits = Arc::new(AtomicUsize::new(0));
-        let server_url = spawn_protected_server("fresh", hits.clone()).await;
+        use axum::{http::StatusCode, response::IntoResponse, routing::get};
+
+        // Server accepting only "Bearer fresh", recording the Authorization
+        // header of every request it sees.
+        let seen: Arc<Mutex<Vec<Option<String>>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_in_handler = seen.clone();
+        let router = axum::Router::new().route(
+            "/channel/repodata.json",
+            get(move |headers: axum::http::HeaderMap| {
+                let seen = seen_in_handler.clone();
+                async move {
+                    let auth = headers
+                        .get("authorization")
+                        .and_then(|v| v.to_str().ok())
+                        .map(str::to_string);
+                    seen.lock().unwrap().push(auth.clone());
+                    if auth.as_deref() == Some("Bearer fresh") {
+                        (StatusCode::OK, "ok").into_response()
+                    } else {
+                        (
+                            StatusCode::UNAUTHORIZED,
+                            [("www-authenticate", r#"Bearer realm="test""#)],
+                            "unauthorized",
+                        )
+                            .into_response()
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        let server_url = Url::parse(&format!("http://{addr}")).unwrap();
+
         let flow = Arc::new(SequenceFlow {
             tokens: Mutex::new(vec!["old", "fresh"]),
             calls: AtomicUsize::new(0),
@@ -851,9 +890,8 @@ mod tests {
         ));
         let url = server_url.join("/channel/repodata.json").unwrap();
 
-        // Request 1: challenge -> flow mints "old" -> replay rejected (401).
-        // "old" is now cached even though the server already rejects it,
-        // simulating a token revoked after acquisition.
+        // Request 1: challenge -> flow mints "old" (cached before the replay
+        // proves it stale) -> replay rejected (401).
         assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
 
         // Request 2: cached "old" attached -> challenged -> cache cleared ->
@@ -861,7 +899,18 @@ mod tests {
         assert_eq!(client.get(url).send().await.unwrap().status(), 200);
 
         assert_eq!(flow.calls.load(Ordering::SeqCst), 2);
-        assert_eq!(hits.load(Ordering::SeqCst), 4);
+        // The header sequence proves the cached path: request 2's first leg
+        // carried the cached "old" token (a non-caching implementation would
+        // send no header there).
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![
+                None,
+                Some("Bearer old".to_string()),
+                Some("Bearer old".to_string()),
+                Some("Bearer fresh".to_string()),
+            ]
+        );
     }
 
     #[tokio::test]
@@ -881,6 +930,10 @@ mod tests {
         assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
         assert_eq!(client.get(url).send().await.unwrap().status(), 401);
         assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+        // Disabled = pass-through (next.run is still called), so both requests
+        // reach the server: request 1 triggers the challenge (1 hit), request 2
+        // is passed through unmodified and also reaches the server (1 hit).
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -99,6 +99,11 @@ fn parse_param(s: &str) -> Option<(String, String)> {
     if key.is_empty() || value.is_empty() || !is_valid_scheme(&key) {
         return None;
     }
+    // A value consisting only of `=` characters is padding from a token68
+    // blob (e.g. `dGVzdA==` splits into key `dGVzdA`, value `=`). Skip it.
+    if value.chars().all(|c| c == '=') {
+        return None;
+    }
     let value = value
         .strip_prefix('"')
         .and_then(|v| v.strip_suffix('"'))
@@ -445,7 +450,7 @@ impl Middleware for AuthChallengeMiddleware {
 mod tests {
     use std::{
         sync::{
-            Arc,
+            Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
         time::{Duration, UNIX_EPOCH},
@@ -708,5 +713,181 @@ mod tests {
         assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
         assert_eq!(client.get(url).send().await.unwrap().status(), 401);
         assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// [`AuthFlow`] yielding a different token per call (for the stale-token test).
+    #[derive(Debug)]
+    struct SequenceFlow {
+        tokens: Mutex<Vec<&'static str>>,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl AuthFlow for SequenceFlow {
+        async fn acquire_token(
+            &self,
+            _url: &Url,
+            _challenges: &[Challenge],
+        ) -> Result<Option<BearerToken>, AuthFlowError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let token = self.tokens.lock().unwrap().remove(0);
+            Ok(Some(BearerToken::new(token.to_string())))
+        }
+    }
+
+    /// [`AuthFlow`] that always fails.
+    #[derive(Debug)]
+    struct FailingFlow {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl AuthFlow for FailingFlow {
+        async fn acquire_token(
+            &self,
+            _url: &Url,
+            _challenges: &[Challenge],
+        ) -> Result<Option<BearerToken>, AuthFlowError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Err(AuthFlowError::new(std::io::Error::other("mint exploded")))
+        }
+    }
+
+    #[tokio::test]
+    async fn non_matching_host_is_untouched() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(Some("abc123"));
+        let other_host = Url::parse("https://example.invalid").unwrap();
+        let client = client_with(AuthChallengeMiddleware::new(other_host, flow.clone()));
+
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 401);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn scheme_mismatch_is_untouched() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        // same host and port, but https configured vs the http test server
+        let mut https_url = server_url.clone();
+        https_url.set_scheme("https").unwrap();
+        let flow = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(https_url, flow.clone()));
+
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 401);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn existing_authorization_header_is_respected() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .header(reqwest::header::AUTHORIZATION, "Bearer user-supplied")
+            .send()
+            .await
+            .unwrap();
+
+        // wrong credentials stay wrong: no override, no replay
+        assert_eq!(response.status(), 401);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn replays_at_most_once() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        // server accepts a token the flow never produces -> always 401
+        let server_url = spawn_protected_server("never-issued", hits.clone()).await;
+        let flow = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 401);
+        // initial request + exactly one replay, nothing more
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn stale_cached_token_is_cleared_and_reacquired() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("fresh", hits.clone()).await;
+        let flow = Arc::new(SequenceFlow {
+            tokens: Mutex::new(vec!["old", "fresh"]),
+            calls: AtomicUsize::new(0),
+        });
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+        let url = server_url.join("/channel/repodata.json").unwrap();
+
+        // Request 1: challenge -> flow mints "old" -> replay rejected (401).
+        // "old" is now cached even though the server already rejects it,
+        // simulating a token revoked after acquisition.
+        assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
+
+        // Request 2: cached "old" attached -> challenged -> cache cleared ->
+        // flow mints "fresh" -> replay succeeds.
+        assert_eq!(client.get(url).send().await.unwrap().status(), 200);
+
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(hits.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn flow_error_is_swallowed_and_negative_cached() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = Arc::new(FailingFlow {
+            calls: AtomicUsize::new(0),
+        });
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+        let url = server_url.join("/channel/repodata.json").unwrap();
+
+        // caller sees the server's 401, not the flow error
+        assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
+        assert_eq!(client.get(url).send().await.unwrap().status(), 401);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn token68_with_double_padding_is_skipped() {
+        let challenges = parse_challenges(&header_map(&["Negotiate dGVzdA=="]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].scheme, "Negotiate");
+        assert!(challenges[0].params.is_empty());
     }
 }

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -1,0 +1,196 @@
+//! Host-scoped middleware that reacts to `WWW-Authenticate` challenges by
+//! acquiring a bearer token from a pluggable `AuthFlow` and replaying the
+//! request once.
+//!
+//! The first `AuthFlow` implementation will be
+//! `crate::trusted_publishing::TrustedPublishingFlow` (added in a later task).
+
+use std::collections::HashMap;
+
+/// One parsed challenge from a `WWW-Authenticate` response header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Challenge {
+    /// The authentication scheme, e.g. `Bearer` (case preserved as sent).
+    pub scheme: String,
+    /// Auth parameters with lowercased keys, e.g. `realm` -> `prefix.dev`.
+    /// `token68` payloads (e.g. base64 blobs after the scheme) are skipped.
+    pub params: HashMap<String, String>,
+}
+
+/// Parse all challenges from every `WWW-Authenticate` header in `headers`.
+///
+/// Tolerant by design: malformed input yields fewer (or no) challenges,
+/// never an error or panic. Handles multiple comma-separated challenges in
+/// one header value as well as the header appearing multiple times.
+pub fn parse_challenges(headers: &http::HeaderMap) -> Vec<Challenge> {
+    headers
+        .get_all(http::header::WWW_AUTHENTICATE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(parse_header_value)
+        .collect()
+}
+
+/// An auth scheme is a token of ASCII alphanumerics plus a few safe symbols.
+/// Stricter than RFC 7235's `token` on purpose: it rejects line noise that
+/// would otherwise be misread as a scheme.
+fn is_valid_scheme(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+fn parse_header_value(value: &str) -> Vec<Challenge> {
+    let mut challenges: Vec<Challenge> = Vec::new();
+    for item in split_commas_respecting_quotes(value) {
+        let item = item.trim();
+        if item.is_empty() {
+            continue;
+        }
+        // A new challenge starts with a scheme token; a continuation item is
+        // a bare `key=value` auth-param belonging to the current challenge.
+        let (first, rest) = match item.split_once(char::is_whitespace) {
+            Some((first, rest)) => (first, Some(rest.trim())),
+            None => (item, None),
+        };
+        if !first.contains('=') {
+            if !is_valid_scheme(first) {
+                continue;
+            }
+            challenges.push(Challenge {
+                scheme: first.to_string(),
+                params: HashMap::new(),
+            });
+            if let (Some(rest), Some(challenge)) = (rest, challenges.last_mut()) {
+                if let Some((key, val)) = parse_param(rest) {
+                    challenge.params.insert(key, val);
+                }
+            }
+        } else if let Some(challenge) = challenges.last_mut() {
+            if let Some((key, val)) = parse_param(item) {
+                challenge.params.insert(key, val);
+            }
+        }
+    }
+    challenges
+}
+
+/// Parse one `key=value` or `key="quoted value"` auth-param. Returns `None`
+/// for non-params (e.g. token68 blobs like `YII=`, which have an empty
+/// "value" after the trailing `=`).
+fn parse_param(s: &str) -> Option<(String, String)> {
+    let (key, value) = s.split_once('=')?;
+    let key = key.trim().to_ascii_lowercase();
+    let value = value.trim();
+    if key.is_empty() || value.is_empty() || !is_valid_scheme(&key) {
+        return None;
+    }
+    let value = value
+        .strip_prefix('"')
+        .and_then(|v| v.strip_suffix('"'))
+        .unwrap_or(value);
+    Some((key, value.replace("\\\"", "\"")))
+}
+
+/// Split on commas that are not inside a double-quoted string.
+fn split_commas_respecting_quotes(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut in_quotes = false;
+    let mut escaped = false;
+    for (i, c) in s.char_indices() {
+        match c {
+            '\\' if in_quotes && !escaped => escaped = true,
+            '"' if !escaped => {
+                in_quotes = !in_quotes;
+                escaped = false;
+            }
+            ',' if !in_quotes => {
+                parts.push(&s[start..i]);
+                start = i + 1;
+                escaped = false;
+            }
+            _ => escaped = false,
+        }
+    }
+    parts.push(&s[start..]);
+    parts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header_map(values: &[&str]) -> http::HeaderMap {
+        let mut headers = http::HeaderMap::new();
+        for v in values {
+            headers.append(
+                http::header::WWW_AUTHENTICATE,
+                http::HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        headers
+    }
+
+    #[test]
+    fn parses_single_bearer_challenge() {
+        let challenges = parse_challenges(&header_map(&[r#"Bearer realm="prefix.dev""#]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].scheme, "Bearer");
+        assert_eq!(challenges[0].params["realm"], "prefix.dev");
+    }
+
+    #[test]
+    fn parses_multiple_challenges_in_one_header() {
+        let challenges = parse_challenges(&header_map(&[
+            r#"Bearer realm="prefix.dev", error="invalid_token", Basic realm="other""#,
+        ]));
+        assert_eq!(challenges.len(), 2);
+        assert_eq!(challenges[0].scheme, "Bearer");
+        assert_eq!(challenges[0].params["realm"], "prefix.dev");
+        assert_eq!(challenges[0].params["error"], "invalid_token");
+        assert_eq!(challenges[1].scheme, "Basic");
+        assert_eq!(challenges[1].params["realm"], "other");
+    }
+
+    #[test]
+    fn parses_multiple_headers() {
+        let challenges =
+            parse_challenges(&header_map(&[r#"Bearer realm="a""#, r#"Basic realm="b""#]));
+        assert_eq!(challenges.len(), 2);
+        assert_eq!(challenges[0].scheme, "Bearer");
+        assert_eq!(challenges[1].scheme, "Basic");
+    }
+
+    #[test]
+    fn quoted_commas_do_not_split_challenges() {
+        let challenges = parse_challenges(&header_map(&[r#"Bearer realm="a,b""#]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].params["realm"], "a,b");
+    }
+
+    #[test]
+    fn unquoted_params_and_case_insensitive_keys() {
+        let challenges = parse_challenges(&header_map(&["Bearer REALM=prefix.dev"]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].params["realm"], "prefix.dev");
+    }
+
+    #[test]
+    fn token68_payload_is_skipped_not_a_param() {
+        // e.g. `Negotiate YII=` — the trailing blob is not a key=value param
+        let challenges = parse_challenges(&header_map(&["Negotiate YII="]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].scheme, "Negotiate");
+        assert!(challenges[0].params.is_empty());
+    }
+
+    #[test]
+    fn garbage_yields_no_challenges_and_no_panic() {
+        assert!(parse_challenges(&header_map(&["= = ="])).is_empty());
+        assert!(parse_challenges(&header_map(&[",,,"])).is_empty());
+        assert!(parse_challenges(&header_map(&[""])).is_empty());
+        assert!(parse_challenges(&header_map(&["%%% ###"])).is_empty());
+        assert!(parse_challenges(&http::HeaderMap::new()).is_empty());
+    }
+}

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -8,6 +8,7 @@
 use std::{
     collections::HashMap,
     fmt,
+    sync::{Arc, Mutex},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -15,6 +16,7 @@ use base64::{
     Engine as _,
     engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
 };
+use reqwest_middleware::{Middleware, Next};
 use serde::Deserialize;
 use thiserror::Error;
 use url::Url;
@@ -131,7 +133,6 @@ fn split_commas_respecting_quotes(s: &str) -> Vec<&str> {
 
 /// Refresh tokens this long before their `exp` so a token does not become
 /// invalid while a request is in flight.
-#[allow(dead_code)]
 const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
 
 /// A short-lived bearer token acquired by an [`AuthFlow`] implementation.
@@ -192,6 +193,12 @@ pub trait AuthFlow: Send + Sync + fmt::Debug {
     /// Return `Ok(None)` when this flow does not apply (e.g. unsupported
     /// scheme, or not running in a CI environment) — the middleware caches
     /// that negatively and stops asking for the lifetime of the process.
+    ///
+    /// `url` is the full URL of the request that was challenged (path and
+    /// query included), not just the server origin. The flow may be invoked
+    /// concurrently by parallel requests racing on the first challenge;
+    /// implementations should tolerate redundant invocations (every returned
+    /// token is cached last-write-wins).
     async fn acquire_token(
         &self,
         url: &Url,
@@ -199,7 +206,6 @@ pub trait AuthFlow: Send + Sync + fmt::Debug {
     ) -> Result<Option<BearerToken>, AuthFlowError>;
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 struct JwtClaims {
     exp: Option<u64>,
@@ -207,7 +213,6 @@ struct JwtClaims {
 
 /// Best-effort extraction of the `exp` claim from a JWT-shaped token.
 /// Returns `None` for opaque tokens, which are then cached without expiry.
-#[allow(dead_code)]
 fn jwt_expiration(token: &str) -> Option<SystemTime> {
     let mut parts = token.split('.');
     let _header = parts.next()?;
@@ -229,20 +234,16 @@ fn jwt_expiration(token: &str) -> Option<SystemTime> {
 
 #[derive(Debug)]
 struct CachedToken {
-    #[allow(dead_code)]
     token: BearerToken,
-    #[allow(dead_code)]
     expires_at: Option<SystemTime>,
 }
 
 impl CachedToken {
-    #[allow(dead_code)]
     fn new(token: BearerToken) -> Self {
         let expires_at = jwt_expiration(token.secret());
         Self { token, expires_at }
     }
 
-    #[allow(dead_code)]
     fn is_fresh(&self, now: SystemTime) -> bool {
         self.expires_at
             .is_none_or(|expires_at| now + TOKEN_REFRESH_MARGIN < expires_at)
@@ -251,7 +252,6 @@ impl CachedToken {
 
 /// Cache state shared by all clones of one middleware instance.
 #[derive(Debug, Default)]
-#[allow(dead_code)]
 enum TokenCache {
     /// No acquisition attempted yet.
     #[default]
@@ -262,11 +262,308 @@ enum TokenCache {
     Token(CachedToken),
 }
 
+/// Outcome of a cache lookup, decoupled from the lock.
+enum CacheLookup {
+    Empty,
+    Disabled,
+    Fresh(BearerToken),
+}
+
+/// Host-scoped `reqwest` middleware that acquires a bearer token via an
+/// [`AuthFlow`] when (and only when) the server answers with a
+/// `WWW-Authenticate` challenge, then replays the request once.
+///
+/// Construct one instance per server. A request is in scope when its scheme,
+/// host, and effective port match `server`; the path is ignored. Requests
+/// that already carry an `Authorization` header are never touched, so
+/// credentials from [`crate::AuthenticationMiddleware`] always win.
+///
+/// The first acquired token is cached (with JWT-expiry-aware refresh); a flow
+/// that reports "not applicable" or fails disables the middleware for the
+/// process lifetime. Acquisition failures are logged, never propagated: the
+/// caller then observes the server's original 401/403 response.
+#[derive(Clone, Debug)]
+pub struct AuthChallengeMiddleware {
+    server: Url,
+    flow: Arc<dyn AuthFlow>,
+    cache: Arc<Mutex<TokenCache>>,
+}
+
+impl AuthChallengeMiddleware {
+    /// Create a middleware guarding the server identified by `server`'s
+    /// scheme, host, and port. `server`'s path is ignored.
+    pub fn new(server: Url, flow: Arc<dyn AuthFlow>) -> Self {
+        Self {
+            server,
+            flow,
+            cache: Arc::new(Mutex::new(TokenCache::Empty)),
+        }
+    }
+
+    fn matches_host(&self, url: &Url) -> bool {
+        url.scheme() == self.server.scheme()
+            && url.host_str() == self.server.host_str()
+            && url.port_or_known_default() == self.server.port_or_known_default()
+    }
+
+    fn lookup_cache(&self) -> CacheLookup {
+        let cache = self
+            .cache
+            .lock()
+            .expect("auth challenge token cache poisoned");
+        match &*cache {
+            TokenCache::Disabled => CacheLookup::Disabled,
+            TokenCache::Token(cached) if cached.is_fresh(SystemTime::now()) => {
+                CacheLookup::Fresh(cached.token.clone())
+            }
+            TokenCache::Empty | TokenCache::Token(_) => CacheLookup::Empty,
+        }
+    }
+
+    /// Run the flow and record the outcome. `Ok(None)` and errors both
+    /// disable the middleware; errors are additionally logged.
+    async fn acquire_and_cache(&self, url: &Url, challenges: &[Challenge]) -> Option<BearerToken> {
+        let result = self.flow.acquire_token(url, challenges).await;
+        let mut cache = self
+            .cache
+            .lock()
+            .expect("auth challenge token cache poisoned");
+        match result {
+            Ok(Some(token)) => {
+                *cache = TokenCache::Token(CachedToken::new(token.clone()));
+                Some(token)
+            }
+            Ok(None) => {
+                tracing::debug!(
+                    "AuthChallengeMiddleware: flow not applicable for {url}, disabling"
+                );
+                *cache = TokenCache::Disabled;
+                None
+            }
+            Err(err) => {
+                tracing::warn!("AuthChallengeMiddleware: failed to acquire token for {url}: {err}");
+                *cache = TokenCache::Disabled;
+                None
+            }
+        }
+    }
+}
+
+fn attach_bearer(
+    req: &mut reqwest::Request,
+    token: &BearerToken,
+) -> reqwest_middleware::Result<()> {
+    let bearer = format!("Bearer {}", token.secret());
+    let mut value = reqwest::header::HeaderValue::from_str(&bearer)
+        .map_err(reqwest_middleware::Error::middleware)?;
+    value.set_sensitive(true);
+    req.headers_mut()
+        .insert(reqwest::header::AUTHORIZATION, value);
+    Ok(())
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Middleware for AuthChallengeMiddleware {
+    async fn handle(
+        &self,
+        mut req: reqwest::Request,
+        extensions: &mut http::Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        if !self.matches_host(req.url())
+            || req.headers().contains_key(reqwest::header::AUTHORIZATION)
+        {
+            return next.run(req, extensions).await;
+        }
+
+        let cached = self.lookup_cache();
+        if matches!(cached, CacheLookup::Disabled) {
+            return next.run(req, extensions).await;
+        }
+
+        let used_cached_token = if let CacheLookup::Fresh(token) = &cached {
+            attach_bearer(&mut req, token)?;
+            true
+        } else {
+            false
+        };
+
+        // Clone before sending so we can replay on a challenge. Fails only
+        // for streaming bodies (absent on the GET-only read path) — then the
+        // response is passed through unmodified.
+        let retry_req = req.try_clone();
+        let url = req.url().clone();
+        let response = next.clone().run(req, extensions).await?;
+
+        let challenges = parse_challenges(response.headers());
+        if challenges.is_empty() {
+            return Ok(response);
+        }
+        let Some(mut retry_req) = retry_req else {
+            return Ok(response);
+        };
+
+        if used_cached_token {
+            // The server rejected a token we believed fresh (revoked early).
+            // Drop it — and its header on the clone — before re-acquiring.
+            *self
+                .cache
+                .lock()
+                .expect("auth challenge token cache poisoned") = TokenCache::Empty;
+            retry_req
+                .headers_mut()
+                .remove(reqwest::header::AUTHORIZATION);
+        }
+
+        let Some(token) = self.acquire_and_cache(&url, &challenges).await else {
+            return Ok(response);
+        };
+        attach_bearer(&mut retry_req, &token)?;
+        // Replay exactly once; the replayed response is returned as-is even
+        // if it is another challenge.
+        next.run(retry_req, extensions).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, UNIX_EPOCH};
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::{Duration, UNIX_EPOCH},
+    };
+
+    use reqwest_middleware::ClientBuilder;
 
     use super::*;
+
+    /// [`AuthFlow`] returning a fixed answer; counts invocations.
+    #[derive(Debug)]
+    struct StaticFlow {
+        token: Option<&'static str>,
+        calls: AtomicUsize,
+    }
+
+    impl StaticFlow {
+        fn new(token: Option<&'static str>) -> Arc<Self> {
+            Arc::new(Self {
+                token,
+                calls: AtomicUsize::new(0),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AuthFlow for StaticFlow {
+        async fn acquire_token(
+            &self,
+            _url: &Url,
+            _challenges: &[Challenge],
+        ) -> Result<Option<BearerToken>, AuthFlowError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.token.map(|t| BearerToken::new(t.to_string())))
+        }
+    }
+
+    /// Axum server: requires `Bearer <accept>` on /channel/repodata.json,
+    /// answers 401 + WWW-Authenticate otherwise. Counts every request.
+    async fn spawn_protected_server(accept: &'static str, hits: Arc<AtomicUsize>) -> Url {
+        use axum::{http::StatusCode, response::IntoResponse, routing::get};
+        let router = axum::Router::new().route(
+            "/channel/repodata.json",
+            get(move |headers: axum::http::HeaderMap| {
+                let hits = hits.clone();
+                async move {
+                    hits.fetch_add(1, Ordering::SeqCst);
+                    let expected = format!("Bearer {accept}");
+                    match headers.get("authorization").and_then(|v| v.to_str().ok()) {
+                        Some(auth) if auth == expected => (StatusCode::OK, "ok").into_response(),
+                        _ => (
+                            StatusCode::UNAUTHORIZED,
+                            [("www-authenticate", r#"Bearer realm="test""#)],
+                            "unauthorized",
+                        )
+                            .into_response(),
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        Url::parse(&format!("http://{addr}")).unwrap()
+    }
+
+    fn client_with(
+        middleware: AuthChallengeMiddleware,
+    ) -> reqwest_middleware::ClientWithMiddleware {
+        ClientBuilder::new(reqwest::Client::new())
+            .with_arc(Arc::new(middleware))
+            .build()
+    }
+
+    #[tokio::test]
+    async fn challenge_triggers_mint_and_replay() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 200);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+        // one challenged request + one replay
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn second_request_reuses_cached_token_without_challenge() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+
+        let url = server_url.join("/channel/repodata.json").unwrap();
+        assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 200);
+        assert_eq!(client.get(url).send().await.unwrap().status(), 200);
+
+        // flow consulted exactly once; second request went straight through
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(hits.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn inapplicable_flow_is_negative_cached() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(None);
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+
+        let url = server_url.join("/channel/repodata.json").unwrap();
+        assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
+        assert_eq!(client.get(url).send().await.unwrap().status(), 401);
+
+        // flow consulted once, then disabled
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+    }
 
     fn header_map(values: &[&str]) -> http::HeaderMap {
         let mut headers = http::HeaderMap::new();

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -61,15 +61,15 @@ fn parse_header_value(value: &str) -> Vec<Challenge> {
                 scheme: first.to_string(),
                 params: HashMap::new(),
             });
-            if let (Some(rest), Some(challenge)) = (rest, challenges.last_mut()) {
-                if let Some((key, val)) = parse_param(rest) {
-                    challenge.params.insert(key, val);
-                }
-            }
-        } else if let Some(challenge) = challenges.last_mut() {
-            if let Some((key, val)) = parse_param(item) {
+            if let (Some(rest), Some(challenge)) = (rest, challenges.last_mut())
+                && let Some((key, val)) = parse_param(rest)
+            {
                 challenge.params.insert(key, val);
             }
+        } else if let Some(challenge) = challenges.last_mut()
+            && let Some((key, val)) = parse_param(item)
+        {
+            challenge.params.insert(key, val);
         }
     }
     challenges

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -234,14 +234,22 @@ fn jwt_expiration(token: &str) -> Option<SystemTime> {
 
 #[derive(Debug)]
 struct CachedToken {
-    token: BearerToken,
+    /// Pre-validated `Bearer <secret>` header value, marked sensitive.
+    header: reqwest::header::HeaderValue,
     expires_at: Option<SystemTime>,
 }
 
 impl CachedToken {
-    fn new(token: BearerToken) -> Self {
-        let expires_at = jwt_expiration(token.secret());
-        Self { token, expires_at }
+    /// Fails when the token cannot be encoded as an HTTP header value —
+    /// callers must treat that like a failed acquisition, not cache it.
+    fn new(token: &BearerToken) -> Result<Self, reqwest::header::InvalidHeaderValue> {
+        let mut header =
+            reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token.secret()))?;
+        header.set_sensitive(true);
+        Ok(Self {
+            header,
+            expires_at: jwt_expiration(token.secret()),
+        })
     }
 
     fn is_fresh(&self, now: SystemTime) -> bool {
@@ -266,7 +274,7 @@ enum TokenCache {
 enum CacheLookup {
     Empty,
     Disabled,
-    Fresh(BearerToken),
+    Fresh(reqwest::header::HeaderValue),
 }
 
 /// Host-scoped `reqwest` middleware that acquires a bearer token via an
@@ -314,7 +322,7 @@ impl AuthChallengeMiddleware {
         match &*cache {
             TokenCache::Disabled => CacheLookup::Disabled,
             TokenCache::Token(cached) if cached.is_fresh(SystemTime::now()) => {
-                CacheLookup::Fresh(cached.token.clone())
+                CacheLookup::Fresh(cached.header.clone())
             }
             TokenCache::Empty | TokenCache::Token(_) => CacheLookup::Empty,
         }
@@ -322,17 +330,32 @@ impl AuthChallengeMiddleware {
 
     /// Run the flow and record the outcome. `Ok(None)` and errors both
     /// disable the middleware; errors are additionally logged.
-    async fn acquire_and_cache(&self, url: &Url, challenges: &[Challenge]) -> Option<BearerToken> {
+    async fn acquire_and_cache(
+        &self,
+        url: &Url,
+        challenges: &[Challenge],
+    ) -> Option<reqwest::header::HeaderValue> {
         let result = self.flow.acquire_token(url, challenges).await;
         let mut cache = self
             .cache
             .lock()
             .expect("auth challenge token cache poisoned");
         match result {
-            Ok(Some(token)) => {
-                *cache = TokenCache::Token(CachedToken::new(token.clone()));
-                Some(token)
-            }
+            Ok(Some(token)) => match CachedToken::new(&token) {
+                Ok(cached) => {
+                    let header = cached.header.clone();
+                    *cache = TokenCache::Token(cached);
+                    Some(header)
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "AuthChallengeMiddleware: flow returned a token for {url} that is \
+                         not a valid header value ({err}), disabling"
+                    );
+                    *cache = TokenCache::Disabled;
+                    None
+                }
+            },
             Ok(None) => {
                 tracing::debug!(
                     "AuthChallengeMiddleware: flow not applicable for {url}, disabling"
@@ -349,17 +372,9 @@ impl AuthChallengeMiddleware {
     }
 }
 
-fn attach_bearer(
-    req: &mut reqwest::Request,
-    token: &BearerToken,
-) -> reqwest_middleware::Result<()> {
-    let bearer = format!("Bearer {}", token.secret());
-    let mut value = reqwest::header::HeaderValue::from_str(&bearer)
-        .map_err(reqwest_middleware::Error::middleware)?;
-    value.set_sensitive(true);
+fn attach_bearer(req: &mut reqwest::Request, header: reqwest::header::HeaderValue) {
     req.headers_mut()
-        .insert(reqwest::header::AUTHORIZATION, value);
-    Ok(())
+        .insert(reqwest::header::AUTHORIZATION, header);
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -382,8 +397,8 @@ impl Middleware for AuthChallengeMiddleware {
             return next.run(req, extensions).await;
         }
 
-        let used_cached_token = if let CacheLookup::Fresh(token) = &cached {
-            attach_bearer(&mut req, token)?;
+        let used_cached_token = if let CacheLookup::Fresh(header) = cached {
+            attach_bearer(&mut req, header);
             true
         } else {
             false
@@ -416,10 +431,10 @@ impl Middleware for AuthChallengeMiddleware {
                 .remove(reqwest::header::AUTHORIZATION);
         }
 
-        let Some(token) = self.acquire_and_cache(&url, &challenges).await else {
+        let Some(header) = self.acquire_and_cache(&url, &challenges).await else {
             return Ok(response);
         };
-        attach_bearer(&mut retry_req, &token)?;
+        attach_bearer(&mut retry_req, header);
         // Replay exactly once; the replayed response is returned as-is even
         // if it is another challenge.
         next.run(retry_req, extensions).await
@@ -670,10 +685,28 @@ mod tests {
     #[test]
     fn cached_jwt_is_stale_inside_refresh_margin() {
         let token = BearerToken::new(unsigned_jwt_with_exp(1_700_000_000));
-        let cached = CachedToken::new(token);
+        let cached = CachedToken::new(&token).unwrap();
         let now = UNIX_EPOCH + Duration::from_secs(1_700_000_000 - 30);
         assert!(!cached.is_fresh(now));
         let earlier = UNIX_EPOCH + Duration::from_secs(1_700_000_000 - 3600);
         assert!(cached.is_fresh(earlier));
+    }
+
+    #[tokio::test]
+    async fn header_invalid_token_is_not_cached_and_does_not_error() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(Some("bad\ntoken"));
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+        let url = server_url.join("/channel/repodata.json").unwrap();
+
+        // The caller sees the server's original 401, not a middleware error,
+        // and the middleware disables itself instead of caching the bad token.
+        assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
+        assert_eq!(client.get(url).send().await.unwrap().status(), 401);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -2,8 +2,8 @@
 //! acquiring a bearer token from a pluggable [`AuthFlow`] and replaying the
 //! request once.
 //!
-//! The first [`AuthFlow`] implementation will be
-//! `crate::trusted_publishing::TrustedPublishingFlow` (added in a later task).
+//! The first [`AuthFlow`] implementation is
+//! [`crate::trusted_publishing::TrustedPublishingFlow`].
 
 use std::{
     collections::HashMap,
@@ -204,6 +204,10 @@ pub trait AuthFlow: Send + Sync + fmt::Debug {
     /// concurrently by parallel requests racing on the first challenge;
     /// implementations should tolerate redundant invocations (every returned
     /// token is cached last-write-wins).
+    ///
+    /// Implementations may treat `url`'s origin as a trusted credential sink;
+    /// dispatchers must therefore only invoke flows for URLs on the host they
+    /// are scoped to.
     async fn acquire_token(
         &self,
         url: &Url,

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -324,6 +324,9 @@ enum CacheLookup {
 /// host, and effective port match `server`; the path is ignored. Requests
 /// that already carry an `Authorization` header are never touched, so
 /// credentials from [`crate::AuthenticationMiddleware`] always win.
+/// (Credentials embedded in the URL path or query — e.g. conda `/t/<token>`
+/// tokens — are not detected; a challenged request carrying such credentials
+/// will still be replayed with a bearer token.)
 ///
 /// The first acquired token is cached (with JWT-expiry-aware refresh); a flow
 /// that reports "not applicable" or fails disables the middleware for the

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -104,11 +104,41 @@ fn parse_param(s: &str) -> Option<(String, String)> {
     if value.chars().all(|c| c == '=') {
         return None;
     }
-    let value = value
-        .strip_prefix('"')
-        .and_then(|v| v.strip_suffix('"'))
-        .unwrap_or(value);
-    Some((key, value.replace("\\\"", "\"")))
+    let value = if let Some(rest) = value.strip_prefix('"') {
+        // Quoted string: require a clean closing quote with nothing after it
+        // and no unescaped quotes inside; anything else (unterminated, or
+        // trailing garbage like a second space-separated param) is malformed
+        // and yields no param rather than a wrong value.
+        let inner = rest.strip_suffix('"')?;
+        if malformed_quoted_interior(inner) {
+            return None;
+        }
+        inner.replace("\\\"", "\"")
+    } else {
+        // Unquoted token: any stray quote means a mangled quoted string.
+        if value.contains('"') {
+            return None;
+        }
+        value.to_string()
+    };
+    Some((key, value))
+}
+
+/// Returns `true` when `s` (the interior of a quoted string, outer quotes
+/// already stripped) contains an unescaped `"` — e.g. two space-separated
+/// quoted params mashed into one value — or ends with a dangling escape,
+/// which means the stripped closing quote was actually escaped (i.e. the
+/// quoted string was never terminated).
+fn malformed_quoted_interior(s: &str) -> bool {
+    let mut escaped = false;
+    for c in s.chars() {
+        match c {
+            '\\' if !escaped => escaped = true,
+            '"' if !escaped => return true,
+            _ => escaped = false,
+        }
+    }
+    escaped
 }
 
 /// Split on commas that are not inside a double-quoted string.
@@ -650,6 +680,24 @@ mod tests {
         let challenges = parse_challenges(&header_map(&["Negotiate YII="]));
         assert_eq!(challenges.len(), 1);
         assert_eq!(challenges[0].scheme, "Negotiate");
+        assert!(challenges[0].params.is_empty());
+    }
+
+    #[test]
+    fn space_separated_params_yield_no_wrong_values() {
+        // Non-RFC space-separated params: scheme parsed, malformed param dropped
+        let challenges = parse_challenges(&header_map(&[
+            r#"Bearer realm="prefix.dev" error="invalid_token""#,
+        ]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].scheme, "Bearer");
+        assert!(challenges[0].params.is_empty());
+    }
+
+    #[test]
+    fn unbalanced_quote_yields_no_param() {
+        let challenges = parse_challenges(&header_map(&[r#"Bearer realm="unterminated"#]));
+        assert_eq!(challenges.len(), 1);
         assert!(challenges[0].params.is_empty());
     }
 

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -3,7 +3,9 @@
 //! Networking utilities for Rattler, specifically authenticating requests
 pub use authentication_middleware::AuthenticationMiddleware;
 pub use authentication_storage::{authentication::Authentication, storage::AuthenticationStorage};
-pub use challenge_middleware::{AuthFlow, AuthFlowError, BearerToken};
+pub use challenge_middleware::{
+    AuthChallengeMiddleware, AuthFlow, AuthFlowError, BearerToken, Challenge,
+};
 pub use lazy_client::LazyClient;
 pub use mirror_middleware::MirrorMiddleware;
 pub use oci_middleware::OciMiddleware;

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -19,6 +19,7 @@ pub use s3_middleware::S3Middleware;
 
 pub mod authentication_middleware;
 pub mod authentication_storage;
+pub mod challenge_middleware;
 pub mod oauth_refresh;
 
 mod lazy_client;

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -3,6 +3,7 @@
 //! Networking utilities for Rattler, specifically authenticating requests
 pub use authentication_middleware::AuthenticationMiddleware;
 pub use authentication_storage::{authentication::Authentication, storage::AuthenticationStorage};
+pub use challenge_middleware::{AuthFlow, AuthFlowError, BearerToken};
 pub use lazy_client::LazyClient;
 pub use mirror_middleware::MirrorMiddleware;
 pub use oci_middleware::OciMiddleware;

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -83,6 +83,24 @@ impl TrustedPublishingOptions {
             mint_path: DEFAULT_MINT_PATH.to_string(),
         })
     }
+
+    /// Options for `server` following the deployed prefix.dev ecosystem
+    /// convention: every prefix.dev deployment (`prefix.dev` and
+    /// `*.prefix.dev`, e.g. `beta.prefix.dev`) validates GitHub OIDC tokens
+    /// against the shared audience `prefix.dev`, while tokens are minted at
+    /// the deployment's own host. Hosts outside that family fall back to
+    /// [`Self::for_host`] (host-derived audience).
+    ///
+    /// Returns `None` when `server` has no host. The caveats on
+    /// [`Self::for_host`] (scheme validation, allow-listing) apply here too.
+    pub fn for_server(server: &Url) -> Option<Self> {
+        let host = server.host_str()?;
+        if host == "prefix.dev" || host.ends_with(".prefix.dev") {
+            Some(Self::for_prefix_dev())
+        } else {
+            Self::for_host(server)
+        }
+    }
 }
 
 /// Outcome of an optional trusted-publishing attempt.
@@ -518,5 +536,33 @@ mod tests {
         )
         .unwrap();
         assert_eq!(options.audience, "beta.prefix.dev");
+    }
+
+    #[test]
+    fn for_server_uses_shared_audience_for_prefix_dev_family() {
+        // prefix.dev deployments share the audience "prefix.dev"
+        let beta = TrustedPublishingOptions::for_server(
+            &Url::parse("https://beta.prefix.dev/some-channel").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(beta.audience, "prefix.dev");
+
+        let prod = TrustedPublishingOptions::for_server(&Url::parse("https://prefix.dev").unwrap())
+            .unwrap();
+        assert_eq!(prod.audience, "prefix.dev");
+
+        // hosts outside the family keep the host-derived audience
+        let other = TrustedPublishingOptions::for_server(
+            &Url::parse("https://conda.example.com/channel").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(other.audience, "conda.example.com");
+
+        // ...and lookalike hosts are not part of the family
+        let evil = TrustedPublishingOptions::for_server(
+            &Url::parse("https://evil-prefix.dev/channel").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(evil.audience, "evil-prefix.dev");
     }
 }

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -41,9 +41,10 @@ pub struct TrustedPublishingOptions {
     /// Path on the server where the ID token is exchanged for a bearer token.
     ///
     /// This path is joined onto arbitrary URLs of the challenged server using
-    /// [`Url::join`]. It must start with `/` so that it replaces the full URL
-    /// path; a relative path would resolve against the challenged URL's path
-    /// and could target an unintended endpoint.
+    /// [`Url::join`]. It should start with `/` so that it replaces the full
+    /// URL path; a relative path would resolve against the challenged URL's
+    /// path and could target an unintended endpoint.
+    /// [`TrustedPublishingFlow::new`] normalizes a missing leading slash.
     pub mint_path: String,
 }
 
@@ -205,8 +206,12 @@ pub struct TrustedPublishingFlow {
 }
 
 impl TrustedPublishingFlow {
-    /// Create a flow with custom [`TrustedPublishingOptions`].
-    pub fn new(options: TrustedPublishingOptions, client: ClientWithMiddleware) -> Self {
+    /// Create a flow with custom [`TrustedPublishingOptions`]. A missing
+    /// leading `/` on [`TrustedPublishingOptions::mint_path`] is normalized.
+    pub fn new(mut options: TrustedPublishingOptions, client: ClientWithMiddleware) -> Self {
+        if !options.mint_path.starts_with('/') {
+            options.mint_path.insert(0, '/');
+        }
         Self { options, client }
     }
 
@@ -316,6 +321,133 @@ mod tests {
             token.expect("expected a minted token").secret(),
             "pfx-jwt.minted"
         );
+    }
+
+    #[tokio::test]
+    async fn mint_path_without_leading_slash_is_normalized() {
+        use axum::routing::post;
+
+        // Mint endpoint at the absolute path /api/x. Without normalization,
+        // a relative mint_path of "api/x" would resolve against the
+        // challenged URL's path (/channel/api/x) and miss this route.
+        let router = axum::Router::new().route("/api/x", post(|| async { "pfx-jwt.minted" }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        let server_url = Url::parse(&format!("http://{addr}")).unwrap();
+
+        let token = temp_env::async_with_vars(
+            [
+                ("GITLAB_CI", Some("true")),
+                ("PREFIX_DEV_ID_TOKEN", Some("fake.oidc.token")),
+                ("GITHUB_ACTIONS", None),
+                ("BUILDKITE", None),
+                ("CIRCLECI", None),
+            ],
+            async {
+                let flow = TrustedPublishingFlow::new(
+                    TrustedPublishingOptions {
+                        audience: "prefix.dev".to_string(),
+                        mint_path: "api/x".to_string(),
+                    },
+                    plain_client(),
+                );
+                flow.acquire_token(
+                    &server_url.join("/channel/repodata.json").unwrap(),
+                    &bearer_challenge(),
+                )
+                .await
+                .unwrap()
+            },
+        )
+        .await;
+
+        assert_eq!(
+            token.expect("expected a minted token").secret(),
+            "pfx-jwt.minted"
+        );
+    }
+
+    #[tokio::test]
+    async fn middleware_with_trusted_publishing_flow_end_to_end() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        use axum::{
+            Json,
+            http::StatusCode,
+            response::IntoResponse,
+            routing::{get, post},
+        };
+
+        use crate::AuthChallengeMiddleware;
+
+        // One server hosting both the protected resource and the mint
+        // endpoint, like a real prefix.dev instance.
+        let mints = Arc::new(AtomicUsize::new(0));
+        let mints_in_handler = mints.clone();
+        let router = axum::Router::new()
+            .route(
+                "/channel/repodata.json",
+                get(|headers: axum::http::HeaderMap| async move {
+                    match headers.get("authorization").and_then(|v| v.to_str().ok()) {
+                        Some("Bearer pfx-jwt.minted") => (StatusCode::OK, "ok").into_response(),
+                        _ => (
+                            StatusCode::UNAUTHORIZED,
+                            [("www-authenticate", r#"Bearer realm="test""#)],
+                            "unauthorized",
+                        )
+                            .into_response(),
+                    }
+                }),
+            )
+            .route(
+                "/api/oidc/mint_token",
+                post(move |Json(body): Json<serde_json::Value>| {
+                    let mints = mints_in_handler.clone();
+                    async move {
+                        assert_eq!(body["token"], "fake.oidc.token");
+                        mints.fetch_add(1, Ordering::SeqCst);
+                        "pfx-jwt.minted"
+                    }
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        let server_url = Url::parse(&format!("http://{addr}")).unwrap();
+
+        temp_env::async_with_vars(
+            [
+                ("GITLAB_CI", Some("true")),
+                ("PREFIX_DEV_ID_TOKEN", Some("fake.oidc.token")),
+                ("GITHUB_ACTIONS", None),
+                ("BUILDKITE", None),
+                ("CIRCLECI", None),
+            ],
+            async {
+                // The mint client must not itself carry the challenge
+                // middleware (it would recurse), so it stays plain.
+                let flow = TrustedPublishingFlow::for_prefix_dev(plain_client());
+                let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
+                    .with_arc(std::sync::Arc::new(AuthChallengeMiddleware::new(
+                        server_url.clone(),
+                        std::sync::Arc::new(flow),
+                    )))
+                    .build();
+                let url = server_url.join("/channel/repodata.json").unwrap();
+
+                // First request: challenge -> OIDC detect -> mint -> replay.
+                assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 200);
+                // Second request: cached token, no second mint.
+                assert_eq!(client.get(url).send().await.unwrap().status(), 200);
+            },
+        )
+        .await;
+
+        assert_eq!(mints.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -22,6 +22,9 @@ use url::Url;
 
 use crate::challenge_middleware::{AuthFlow, AuthFlowError, BearerToken, Challenge};
 
+/// Default path of the prefix.dev-convention mint endpoint.
+const DEFAULT_MINT_PATH: &str = "/api/oidc/mint_token";
+
 /// Knobs for the trusted-publishing flow. Use
 /// [`for_prefix_dev`](Self::for_prefix_dev) for the prefix.dev defaults, or
 /// construct directly to point at a different server.
@@ -54,7 +57,7 @@ impl TrustedPublishingOptions {
     pub fn for_prefix_dev() -> Self {
         Self {
             audience: "prefix.dev".to_string(),
-            mint_path: "/api/oidc/mint_token".to_string(),
+            mint_path: DEFAULT_MINT_PATH.to_string(),
         }
     }
 
@@ -67,10 +70,17 @@ impl TrustedPublishingOptions {
     /// Deriving the audience from the host scopes each OIDC ID token to the
     /// server it is sent to: a token minted with `aud = <host>` is only
     /// redeemable at that host.
+    ///
+    /// This constructor does not validate the scheme or host. Callers
+    /// handling ambient CI credentials must ensure `server` uses `https`
+    /// and apply their own host allow-list before attaching this flow.
+    /// The audience is the URL-normalized host: lowercased, IDN hosts in
+    /// punycode, and without any port. See the struct-level docs for how
+    /// the audience determines the GitLab CI env-var name.
     pub fn for_host(server: &Url) -> Option<Self> {
         Some(Self {
             audience: server.host_str()?.to_string(),
-            mint_path: "/api/oidc/mint_token".to_string(),
+            mint_path: DEFAULT_MINT_PATH.to_string(),
         })
     }
 }
@@ -499,5 +509,14 @@ mod tests {
         // data: URLs have no host component
         let url = Url::parse("data:text/plain,hello").unwrap();
         assert!(TrustedPublishingOptions::for_host(&url).is_none());
+    }
+
+    #[test]
+    fn for_host_normalizes_case_and_drops_default_port() {
+        let options = TrustedPublishingOptions::for_host(
+            &Url::parse("https://Beta.PREFIX.dev:443/some-channel").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(options.audience, "beta.prefix.dev");
     }
 }

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -57,6 +57,22 @@ impl TrustedPublishingOptions {
             mint_path: "/api/oidc/mint_token".to_string(),
         }
     }
+
+    /// Options for any trusted-publishing server following the prefix.dev
+    /// convention: the OIDC audience is the server's host name and tokens
+    /// are minted at `/api/oidc/mint_token`.
+    ///
+    /// Returns `None` when `server` has no host (e.g. `data:` URLs).
+    ///
+    /// Deriving the audience from the host scopes each OIDC ID token to the
+    /// server it is sent to: a token minted with `aud = <host>` is only
+    /// redeemable at that host.
+    pub fn for_host(server: &Url) -> Option<Self> {
+        Some(Self {
+            audience: server.host_str()?.to_string(),
+            mint_path: "/api/oidc/mint_token".to_string(),
+        })
+    }
 }
 
 /// Outcome of an optional trusted-publishing attempt.
@@ -455,5 +471,33 @@ mod tests {
         let opts = TrustedPublishingOptions::for_prefix_dev();
         assert_eq!(opts.audience, "prefix.dev");
         assert_eq!(opts.mint_path, "/api/oidc/mint_token");
+    }
+
+    #[test]
+    fn for_host_derives_audience_from_host() {
+        let options = TrustedPublishingOptions::for_host(
+            &Url::parse("https://beta.prefix.dev/some-channel/noarch/repodata.json").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(options.audience, "beta.prefix.dev");
+        assert_eq!(options.mint_path, "/api/oidc/mint_token");
+
+        let prod =
+            TrustedPublishingOptions::for_host(&Url::parse("https://prefix.dev").unwrap()).unwrap();
+        assert_eq!(
+            prod.audience,
+            TrustedPublishingOptions::for_prefix_dev().audience
+        );
+        assert_eq!(
+            prod.mint_path,
+            TrustedPublishingOptions::for_prefix_dev().mint_path
+        );
+    }
+
+    #[test]
+    fn for_host_returns_none_without_host() {
+        // data: URLs have no host component
+        let url = Url::parse("data:text/plain,hello").unwrap();
+        assert!(TrustedPublishingOptions::for_host(&url).is_none());
     }
 }

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -23,6 +23,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
+use crate::challenge_middleware::{AuthFlow, AuthFlowError, Challenge};
+
 /// Refresh minted JWT tokens before they expire to avoid sending a token that
 /// becomes invalid while a request is in flight.
 const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
@@ -229,6 +231,61 @@ async fn get_publish_token(
     }
 }
 
+/// [`AuthFlow`] implementation backed by trusted publishing (CI OIDC).
+///
+/// Responds only to `Bearer` challenges. On a challenge it asks `ambient-id`
+/// for an OIDC ID token (returns `Ok(None)` outside supported CI providers)
+/// and exchanges it at the challenged host's mint endpoint
+/// ([`TrustedPublishingOptions::mint_path`]). Because the surrounding
+/// [`crate::AuthChallengeMiddleware`] is host-scoped, the challenged URL is
+/// always the right host to mint against.
+///
+/// `client` is used only for the mint exchange; it must not itself layer in
+/// [`crate::AuthChallengeMiddleware`] or the mint call will recurse.
+#[derive(Debug, Clone)]
+pub struct TrustedPublishingFlow {
+    options: TrustedPublishingOptions,
+    client: ClientWithMiddleware,
+}
+
+impl TrustedPublishingFlow {
+    /// Create a flow with custom [`TrustedPublishingOptions`].
+    pub fn new(options: TrustedPublishingOptions, client: ClientWithMiddleware) -> Self {
+        Self { options, client }
+    }
+
+    /// Create a flow preconfigured for prefix.dev.
+    pub fn for_prefix_dev(client: ClientWithMiddleware) -> Self {
+        Self::new(TrustedPublishingOptions::for_prefix_dev(), client)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl AuthFlow for TrustedPublishingFlow {
+    async fn acquire_token(
+        &self,
+        url: &Url,
+        challenges: &[Challenge],
+    ) -> Result<Option<crate::challenge_middleware::BearerToken>, AuthFlowError> {
+        if !challenges
+            .iter()
+            .any(|challenge| challenge.scheme.eq_ignore_ascii_case("bearer"))
+        {
+            return Ok(None);
+        }
+        // `get_token` still returns the old `TrustedPublishingToken` until
+        // Task 7 swaps it to `BearerToken`; convert explicitly for now.
+        match get_token(&self.client, url, &self.options).await {
+            Ok(Some(token)) => Ok(Some(crate::challenge_middleware::BearerToken::new(
+                token.secret().to_string(),
+            ))),
+            Ok(None) => Ok(None),
+            Err(err) => Err(AuthFlowError::new(err)),
+        }
+    }
+}
+
 /// `reqwest` middleware that injects a [`TrustedPublishingToken`] as a
 /// `Bearer` `Authorization` header for requests targeting a specific channel.
 ///
@@ -407,7 +464,85 @@ impl Middleware for TrustedPublishingMiddleware {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
+    use crate::challenge_middleware::{AuthFlow, Challenge};
+
+    fn bearer_challenge() -> Vec<Challenge> {
+        vec![Challenge {
+            scheme: "Bearer".to_string(),
+            params: HashMap::new(),
+        }]
+    }
+
+    fn plain_client() -> reqwest_middleware::ClientWithMiddleware {
+        reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build()
+    }
+
+    #[tokio::test]
+    async fn flow_ignores_non_bearer_challenges() {
+        let flow = TrustedPublishingFlow::for_prefix_dev(plain_client());
+        let challenges = vec![Challenge {
+            scheme: "Basic".to_string(),
+            params: HashMap::new(),
+        }];
+        let result = flow
+            .acquire_token(
+                &Url::parse("https://prefix.dev/channel/repodata.json").unwrap(),
+                &challenges,
+            )
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn flow_mints_token_via_gitlab_env() {
+        use axum::{Json, routing::post};
+
+        // Mint endpoint: verifies it receives the CI-provided OIDC token and
+        // returns the minted bearer token as the raw response body.
+        let router = axum::Router::new().route(
+            "/api/oidc/mint_token",
+            post(|Json(body): Json<serde_json::Value>| async move {
+                assert_eq!(body["token"], "fake.oidc.token");
+                "pfx-jwt.minted"
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        let server_url = Url::parse(&format!("http://{addr}")).unwrap();
+
+        // Force the GitLab detector: GITLAB_CI on, every other provider off.
+        // (rattler's own CI runs on GitHub Actions, so GITHUB_ACTIONS must be
+        // explicitly unset.)
+        let token = temp_env::async_with_vars(
+            [
+                ("GITLAB_CI", Some("true")),
+                ("PREFIX_DEV_ID_TOKEN", Some("fake.oidc.token")),
+                ("GITHUB_ACTIONS", None),
+                ("BUILDKITE", None),
+                ("CIRCLECI", None),
+            ],
+            async {
+                let flow = TrustedPublishingFlow::for_prefix_dev(plain_client());
+                flow.acquire_token(
+                    &server_url.join("/channel/repodata.json").unwrap(),
+                    &bearer_challenge(),
+                )
+                .await
+                .unwrap()
+            },
+        )
+        .await;
+
+        assert_eq!(
+            token.expect("expected a minted token").secret(),
+            "pfx-jwt.minted"
+        );
+    }
 
     #[test]
     fn for_prefix_dev_matches_prefix_dev() {

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -2,7 +2,7 @@
 //!
 //! This module owns the OIDC exchange with the server's mint endpoint and
 //! provides [`TrustedPublishingFlow`], an [`AuthFlow`] implementation that
-//! plugs into [`crate::challenge_middleware`]. Challenge-reactive read
+//! plugs into [`crate::challenge_middleware`]. Challenge-reactive HTTP
 //! authentication (reacting to `WWW-Authenticate` responses) lives in
 //! [`crate::challenge_middleware`].
 //!

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -45,8 +45,12 @@ pub struct TrustedPublishingOptions {
     /// this against the trusted-publisher configuration before minting a
     /// token.
     pub audience: String,
-    /// Path on the server (joined onto `server_url`) where the ID token is
-    /// exchanged for a bearer token.
+    /// Path on the server where the ID token is exchanged for a bearer token.
+    ///
+    /// This path is joined onto arbitrary URLs of the challenged server using
+    /// [`Url::join`]. It must start with `/` so that it replaces the full URL
+    /// path; a relative path would resolve against the challenged URL's path
+    /// and could target an unintended endpoint.
     pub mint_path: String,
 }
 
@@ -242,6 +246,15 @@ async fn get_publish_token(
 ///
 /// `client` is used only for the mint exchange; it must not itself layer in
 /// [`crate::AuthChallengeMiddleware`] or the mint call will recurse.
+///
+/// # Security
+///
+/// `acquire_token` sends the CI provider's OIDC ID token — a live
+/// credential — to `url`'s origin (joined with
+/// [`TrustedPublishingOptions::mint_path`]). Only drive this flow from a
+/// dispatcher that is scoped to a single trusted host, such as
+/// [`crate::AuthChallengeMiddleware`]; never pass it URLs derived from
+/// untrusted input.
 #[derive(Debug, Clone)]
 pub struct TrustedPublishingFlow {
     options: TrustedPublishingOptions,

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -1,5 +1,11 @@
 //! Trusted publishing (via OIDC).
 //!
+//! This module owns the OIDC exchange with the server's mint endpoint and
+//! provides [`TrustedPublishingFlow`], an [`AuthFlow`] implementation that
+//! plugs into [`crate::challenge_middleware`]. Challenge-reactive read
+//! authentication (reacting to `WWW-Authenticate` responses) lives in
+//! [`crate::challenge_middleware`].
+//!
 //! The flow:
 //! 1. Ask `ambient-id` for an OIDC ID token with the configured `audience`
 //!    claim. It owns CI-provider detection and returns `None` when no
@@ -8,26 +14,13 @@
 //!    bearer token usable against the server (read or write, depending on
 //!    server policy).
 
-use std::{
-    sync::{Arc, Mutex},
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
-
-use base64::{
-    Engine as _,
-    engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
-};
 use reqwest::StatusCode;
-use reqwest_middleware::{ClientWithMiddleware, Middleware, Next};
-use serde::{Deserialize, Serialize};
+use reqwest_middleware::ClientWithMiddleware;
+use serde::Serialize;
 use thiserror::Error;
 use url::Url;
 
-use crate::challenge_middleware::{AuthFlow, AuthFlowError, Challenge};
-
-/// Refresh minted JWT tokens before they expire to avoid sending a token that
-/// becomes invalid while a request is in flight.
-const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
+use crate::challenge_middleware::{AuthFlow, AuthFlowError, BearerToken, Challenge};
 
 /// Knobs for the trusted-publishing flow. Use
 /// [`for_prefix_dev`](Self::for_prefix_dev) for the prefix.dev defaults, or
@@ -70,7 +63,7 @@ pub enum TrustedPublishResult {
     /// We didn't check for trusted publishing (no CI provider detected).
     Skipped,
     /// We checked for trusted publishing and got a token.
-    Configured(TrustedPublishingToken),
+    Configured(BearerToken),
     /// We checked for optional trusted publishing, but it didn't succeed.
     Ignored(TrustedPublishingError),
 }
@@ -97,62 +90,14 @@ pub enum TrustedPublishingError {
     OidcToken(#[from] ambient_id::Error),
 }
 
-/// A short-lived bearer token minted by the server. The inner string is
-/// `Deserialize`-friendly (the mint endpoint returns the raw token as a JSON
-/// string body) and `Clone` so the same token can be shared across middleware
-/// and stored in auth state.
-#[derive(Clone, Deserialize)]
-#[serde(transparent)]
-pub struct TrustedPublishingToken(String);
-
-impl TrustedPublishingToken {
-    /// Wrap an already-minted token (mostly for tests).
-    pub fn new(token: String) -> Self {
-        Self(token)
-    }
-
-    /// The raw bearer token. Treat as sensitive; don't log it.
-    pub fn secret(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Debug for TrustedPublishingToken {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("TrustedPublishingToken")
-            .field(&"<redacted>")
-            .finish()
-    }
-}
+/// Deprecated alias kept for backwards compatibility.
+#[deprecated(note = "use `rattler_networking::BearerToken` instead")]
+pub type TrustedPublishingToken = BearerToken;
 
 /// The body sent to the server's mint endpoint.
 #[derive(Serialize)]
 struct MintTokenRequest {
     token: String,
-}
-
-#[derive(Deserialize)]
-struct JwtClaims {
-    exp: Option<u64>,
-}
-
-fn jwt_expiration(token: &str) -> Option<SystemTime> {
-    let mut parts = token.split('.');
-    let _header = parts.next()?;
-    let payload = parts.next()?;
-    let _signature = parts.next()?;
-    if parts.next().is_some() {
-        return None;
-    }
-
-    let payload = URL_SAFE_NO_PAD
-        .decode(payload)
-        .or_else(|_| URL_SAFE.decode(payload))
-        .ok()?;
-    let claims: JwtClaims = serde_json::from_slice(&payload).ok()?;
-    claims
-        .exp
-        .and_then(|exp| UNIX_EPOCH.checked_add(Duration::from_secs(exp)))
 }
 
 /// If applicable, attempt to obtain a bearer token via trusted publishing.
@@ -185,7 +130,7 @@ pub async fn get_token(
     client: &ClientWithMiddleware,
     server_url: &Url,
     options: &TrustedPublishingOptions,
-) -> Result<Option<TrustedPublishingToken>, TrustedPublishingError> {
+) -> Result<Option<BearerToken>, TrustedPublishingError> {
     let detector = ambient_id::Detector::new_with_client(client.clone());
     let Some(oidc_token) = detector.detect(&options.audience).await? else {
         return Ok(None);
@@ -203,7 +148,7 @@ async fn get_publish_token(
     server_url: &Url,
     client: &ClientWithMiddleware,
     options: &TrustedPublishingOptions,
-) -> Result<TrustedPublishingToken, TrustedPublishingError> {
+) -> Result<BearerToken, TrustedPublishingError> {
     let mint_token_url = server_url.join(&options.mint_path)?;
     tracing::info!("Querying the trusted publishing token from {mint_token_url}");
     let mint_token_payload = MintTokenRequest {
@@ -224,9 +169,7 @@ async fn get_publish_token(
         .map_err(|err| TrustedPublishingError::Reqwest(mint_token_url.clone(), err))?;
 
     if status.is_success() {
-        Ok(TrustedPublishingToken(
-            String::from_utf8_lossy(&body).to_string(),
-        ))
+        Ok(BearerToken::new(String::from_utf8_lossy(&body).to_string()))
     } else {
         Err(TrustedPublishingError::MintToken(
             status,
@@ -280,198 +223,16 @@ impl AuthFlow for TrustedPublishingFlow {
         &self,
         url: &Url,
         challenges: &[Challenge],
-    ) -> Result<Option<crate::challenge_middleware::BearerToken>, AuthFlowError> {
+    ) -> Result<Option<BearerToken>, AuthFlowError> {
         if !challenges
             .iter()
             .any(|challenge| challenge.scheme.eq_ignore_ascii_case("bearer"))
         {
             return Ok(None);
         }
-        // `get_token` still returns the old `TrustedPublishingToken` until
-        // Task 7 swaps it to `BearerToken`; convert explicitly for now.
-        match get_token(&self.client, url, &self.options).await {
-            Ok(Some(token)) => Ok(Some(crate::challenge_middleware::BearerToken::new(
-                token.secret().to_string(),
-            ))),
-            Ok(None) => Ok(None),
-            Err(err) => Err(AuthFlowError::new(err)),
-        }
-    }
-}
-
-/// `reqwest` middleware that injects a [`TrustedPublishingToken`] as a
-/// `Bearer` `Authorization` header for requests targeting a specific channel.
-///
-/// Layered alongside [`crate::AuthenticationMiddleware`]: it only sets the
-/// header when no `Authorization` is already present and only when the
-/// request URL's host and path prefix match the configured channel. This
-/// keeps the minted token scoped to the channel it was issued for, instead
-/// of leaking it to unrelated channels (which may share a host, e.g.
-/// `https://prefix.dev/my-channel/` vs `https://prefix.dev/other-channel/`).
-#[derive(Clone, Debug)]
-pub struct TrustedPublishingMiddleware {
-    channel_url: Url,
-    state: TrustedPublishingState,
-}
-
-#[derive(Clone, Debug)]
-enum TrustedPublishingState {
-    /// Caller supplied an already-minted token.
-    Token(TrustedPublishingToken),
-    /// Token will be minted on the first matching request.
-    Lazy {
-        server_url: Url,
-        options: TrustedPublishingOptions,
-        client: ClientWithMiddleware,
-        cache: Arc<Mutex<TrustedPublishingCache>>,
-    },
-}
-
-#[derive(Debug, Default)]
-enum TrustedPublishingCache {
-    #[default]
-    Empty,
-    Disabled,
-    Token(CachedTrustedPublishingToken),
-}
-
-#[derive(Clone, Debug)]
-struct CachedTrustedPublishingToken {
-    token: TrustedPublishingToken,
-    expires_at: Option<SystemTime>,
-}
-
-impl CachedTrustedPublishingToken {
-    fn new(token: TrustedPublishingToken) -> Self {
-        let expires_at = jwt_expiration(token.secret());
-        Self { token, expires_at }
-    }
-
-    fn is_fresh(&self, now: SystemTime) -> bool {
-        self.expires_at
-            .is_none_or(|expires_at| now + TOKEN_REFRESH_MARGIN < expires_at)
-    }
-}
-
-impl TrustedPublishingMiddleware {
-    /// Create a middleware that will mint a token lazily on the first
-    /// matching request using `options`. `client` is used only for the OIDC
-    /// mint exchange; it must not itself layer in `TrustedPublishingMiddleware`
-    /// or the mint call will recurse.
-    pub fn new(
-        server_url: Url,
-        options: TrustedPublishingOptions,
-        client: ClientWithMiddleware,
-    ) -> Self {
-        let channel_url = normalize_channel_url(&server_url);
-        Self {
-            channel_url,
-            state: TrustedPublishingState::Lazy {
-                server_url,
-                options,
-                client,
-                cache: Arc::new(Mutex::new(TrustedPublishingCache::Empty)),
-            },
-        }
-    }
-
-    /// Create a middleware that injects an already-minted `token` on
-    /// requests whose URL host and path prefix match `server_url`.
-    pub fn with_token(server_url: &Url, token: TrustedPublishingToken) -> Self {
-        Self {
-            channel_url: normalize_channel_url(server_url),
-            state: TrustedPublishingState::Token(token),
-        }
-    }
-
-    /// Resolve the token to inject, performing (and caching) the OIDC
-    /// exchange on demand for the `Lazy` variant.
-    async fn token(&self) -> Option<TrustedPublishingToken> {
-        match &self.state {
-            TrustedPublishingState::Token(token) => Some(token.clone()),
-            TrustedPublishingState::Lazy {
-                server_url,
-                options,
-                client,
-                cache,
-            } => {
-                {
-                    let cache = cache.lock().expect("trusted publishing cache poisoned");
-                    match &*cache {
-                        TrustedPublishingCache::Token(token)
-                            if token.is_fresh(SystemTime::now()) =>
-                        {
-                            return Some(token.token.clone());
-                        }
-                        TrustedPublishingCache::Disabled => return None,
-                        TrustedPublishingCache::Empty | TrustedPublishingCache::Token(_) => {}
-                    }
-                }
-
-                let token = match check_trusted_publishing(client, server_url, options).await {
-                    TrustedPublishResult::Configured(token) => Some(token),
-                    TrustedPublishResult::Skipped => {
-                        tracing::debug!(
-                            "TrustedPublishingMiddleware: no CI provider detected, skipping OIDC token exchange"
-                        );
-                        None
-                    }
-                    TrustedPublishResult::Ignored(err) => {
-                        tracing::warn!(
-                            "TrustedPublishingMiddleware: trusted publishing failed: {err}"
-                        );
-                        None
-                    }
-                };
-
-                let mut cache = cache.lock().expect("trusted publishing cache poisoned");
-                if let Some(token) = token {
-                    let token = CachedTrustedPublishingToken::new(token);
-                    let result = token.token.clone();
-                    *cache = TrustedPublishingCache::Token(token);
-                    Some(result)
-                } else {
-                    *cache = TrustedPublishingCache::Disabled;
-                    None
-                }
-            }
-        }
-    }
-}
-
-/// Normalize a channel URL so its path always ends with `/`. This avoids a
-/// prefix-collision bug where `/my-channel` would also match `/my-channel-evil`.
-fn normalize_channel_url(url: &Url) -> Url {
-    let mut url = url.clone();
-    if !url.path().ends_with('/') {
-        let new_path = format!("{}/", url.path());
-        url.set_path(&new_path);
-    }
-    url
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl Middleware for TrustedPublishingMiddleware {
-    async fn handle(
-        &self,
-        mut req: reqwest::Request,
-        extensions: &mut http::Extensions,
-        next: Next<'_>,
-    ) -> reqwest_middleware::Result<reqwest::Response> {
-        if req.headers().get(reqwest::header::AUTHORIZATION).is_none()
-            && req.url().host_str() == self.channel_url.host_str()
-            && req.url().path().starts_with(self.channel_url.path())
-            && let Some(token) = self.token().await
-        {
-            let bearer_auth = format!("Bearer {}", token.secret());
-            let mut header_value = reqwest::header::HeaderValue::from_str(&bearer_auth)
-                .map_err(reqwest_middleware::Error::middleware)?;
-            header_value.set_sensitive(true);
-            req.headers_mut()
-                .insert(reqwest::header::AUTHORIZATION, header_value);
-        }
-        next.run(req, extensions).await
+        get_token(&self.client, url, &self.options)
+            .await
+            .map_err(AuthFlowError::new)
     }
 }
 
@@ -562,233 +323,5 @@ mod tests {
         let opts = TrustedPublishingOptions::for_prefix_dev();
         assert_eq!(opts.audience, "prefix.dev");
         assert_eq!(opts.mint_path, "/api/oidc/mint_token");
-    }
-
-    #[test]
-    fn token_debug_is_redacted() {
-        let token = TrustedPublishingToken::new("supersecret".to_string());
-        let formatted = format!("{token:?}");
-        assert!(!formatted.contains("supersecret"));
-        assert!(formatted.contains("redacted"));
-    }
-
-    fn unsigned_jwt_with_exp(exp: u64) -> String {
-        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
-        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
-        format!("{header}.{payload}.")
-    }
-
-    #[test]
-    fn jwt_expiration_reads_exp_claim() {
-        let token = unsigned_jwt_with_exp(1_700_000_000);
-        assert_eq!(
-            jwt_expiration(&token),
-            UNIX_EPOCH.checked_add(Duration::from_secs(1_700_000_000))
-        );
-    }
-
-    #[test]
-    fn cached_jwt_is_stale_inside_refresh_margin() {
-        let token = TrustedPublishingToken::new(unsigned_jwt_with_exp(1_700_000_000));
-        let cached = CachedTrustedPublishingToken::new(token);
-        let now = UNIX_EPOCH + Duration::from_secs(1_700_000_000 - 30);
-        assert!(!cached.is_fresh(now));
-    }
-
-    #[tokio::test]
-    async fn middleware_injects_bearer_for_matching_host() {
-        use reqwest_middleware::ClientBuilder;
-        use std::sync::Arc;
-
-        let server = axum::Router::new().route(
-            "/check",
-            axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                headers
-                    .get("authorization")
-                    .map(|v| v.to_str().unwrap().to_string())
-                    .unwrap_or_default()
-            }),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move { axum::serve(listener, server).await.unwrap() });
-
-        let server_url = Url::parse(&format!("http://{addr}")).unwrap();
-        let token = TrustedPublishingToken::new("abc123".to_string());
-        let middleware = TrustedPublishingMiddleware::with_token(&server_url, token);
-
-        let client = ClientBuilder::new(reqwest::Client::new())
-            .with_arc(Arc::new(middleware))
-            .build();
-
-        let body = client
-            .get(server_url.join("/check").unwrap())
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "Bearer abc123");
-    }
-
-    #[tokio::test]
-    async fn middleware_skips_same_host_different_channel() {
-        use reqwest_middleware::ClientBuilder;
-        use std::sync::Arc;
-
-        let server = axum::Router::new()
-            .route(
-                "/my-channel/check",
-                axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                    if headers.contains_key("authorization") {
-                        "has-auth".to_string()
-                    } else {
-                        "no-auth".to_string()
-                    }
-                }),
-            )
-            .route(
-                "/other-channel/check",
-                axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                    if headers.contains_key("authorization") {
-                        "has-auth".to_string()
-                    } else {
-                        "no-auth".to_string()
-                    }
-                }),
-            )
-            .route(
-                "/my-channel-evil/check",
-                axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                    if headers.contains_key("authorization") {
-                        "has-auth".to_string()
-                    } else {
-                        "no-auth".to_string()
-                    }
-                }),
-            )
-            .route(
-                "/my-channel/subdir/check",
-                axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                    if headers.contains_key("authorization") {
-                        "has-auth".to_string()
-                    } else {
-                        "no-auth".to_string()
-                    }
-                }),
-            );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move { axum::serve(listener, server).await.unwrap() });
-
-        // Middleware scoped to /my-channel/ on the test host.
-        let channel_url = Url::parse(&format!("http://{addr}/my-channel/")).unwrap();
-        let token = TrustedPublishingToken::new("abc123".to_string());
-        let middleware = TrustedPublishingMiddleware::with_token(&channel_url, token);
-
-        let client = ClientBuilder::new(reqwest::Client::new())
-            .with_arc(Arc::new(middleware))
-            .build();
-
-        // Same host, different channel: token must NOT be injected.
-        let body = client
-            .get(format!("http://{addr}/other-channel/check"))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "no-auth");
-
-        // Prefix collision: /my-channel-evil must NOT match /my-channel/.
-        let body = client
-            .get(format!("http://{addr}/my-channel-evil/check"))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "no-auth");
-
-        // Same channel: token IS injected.
-        let body = client
-            .get(format!("http://{addr}/my-channel/check"))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "has-auth");
-
-        // Sub-path under the same channel: token IS injected.
-        let body = client
-            .get(format!("http://{addr}/my-channel/subdir/check"))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "has-auth");
-    }
-
-    #[test]
-    fn normalize_channel_url_adds_trailing_slash() {
-        let with_path = Url::parse("https://prefix.dev/my-channel").unwrap();
-        assert_eq!(normalize_channel_url(&with_path).path(), "/my-channel/");
-
-        let already_trailing = Url::parse("https://prefix.dev/my-channel/").unwrap();
-        assert_eq!(
-            normalize_channel_url(&already_trailing).path(),
-            "/my-channel/"
-        );
-
-        // The url crate normalizes a host-only URL to path "/".
-        let host_only = Url::parse("https://prefix.dev").unwrap();
-        assert_eq!(host_only.path(), "/");
-        assert_eq!(normalize_channel_url(&host_only).path(), "/");
-    }
-
-    #[tokio::test]
-    async fn middleware_skips_non_matching_host() {
-        use reqwest_middleware::ClientBuilder;
-        use std::sync::Arc;
-
-        let server = axum::Router::new().route(
-            "/check",
-            axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                if headers.contains_key("authorization") {
-                    "has-auth".to_string()
-                } else {
-                    "no-auth".to_string()
-                }
-            }),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move { axum::serve(listener, server).await.unwrap() });
-
-        // Middleware is configured for a different host than the one we hit.
-        let other_url = Url::parse("https://example.invalid").unwrap();
-        let token = TrustedPublishingToken::new("abc123".to_string());
-        let middleware = TrustedPublishingMiddleware::with_token(&other_url, token);
-
-        let client = ClientBuilder::new(reqwest::Client::new())
-            .with_arc(Arc::new(middleware))
-            .build();
-
-        let body = client
-            .get(format!("http://{addr}/check"))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "no-auth");
     }
 }

--- a/crates/rattler_upload/src/upload/prefix.rs
+++ b/crates/rattler_upload/src/upload/prefix.rs
@@ -214,7 +214,7 @@ pub async fn upload_package_to_prefix(
         None => match check_trusted_publishing(
             &client,
             &prefix_data.url,
-            &TrustedPublishingOptions::for_host(&prefix_data.url)
+            &TrustedPublishingOptions::for_server(&prefix_data.url)
                 .unwrap_or_else(TrustedPublishingOptions::for_prefix_dev),
         )
         .await
@@ -252,7 +252,7 @@ pub async fn upload_package_to_prefix(
         None => match check_trusted_publishing(
             &client,
             &prefix_data.url,
-            &TrustedPublishingOptions::for_host(&prefix_data.url)
+            &TrustedPublishingOptions::for_server(&prefix_data.url)
                 .unwrap_or_else(TrustedPublishingOptions::for_prefix_dev),
         )
         .await

--- a/crates/rattler_upload/src/upload/prefix.rs
+++ b/crates/rattler_upload/src/upload/prefix.rs
@@ -214,7 +214,8 @@ pub async fn upload_package_to_prefix(
         None => match check_trusted_publishing(
             &client,
             &prefix_data.url,
-            &TrustedPublishingOptions::for_prefix_dev(),
+            &TrustedPublishingOptions::for_host(&prefix_data.url)
+                .unwrap_or_else(TrustedPublishingOptions::for_prefix_dev),
         )
         .await
         {
@@ -251,7 +252,8 @@ pub async fn upload_package_to_prefix(
         None => match check_trusted_publishing(
             &client,
             &prefix_data.url,
-            &TrustedPublishingOptions::for_prefix_dev(),
+            &TrustedPublishingOptions::for_host(&prefix_data.url)
+                .unwrap_or_else(TrustedPublishingOptions::for_prefix_dev),
         )
         .await
         {

--- a/pixi.lock
+++ b/pixi.lock
@@ -583,6 +583,44 @@ environments:
       - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
       - conda_source: rattler[9e891123] @ crates/rattler-bin
       - conda_source: rattler_index[9e891123] @ crates/rattler_index
+  prefix-dev-e2e:
+    channels:
+    - url: https://prefix.dev/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/nushell-0.106.1-h7663d75_1.conda
+      - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda_source: rattler[f538e55a] @ crates/rattler-bin
+      osx-64:
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libcxx-22.1.7-h19cb2f5_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/nushell-0.106.1-haf43392_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
+      - conda_source: rattler[269e468a] @ crates/rattler-bin
+      osx-arm64:
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.7-h55c6f16_0.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/nushell-0.106.1-h267bf11_1.conda
+      - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+      - conda_source: rattler[6f9e045e] @ crates/rattler-bin
+      win-64:
+      - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-h4c7d964_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
+      - conda: https://prefix.dev/conda-forge/win-64/nushell-0.106.1-h7281763_1.conda
+      - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.2-hf411b9b_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+      - conda_source: rattler[0ca6f4c8] @ crates/rattler-bin
   s3:
     channels:
     - url: https://prefix.dev/conda-forge/
@@ -1315,6 +1353,23 @@ packages:
   license_family: GPL
   size: 69987984
   timestamp: 1759965829687
+- conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-ha6850e4_19.conda
+  sha256: 2c0b2870210cfc7e8561676844f4bd3884b345c19100e1da84cbfb4994d8f104
+  md5: 1c2eddf7501ef92050d3fbb11df61ee3
+  depends:
+  - binutils_impl_linux-64 >=2.45
+  - libgcc >=15.2.0
+  - libgcc-devel_linux-64 15.2.0 hcc6f6b0_119
+  - libgomp >=15.2.0
+  - libsanitizer 15.2.0 h90f66d4_19
+  - libstdcxx >=15.2.0
+  - libstdcxx-devel_linux-64 15.2.0 hd446a21_119
+  - sysroot_linux-64
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 81043749
+  timestamp: 1778860073982
 - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-he420e7e_18.conda
   sha256: a088cfd3ae6fa83815faa8703bc9d21cc915f17bd1b51aac9c16ddf678da21e4
   md5: cf56b6d74f580b91fd527e10d9a2e324
@@ -1357,6 +1412,20 @@ packages:
     - libgcc >=15
   size: 29081
   timestamp: 1777144726741
+- conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_25.conda
+  sha256: 3fbe01ebb16418d9f1971a283f969dc0f0e1071119f24164f4293057c79dc58c
+  md5: 46ca2358101b2477cb098c4248795d12
+  depends:
+  - gcc_impl_linux-64 15.2.0.*
+  - binutils_linux-64
+  - sysroot_linux-64
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - libgcc >=15
+  size: 29190
+  timestamp: 1779371750402
 - conda: https://prefix.dev/conda-forge/linux-64/gfortran-14.3.0-he448592_7.conda
   sha256: 7ab008dd3dc5e6ca0de2614771019a1d35480d51df6216c96b1cf6a5e660ee40
   md5: 94394acdc56dcb4d55dddf0393134966
@@ -1611,6 +1680,19 @@ packages:
   run_exports: {}
   size: 76624
   timestamp: 1774719175983
+- conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+  sha256: 363018b25fdb5534c79783d912bd4b685a3547f4fc5996357ad548899b0ee8e7
+  md5: 93764a5ca80616e9c10106cdaec92f74
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - expat 2.8.1.*
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 77294
+  timestamp: 1779278686680
 - conda: https://prefix.dev/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
   sha256: 25cbdfa65580cfab1b8d15ee90b4c9f1e0d72128f1661449c9a999d341377d54
   md5: 35f29eec58405aaf55e01cb470d8c26a
@@ -1648,6 +1730,20 @@ packages:
   run_exports: {}
   size: 1041788
   timestamp: 1771378212382
+- conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  sha256: 8e0a3b5e41272e5678499b5dfc4cddb673f9e935de01eb0767ce857001229f46
+  md5: 57736f29cc2b0ec0b6c2952d3f101b6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  constrains:
+  - libgcc-ng ==15.2.0=*_19
+  - libgomp 15.2.0 he0feb66_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 1041084
+  timestamp: 1778269013026
 - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_18.conda
   sha256: e318a711400f536c81123e753d4c797a821021fb38970cebfb3f454126016893
   md5: d5e96b1ed75ca01906b3d2469b4ce493
@@ -1660,6 +1756,18 @@ packages:
     - libgcc
   size: 27526
   timestamp: 1771378224552
+- conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+  sha256: 9dcf54adfaa5e861123c2da4f2f0451a685464ea7e5a41ad91cf67b31d658d98
+  md5: 331ee9b72b9dff570d56b1302c5ab37d
+  depends:
+  - libgcc 15.2.0 he0feb66_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports:
+    strong:
+    - libgcc
+  size: 27694
+  timestamp: 1778269016987
 - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_7.conda
   sha256: 2045066dd8e6e58aaf5ae2b722fb6dfdbb57c862b5f34ac7bfb58c40ef39b6ad
   md5: 280ea6eee9e2ddefde25ff799c4f0363
@@ -1702,6 +1810,18 @@ packages:
     - _openmp_mutex >=4.5
   size: 603262
   timestamp: 1771378117851
+- conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  sha256: 5abe4ab9d93f6c9757d654f1969ae2267d4505315c1f2f8fe705fd60af084f1b
+  md5: faac990cb7aedc7f3a2224f2c9b0c26c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports:
+    strong:
+    - _openmp_mutex >=4.5
+  size: 603817
+  timestamp: 1778268942614
 - conda: https://prefix.dev/conda-forge/linux-64/libhwloc-2.12.1-default_h7f8ec31_1002.conda
   sha256: f7fbc792dbcd04bf27219c765c10c239937b34c6c1a1f77a5827724753e02da1
   md5: c01021ae525a76fe62720c7346212d74
@@ -1844,6 +1964,20 @@ packages:
     - libsanitizer 15.2.0
   size: 8095113
   timestamp: 1771378289674
+- conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+  sha256: 7a58892a52739ce4c0f7109de9e91b4353104748eb04fc6441d88e8af444ba99
+  md5: 67eef12ce33f7ff99900c212d7076fc2
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=15.2.0
+  - libstdcxx >=15.2.0
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports:
+    weak:
+    - libsanitizer 15.2.0
+  size: 7930689
+  timestamp: 1778269054623
 - conda: https://prefix.dev/conda-forge/linux-64/libsqlite-3.51.0-hee844dc_0.conda
   sha256: 4c992dcd0e34b68f843e75406f7f303b1b97c248d18f3c7c330bdc0bc26ae0b3
   md5: 729a572a3ebb8c43933b30edcc628ceb
@@ -1895,6 +2029,19 @@ packages:
   run_exports: {}
   size: 5852330
   timestamp: 1771378262446
+- conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  sha256: dff1058c76ec6b8759e41cefa2508162d00e4a5e6721aa68ec3fd10094e702dc
+  md5: 5794b3bdc38177caf969dabd3af08549
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 he0feb66_19
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_19
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 5852044
+  timestamp: 1778269036376
 - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-ng-15.2.0-h4852527_7.conda
   sha256: 024fd46ac3ea8032a5ec3ea7b91c4c235701a8bf0e6520fe5e6539992a6bd05f
   md5: f627678cf829bd70bccf141a19c3ad3e
@@ -1927,6 +2074,19 @@ packages:
     - libuv >=1.51.0,<2.0a0
   size: 895108
   timestamp: 1753948278280
+- conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+  sha256: e28e4519223f78b3163599ca89c3f2d80bfb53e907e7fc74e806e60d1efa578b
+  md5: 4e33d49bf4fc853855a3b00643aa5484
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  run_exports:
+    weak:
+    - libuv >=1.52.1,<2.0a0
+  size: 419935
+  timestamp: 1779396012261
 - conda: https://prefix.dev/conda-forge/linux-64/libxml2-16-2.15.1-ha9997c6_0.conda
   sha256: 71436e72a286ef8b57d6f4287626ff91991eb03c7bdbe835280521791efd1434
   md5: e7733bc6785ec009e47a224a71917e84
@@ -2103,6 +2263,7 @@ packages:
   - __glibc >=2.17
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 10460237
   timestamp: 1759934195127
 - conda: https://prefix.dev/conda-forge/linux-64/nushell-0.110.0-h25c72ac_2.conda
@@ -2311,6 +2472,21 @@ packages:
     - __glibc >=2.17
   size: 11493
   timestamp: 1777897031483
+- conda: https://prefix.dev/conda-forge/linux-64/rust_linux-64-1.95.0-hb4ea61c_2.conda
+  sha256: f0e7e6b6dbec4ff4ef3c9c080a82f52af08c4983b568af0433f217be1045a6fe
+  md5: 371cfdd3ecb3fd19343bf7f21101da48
+  depends:
+  - gcc_linux-64
+  - rust 1.95.0.*
+  - rust-std-x86_64-unknown-linux-gnu 1.95.0.*
+  - sysroot_linux-64 >=2.17
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong_constrains:
+    - __glibc >=2.17
+  size: 11761
+  timestamp: 1780066916977
 - conda: https://prefix.dev/conda-forge/linux-64/s2n-1.6.0-h8399546_1.conda
   sha256: f5b294ce9b40d15a4bc31b315364459c0d702dd3e8751fe8735c88ac6a9ddc67
   md5: 8dbc626b1b11e7feb40a14498567b954
@@ -2463,6 +2639,24 @@ packages:
   run_exports: {}
   size: 131039
   timestamp: 1776865545798
+- conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-h4c7d964_0.conda
+  sha256: 86981d764e4ea1883409d30447ff9da46127426d31a63df08315aaded768e652
+  md5: c9b86eece2f944541b86441c94117ab3
+  depends:
+  - __win
+  license: ISC
+  run_exports: {}
+  size: 130182
+  timestamp: 1779289939595
+- conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  sha256: 9812a303a1395e1dafbd92e5bc8a1ff6013bcbba0a09c7f03a8d23e43560aa9b
+  md5: 489b8e97e666c93f68fdb35c3c9b957f
+  depends:
+  - __unix
+  license: ISC
+  run_exports: {}
+  size: 129868
+  timestamp: 1779289852439
 - conda: https://prefix.dev/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
   sha256: ab29d57dc70786c1269633ba3dff20288b81664d3ff8d21af995742e2bb03287
   md5: 962b9857ee8e7018c22f2776ffa0b2d7
@@ -2482,6 +2676,16 @@ packages:
   run_exports: {}
   size: 10801573
   timestamp: 1776837550762
+- conda: https://prefix.dev/conda-forge/noarch/compiler-rt22_osx-64-22.1.7-hcf80936_0.conda
+  sha256: 87c48a861f8c06c2be4f8ad7e7b774e2c6d4891e617dc6461d9c670bae17b790
+  md5: 9829c9c1cd2b57757ccb80aa1f5ab019
+  constrains:
+  - compiler-rt >=9.0.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 10910520
+  timestamp: 1780458666064
 - conda: https://prefix.dev/conda-forge/noarch/compiler-rt22_osx-arm64-22.1.4-h7e67a1e_0.conda
   sha256: 063f451ae646868f72e65b80a1db0b9076a0852d1f4f6fb90f228ef2aa2923d9
   md5: 24fe8a66a15acb324986cabdb8e1d6f5
@@ -2492,6 +2696,16 @@ packages:
   run_exports: {}
   size: 10910882
   timestamp: 1776838303277
+- conda: https://prefix.dev/conda-forge/noarch/compiler-rt22_osx-arm64-22.1.7-h7e67a1e_0.conda
+  sha256: f3d32eba79cd7815b20277c5a0dc0b265d7f5ca0eabad9daa6fd68be87fb8af7
+  md5: 08a65a1a0cf1ca2053c7179e534b685e
+  constrains:
+  - compiler-rt >=9.0.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 10727649
+  timestamp: 1780457616663
 - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-64-19.1.7-h138dee1_1.conda
   sha256: e6effe89523fc6143819f7a68372b28bf0c176af5b050fe6cf75b62e9f6c6157
   md5: 32deecb68e11352deaa3235b709ddab2
@@ -2516,6 +2730,18 @@ packages:
   run_exports: {}
   size: 16574
   timestamp: 1776837668381
+- conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-64-22.1.7-h694c41f_0.conda
+  sha256: a5118bf285946d0a04e0d5bf989b729340d72b317a6b115d6c41e8dfe959081e
+  md5: c6e2bd3d209f0bf87ad5bc3a8046fef4
+  depends:
+  - compiler-rt22_osx-64 22.1.7 hcf80936_0
+  constrains:
+  - clang 22.1.7
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 16809
+  timestamp: 1780458741409
 - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-arm64-19.1.7-he32a8d3_1.conda
   sha256: 8c32a3db8adf18ed58197e8895ce4f24a83ed63c817512b9a26724753b116f2a
   md5: 8d99c82e0f5fed6cc36fcf66a11e03f0
@@ -2540,6 +2766,18 @@ packages:
   run_exports: {}
   size: 16667
   timestamp: 1776838471158
+- conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-arm64-22.1.7-hce30654_0.conda
+  sha256: fc9f7f6322088f2efc014dac83219cd00e42583dc6502c7314c98183b6554c3d
+  md5: c49b5fb0d1b3d9a4c6e2dff11fdf51fd
+  depends:
+  - compiler-rt22_osx-arm64 22.1.7 h7e67a1e_0
+  constrains:
+  - clang 22.1.7
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 16797
+  timestamp: 1780457650249
 - conda: https://prefix.dev/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
   sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
   md5: 67999c5465064480fa8016d00ac768f6
@@ -2596,6 +2834,16 @@ packages:
   run_exports: {}
   size: 3085932
   timestamp: 1771378098166
+- conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+  sha256: 38a557eba305468ac1f90ac85e50d8defd76141cb0b8a43b2fc1aca71dd5d5f2
+  md5: 683fcb168e1df9a21fa80d5aa2d9330b
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 3095909
+  timestamp: 1778268932148
 - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-14.3.0-h85bb3a7_107.conda
   sha256: 54ba5632d93faebbec3899d9df84c6e71c4574d70a2f3babfc5aac4247874038
   md5: eaf0f047b048c4d86a4b8c60c0e95f38
@@ -2615,6 +2863,16 @@ packages:
   run_exports: {}
   size: 20669511
   timestamp: 1771378139786
+- conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+  sha256: a2385f3611d5cd25378f9cf2367183320731709c067ddd08d43330d3170f15b8
+  md5: bcfe7eae40158c3e355d2f9d3ed41230
+  depends:
+  - __unix
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  run_exports: {}
+  size: 20765069
+  timestamp: 1778268963689
 - conda: https://prefix.dev/conda-forge/noarch/macosx_deployment_target_osx-64-26.0-hb5ce262_7.conda
   sha256: e1a32fb9babf5e88706fcf4180c24436f1c59536af39e91869acd72dee7b0a10
   md5: 8231d152a1534e90b903a9560295e40d
@@ -3227,6 +3485,20 @@ packages:
   run_exports: {}
   size: 818667
   timestamp: 1776945226955
+- conda: https://prefix.dev/conda-forge/osx-64/clang-22-22.1.7-default_h3b8fe2e_1.conda
+  sha256: 8acd160b174fe02c61efd926b574d0bce11fc800ab1b8882817461f7940b2561
+  md5: a0c754cdc84949d979bc15462df8c0ee
+  depends:
+  - __osx >=11.0
+  - compiler-rt22 22.1.7.*
+  - libclang-cpp22.1 22.1.7 default_h9399c5b_1
+  - libcxx >=22.1.7
+  - libllvm22 >=22.1.7,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 826158
+  timestamp: 1780524355900
 - conda: https://prefix.dev/conda-forge/osx-64/clang_impl_osx-64-19.1.7-hc73cdc9_25.conda
   sha256: 88edc0b34affbfffcec5ffea59b432ee3dd114124fd4d5f992db6935421f4a64
   md5: 76954503be09430fb7f4683a61ffb7b0
@@ -3254,6 +3526,20 @@ packages:
   run_exports: {}
   size: 27895
   timestamp: 1776945498764
+- conda: https://prefix.dev/conda-forge/osx-64/clang_impl_osx-64-22.1.7-default_hb18168d_1.conda
+  sha256: f9a91571fc4c63030e79a8e7aad11a0a42e451f3fc624bb893a7189141a2ffad
+  md5: cded0f2d26fa6d3163451cb64840d3ee
+  depends:
+  - cctools_impl_osx-64
+  - clang-22 22.1.7 default_h3b8fe2e_1
+  - compiler-rt 22.1.7.*
+  - compiler-rt_osx-64
+  - ld64_osx-64 * llvm22_1_*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 29139
+  timestamp: 1780524488866
 - conda: https://prefix.dev/conda-forge/osx-64/clang_osx-64-19.1.7-h7e5c614_25.conda
   sha256: 6435fdeae76f72109bc9c7b41596104075a2a8a9df3ee533bd98bb06548bbc83
   md5: a526ba9df7e7d5448d57b33941614dae
@@ -3275,6 +3561,18 @@ packages:
   run_exports: {}
   size: 20971
   timestamp: 1776998812584
+- conda: https://prefix.dev/conda-forge/osx-64/clang_osx-64-22.1.7-hb0d1528_32.conda
+  sha256: 719d2bda314068a6446fde8673a931764e43dec2f8017b66d51232fd1898aeec
+  md5: 443550581ad436305c85b7b11ec7d908
+  depends:
+  - cctools_osx-64
+  - clang_impl_osx-64 22.1.7.*
+  - sdkroot_env_osx-64
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 21209
+  timestamp: 1780546451340
 - conda: https://prefix.dev/conda-forge/osx-64/clangxx-19.1.7-default_h1c12a56_5.conda
   sha256: 6553c7b6a898bd00c218656d3438dc3a70f2bb79f795ce461792c55304558af2
   md5: 6b6f3133d60b448c0f12885f53d5ed09
@@ -3351,6 +3649,19 @@ packages:
   run_exports: {}
   size: 16460
   timestamp: 1776837669831
+- conda: https://prefix.dev/conda-forge/osx-64/compiler-rt-22.1.7-h694c41f_0.conda
+  sha256: 057879f1f517b25a2394639fcedfc04005f6bbf63ab003182bc479e641db2b2c
+  md5: d3834d21abeff2613f6c806ff41a3059
+  depends:
+  - compiler-rt22 22.1.7 h1637cdf_0
+  - libcompiler-rt 22.1.7 h1637cdf_0
+  constrains:
+  - clang 22.1.7
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 16675
+  timestamp: 1780458743280
 - conda: https://prefix.dev/conda-forge/osx-64/compiler-rt22-22.1.4-h1637cdf_0.conda
   sha256: a6d98bef8c92940df9940c4c620e5f9a0e47486c97e97a87f9d18fd41f5e28ba
   md5: 1a85ba2ed4edaa0e3fd54e0beb36460d
@@ -3362,6 +3673,17 @@ packages:
   run_exports: {}
   size: 99155
   timestamp: 1776837666232
+- conda: https://prefix.dev/conda-forge/osx-64/compiler-rt22-22.1.7-h1637cdf_0.conda
+  sha256: f67af723c48fa4c789d1b3cdcde618d7479622fd410cb51f9457f0b70dc8c13d
+  md5: 1366301c61cad16bcdbf00c9f43576cf
+  depends:
+  - __osx >=11.0
+  - compiler-rt22_osx-64 22.1.7.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 99264
+  timestamp: 1780458739013
 - conda: https://prefix.dev/conda-forge/osx-64/cxx-compiler-1.11.0-h307afc9_0.conda
   sha256: d6976f8d8b51486072abfe1e76a733688380dcbd1a8e993a43d59b80f7288478
   md5: 463bb03bb27f9edc167fb3be224efe96
@@ -3507,6 +3829,20 @@ packages:
     - libclang-cpp22.1 >=22.1.4,<22.2.0a0
   size: 15007676
   timestamp: 1776944952122
+- conda: https://prefix.dev/conda-forge/osx-64/libclang-cpp22.1-22.1.7-default_h9399c5b_1.conda
+  sha256: f354e26f811a31427ff4cc4695a6773187bb2ac9ad9197eebf41da470e637968
+  md5: 135131fca92856cfe4e32af9ffbfc9c2
+  depends:
+  - __osx >=11.0
+  - libcxx >=22.1.7
+  - libllvm22 >=22.1.7,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libclang-cpp22.1 >=22.1.7,<22.2.0a0
+  size: 15007643
+  timestamp: 1780524215578
 - conda: https://prefix.dev/conda-forge/osx-64/libcompiler-rt-22.1.4-h1637cdf_0.conda
   sha256: decd9684b3658dab99667491785413a587952fd8efb291392ac9aab6745868f0
   md5: 1c9992375eea400d47b72deeee70f4a6
@@ -3521,6 +3857,20 @@ packages:
     - libcompiler-rt >=22.1.4
   size: 1373637
   timestamp: 1776837637097
+- conda: https://prefix.dev/conda-forge/osx-64/libcompiler-rt-22.1.7-h1637cdf_0.conda
+  sha256: d0ef06b0c7d1312e572f3726b867f81e22eed158e6255b66e58448ede7647b49
+  md5: 45d588315fef679cd57cf06ccbc1a6ab
+  depends:
+  - __osx >=11.0
+  constrains:
+  - compiler-rt >=9.0.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libcompiler-rt >=22.1.7
+  size: 1374021
+  timestamp: 1780458717254
 - conda: https://prefix.dev/conda-forge/osx-64/libcurl-8.17.0-h7dd4100_0.conda
   sha256: a58ca5a28c1cb481f65800781cee9411bd68e8bda43a69817aaeb635d25f7d75
   md5: b3985ef7ca4cd2db59756bae2963283a
@@ -3555,6 +3905,16 @@ packages:
   run_exports: {}
   size: 567125
   timestamp: 1776815441323
+- conda: https://prefix.dev/conda-forge/osx-64/libcxx-22.1.7-h19cb2f5_0.conda
+  sha256: c03c298355dea54b729ed6c5f1e6dbd0e2426906039eba8aa2ba1254d005b7d8
+  md5: 423373b842c3861da6cfa8c8915798ce
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 564939
+  timestamp: 1780442565078
 - conda: https://prefix.dev/conda-forge/osx-64/libcxx-devel-19.1.7-h7c275be_1.conda
   sha256: d1ee08b0614d8f9bca84aa91b4015c5efa96162fd865590a126544243699dfc6
   md5: 0f3f15e69e98ce9b3307c1d8309d1659
@@ -3659,6 +4019,23 @@ packages:
     - libllvm22 >=22.1.4,<22.2.0a0
   size: 31844852
   timestamp: 1776826206742
+- conda: https://prefix.dev/conda-forge/osx-64/libllvm22-22.1.7-hab754da_0.conda
+  sha256: 9ef76e7c6a078cbead8a462af85cfae4f8fe2a9480ec0ee483f00332703a02ca
+  md5: c198bc1edfa11159777da98e194d06f3
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libllvm22 >=22.1.7,<22.2.0a0
+  size: 31842884
+  timestamp: 1780447725513
 - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.1-hd471939_2.conda
   sha256: 7e22fd1bdb8bf4c2be93de2d4e718db5c548aa082af47a7430eb23192de6bb36
   md5: 8468beea04b9065b9807fc8b9cdc5894
@@ -3900,6 +4277,20 @@ packages:
   run_exports: {}
   size: 18979793
   timestamp: 1776826466814
+- conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-22-22.1.7-hc181bea_0.conda
+  sha256: 86158dd6e99018e83c4ecd0d504511efd284d242d891723b6fc7edab1fd41b44
+  md5: 7b43a01695fe09c7786a99907312c588
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libllvm22 22.1.7 hab754da_0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 18996311
+  timestamp: 1780447964134
 - conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-22.1.4-h1637cdf_0.conda
   sha256: c7348a99758d6b9cb2e15aa7b3d4fbfae1a4f9e8217570a75f87d038ab575b89
   md5: 95c7c0415da24827c936461bb8410642
@@ -3917,6 +4308,23 @@ packages:
   run_exports: {}
   size: 51799
   timestamp: 1776826600676
+- conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-22.1.7-h1637cdf_0.conda
+  sha256: 432f04a68a18e487f4339d89bf8cea1054850fb92d0e3397605c219382892666
+  md5: 40a7058aac858d574e37265a03b49777
+  depends:
+  - __osx >=11.0
+  - libllvm22 22.1.7 hab754da_0
+  - llvm-tools-22 22.1.7 hc181bea_0
+  constrains:
+  - llvm        22.1.7
+  - clang-tools 22.1.7
+  - clang       22.1.7
+  - llvmdev     22.1.7
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 52128
+  timestamp: 1780448062183
 - conda: https://prefix.dev/conda-forge/osx-64/make-4.4.1-h00291cd_2.conda
   sha256: 5a5ab3ee828309185e0a76ca80f5da85f31d8480d923abb508ca00fe194d1b5a
   md5: 59b4ad97bbb36ef5315500d5bde4bcfc
@@ -3975,6 +4383,7 @@ packages:
   - __osx >=10.13
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 10924291
   timestamp: 1759934264932
 - conda: https://prefix.dev/conda-forge/osx-64/nushell-0.110.0-h03e26d9_2.conda
@@ -4163,6 +4572,22 @@ packages:
     - __osx >=10.13
   size: 11473
   timestamp: 1777897327134
+- conda: https://prefix.dev/conda-forge/osx-64/rust_osx-64-1.95.0-hce10650_2.conda
+  sha256: c9d96cfdf8271da6da1c9e4f5102781faeadb50171d7a868cae756ea71c57d28
+  md5: 09b2698f7489199eb2fc42f98777fdcd
+  depends:
+  - clang_osx-64
+  - ld64_osx-64
+  - macosx_deployment_target_osx-64 >=11.0
+  - rust 1.95.0.*
+  - rust-std-x86_64-apple-darwin 1.95.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong_constrains:
+    - __osx >=11.0
+  size: 11785
+  timestamp: 1780067434899
 - conda: https://prefix.dev/conda-forge/osx-64/shellcheck-0.10.0-h7dd6a17_0.conda
   sha256: 383901632d791e01f6799a8882c202c1fcf5ec2914f869b2bdd8ae6e139c20b7
   md5: 6870813f912971e13d56360d2db55bde
@@ -4632,6 +5057,20 @@ packages:
   run_exports: {}
   size: 821681
   timestamp: 1776926764338
+- conda: https://prefix.dev/conda-forge/osx-arm64/clang-22-22.1.7-default_hd632d02_1.conda
+  sha256: 3a438c7a27c86ef14a41c991b8688ef53efe92ad1db8ae930f27fce410ca843a
+  md5: 36f28e96e3bff9566e44cc625b87408c
+  depends:
+  - __osx >=11.0
+  - compiler-rt22 22.1.7.*
+  - libclang-cpp22.1 22.1.7 default_h8e162e0_1
+  - libcxx >=22.1.7
+  - libllvm22 >=22.1.7,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 830975
+  timestamp: 1780519560746
 - conda: https://prefix.dev/conda-forge/osx-arm64/clang_impl_osx-arm64-19.1.7-h76e6a08_25.conda
   sha256: ee3c0976bde0ac19f84d29213ea3d9c3fd9c56d56c33ee471a8680cf69307ce1
   md5: a4e2f211f7c3cf582a6cb447bee2cad9
@@ -4659,6 +5098,20 @@ packages:
   run_exports: {}
   size: 27845
   timestamp: 1776927011611
+- conda: https://prefix.dev/conda-forge/osx-arm64/clang_impl_osx-arm64-22.1.7-default_h17d1ed9_1.conda
+  sha256: 09a6fa56849653389f4db79e548832dda874fa9255740a292adec0941a6b8902
+  md5: 87567b36faebd1d3423321f5122096ae
+  depends:
+  - cctools_impl_osx-arm64
+  - clang-22 22.1.7 default_hd632d02_1
+  - compiler-rt 22.1.7.*
+  - compiler-rt_osx-arm64
+  - ld64_osx-arm64 * llvm22_1_*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 29007
+  timestamp: 1780519625415
 - conda: https://prefix.dev/conda-forge/osx-arm64/clang_osx-arm64-19.1.7-h07b0088_25.conda
   sha256: 92a45a972af5eba3b7fca66880c3d5bdf73d0c69a3e21d1b3999fb9b5be1b323
   md5: 1b53cb5305ae53b5aeba20e58c625d96
@@ -4680,6 +5133,18 @@ packages:
   run_exports: {}
   size: 21087
   timestamp: 1776998964888
+- conda: https://prefix.dev/conda-forge/osx-arm64/clang_osx-arm64-22.1.7-hf119d2b_32.conda
+  sha256: a14407fdd92a35b3410796b20f209abbe53f59ea6417c66bf900730a1efdf203
+  md5: 75afaa2f7151ace4f1fff9b676db4d2e
+  depends:
+  - cctools_osx-arm64
+  - clang_impl_osx-arm64 22.1.7.*
+  - sdkroot_env_osx-arm64
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 21218
+  timestamp: 1780546185093
 - conda: https://prefix.dev/conda-forge/osx-arm64/clangxx-19.1.7-default_h36137df_5.conda
   sha256: f8f94321aee9ad83cb1cdf90660885fccb482c34c82ba84c2c167d452376834f
   md5: c11a3a5a0cdb74d8ce58c6eac8d1f662
@@ -4756,6 +5221,19 @@ packages:
   run_exports: {}
   size: 16494
   timestamp: 1776838473207
+- conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt-22.1.7-hce30654_0.conda
+  sha256: 721b702d79bf70de4e938e552dbae794ff60590ceb4594bd5dadcaf77fa90c8b
+  md5: c5bf9cc793f5cab214f90c5c0e1851e6
+  depends:
+  - compiler-rt22 22.1.7 hd34ed20_0
+  - libcompiler-rt 22.1.7 hd34ed20_0
+  constrains:
+  - clang 22.1.7
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 16641
+  timestamp: 1780457650764
 - conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt22-22.1.4-hd34ed20_0.conda
   sha256: f6097d3968ca1d29a27355407040fdf81a31600201cca32be0091166c7d518be
   md5: e257f7ace4ad961f08cf699da266a74d
@@ -4767,6 +5245,17 @@ packages:
   run_exports: {}
   size: 99681
   timestamp: 1776838467203
+- conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt22-22.1.7-hd34ed20_0.conda
+  sha256: cfe6a196223f735b49b093586359615e059d9944b3cf049101a20ce135a94300
+  md5: 3893c0e24c5f19efb9138762f0eb693c
+  depends:
+  - __osx >=11.0
+  - compiler-rt22_osx-arm64 22.1.7.*
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports: {}
+  size: 98795
+  timestamp: 1780457649475
 - conda: https://prefix.dev/conda-forge/osx-arm64/cxx-compiler-1.11.0-h88570a1_0.conda
   sha256: 99800d97a3a2ee9920dfc697b6d4c64e46dc7296c78b1b6c746ff1c24dea5e6c
   md5: 043afed05ca5a0f2c18252ae4378bdee
@@ -4920,6 +5409,20 @@ packages:
     - libclang-cpp22.1 >=22.1.4,<22.2.0a0
   size: 14185091
   timestamp: 1776926580464
+- conda: https://prefix.dev/conda-forge/osx-arm64/libclang-cpp22.1-22.1.7-default_h8e162e0_1.conda
+  sha256: 27fe54bb8da8a80793bbd9346324cfbc9609cee498b79d6ae8cbd89e09c197be
+  md5: 08dd791ea92568bdca26bb174b2c0e3a
+  depends:
+  - __osx >=11.0
+  - libcxx >=22.1.7
+  - libllvm22 >=22.1.7,<22.2.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libclang-cpp22.1 >=22.1.7,<22.2.0a0
+  size: 14193041
+  timestamp: 1780519486860
 - conda: https://prefix.dev/conda-forge/osx-arm64/libcompiler-rt-22.1.4-hd34ed20_0.conda
   sha256: cc75861e27dc7c6385d9cd9f581d62c507ef23a98b26be0a89fb8ccf54a9a6ea
   md5: bc957fe2d1c1b0b69c70353599cde50e
@@ -4934,6 +5437,20 @@ packages:
     - libcompiler-rt >=22.1.4
   size: 1376608
   timestamp: 1776838427260
+- conda: https://prefix.dev/conda-forge/osx-arm64/libcompiler-rt-22.1.7-hd34ed20_0.conda
+  sha256: 35f6b1f2a1e61e043eb17aab49cccf65234d7cb137f26ed87ea7163f6937ab6b
+  md5: f5766b2bf9c3630b9bef99319629531d
+  depends:
+  - __osx >=11.0
+  constrains:
+  - compiler-rt >=9.0.1
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: APACHE
+  run_exports:
+    weak:
+    - libcompiler-rt >=22.1.7
+  size: 1373087
+  timestamp: 1780457641235
 - conda: https://prefix.dev/conda-forge/osx-arm64/libcurl-8.17.0-hdece5d2_0.conda
   sha256: 2980c5de44ac3ca2ecbd4a00756da1648ea2945d9e4a2ad9f216c7787df57f10
   md5: 791003efe92c17ed5949b309c61a5ab1
@@ -4968,6 +5485,16 @@ packages:
   run_exports: {}
   size: 569927
   timestamp: 1776816293111
+- conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.7-h55c6f16_0.conda
+  sha256: cceb668dc1b71f054b1036dd83eca2e02c0c3a4b2ba3ad28c74a982d819597a3
+  md5: 0325fbe13eb6dd39234eb305ac1b3cb8
+  depends:
+  - __osx >=11.0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 568252
+  timestamp: 1780441702930
 - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-devel-19.1.7-h6dc3340_1.conda
   sha256: 6dd08a65b8ef162b058dc931aba3bdb6274ba5f05b6c86fbd0c23f2eafc7cc47
   md5: 1399af81db60d441e7c6577307d5cf82
@@ -5081,6 +5608,23 @@ packages:
     - libllvm22 >=22.1.4,<22.2.0a0
   size: 30048795
   timestamp: 1776828423000
+- conda: https://prefix.dev/conda-forge/osx-arm64/libllvm22-22.1.7-h89af1be_0.conda
+  sha256: 533929d04a94ee43431c6f7f0916b0f5a387f6b02b5339f06301bbfa9e180c84
+  md5: 0525fa45bcc945c301ee8f583a442ce1
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports:
+    weak:
+    - libllvm22 >=22.1.7,<22.2.0a0
+  size: 30014727
+  timestamp: 1780441538232
 - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
   sha256: 0cb92a9e026e7bd4842f410a5c5c665c89b2eb97794ffddba519a626b8ce7285
   md5: d6df911d4564d77c4374b02552cb17d1
@@ -5351,6 +5895,20 @@ packages:
   run_exports: {}
   size: 17825171
   timestamp: 1776828746788
+- conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-22-22.1.7-hb545844_0.conda
+  sha256: fd44ba14755380db3d89b75485c2e9a9982fefe54e7853d9a91a250948b2c48c
+  md5: 14e37880dc53c9da027752c005ddb7ec
+  depends:
+  - __osx >=11.0
+  - libcxx >=19
+  - libllvm22 22.1.7 h89af1be_0
+  - libzlib >=1.3.2,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 17845007
+  timestamp: 1780441650670
 - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-22.1.4-hd34ed20_0.conda
   sha256: e23532a849f181d62c8d3a5a9872c301aa66c731be0dbda64c7f29af58d6dd2b
   md5: 0a61bb0d9187887cab1315bb62c6cab8
@@ -5368,6 +5926,23 @@ packages:
   run_exports: {}
   size: 51640
   timestamp: 1776828919113
+- conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-22.1.7-hd34ed20_0.conda
+  sha256: eafdac4500c69bed1e5964efc8f6a024a4a70f57a91e5c5e099bc9ed5ff4695b
+  md5: b0eff8fdd52342dc666a05ba33acf8f8
+  depends:
+  - __osx >=11.0
+  - libllvm22 22.1.7 h89af1be_0
+  - llvm-tools-22 22.1.7 hb545844_0
+  constrains:
+  - clang-tools 22.1.7
+  - llvmdev     22.1.7
+  - clang       22.1.7
+  - llvm        22.1.7
+  license: Apache-2.0 WITH LLVM-exception
+  license_family: Apache
+  run_exports: {}
+  size: 52222
+  timestamp: 1780441714363
 - conda: https://prefix.dev/conda-forge/osx-arm64/make-4.4.1-hc9fafa5_2.conda
   sha256: 90ca65e788406d9029ae23ad4bd944a8b5353ad5f59bd6ce326f980cde46f37e
   md5: 9f44ef1fea0a25d6a3491c58f3af8460
@@ -5422,6 +5997,7 @@ packages:
   - __osx >=11.0
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 10482392
   timestamp: 1759934241172
 - conda: https://prefix.dev/conda-forge/osx-arm64/nushell-0.110.0-h979b848_0.conda
@@ -5610,6 +6186,22 @@ packages:
     - __osx >=11.0
   size: 11510
   timestamp: 1777897493351
+- conda: https://prefix.dev/conda-forge/osx-arm64/rust_osx-arm64-1.95.0-h9bac32b_2.conda
+  sha256: e139d859f9cbdfabecc1cd18d2ad0888e7ceba9909c5bee05f61a3332c177fd8
+  md5: 9e4df6abb71480373e94aae8e531faaf
+  depends:
+  - clang_osx-arm64
+  - ld64_osx-arm64
+  - macosx_deployment_target_osx-arm64 >=11.0
+  - rust 1.95.0.*
+  - rust-std-aarch64-apple-darwin 1.95.0.*
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong_constrains:
+    - __osx >=11.0
+  size: 11811
+  timestamp: 1780067379835
 - conda: https://prefix.dev/conda-forge/osx-arm64/shellcheck-0.10.0-hecfb573_0.conda
   sha256: d175f46af454d3f2ba97f0a4be8a4fdf962aaec996db54dfcf8044d38da3769c
   md5: 6b2856ca39fa39c438dcd46140cd894e
@@ -6225,6 +6817,22 @@ packages:
   license_family: Other
   size: 55476
   timestamp: 1727963768015
+- conda: https://prefix.dev/conda-forge/win-64/libzlib-1.3.2-hfd05255_2.conda
+  sha256: 88609816e0cc7452bac637aaf65783e5edf4fee8a9f8e22bdc3a75882c536061
+  md5: dbabbd6234dea34040e631f87676292f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - zlib 1.3.2 *_2
+  license: Zlib
+  license_family: Other
+  run_exports:
+    weak:
+    - libzlib >=1.3.2,<2.0a0
+  size: 58347
+  timestamp: 1774072851498
 - conda: https://prefix.dev/conda-forge/win-64/make-4.4.1-h0e40799_2.conda
   sha256: a810cdca3d5fa50d562cda23c0c1195b45ff5f9b0c41e0d4c8c2dd3c043ff4f2
   md5: 77ff648ad9fec660f261aa8ab0949f62
@@ -6264,6 +6872,7 @@ packages:
   - openssl >=3.5.4,<4.0a0
   license: MIT
   license_family: MIT
+  run_exports: {}
   size: 10014075
   timestamp: 1759934231561
 - conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
@@ -6278,6 +6887,21 @@ packages:
   license_family: Apache
   size: 9440812
   timestamp: 1762841722179
+- conda: https://prefix.dev/conda-forge/win-64/openssl-3.6.2-hf411b9b_0.conda
+  sha256: feb5815125c60f2be4a411e532db1ed1cd2d7261a6a43c54cb6ae90724e2e154
+  md5: 05c7d624cff49dbd8db1ad5ba537a8a3
+  depends:
+  - ca-certificates
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  run_exports:
+    weak:
+    - openssl >=3.6.2,<4.0a0
+  size: 9410183
+  timestamp: 1775589779763
 - conda: https://prefix.dev/conda-forge/win-64/pcre2-10.46-h3402e2f_0.conda
   sha256: 29c2ed44a8534d27faad96bdce16efe29c2788f556f4c5409d4ae8ae074681ec
   md5: 889053e920d15353c2665fa6310d7a7a
@@ -6412,6 +7036,18 @@ packages:
   run_exports: {}
   size: 11252
   timestamp: 1777897157443
+- conda: https://prefix.dev/conda-forge/win-64/rust_win-64-1.95.0-h533a698_2.conda
+  sha256: 8e8c0cdde4e371338fe7cc408a2b71a44135ba4d3a5f911180de231f32c333a4
+  md5: 38d16cbf8a44d04459fbcfb662024da8
+  depends:
+  - rust 1.95.0.*
+  - rust-std-x86_64-pc-windows-msvc 1.95.0.*
+  - vs_win-64 >=2019
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 11561
+  timestamp: 1780067165294
 - conda: https://prefix.dev/conda-forge/win-64/shellcheck-0.10.0-h57928b3_0.conda
   sha256: a7a08960774abdf394791867fa5ec26752eaaf4beda70f7daefbb7076054ee9b
   md5: c79f416ceb03e3add6e16381ecfdadd9
@@ -6474,6 +7110,18 @@ packages:
   run_exports: {}
   size: 19356
   timestamp: 1767320221521
+- conda: https://prefix.dev/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+  sha256: 61b68e5a4fc71a17f8d64b12e013a2f971ad980bd08e9c389d5e68efe1a67de0
+  md5: 774568633f3b26d7a4a6dd4f9ea6d3e1
+  depends:
+  - vc14_runtime >=14.51.36231
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports: {}
+  size: 20187
+  timestamp: 1780005880049
 - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_32.conda
   sha256: e3a3656b70d1202e0d042811ceb743bd0d9f7e00e2acdf824d231b044ef6c0fd
   md5: 378d5dcec45eaea8d303da6f00447ac0
@@ -6499,6 +7147,19 @@ packages:
   run_exports: {}
   size: 683233
   timestamp: 1767320219644
+- conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+  sha256: 957c7c65583c7107a5e76f39756c6361fcb7b0dc101ac7c0aea86e7ca09fe49c
+  md5: 2cdcd8ea1010920911bb2eacb4c61227
+  depends:
+  - ucrt >=10.0.20348.0
+  - vcomp14 14.51.36231 h1b9f54f_38
+  constrains:
+  - vs2015_runtime 14.51.36231.* *_38
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  run_exports: {}
+  size: 740997
+  timestamp: 1780005875753
 - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_32.conda
   sha256: f3790c88fbbdc55874f41de81a4237b1b91eab75e05d0e58661518ff04d2a8a1
   md5: 58f67b437acbf2764317ba273d731f1d
@@ -6524,6 +7185,20 @@ packages:
     - vcomp14 >=14.44.35208
   size: 115235
   timestamp: 1767320173250
+- conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+  sha256: c645fdc1f0f47718431d973386e946754a10200e7ba2c32032560913a970cacd
+  md5: 63ee70d69d7540e821940dac5d4d9ba2
+  depends:
+  - ucrt >=10.0.20348.0
+  constrains:
+  - vs2015_runtime 14.51.36231.* *_38
+  license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
+  license_family: Proprietary
+  run_exports:
+    strong:
+    - vcomp14 >=14.51.36231
+  size: 123561
+  timestamp: 1780005858779
 - conda: https://prefix.dev/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_32.conda
   sha256: 65cea43f4de99bc81d589e746c538908b2e95aead9042fecfbc56a4d14684a87
   md5: dfc1e5bbf1ecb0024a78e4e8bd45239d
@@ -6564,6 +7239,24 @@ packages:
     - ucrt >=10.0.20348.0
   size: 23060
   timestamp: 1767320175868
+- conda: https://prefix.dev/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_38.conda
+  sha256: d602239c40b42411268dc15f0325d4c67c6e6b51b6f31d4455935f07cd170111
+  md5: 2d59c2ac7e4c06c9d60731d10cd6254a
+  depends:
+  - vswhere
+  constrains:
+  - vs_win-64 2022.14
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - vc >=14.3,<15
+    - vc14_runtime >=14.44.35208
+    - ucrt >=10.0.20348.0
+  size: 24145
+  timestamp: 1780005884976
 - conda: https://prefix.dev/conda-forge/win-64/vs_win-64-2022.14-ha74f236_34.conda
   sha256: b07ba17e1f407eba3e8c714530cce9b111439e3ffecd123e58555308a7304a60
   md5: b8f1c3f5c2347270f0fa06385ab16c5c
@@ -6580,6 +7273,22 @@ packages:
     - ucrt >=10.0.20348.0
   size: 19606
   timestamp: 1767320221083
+- conda: https://prefix.dev/conda-forge/win-64/vs_win-64-2022.14-ha74f236_38.conda
+  sha256: 4a96f5ce6836d4f76daca3ab23f9e153ce0158323bc03ff8d5e9da12b16d462a
+  md5: 7256679ce67559e8c04f119ed509d3d4
+  depends:
+  - vs2022_win-64 19.44.35207.*
+  track_features:
+  - vc14
+  license: BSD-3-Clause
+  license_family: BSD
+  run_exports:
+    strong:
+    - vc >=14.3,<15
+    - vc14_runtime >=14.44.35208
+    - ucrt >=10.0.20348.0
+  size: 20588
+  timestamp: 1780005904892
 - conda: https://prefix.dev/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
   sha256: bc64864377d809b904e877a98d0584f43836c9f2ef27d3d2a1421fa6eae7ca04
   md5: 21f56217d6125fb30c3c3f10c786d751
@@ -6592,6 +7301,69 @@ packages:
   license_family: BSD
   size: 354697
   timestamp: 1742433568506
+- conda_source: rattler[0ca6f4c8] @ crates/rattler-bin
+  variants:
+    c_compiler: vs2022
+    rust_compiler_version: 1.95.0
+    target_platform: win-64
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: BSD-3-Clause
+  build_packages:
+  - conda: https://prefix.dev/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.95.0-h17fc481_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/vswhere-3.1.7-h40126e0_1.conda
+  - conda: https://prefix.dev/conda-forge/win-64/rust-1.95.0-hf8d6059_1.conda
+  - conda: https://prefix.dev/conda-forge/win-64/rust_win-64-1.95.0-h533a698_2.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vs2022_win-64-19.44.35207-ha74f236_38.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vs_win-64-2022.14-ha74f236_38.conda
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+  - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+- conda_source: rattler[269e468a] @ crates/rattler-bin
+  variants:
+    rust_compiler_version: 1.95.0
+    target_platform: osx-64
+  constrains:
+  - __osx >=11.0
+  license: BSD-3-Clause
+  build_packages:
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/compiler-rt22_osx-64-22.1.7-hcf80936_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-64-22.1.7-h694c41f_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/macosx_deployment_target_osx-64-26.0-hb5ce262_7.conda
+  - conda: https://prefix.dev/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.95.0-h38e4360_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/sdkroot_env_osx-64-26.0-h62b880e_7.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/cctools_impl_osx-64-1030.6.3-llvm22_1_h8fe25a2_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/cctools_osx-64-1030.6.3-llvm22_1_h0a1bb1c_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/clang-22-22.1.7-default_h3b8fe2e_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/clang_impl_osx-64-22.1.7-default_hb18168d_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/clang_osx-64-22.1.7-hb0d1528_32.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/compiler-rt-22.1.7-h694c41f_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/compiler-rt22-22.1.7-h1637cdf_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/ld64_osx-64-956.6-llvm22_1_h163eae7_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libclang-cpp22.1-22.1.7-default_h9399c5b_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libcompiler-rt-22.1.7-h1637cdf_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libcxx-22.1.7-h19cb2f5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libiconv-1.18-h57a12c2_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libllvm22-22.1.7-hab754da_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libsigtool-0.1.3-hc0f2934_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libxml2-16-2.15.3-h0d7f165_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libxml2-2.15.3-h0712280_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-22-22.1.7-hc181bea_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/llvm-tools-22.1.7-h1637cdf_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/openssl-3.6.2-hc881268_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/rust-1.95.0-h5655b98_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/rust_osx-64-1.95.0-hce10650_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/sigtool-codesign-0.1.3-hc0f2934_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/tapi-1600.0.11.8-h8d8e812_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
 - conda_source: rattler[3dca0d54] @ crates/rattler-bin
   variants:
     rust_compiler_version: 1.95.0
@@ -6684,6 +7456,47 @@ packages:
   - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
   - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+- conda_source: rattler[6f9e045e] @ crates/rattler-bin
+  variants:
+    rust_compiler_version: 1.95.0
+    target_platform: osx-arm64
+  constrains:
+  - __osx >=11.0
+  license: BSD-3-Clause
+  build_packages:
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/compiler-rt22_osx-arm64-22.1.7-h7e67a1e_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/compiler-rt_osx-arm64-22.1.7-hce30654_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/macosx_deployment_target_osx-arm64-26.0-h445c915_7.conda
+  - conda: https://prefix.dev/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.95.0-hf6ec828_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/sdkroot_env_osx-arm64-26.0-ha3f98da_7.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/cctools_impl_osx-arm64-1030.6.3-llvm22_1_hb5e89dc_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/cctools_osx-arm64-1030.6.3-llvm22_1_hbe26303_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/clang-22-22.1.7-default_hd632d02_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/clang_impl_osx-arm64-22.1.7-default_h17d1ed9_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/clang_osx-arm64-22.1.7-hf119d2b_32.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt-22.1.7-hce30654_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/compiler-rt22-22.1.7-hd34ed20_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ld64_osx-arm64-956.6-llvm22_1_h692d5aa_4.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libclang-cpp22.1-22.1.7-default_h8e162e0_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libcompiler-rt-22.1.7-hd34ed20_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libcxx-22.1.7-h55c6f16_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libiconv-1.18-h23cfdf5_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libllvm22-22.1.7-h89af1be_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libsigtool-0.1.3-h98dc951_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-16-2.15.3-h6967ea9_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libxml2-2.15.3-heed7d32_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-22-22.1.7-hb545844_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/llvm-tools-22.1.7-hd34ed20_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/ncurses-6.6-h1d4f5a5_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/openssl-3.6.2-hd24854e_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/rust-1.95.0-h4ff7c5d_1.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/rust_osx-arm64-1.95.0-h9bac32b_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/sigtool-codesign-0.1.3-h98dc951_0.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/tapi-1600.0.11.8-h997e182_2.conda
+  - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
 - conda_source: rattler[9e891123] @ crates/rattler-bin
   variants:
     c_compiler: vs2022
@@ -6705,6 +7518,59 @@ packages:
   - conda: https://prefix.dev/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
   - conda: https://prefix.dev/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
   - conda: https://prefix.dev/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
+- conda_source: rattler[f538e55a] @ crates/rattler-bin
+  variants:
+    rust_compiler_version: 1.95.0
+    target_platform: linux-64
+  depends:
+  - libgcc >=15
+  constrains:
+  - __glibc >=2.17
+  license: BSD-3-Clause
+  build_packages:
+  - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/binutils_impl_linux-64-2.45.1-default_hfdba357_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/binutils_linux-64-2.45.1-default_h4852527_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/cmake-3.31.8-hc85cc9f_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gcc_impl_linux-64-15.2.0-ha6850e4_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/gcc_linux-64-15.2.0-h7be306e_25.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/krb5-1.22.2-ha1258a1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_102.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libcurl-8.20.0-hcf29cc6_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libexpat-2.8.1-hecca717_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/liblzma-5.8.3-hb03c661_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libnghttp2-1.68.1-h877daf1_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libsanitizer-15.2.0-h90f66d4_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libuv-1.52.1-h280c20c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/make-4.4.1-hb9d3cd8_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/rhash-1.4.6-hb9d3cd8_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/rust-1.95.0-h53717f1_1.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/rust_linux-64-1.95.0-hb4ea61c_2.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+  - conda: https://prefix.dev/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
+  - conda: https://prefix.dev/conda-forge/noarch/kernel-headers_linux-64-4.18.0-he073ed8_9.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libgcc-devel_linux-64-15.2.0-hcc6f6b0_119.conda
+  - conda: https://prefix.dev/conda-forge/noarch/libstdcxx-devel_linux-64-15.2.0-hd446a21_119.conda
+  - conda: https://prefix.dev/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.95.0-h2c6d0dc_1.conda
+  - conda: https://prefix.dev/conda-forge/noarch/sysroot_linux-64-2.28-h4ee821c_9.conda
+  - conda: https://prefix.dev/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+  host_packages:
+  - conda: https://prefix.dev/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
+  - conda: https://prefix.dev/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
 - conda_source: rattler[fb666d63] @ crates/rattler-bin
   variants:
     rust_compiler_version: 1.95.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -114,3 +114,17 @@ e2e-s3-aws = "nu scripts/e2e/s3-aws.nu"
 [environments.s3]
 features = ["s3"]
 no-default-feature = true
+
+#------------------------------
+# prefix.dev OIDC E2E test
+#------------------------------
+[feature.prefix-dev-e2e.dependencies]
+rattler = { path = "crates/rattler-bin" }
+nushell = ">=0.106.1,<0.107"
+
+[feature.prefix-dev-e2e.tasks]
+e2e-prefix-dev = "nu scripts/e2e/prefix-dev-oidc.nu"
+
+[environments.prefix-dev-e2e]
+features = ["prefix-dev-e2e"]
+no-default-feature = true

--- a/scripts/e2e/prefix-dev-oidc.nu
+++ b/scripts/e2e/prefix-dev-oidc.nu
@@ -84,13 +84,20 @@ let oidc_token = (
     fail "could not fetch the GitHub Actions OIDC token — runner/permissions problem"
   }
 )
-let minted = (
+let mint_resp = (
   try {
-    http post --max-time 30sec --content-type application/json $"($host)/api/oidc/mint_token" { token: $oidc_token }
+    http post --full --allow-errors --max-time 30sec --content-type application/json $"($host)/api/oidc/mint_token" { token: $oidc_token }
   } catch {
-    fail $"mint endpoint ($host)/api/oidc/mint_token rejected the OIDC token — check the repository-access config \(repo + audience ($audience)\) on the server"
+    fail $"mint endpoint ($host)/api/oidc/mint_token unreachable — connection/DNS failure"
   }
 )
+if $mint_resp.status != 200 {
+  # The server's error body is a plain diagnostic message (never a token);
+  # truncate defensively so a surprising body cannot dump a credential.
+  let detail = ($mint_resp.body | into string | str substring 0..300)
+  fail $"mint endpoint ($host)/api/oidc/mint_token rejected the OIDC token \(status ($mint_resp.status)\): ($detail) — check the repository-access config \(repo + workflow + audience ($audience)\) on the server"
+}
+let minted = $mint_resp.body
 if ($minted | describe) != "string" {
   fail "mint endpoint returned a non-string response (expected the raw token)"
 }

--- a/scripts/e2e/prefix-dev-oidc.nu
+++ b/scripts/e2e/prefix-dev-oidc.nu
@@ -9,7 +9,7 @@
 #   4. anonymous challenge check   -> server WWW-Authenticate behavior
 #   5. challenge-reactive read     -> AuthChallengeMiddleware / TrustedPublishingFlow
 
-let host = ($env.PREFIX_DEV_E2E_HOST? | default "https://beta.prefix.dev")
+let host = ($env.PREFIX_DEV_E2E_HOST? | default "https://beta.prefix.dev" | str trim --right --char "/")
 let channel = ($env.PREFIX_DEV_E2E_CHANNEL? | default "rattler-e2e")
 let package_file = "test-data/packages/empty-0.1.0-h4616a5c_0.conda"
 let package_filename = "empty-0.1.0-h4616a5c_0.conda"
@@ -28,6 +28,28 @@ def must [desc: string, indicts: string, cmd: closure] {
   if $code != 0 {
     fail $"($desc) failed \(exit=($code)\) — ($indicts)"
   }
+}
+
+def check_challenge [url: string] {
+  let resp = (
+    try {
+      http get --full --allow-errors --max-time 30sec $url
+    } catch {
+      fail $"Step 4: could not reach ($url) — connection/DNS failure"
+    }
+  )
+  if not ($resp.status in [401 403]) {
+    fail $"expected 401/403 for anonymous access to ($url), got ($resp.status) — is the channel private?"
+  }
+  let www = ($resp.headers.response | where name == "www-authenticate")
+  if ($www | is-empty) {
+    fail $"got ($resp.status) for ($url) but no WWW-Authenticate header — the server does not fire the challenge"
+  }
+  let www_value = ($www | first | get value)
+  if not ($www_value | str downcase | str contains "bearer") {
+    fail $"WWW-Authenticate present for ($url) but without a Bearer scheme: ($www_value)"
+  }
+  print $"   ($url) challenged with: ($www_value)"
 }
 
 # -- Step 0: preconditions ---------------------------------------------------
@@ -92,26 +114,10 @@ must $"Step 3: rattler upload prefix to ($host)/($channel)" "proactive OIDC uplo
 }
 
 # -- Step 4: the server must fire the challenge for anonymous access ----------
-print "== Step 4: anonymous request must be challenged with WWW-Authenticate"
-let resp = (
-  try {
-    http get --full --allow-errors --max-time 30sec $"($host)/($channel)/noarch/repodata.json"
-  } catch {
-    fail $"Step 4: could not reach ($host) — connection/DNS failure"
-  }
-)
-if not ($resp.status in [401 403]) {
-  fail $"expected 401/403 for anonymous access, got ($resp.status) — is the channel private?"
-}
-let www = ($resp.headers.response | where name == "www-authenticate")
-if ($www | is-empty) {
-  fail $"got ($resp.status) but no WWW-Authenticate header — the server does not fire the challenge"
-}
-let www_value = ($www | first | get value)
-if not ($www_value | str downcase | str contains "bearer") {
-  fail $"WWW-Authenticate present but without a Bearer scheme: ($www_value)"
-}
-print $"   challenged with: ($www_value)"
+print "== Step 4: anonymous requests must be challenged with WWW-Authenticate"
+check_challenge $"($host)/($channel)/noarch/repodata.json"
+# The CLI's first request goes to the sharded index; it must be challenged too.
+check_challenge $"($host)/($channel)/noarch/repodata_shards.msgpack.zst"
 
 # -- Step 5: the actual challenge-reactive read through the rattler CLI -------
 must $"Step 5: rattler create --dry-run from ($host)/($channel)" "challenge-reactive read path (AuthChallengeMiddleware / TrustedPublishingFlow)" {

--- a/scripts/e2e/prefix-dev-oidc.nu
+++ b/scripts/e2e/prefix-dev-oidc.nu
@@ -31,18 +31,32 @@ def must [desc: string, indicts: string, cmd: closure] {
 }
 
 # -- Step 0: preconditions ---------------------------------------------------
+# Hosted runners have an empty keyring; guard the file-based sources that
+# could otherwise satisfy auth and silently bypass the challenge path.
+# Default FileStorage path: ~/.rattler/credentials.json
+# (see crates/rattler_networking/src/authentication_storage/backends/file.rs)
 if ($env.RATTLER_AUTH_FILE? | default "" | is-not-empty) {
   fail "RATTLER_AUTH_FILE is set; this test must run without stored credentials"
 }
+if ($env.NETRC? | default "" | is-not-empty) {
+  fail "NETRC is set; this test must run without stored credentials"
+}
+let default_credentials = ($nu.home-path | path join ".rattler" "credentials.json")
+if ($default_credentials | path exists) {
+  fail $"($default_credentials) exists; this test must run without stored credentials"
+}
 if ($env.ACTIONS_ID_TOKEN_REQUEST_URL? | default "" | is-empty) {
   fail "ACTIONS_ID_TOKEN_REQUEST_URL missing; the job needs `permissions: id-token: write`"
+}
+if ($env.ACTIONS_ID_TOKEN_REQUEST_TOKEN? | default "" | is-empty) {
+  fail "ACTIONS_ID_TOKEN_REQUEST_TOKEN missing; the job needs `permissions: id-token: write`"
 }
 
 # -- Step 1: independent mint (proves server half without any rattler code) --
 print $"== Step 1: independent OIDC mint against ($host) \(audience ($audience)\)"
 let oidc_token = (
   try {
-    http get --headers [Authorization $"bearer ($env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)"] $"($env.ACTIONS_ID_TOKEN_REQUEST_URL)&audience=($audience)"
+    http get --max-time 30sec --headers [Authorization $"bearer ($env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)"] $"($env.ACTIONS_ID_TOKEN_REQUEST_URL)&audience=($audience)"
       | get value
   } catch {
     fail "could not fetch the GitHub Actions OIDC token — runner/permissions problem"
@@ -50,12 +64,15 @@ let oidc_token = (
 )
 let minted = (
   try {
-    http post --content-type application/json $"($host)/api/oidc/mint_token" { token: $oidc_token }
+    http post --max-time 30sec --content-type application/json $"($host)/api/oidc/mint_token" { token: $oidc_token }
   } catch {
     fail $"mint endpoint ($host)/api/oidc/mint_token rejected the OIDC token — check the repository-access config \(repo + audience ($audience)\) on the server"
   }
 )
-if not ($minted | into string | str starts-with "pfx-jwt") {
+if ($minted | describe) != "string" {
+  fail "mint endpoint returned a non-string response (expected the raw token)"
+}
+if not ($minted | str starts-with "pfx-jwt") {
   fail "mint endpoint returned something that is not a pfx-jwt token"
 }
 print "   minted a short-lived token: server mint + repository access OK"
@@ -63,7 +80,7 @@ print "   minted a short-lived token: server mint + repository access OK"
 # -- Step 2: best-effort cleanup of a previous run's package ------------------
 print "== Step 2: best-effort cleanup of previous package"
 try {
-  http delete --headers [Authorization $"Bearer ($minted)"] $"($host)/api/v1/delete/($channel)/noarch/($package_filename)"
+  http delete --max-time 30sec --headers [Authorization $"Bearer ($minted)"] $"($host)/api/v1/delete/($channel)/noarch/($package_filename)"
   print "   deleted previous package"
 } catch {
   print "   nothing to delete (or delete refused) — continuing; upload uses --skip-existing"
@@ -76,7 +93,13 @@ must $"Step 3: rattler upload prefix to ($host)/($channel)" "proactive OIDC uplo
 
 # -- Step 4: the server must fire the challenge for anonymous access ----------
 print "== Step 4: anonymous request must be challenged with WWW-Authenticate"
-let resp = (http get --full --allow-errors $"($host)/($channel)/noarch/repodata.json")
+let resp = (
+  try {
+    http get --full --allow-errors --max-time 30sec $"($host)/($channel)/noarch/repodata.json"
+  } catch {
+    fail $"Step 4: could not reach ($host) — connection/DNS failure"
+  }
+)
 if not ($resp.status in [401 403]) {
   fail $"expected 401/403 for anonymous access, got ($resp.status) — is the channel private?"
 }

--- a/scripts/e2e/prefix-dev-oidc.nu
+++ b/scripts/e2e/prefix-dev-oidc.nu
@@ -1,0 +1,98 @@
+#!/usr/bin/env nu
+# End-to-end test of the prefix.dev OIDC flow (see
+# docs/superpowers/specs/2026-06-11-prefix-dev-oidc-e2e-design.md).
+#
+# Steps are ordered so the first failure names the broken component:
+#   1. independent mint            -> repository-access config / mint endpoint
+#   2. best-effort cleanup         -> (tolerant)
+#   3. upload (proactive OIDC)     -> rattler_upload audience / write scope
+#   4. anonymous challenge check   -> server WWW-Authenticate behavior
+#   5. challenge-reactive read     -> AuthChallengeMiddleware / TrustedPublishingFlow
+
+let host = ($env.PREFIX_DEV_E2E_HOST? | default "https://beta.prefix.dev")
+let channel = ($env.PREFIX_DEV_E2E_CHANNEL? | default "rattler-e2e")
+let package_file = "test-data/packages/empty-0.1.0-h4616a5c_0.conda"
+let package_filename = "empty-0.1.0-h4616a5c_0.conda"
+let audience = ($host | url parse | get host)
+
+def fail [msg: string] {
+  print $"FAIL: ($msg)"
+  exit 1
+}
+
+# Run an external command; hard-fail with `indicts` if it exits non-zero.
+def must [desc: string, indicts: string, cmd: closure] {
+  print $"== ($desc)"
+  try { do $cmd } catch { }
+  let code = ($env.LAST_EXIT_CODE? | default 0)
+  if $code != 0 {
+    fail $"($desc) failed \(exit=($code)\) — ($indicts)"
+  }
+}
+
+# -- Step 0: preconditions ---------------------------------------------------
+if ($env.RATTLER_AUTH_FILE? | default "" | is-not-empty) {
+  fail "RATTLER_AUTH_FILE is set; this test must run without stored credentials"
+}
+if ($env.ACTIONS_ID_TOKEN_REQUEST_URL? | default "" | is-empty) {
+  fail "ACTIONS_ID_TOKEN_REQUEST_URL missing; the job needs `permissions: id-token: write`"
+}
+
+# -- Step 1: independent mint (proves server half without any rattler code) --
+print $"== Step 1: independent OIDC mint against ($host) \(audience ($audience)\)"
+let oidc_token = (
+  try {
+    http get --headers [Authorization $"bearer ($env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)"] $"($env.ACTIONS_ID_TOKEN_REQUEST_URL)&audience=($audience)"
+      | get value
+  } catch {
+    fail "could not fetch the GitHub Actions OIDC token — runner/permissions problem"
+  }
+)
+let minted = (
+  try {
+    http post --content-type application/json $"($host)/api/oidc/mint_token" { token: $oidc_token }
+  } catch {
+    fail $"mint endpoint ($host)/api/oidc/mint_token rejected the OIDC token — check the repository-access config \(repo + audience ($audience)\) on the server"
+  }
+)
+if not ($minted | into string | str starts-with "pfx-jwt") {
+  fail "mint endpoint returned something that is not a pfx-jwt token"
+}
+print "   minted a short-lived token: server mint + repository access OK"
+
+# -- Step 2: best-effort cleanup of a previous run's package ------------------
+print "== Step 2: best-effort cleanup of previous package"
+try {
+  http delete --headers [Authorization $"Bearer ($minted)"] $"($host)/api/v1/delete/($channel)/noarch/($package_filename)"
+  print "   deleted previous package"
+} catch {
+  print "   nothing to delete (or delete refused) — continuing; upload uses --skip-existing"
+}
+
+# -- Step 3: upload through the proactive trusted-publishing path -------------
+must $"Step 3: rattler upload prefix to ($host)/($channel)" "proactive OIDC upload path (rattler_upload audience or write scope)" {
+  ^rattler upload prefix --url $host --channel $channel --skip-existing $package_file
+}
+
+# -- Step 4: the server must fire the challenge for anonymous access ----------
+print "== Step 4: anonymous request must be challenged with WWW-Authenticate"
+let resp = (http get --full --allow-errors $"($host)/($channel)/noarch/repodata.json")
+if not ($resp.status in [401 403]) {
+  fail $"expected 401/403 for anonymous access, got ($resp.status) — is the channel private?"
+}
+let www = ($resp.headers.response | where name == "www-authenticate")
+if ($www | is-empty) {
+  fail $"got ($resp.status) but no WWW-Authenticate header — the server does not fire the challenge"
+}
+let www_value = ($www | first | get value)
+if not ($www_value | str downcase | str contains "bearer") {
+  fail $"WWW-Authenticate present but without a Bearer scheme: ($www_value)"
+}
+print $"   challenged with: ($www_value)"
+
+# -- Step 5: the actual challenge-reactive read through the rattler CLI -------
+must $"Step 5: rattler create --dry-run from ($host)/($channel)" "challenge-reactive read path (AuthChallengeMiddleware / TrustedPublishingFlow)" {
+  ^rattler create --dry-run -c $"($host)/($channel)" "empty==0.1.0"
+}
+
+print "== SUCCESS: full OIDC circle (independent mint, upload, challenge, reactive read) passed"

--- a/scripts/e2e/prefix-dev-oidc.nu
+++ b/scripts/e2e/prefix-dev-oidc.nu
@@ -13,7 +13,15 @@ let host = ($env.PREFIX_DEV_E2E_HOST? | default "https://beta.prefix.dev" | str 
 let channel = ($env.PREFIX_DEV_E2E_CHANNEL? | default "rattler-e2e")
 let package_file = "test-data/packages/empty-0.1.0-h4616a5c_0.conda"
 let package_filename = "empty-0.1.0-h4616a5c_0.conda"
-let audience = ($host | url parse | get host)
+# prefix.dev deployments (prefix.dev and *.prefix.dev, e.g. beta) all validate
+# GitHub OIDC tokens against the shared audience "prefix.dev"; other hosts use
+# their own host name. Mirrors TrustedPublishingOptions::for_server.
+let host_name = ($host | url parse | get host)
+let audience = if ($host_name == "prefix.dev") or ($host_name | str ends-with ".prefix.dev") {
+  "prefix.dev"
+} else {
+  $host_name
+}
 
 def fail [msg: string] {
   print $"FAIL: ($msg)"

--- a/scripts/e2e/prefix-dev-oidc.nu
+++ b/scripts/e2e/prefix-dev-oidc.nu
@@ -114,13 +114,22 @@ if not ($minted | str starts-with "pfx-jwt") {
 }
 print "   minted a short-lived token: server mint + repository access OK"
 
+# Bring-up escape hatch: skip the write steps (2 and 3) while the upload
+# endpoint's 403 for minted tokens is under investigation server-side. The
+# read-path verification (steps 4-5) is what fixes pixi#6318 and stands alone.
+let skip_upload = (($env.PREFIX_DEV_E2E_SKIP_UPLOAD? | default "") == "true")
+
 # -- Step 2: best-effort cleanup of a previous run's package ------------------
-print "== Step 2: best-effort cleanup of previous package"
-try {
-  http delete --max-time 30sec --headers [Authorization $"Bearer ($minted)"] $"($host)/api/v1/delete/($channel)/noarch/($package_filename)"
-  print "   deleted previous package"
-} catch {
-  print "   nothing to delete (or delete refused) — continuing; upload uses --skip-existing"
+if $skip_upload {
+  print "== Step 2: SKIPPED (PREFIX_DEV_E2E_SKIP_UPLOAD)"
+} else {
+  print "== Step 2: best-effort cleanup of previous package"
+  try {
+    http delete --max-time 30sec --headers [Authorization $"Bearer ($minted)"] $"($host)/api/v1/delete/($channel)/noarch/($package_filename)"
+    print "   deleted previous package"
+  } catch {
+    print "   nothing to delete (or delete refused) — continuing; upload uses --skip-existing"
+  }
 }
 
 # -- Step 2b: diagnostic — what can the minted token actually do? -------------
@@ -139,8 +148,12 @@ let probe = (
 print $"   authenticated GET ($channel)/noarch/repodata.json -> status ($probe.status)"
 
 # -- Step 3: upload through the proactive trusted-publishing path -------------
-must $"Step 3: rattler upload prefix to ($host)/($channel)" "proactive OIDC upload path (rattler_upload audience or write scope)" {
-  ^rattler upload prefix --url $host --channel $channel --skip-existing $package_file
+if $skip_upload {
+  print "== Step 3: SKIPPED (PREFIX_DEV_E2E_SKIP_UPLOAD)"
+} else {
+  must $"Step 3: rattler upload prefix to ($host)/($channel)" "proactive OIDC upload path (rattler_upload audience or write scope)" {
+    ^rattler upload prefix --url $host --channel $channel --skip-existing $package_file
+  }
 }
 
 # -- Step 4: the server must fire the challenge for anonymous access ----------
@@ -150,8 +163,25 @@ check_challenge $"($host)/($channel)/noarch/repodata.json"
 check_challenge $"($host)/($channel)/noarch/repodata_shards.msgpack.zst"
 
 # -- Step 5: the actual challenge-reactive read through the rattler CLI -------
-must $"Step 5: rattler create --dry-run from ($host)/($channel)" "challenge-reactive read path (AuthChallengeMiddleware / TrustedPublishingFlow)" {
-  ^rattler create --dry-run -c $"($host)/($channel)" "empty==0.1.0"
+# Step 0 removed every stored-credential source and step 4 proved anonymous
+# access is rejected, so the only way this solve can see the repodata is the
+# middleware reacting to the WWW-Authenticate challenge (mint + replay).
+print $"== Step 5: rattler create --dry-run from ($host)/($channel) \(challenge-reactive read\)"
+let create = (do { ^rattler create --dry-run -c $"($host)/($channel)" "empty==0.1.0" } | complete)
+let combined = ($create.stdout + "\n" + $create.stderr)
+if $create.exit_code == 0 {
+  print "   solved through the challenge-reactive path"
+  print "== SUCCESS: OIDC circle (independent mint, challenge, reactive read) passed"
+} else if ($combined | str downcase | str contains "no candidates") {
+  # A "no candidates" solve error means the repodata download itself
+  # SUCCEEDED (an auth failure would surface as a 401/download error):
+  # the challenge-reactive auth path is verified; only the test package
+  # is missing from the channel.
+  print "   AUTH PATH VERIFIED: repodata was fetched through the challenge-reactive"
+  print "   path, but the channel does not contain the test package yet."
+  print "   Upload empty-0.1.0 (manually or once step 3 works) for the full circle."
+  print "== SUCCESS (read-path verification): challenge-reactive auth works"
+} else {
+  print ($combined | lines | last 25 | str join "\n")
+  fail "Step 5: challenge-reactive read failed — AuthChallengeMiddleware / TrustedPublishingFlow (see output above)"
 }
-
-print "== SUCCESS: full OIDC circle (independent mint, upload, challenge, reactive read) passed"

--- a/scripts/e2e/prefix-dev-oidc.nu
+++ b/scripts/e2e/prefix-dev-oidc.nu
@@ -123,6 +123,21 @@ try {
   print "   nothing to delete (or delete refused) — continuing; upload uses --skip-existing"
 }
 
+# -- Step 2b: diagnostic — what can the minted token actually do? -------------
+# An authenticated read with the minted token discriminates failure modes:
+# 200 = token is scoped to the channel (a later write failure means scope),
+# 401/403 = token not authorized for this channel at all (wrong attachment),
+# 404 = channel/namespace mismatch.
+print "== Step 2b: authenticated read probe with the minted token"
+let probe = (
+  try {
+    http get --full --allow-errors --max-time 30sec --headers [Authorization $"Bearer ($minted)"] $"($host)/($channel)/noarch/repodata.json"
+  } catch {
+    fail $"Step 2b: could not reach ($host) — connection/DNS failure"
+  }
+)
+print $"   authenticated GET ($channel)/noarch/repodata.json -> status ($probe.status)"
+
 # -- Step 3: upload through the proactive trusted-publishing path -------------
 must $"Step 3: rattler upload prefix to ($host)/($channel)" "proactive OIDC upload path (rattler_upload audience or write scope)" {
   ^rattler upload prefix --url $host --channel $channel --skip-existing $package_file


### PR DESCRIPTION
## Summary

Stacked on #2504 — the first 14 commits are that PR's `AuthChallengeMiddleware` work and will disappear from this diff once it merges. New here:

- `TrustedPublishingOptions::for_host` / `for_server`: derive the mint endpoint from the upload/channel host, with the fixed `prefix.dev` audience that prefix.dev deployments validate GitHub OIDC tokens against (not per-host).
- `rattler_upload`: derive the trusted publishing audience from the upload host instead of hardcoding it.
- `rattler-bin`: wire `AuthChallengeMiddleware` for prefix.dev channel hosts (port-aware middleware dedup).
- End-to-end test (`scripts/e2e/prefix-dev-oidc.nu` + `pixi run e2e-prefix-dev` + `workflow_dispatch` CI job) exercising the full challenge → mint → replay flow against a live prefix.dev deployment, with an authenticated-read probe and a `skip_upload` mode for read-path-only verification.

## Status

Verified live against beta.prefix.dev (2026-06-12): private-channel read path (401 challenge → OIDC token mint → authenticated replay) is green end to end. The upload leg currently returns 403 on beta for minted tokens that can read — under investigation server-side; `skip_upload=true` covers the read path until that's resolved.

Draft until #2504 lands; will rebase to shrink the diff to the e2e commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)