### PR TITLE
feat(lock): Add build and host environments to source data

### DIFF
--- a/crates/rattler_lock/src/conda.rs
+++ b/crates/rattler_lock/src/conda.rs
@@ -414,6 +414,22 @@ impl CondaSourceData<SourceMetadata> {
         }
     }
 
+    /// Returns the build environment packages for this source package.
+    ///
+    /// These are the packages (compilers, build tools, etc.) that were present
+    /// in the build environment when this source package was built.
+    pub fn build_packages(&self) -> &crate::EnvironmentPackages {
+        &self.source_data.build_packages
+    }
+
+    /// Returns the host environment packages for this source package.
+    ///
+    /// These are the packages (libraries to link against, etc.) that were
+    /// present in the host environment when this source package was built.
+    pub fn host_packages(&self) -> &crate::EnvironmentPackages {
+        &self.source_data.host_packages
+    }
+
     /// Attempts to convert into a `CondaSourceData<PackageRecord>`.
     /// Returns `None` if the metadata is partial.
     pub fn into_full(self) -> Option<CondaSourceData<PackageRecord>> {
@@ -440,13 +456,41 @@ impl CondaSourceData<SourceMetadata> {
         package_record: PackageRecord,
         sources: BTreeMap<String, SourceLocation>,
     ) -> Self {
+        Self::full_with_source_data(
+            location,
+            package_build_source,
+            variants,
+            identifier_hash,
+            package_record,
+            sources,
+            SourceData::default(),
+        )
+    }
+
+    /// Convenience constructor for a full source data with explicit build and
+    /// host environment packages.
+    ///
+    /// Use this when you already have the resolved build and host environments
+    /// (e.g. when reconstructing from a lockfile). For building new source
+    /// packages, prefer [`crate::builder::LockFileBuilder::register_conda_source_package`]
+    /// which validates the package handles.
+    #[allow(clippy::too_many_arguments)]
+    pub fn full_with_source_data(
+        location: UrlOrPath,
+        package_build_source: Option<PackageBuildSource>,
+        variants: BTreeMap<String, VariantValue>,
+        identifier_hash: Option<String>,
+        package_record: PackageRecord,
+        sources: BTreeMap<String, SourceLocation>,
+        source_data: SourceData,
+    ) -> Self {
         Self {
             location,
             package_build_source,
             variants,
             identifier_hash,
             sources,
-            source_data: SourceData::default(),
+            source_data,
             metadata: SourceMetadata::Full(Box::new(package_record)),
         }
     }

--- a/py-rattler/rattler/lock/package.py
+++ b/py-rattler/rattler/lock/package.py
@@ -261,7 +261,65 @@ class PypiLockedPackage(LockedPackage):
 class CondaLockedSourcePackage(CondaLockedPackage):
     """
     A locked conda source package in a lock file.
+
+    Source packages contain references to the build and host environment
+    packages that were used when building the package. These can be
+    accessed via the `build_packages` and `host_packages` properties.
     """
+
+    @property
+    def build_packages(self) -> List[LockedPackage]:
+        """
+        Returns the packages from the build environment of this source package.
+
+        These are the packages (compilers, build tools, etc.) that were present
+        in the build environment when this source package was built.
+
+        Returns an empty list if no build packages were recorded.
+
+        Examples
+        --------
+        ```python
+        >>> from rattler import LockFile
+        >>> lock_file = LockFile.from_path("pixi.lock")
+        >>> env = lock_file.default_environment()
+        >>> for platform in env.platforms():
+        ...     for pkg in env.packages(platform):
+        ...         if isinstance(pkg, CondaLockedSourcePackage):
+        ...             for bp in pkg.build_packages:
+        ...                 print(f"  build dep: {bp.name}")
+        ...
+        >>>
+        ```
+        """
+        return [LockedPackage._from_py_locked_package(p) for p in self._package.build_packages]
+
+    @property
+    def host_packages(self) -> List[LockedPackage]:
+        """
+        Returns the packages from the host environment of this source package.
+
+        These are the packages (libraries to link against, etc.) that were
+        present in the host environment when this source package was built.
+
+        Returns an empty list if no host packages were recorded.
+
+        Examples
+        --------
+        ```python
+        >>> from rattler import LockFile
+        >>> lock_file = LockFile.from_path("pixi.lock")
+        >>> env = lock_file.default_environment()
+        >>> for platform in env.platforms():
+        ...     for pkg in env.packages(platform):
+        ...         if isinstance(pkg, CondaLockedSourcePackage):
+        ...             for hp in pkg.host_packages:
+        ...                 print(f"  host dep: {hp.name}")
+        ...
+        >>>
+        ```
+        """
+        return [LockedPackage._from_py_locked_package(p) for p in self._package.host_packages]
 
 
 class CondaLockedBinaryPackage(CondaLockedPackage):

--- a/py-rattler/src/lock/mod.rs
+++ b/py-rattler/src/lock/mod.rs
@@ -517,9 +517,13 @@ impl PyEnvironment {
 
     /// Returns all the packages for a specific platform in this environment.
     pub fn packages(&self, platform: PyLockPlatform) -> Option<Vec<PyLockedPackage>> {
-        self.as_ref()
-            .packages(platform.platform())
-            .map(|packages| packages.cloned().map(Into::into).collect())
+        let lock_file = self.environment.lock_file();
+        self.as_ref().packages(platform.platform()).map(|packages| {
+            packages
+                .cloned()
+                .map(|pkg| PyLockedPackage::with_lock_file(pkg, lock_file.clone()))
+                .collect()
+        })
     }
 
     /// Returns a list of all packages and platforms defined for this
@@ -531,7 +535,9 @@ impl PyEnvironment {
             .map(|(platform, pkgs)| {
                 (
                     platform.to_owned(&lock_file).into(),
-                    pkgs.cloned().map(Into::into).collect(),
+                    pkgs.cloned()
+                        .map(|pkg| PyLockedPackage::with_lock_file(pkg, lock_file.clone()))
+                        .collect(),
                 )
             })
             .collect()
@@ -539,11 +545,17 @@ impl PyEnvironment {
 
     /// Returns all pypi packages for all platforms
     pub fn pypi_packages(&self) -> HashMap<String, Vec<PyLockedPackage>> {
+        let lock_file = self.environment.lock_file();
         self.as_ref()
             .pypi_packages_by_platform()
             .map(|(platform, data_vec)| {
                 let data = data_vec
-                    .map(|pkg_data| PyLockedPackage::from(LockedPackage::Pypi(pkg_data.clone())))
+                    .map(|pkg_data| {
+                        PyLockedPackage::with_lock_file(
+                            LockedPackage::Pypi(pkg_data.clone()),
+                            lock_file.clone(),
+                        )
+                    })
                     .collect::<Vec<_>>();
                 (platform.name().to_string(), data)
             })
@@ -591,11 +603,17 @@ impl PyEnvironment {
         &self,
         platform: PyLockPlatform,
     ) -> Option<Vec<PyLockedPackage>> {
+        let lock_file = self.environment.lock_file();
         self.as_ref()
             .pypi_packages(platform.platform())
             .map(|data| {
-                data.map(|pkg| PyLockedPackage::from(LockedPackage::Pypi(pkg.clone())))
-                    .collect()
+                data.map(|pkg| {
+                    PyLockedPackage::with_lock_file(
+                        LockedPackage::Pypi(pkg.clone()),
+                        lock_file.clone(),
+                    )
+                })
+                .collect()
             })
     }
 }
@@ -642,15 +660,31 @@ impl PyLockChannel {
 }
 
 #[pyclass]
-#[repr(transparent)]
 #[derive(Clone)]
 pub struct PyLockedPackage {
     pub(crate) inner: LockedPackage,
+    /// Optional reference to the parent lock file, needed to resolve
+    /// build/host package handles in source packages.
+    lock_file: Option<LockFile>,
+}
+
+impl PyLockedPackage {
+    /// Creates a `PyLockedPackage` that carries a reference to the lock file
+    /// it originated from, enabling resolution of build/host packages.
+    fn with_lock_file(inner: LockedPackage, lock_file: LockFile) -> Self {
+        Self {
+            inner,
+            lock_file: Some(lock_file),
+        }
+    }
 }
 
 impl From<LockedPackage> for PyLockedPackage {
     fn from(value: LockedPackage) -> Self {
-        Self { inner: value }
+        Self {
+            inner: value,
+            lock_file: None,
+        }
     }
 }
 
@@ -785,6 +819,70 @@ impl PyLockedPackage {
     #[getter]
     pub fn is_pypi(&self) -> bool {
         matches!(&self.inner, LockedPackage::Pypi(..))
+    }
+
+    /// Returns the packages from the build environment of this source package.
+    ///
+    /// These are the packages (compilers, build tools, etc.) that were present
+    /// in the build environment when this source package was built.
+    ///
+    /// Returns an empty list for binary or pypi packages.
+    /// Raises an error if the package was not loaded from a lock file.
+    #[getter]
+    pub fn build_packages(&self) -> PyResult<Vec<PyLockedPackage>> {
+        let source = match &self.inner {
+            LockedPackage::Conda(CondaPackageData::Source(data)) => data,
+            _ => return Ok(vec![]),
+        };
+        if source.build_packages().is_empty() {
+            return Ok(vec![]);
+        }
+        let lock_file = self.lock_file.as_ref().ok_or_else(|| {
+            PyRattlerError::LockFileError(
+                "Cannot resolve build packages: package was not loaded from a lock file".into(),
+            )
+        })?;
+        source
+            .build_packages()
+            .iter(lock_file)
+            .map(|result| {
+                result
+                    .map(|pkg| PyLockedPackage::with_lock_file(pkg.clone(), lock_file.clone()))
+                    .map_err(|e| PyRattlerError::LockFileError(e.to_string()).into())
+            })
+            .collect()
+    }
+
+    /// Returns the packages from the host environment of this source package.
+    ///
+    /// These are the packages (libraries to link against, etc.) that were
+    /// present in the host environment when this source package was built.
+    ///
+    /// Returns an empty list for binary or pypi packages.
+    /// Raises an error if the package was not loaded from a lock file.
+    #[getter]
+    pub fn host_packages(&self) -> PyResult<Vec<PyLockedPackage>> {
+        let source = match &self.inner {
+            LockedPackage::Conda(CondaPackageData::Source(data)) => data,
+            _ => return Ok(vec![]),
+        };
+        if source.host_packages().is_empty() {
+            return Ok(vec![]);
+        }
+        let lock_file = self.lock_file.as_ref().ok_or_else(|| {
+            PyRattlerError::LockFileError(
+                "Cannot resolve host packages: package was not loaded from a lock file".into(),
+            )
+        })?;
+        source
+            .host_packages()
+            .iter(lock_file)
+            .map(|result| {
+                result
+                    .map(|pkg| PyLockedPackage::with_lock_file(pkg.clone(), lock_file.clone()))
+                    .map_err(|e| PyRattlerError::LockFileError(e.to_string()).into())
+            })
+            .collect()
     }
 }
 


### PR DESCRIPTION
### Description

This PR implements the storage of build and host environments directly in the conda source package data within the `rattler_lock` v7 format. 

By capturing both the build and host packages for source definitions, frontends like `pixi` and `rattler-build` can now achieve full reproducibility of source packages. This eliminates the need to rely on timestamps or other hacks to resolve stable dependencies for historically checked-out source packages.

**Changes:**
- Added `build_packages()` and `host_packages()` accessors to `CondaSourceData` to resolve selectors and expose concrete environment packages.
- Added a `full_with_source_data()` constructor for `CondaSourceData`.
- Enhanced `SourceIdentifier` hashing to include build and host packages for accurate deduplication.

Fixes #2340

### How Has This Been Tested?

- Added a comprehensive roundtrip test `test_source_package_build_host_roundtrip_with_accessors` in `rattler_lock/src/builder.rs`.
- The test verifies that `CondaSourceData` correctly captures the binary packages injected into the build/host fields.
- Validated serialization output with `insta` snapshots to ensure `build_packages` and `host_packages` are accurately persisted in the `v7` lockfile YAML format.
- Passed full test suite (`cargo nextest`), `cargo fmt`, and `cargo clippy`.

### AI Disclosure
AI tools were used for ideation, understanding the codebase architecture, and planning the approach (e.g., understanding how PackageHandle resolution works across the FFI boundary, figuring out the LockFile propagation pattern). The code was written and tested by me. The redundant test that was flagged has been removed - it was left over from the initial version of this PR before the py-rattler bindings were added as the core functionality.

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

