### PR TITLE
fix(rattler_index): use atomic writes for repodata.json to support memory-mapped files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5179,6 +5179,7 @@ dependencies = [
  "rattler_digest",
  "rattler_networking",
  "rattler_package_streaming",
+ "rattler_repodata_gateway",
  "rattler_s3",
  "reqwest 0.13.4",
  "retry-policies",

--- a/crates/rattler_index/Cargo.toml
+++ b/crates/rattler_index/Cargo.toml
@@ -77,5 +77,8 @@ zstd = { workspace = true }
 retry-policies = { workspace = true }
 
 [dev-dependencies]
+rattler_repodata_gateway = { path = "../rattler_repodata_gateway", default-features = false, features = [
+  "sparse",
+] }
 tempfile = { workspace = true }
 tools = { path = "../tools", default-features = false }

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -1385,7 +1385,15 @@ pub async fn index_fs_with_channel_metadata(
     channel_metadata: ChannelMetadata,
 ) -> anyhow::Result<()> {
     let mut config = FsConfig::default();
-    config.root = Some(channel.canonicalize()?.to_string_lossy().to_string());
+    let root = channel.canonicalize()?;
+    config.root = Some(root.to_string_lossy().to_string());
+    // Atomic writes: write to a temp dir on the same volume, then rename over
+    // the target. Avoids truncating files in place — required on Windows where a
+    // memory-mapped repodata.json cannot be resized (ERROR_USER_MAPPED_FILE 1224).
+    // The temp dir lives inside the channel root so it is on the same volume /
+    // network share, keeping the rename atomic; it is ignored when enumerating
+    // subdirs because `.tmp` does not parse as a `Platform`.
+    config.atomic_write_dir = Some(root.join(".tmp").to_string_lossy().to_string());
     let builder = config.into_builder();
     let op = Operator::new(builder)?.finish();
     index_with_channel_metadata(
@@ -1756,7 +1764,11 @@ pub async fn ensure_channel_initialized_fs_with_channel_metadata(
     channel_metadata: ChannelMetadata,
 ) -> anyhow::Result<()> {
     let mut config = FsConfig::default();
-    config.root = Some(channel.canonicalize()?.to_string_lossy().to_string());
+    let root = channel.canonicalize()?;
+    config.root = Some(root.to_string_lossy().to_string());
+    // Atomic writes: see the note in `index_fs_with_channel_metadata`. The temp
+    // dir lives inside the channel root so the rename stays on the same volume.
+    config.atomic_write_dir = Some(root.join(".tmp").to_string_lossy().to_string());
     let op = Operator::new(config.into_builder())?.finish();
     ensure_channel_initialized_with_channel_metadata(&op, channel_metadata).await
 }

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -1387,12 +1387,10 @@ pub async fn index_fs_with_channel_metadata(
     let mut config = FsConfig::default();
     let root = channel.canonicalize()?;
     config.root = Some(root.to_string_lossy().to_string());
-    // Atomic writes: write to a temp dir on the same volume, then rename over
-    // the target. Avoids truncating files in place — required on Windows where a
-    // memory-mapped repodata.json cannot be resized (ERROR_USER_MAPPED_FILE 1224).
-    // The temp dir lives inside the channel root so it is on the same volume /
-    // network share, keeping the rename atomic; it is ignored when enumerating
-    // subdirs because `.tmp` does not parse as a `Platform`.
+    // Write through a temp dir on the same volume and rename over the target,
+    // so a memory-mapped repodata.json isn't truncated in place (fails with
+    // ERROR_USER_MAPPED_FILE on Windows). `.tmp` is skipped during subdir
+    // enumeration since it doesn't parse as a `Platform`.
     config.atomic_write_dir = Some(root.join(".tmp").to_string_lossy().to_string());
     let builder = config.into_builder();
     let op = Operator::new(builder)?.finish();
@@ -1766,8 +1764,7 @@ pub async fn ensure_channel_initialized_fs_with_channel_metadata(
     let mut config = FsConfig::default();
     let root = channel.canonicalize()?;
     config.root = Some(root.to_string_lossy().to_string());
-    // Atomic writes: see the note in `index_fs_with_channel_metadata`. The temp
-    // dir lives inside the channel root so the rename stays on the same volume.
+    // Atomic writes, see `index_fs_with_channel_metadata`.
     config.atomic_write_dir = Some(root.join(".tmp").to_string_lossy().to_string());
     let op = Operator::new(config.into_builder())?.finish();
     ensure_channel_initialized_with_channel_metadata(&op, channel_metadata).await

--- a/crates/rattler_index/tests/integration/atomic_write.rs
+++ b/crates/rattler_index/tests/integration/atomic_write.rs
@@ -1,0 +1,69 @@
+use rattler_conda_types::{Channel, ChannelConfig, Platform};
+use rattler_index::{IndexFsConfig, PackageRevisionAssignment, index_fs};
+use rattler_repodata_gateway::sparse::SparseRepoData;
+
+/// Regression test for indexing a channel whose `repodata.json` is currently
+/// memory-mapped, as the repodata gateway does via
+/// [`SparseRepoData::from_file`].
+///
+/// On Windows, re-writing a memory-mapped file in place fails with
+/// `ERROR_USER_MAPPED_FILE` (os error 1224). `index_fs` now writes through an
+/// atomic temp dir on the same volume and renames over the target, so the
+/// mapped file is replaced rather than truncated. Combined with the gateway
+/// opening the file with `FILE_SHARE_DELETE`, the rename succeeds while the
+/// mapping is still live.
+///
+/// On other platforms the rename is harmless and the test simply asserts that
+/// indexing over a mapped file keeps working.
+#[tokio::test]
+async fn test_index_fs_over_memory_mapped_repodata() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let channel_path = temp_dir.path().to_path_buf();
+
+    let make_config = || IndexFsConfig {
+        channel: channel_path.clone(),
+        target_platform: Some(Platform::NoArch),
+        repodata_patch: None,
+        write_zst: false,
+        write_shards: false,
+        repodata_revisions: Vec::new(),
+        package_revision_assignment: PackageRevisionAssignment::default(),
+        force: true,
+        max_parallel: 8,
+        multi_progress: None,
+    };
+
+    // First pass: generate `noarch/repodata.json`.
+    index_fs(make_config())
+        .await
+        .expect("initial indexing should succeed");
+
+    let repodata_path = channel_path.join("noarch").join("repodata.json");
+    assert!(
+        repodata_path.exists(),
+        "expected {repodata_path:?} to exist"
+    );
+
+    // Map the freshly generated repodata.json exactly like the gateway does and
+    // keep the mapping alive across the second indexing pass.
+    let channel_config = ChannelConfig::default_with_root_dir(channel_path.clone());
+    let channel = Channel::from_str("dummy", &channel_config).unwrap();
+    let sparse = SparseRepoData::from_file(channel, "noarch", &repodata_path, None)
+        .expect("mapping repodata.json should succeed");
+
+    // Second pass: must succeed even though the file is still memory-mapped.
+    index_fs(make_config())
+        .await
+        .expect("re-indexing over a mapped repodata.json should succeed");
+
+    // The atomic write dir lives inside the channel root but must not be treated
+    // as a subdir.
+    assert!(
+        channel_path.join(".tmp").exists(),
+        "atomic write dir should have been created inside the channel root"
+    );
+
+    // Keep the mapping alive until after the second write so the regression is
+    // actually exercised.
+    drop(sparse);
+}

--- a/crates/rattler_index/tests/integration/atomic_write.rs
+++ b/crates/rattler_index/tests/integration/atomic_write.rs
@@ -2,19 +2,9 @@ use rattler_conda_types::{Channel, ChannelConfig, Platform};
 use rattler_index::{IndexFsConfig, PackageRevisionAssignment, index_fs};
 use rattler_repodata_gateway::sparse::SparseRepoData;
 
-/// Regression test for indexing a channel whose `repodata.json` is currently
-/// memory-mapped, as the repodata gateway does via
-/// [`SparseRepoData::from_file`].
-///
-/// On Windows, re-writing a memory-mapped file in place fails with
-/// `ERROR_USER_MAPPED_FILE` (os error 1224). `index_fs` now writes through an
-/// atomic temp dir on the same volume and renames over the target, so the
-/// mapped file is replaced rather than truncated. Combined with the gateway
-/// opening the file with `FILE_SHARE_DELETE`, the rename succeeds while the
-/// mapping is still live.
-///
-/// On other platforms the rename is harmless and the test simply asserts that
-/// indexing over a mapped file keeps working.
+/// Indexing must succeed while `repodata.json` is memory-mapped (as the gateway
+/// maps it). Atomic writes rename over the file instead of truncating it, which
+/// on Windows would fail with `ERROR_USER_MAPPED_FILE`.
 #[tokio::test]
 async fn test_index_fs_over_memory_mapped_repodata() {
     let temp_dir = tempfile::tempdir().unwrap();
@@ -33,7 +23,7 @@ async fn test_index_fs_over_memory_mapped_repodata() {
         multi_progress: None,
     };
 
-    // First pass: generate `noarch/repodata.json`.
+    // Generate the initial repodata.
     index_fs(make_config())
         .await
         .expect("initial indexing should succeed");
@@ -44,26 +34,21 @@ async fn test_index_fs_over_memory_mapped_repodata() {
         "expected {repodata_path:?} to exist"
     );
 
-    // Map the freshly generated repodata.json exactly like the gateway does and
-    // keep the mapping alive across the second indexing pass.
+    // Map it like the gateway does and keep the mapping alive across re-indexing.
     let channel_config = ChannelConfig::default_with_root_dir(channel_path.clone());
     let channel = Channel::from_str("dummy", &channel_config).unwrap();
     let sparse = SparseRepoData::from_file(channel, "noarch", &repodata_path, None)
         .expect("mapping repodata.json should succeed");
 
-    // Second pass: must succeed even though the file is still memory-mapped.
+    // Must succeed while the file is still mapped.
     index_fs(make_config())
         .await
         .expect("re-indexing over a mapped repodata.json should succeed");
 
-    // The atomic write dir lives inside the channel root but must not be treated
-    // as a subdir.
     assert!(
         channel_path.join(".tmp").exists(),
-        "atomic write dir should have been created inside the channel root"
+        "atomic write dir expected"
     );
 
-    // Keep the mapping alive until after the second write so the regression is
-    // actually exercised.
     drop(sparse);
 }

--- a/crates/rattler_index/tests/integration/mod.rs
+++ b/crates/rattler_index/tests/integration/mod.rs
@@ -1,4 +1,5 @@
 // Integration test modules
+mod atomic_write;
 mod basic_indexing;
 mod cache_tests;
 mod concurrent_indexing;

--- a/py-rattler/tests/unit/test_index.py
+++ b/py-rattler/tests/unit/test_index.py
@@ -34,7 +34,8 @@ def package_directory(tmp_path, package_file_ruff: Path, package_file_pytweening
 async def test_index(package_directory):
     await index_fs(package_directory)
 
-    assert set(os.listdir(package_directory)) == {"noarch", "win-64"}
+    # `.tmp` is the atomic-write staging dir created in the channel root; ignore it.
+    assert {name for name in os.listdir(package_directory) if name != ".tmp"} == {"noarch", "win-64"}
     assert "repodata.json" in os.listdir(package_directory / "win-64")
     with open(package_directory / "win-64/repodata.json") as f:
         assert "ruff-0.0.171-py310h298983d_0" in f.read()


### PR DESCRIPTION
### Description

This PR fixes an issue on Windows where `index_fs` fails when reindexing a channel whose `repodata.json` is currently memory-mapped by the repodata gateway.

On Windows, attempting to truncate a memory-mapped file in place fails with `ERROR_USER_MAPPED_FILE` (os error 1224). The fix implements atomic writes by:

1. Writing to a temporary directory (`.tmp`) on the same volume as the channel root
2. Renaming the temp file over the target file instead of truncating in place
3. The rename succeeds even while the file is memory-mapped, as long as it's opened with `FILE_SHARE_DELETE` (which the gateway does)

The `.tmp` directory is placed inside the channel root to ensure it's on the same volume/network share, keeping the rename atomic. It's automatically ignored when enumerating platform subdirectories since `.tmp` doesn't parse as a valid `Platform`.

This change is applied to both `index_fs_with_channel_metadata` and `ensure_channel_initialized_fs_with_channel_metadata` functions.

### How Has This Been Tested?

Added a regression test `test_index_fs_over_memory_mapped_repodata` that:
1. Generates initial `repodata.json` via `index_fs`
2. Memory-maps the file using `SparseRepoData::from_file` (same as the gateway does)
3. Runs `index_fs` again while the mapping is still active
4. Verifies the operation succeeds and the atomic write directory is created

The test exercises the actual regression on Windows and ensures the functionality works correctly on other platforms as well.

### Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes

https://claude.ai/code/session_01FEVryK7L3mvcahvkxpVq6t