### PR TITLE
feat: update resolvo to 0.11.1 and use gateway for snapshot tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,10 +1576,8 @@ dependencies = [
  "itertools 0.14.0",
  "rattler_cache",
  "rattler_conda_types",
- "rattler_networking",
  "rattler_repodata_gateway",
  "rattler_solve",
- "reqwest",
  "resolvo",
  "serde_json",
  "tokio",
@@ -5819,9 +5817,9 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2985c35f7dd19ed00659031b77ce05d1828a12eb9c6b37104da21b09d218fc24"
+checksum = "cbc9b6c092a52fadb381b74d0f859b321ea7b9f4f8365acd7e4947f3a26517aa"
 dependencies = [
  "ahash",
  "bitvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ regex = "1.11.1"
 reqwest = { version = "0.13.3", default-features = false }
 reqwest-middleware = { package = "astral-reqwest-middleware", version = "0.5.1" }
 reqwest-retry = { package = "astral-reqwest-retry", version = "0.9.1" }
-resolvo = { version = "0.10.0" }
+resolvo = { version = "0.11.1" }
 retry-policies = { version = "0.5.1", default-features = false }
 rmp = { version = "0.8.14" }
 rmp-serde = { version = "1.3.0" }

--- a/crates/rattler_solve/benches/sorting_bench.rs
+++ b/crates/rattler_solve/benches/sorting_bench.rs
@@ -4,7 +4,10 @@ use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use futures::FutureExt;
 use rattler_conda_types::{Channel, MatchSpec};
 use rattler_repodata_gateway::sparse::{PackageFormatSelection, SparseRepoData};
-use rattler_solve::{ChannelPriority, resolvo::CondaDependencyProvider};
+use rattler_solve::{
+    ChannelPriority,
+    resolvo::{CondaDependencyProvider, NameType},
+};
 use resolvo::SolverCache;
 
 fn bench_sort(c: &mut Criterion, sparse_repo_data: &SparseRepoData, spec: &str) {
@@ -42,7 +45,9 @@ fn bench_sort(c: &mut Criterion, sparse_repo_data: &SparseRepoData, spec: &str) 
                 )
                 .expect("failed to create dependency provider");
 
-                let name = dependency_provider.pool.intern_package_name(&package_name);
+                let name = dependency_provider
+                    .pool
+                    .intern_package_name(NameType::from(&package_name));
                 let version_set = dependency_provider
                     .pool
                     .intern_version_set(name, match_spec.into_nameless().1.into());

--- a/crates/rattler_solve/src/resolvo/mod.rs
+++ b/crates/rattler_solve/src/resolvo/mod.rs
@@ -339,7 +339,7 @@ impl<'a> CondaDependencyProvider<'a> {
 
         // Add virtual packages to the records
         for virtual_package in virtual_packages {
-            let name = pool.intern_package_name(&virtual_package.name);
+            let name = pool.intern_package_name(NameType::from(&virtual_package.name));
             let solvable =
                 pool.intern_solvable(name, SolverPackageRecord::VirtualPackage(virtual_package));
             records.entry(name).or_default().candidates.push(solvable);
@@ -349,7 +349,7 @@ impl<'a> CondaDependencyProvider<'a> {
         let direct_dependencies = match_specs
             .iter()
             .filter_map(|spec| spec.name.as_exact())
-            .map(|name| pool.intern_package_name(name))
+            .map(|name| pool.intern_package_name(NameType::from(name)))
             .collect();
 
         // TODO: Normalize these channel names to urls so we can compare them correctly.
@@ -435,7 +435,8 @@ impl<'a> CondaDependencyProvider<'a> {
             }
 
             for record in ordered_repodata {
-                let package_name = pool.intern_package_name(&record.package_record.name);
+                let package_name =
+                    pool.intern_package_name(NameType::from(&record.package_record.name));
                 let solvable_id =
                     pool.intern_solvable(package_name, SolverPackageRecord::Record(record));
 
@@ -542,7 +543,8 @@ impl<'a> CondaDependencyProvider<'a> {
 
         // Add favored packages to the records
         for &favored_record in favored_records {
-            let name = pool.intern_package_name(&favored_record.package_record.name);
+            let name =
+                pool.intern_package_name(NameType::from(&favored_record.package_record.name));
             let solvable = pool.intern_solvable(name, SolverPackageRecord::Record(favored_record));
             let candidates = records.entry(name).or_default();
             candidates.candidates.push(solvable);
@@ -550,7 +552,7 @@ impl<'a> CondaDependencyProvider<'a> {
         }
 
         for &locked_record in locked_records {
-            let name = pool.intern_package_name(&locked_record.package_record.name);
+            let name = pool.intern_package_name(NameType::from(&locked_record.package_record.name));
             let solvable = pool.intern_solvable(name, SolverPackageRecord::Record(locked_record));
             let candidates = records.entry(name).or_default();
             candidates.candidates.push(solvable);
@@ -635,6 +637,9 @@ pub enum CancelReason {
 }
 
 impl Interner for CondaDependencyProvider<'_> {
+    type NameId = NameId;
+    type SolvableId = SolvableId;
+
     fn display_solvable(&self, solvable: SolvableId) -> impl Display + '_ {
         &self.pool.resolve_solvable(solvable).record
     }
@@ -1028,7 +1033,9 @@ impl super::SolverImpl for Solver {
 
         // Construct the requirements that the solver needs to satisfy.
         let virtual_package_requirements = task.virtual_packages.iter().map(|spec| {
-            let name_id = provider.pool.intern_package_name(&spec.name);
+            let name_id = provider
+                .pool
+                .intern_package_name(NameType::from(&spec.name));
             provider
                 .pool
                 .intern_version_set(name_id, NamelessMatchSpec::default().into())
@@ -1062,7 +1069,7 @@ impl super::SolverImpl for Solver {
                 let (PackageNameMatcher::Exact(name), spec) = spec.clone().into_nameless() else {
                     unimplemented!("only exact package names are supported");
                 };
-                let name_id = provider.pool.intern_package_name(&name);
+                let name_id = provider.pool.intern_package_name(NameType::from(&name));
                 provider.pool.intern_version_set(name_id, spec.into())
             })
             .collect();
@@ -1156,7 +1163,7 @@ fn version_sets_for_match_spec(
     }
 
     // Create a version set for the match spec itself.
-    let dependency_name = pool.intern_package_name(&name);
+    let dependency_name = pool.intern_package_name(NameType::from(&name));
     let version_set_id = pool.intern_version_set(dependency_name, spec.into());
     version_set_ids.push(version_set_id);
 

--- a/crates/rattler_solve/tests/sorting.rs
+++ b/crates/rattler_solve/tests/sorting.rs
@@ -8,7 +8,10 @@ use rattler_conda_types::{
     Channel, MatchSpec, PackageName, ParseStrictness::Lenient, RepoDataRecord,
 };
 use rattler_repodata_gateway::sparse::{PackageFormatSelection, SparseRepoData};
-use rattler_solve::{ChannelPriority, SolveStrategy, resolvo::CondaDependencyProvider};
+use rattler_solve::{
+    ChannelPriority, SolveStrategy,
+    resolvo::{CondaDependencyProvider, NameType},
+};
 use resolvo::{Interner, SolverCache};
 use rstest::*;
 
@@ -56,7 +59,9 @@ fn create_sorting_snapshot(package_name: &str, strategy: SolveStrategy) -> Strin
     )
     .expect("failed to create dependency provider");
 
-    let name = dependency_provider.pool.intern_package_name(&package_name);
+    let name = dependency_provider
+        .pool
+        .intern_package_name(NameType::from(&package_name));
     let version_set = dependency_provider
         .pool
         .intern_version_set(name, match_spec.into_nameless().1.into());

--- a/js-rattler/Cargo.lock
+++ b/js-rattler/Cargo.lock
@@ -117,15 +117,15 @@ dependencies = [
 
 [[package]]
 name = "astral_async_zip"
-version = "0.0.17"
+version = "0.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab72a761e6085828cc8f0e05ed332b2554701368c5dc54de551bfaec466518ba"
+checksum = "c15fc5b591f19dfbbbce736615908d74f1d9252bb34b231873cb995f2a997ffb"
 dependencies = [
  "async-compression",
  "crc32fast",
  "futures-lite",
  "pin-project",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util",
 ]
@@ -353,10 +353,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1422,6 +1420,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jiff"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "js-sys",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,12 +1526,13 @@ name = "js-rattler"
 version = "0.1.1"
 dependencies = [
  "astral-reqwest-middleware",
- "chrono",
  "console_error_panic_hook",
  "getrandom 0.2.16",
  "getrandom 0.3.4",
  "getrandom 0.4.2",
  "hex",
+ "jiff",
+ "js-sys",
  "rattler_conda_types",
  "rattler_digest",
  "rattler_repodata_gateway",
@@ -1883,6 +1925,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2051,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.8.2"
+version = "0.9.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2083,10 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.46.4"
+version = "0.47.1"
 dependencies = [
  "ahash",
- "chrono",
  "core-foundation",
  "dirs",
  "fancy-regex",
@@ -2096,6 +2146,7 @@ dependencies = [
  "hex",
  "indexmap 2.13.0",
  "itertools",
+ "jiff",
  "lazy-regex",
  "memmap2",
  "nom",
@@ -2124,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_digest"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "blake2",
  "digest",
@@ -2142,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_macros"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "quote",
  "syn",
@@ -2150,7 +2201,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.27.2"
+version = "0.28.1"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -2174,7 +2225,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.26.2"
+version = "0.26.4"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -2183,7 +2234,7 @@ dependencies = [
  "async-compression",
  "async-spooled-tempfile",
  "bzip2",
- "chrono",
+ "filetime",
  "fs-err",
  "futures",
  "futures-util",
@@ -2191,6 +2242,7 @@ dependencies = [
  "getrandom 0.4.2",
  "hex",
  "http",
+ "jiff",
  "num_cpus",
  "rattler_conda_types",
  "rattler_digest",
@@ -2221,7 +2273,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.29.2"
+version = "0.29.5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2233,7 +2285,6 @@ dependencies = [
  "bytes",
  "cache_control",
  "cfg-if 1.0.4",
- "chrono",
  "coalesced_map",
  "dashmap",
  "dirs",
@@ -2248,6 +2299,7 @@ dependencies = [
  "humansize",
  "humantime",
  "itertools",
+ "jiff",
  "json-patch",
  "libc",
  "memmap2",
@@ -2282,13 +2334,12 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "7.1.1"
+version = "7.1.3"
 dependencies = [
- "chrono",
  "futures",
  "hex",
- "humantime",
  "itertools",
+ "jiff",
  "rattler_conda_types",
  "rattler_digest",
  "resolvo",
@@ -2430,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670175f9a825ad2419bea0e14bfe74e5dcc0227ec7a652a655b1c11e2b911754"
+checksum = "cbc9b6c092a52fadb381b74d0f859b321ea7b9f4f8365acd7e4947f3a26517aa"
 dependencies = [
  "ahash",
  "bitvec",

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "rattler"
-version = "0.44.3"
+version = "0.44.4"
 dependencies = [
  "anyhow",
  "astral-reqwest-middleware",
@@ -4134,7 +4134,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_cache"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_conda_types"
-version = "0.47.0"
+version = "0.47.1"
 dependencies = [
  "ahash",
  "core-foundation 0.10.1",
@@ -4206,7 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_config"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "console",
  "fs-err",
@@ -4240,7 +4240,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_index"
-version = "0.30.3"
+version = "0.30.4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4278,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_lock"
-version = "0.31.0"
+version = "0.31.1"
 dependencies = [
  "ahash",
  "file_url",
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_menuinst"
-version = "0.2.65"
+version = "0.2.66"
 dependencies = [
  "configparser",
  "dirs",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_networking"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "ambient-id",
  "anyhow",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_package_streaming"
-version = "0.26.3"
+version = "0.26.4"
 dependencies = [
  "astral-reqwest-middleware",
  "astral-tokio-tar",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_repodata_gateway"
-version = "0.29.4"
+version = "0.29.5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4497,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_s3"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -4513,7 +4513,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_shell"
-version = "0.27.5"
+version = "0.27.6"
 dependencies = [
  "anyhow",
  "enum_dispatch",
@@ -4532,7 +4532,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_solve"
-version = "7.1.2"
+version = "7.1.3"
 dependencies = [
  "futures",
  "hex",
@@ -4549,7 +4549,7 @@ dependencies = [
 
 [[package]]
 name = "rattler_virtual_packages"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "archspec",
  "libloading",
@@ -4778,9 +4778,9 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2985c35f7dd19ed00659031b77ce05d1828a12eb9c6b37104da21b09d218fc24"
+checksum = "cbc9b6c092a52fadb381b74d0f859b321ea7b9f4f8365acd7e4947f3a26517aa"
 dependencies = [
  "ahash",
  "bitvec",

--- a/tools/create-resolvo-snapshot/Cargo.toml
+++ b/tools/create-resolvo-snapshot/Cargo.toml
@@ -14,10 +14,8 @@ clap = { workspace = true }
 itertools = { workspace = true }
 rattler_cache = { path = "../../crates/rattler_cache" }
 rattler_conda_types = { path = "../../crates/rattler_conda_types" }
-rattler_repodata_gateway = { path = "../../crates/rattler_repodata_gateway", default-features = false, version = "*" }
-rattler_networking = { path = "../../crates/rattler_networking", default-features = false, version = "*" }
+rattler_repodata_gateway = { path = "../../crates/rattler_repodata_gateway", default-features = false, version = "*", features = ["gateway", "rustls"] }
 rattler_solve = { path = "../../crates/rattler_solve" }
-reqwest = { workspace = true, default-features = false, features = ["rustls"] }
 resolvo = { workspace = true, features = ["serde"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/tools/create-resolvo-snapshot/src/main.rs
+++ b/tools/create-resolvo-snapshot/src/main.rs
@@ -2,9 +2,8 @@ use std::{collections::HashSet, io::BufWriter, path::Path};
 
 use clap::Parser;
 use itertools::Itertools;
-use rattler_conda_types::{Channel, ChannelConfig, Platform};
-use rattler_networking::LazyClient;
-use rattler_repodata_gateway::fetch::FetchRepoDataOptions;
+use rattler_conda_types::{Channel, ChannelConfig, MatchSpec, Platform};
+use rattler_repodata_gateway::Gateway;
 use rattler_solve::{ChannelPriority, SolveStrategy};
 
 #[derive(Parser)]
@@ -33,42 +32,57 @@ async fn main() {
     )
     .unwrap();
 
-    // Fetch the repodata for all the subdirs.
+    // Determine the subdirs to query.
     let mut subdirs: HashSet<Platform> = HashSet::from_iter(args.subdir);
     if subdirs.is_empty() {
         subdirs.insert(Platform::current());
     }
     subdirs.insert(Platform::NoArch);
+    let platforms = subdirs.iter().copied().collect_vec();
 
-    let client = LazyClient::default();
-    let mut records = Vec::new();
-    for &subdir in &subdirs {
-        eprintln!("fetching repodata for {subdir:?}..");
-        let repodata = rattler_repodata_gateway::fetch::fetch_repo_data(
-            channel.platform_url(subdir),
-            client.clone(),
+    // Construct a gateway to fetch repodata. The gateway transparently handles
+    // sharded repodata which is required to capture channels like `conda-pypi`
+    // that do not expose a monolithic `repodata.json`.
+    let gateway = Gateway::builder()
+        .with_cache_dir(
             rattler_cache::default_cache_dir()
                 .unwrap()
                 .join(rattler_cache::REPODATA_CACHE_DIR),
-            FetchRepoDataOptions::default(),
-            None,
         )
+        .finish();
+
+    // Enumerate every package name available in the channel so we can pull in
+    // the complete set of records, not just those reachable from a single spec.
+    eprintln!("fetching package names..");
+    let names = gateway
+        .names(vec![channel.clone()], platforms.clone())
+        .await
+        .unwrap();
+    eprintln!("found {} package names", names.len());
+
+    // Query the repodata for all names. Providing every name guarantees that the
+    // resulting snapshot captures the entire channel.
+    eprintln!("fetching repodata..");
+    let specs = names.into_iter().map(MatchSpec::from).collect_vec();
+    let repodatas = gateway
+        .query(vec![channel.clone()], platforms, specs)
+        .recursive(false)
         .await
         .unwrap();
 
-        eprintln!("parsing repodata..");
-        let repodata = rattler_conda_types::RepoData::from_path(repodata.repo_data_json_path)
-            .unwrap()
-            .into_repo_data_records(&channel);
-
-        records.push(repodata);
-    }
+    let total_records: usize = repodatas
+        .iter()
+        .map(rattler_repodata_gateway::RepoData::len)
+        .sum();
+    eprintln!("fetched {total_records} records");
 
     // Create the dependency provider
     let provider = rattler_solve::resolvo::CondaDependencyProvider::new(
-        records
-            .iter()
-            .map(rattler_solve::resolvo::RepoData::from_iter),
+        repodatas.iter().map(|repo_data| {
+            repo_data
+                .iter()
+                .collect::<rattler_solve::resolvo::RepoData<'_>>()
+        }),
         &[],
         &[],
         &[],


### PR DESCRIPTION
### Description

Bump `resolvo` from 0.10 to **0.11.1** and adapt to the breaking API changes introduced in the 0.11 line:

- `Interner` now requires `NameId` / `SolvableId` associated types.
- `Pool::intern_package_name` no longer accepts `&PackageName` for a `NameType` pool; the call sites now convert via `NameType::from`.

The 0.11 line reworks the solver's id/variable layout and clause encoding and fixes a conflict-storm regression on conda-style problems, so this is a solid solve-time win across the board (see below).

Additionally, rewrite the `create-resolvo-snapshot` tool to build snapshots through the `Gateway` instead of `fetch_repo_data`. The gateway transparently handles sharded repodata, which is required to capture channels such as `conda-pypi` that do not expose a monolithic `repodata.json`. All package names are enumerated via the gateway and then queried so the snapshot captures the full channel.

### How Has This Been Tested?

- `cargo test -p rattler_solve --no-default-features --features resolvo --test backends --test sorting` — 69 + 8 tests pass against resolvo 0.11.1.
- Solve benchmarks (`cargo bench -p rattler_solve --bench bench`), **main (resolvo 0.10.0) vs this PR (resolvo 0.11.1)** on the same machine and base, criterion medians (all changes p < 0.05):

  | benchmark | main — 0.10.0 | this PR — 0.11.1 | change |
  |---|---:|---:|---:|
  | quetz | 413 ms | 242 ms | **-41%** |
  | tensorboard=2.1.1, grpc-cpp=1.39.1 | 132 ms | 79 ms | **-40%** |
  | tensorflow | 283 ms | 175 ms | **-38%** |
  | python=3.9 | 4.05 ms | 3.19 ms | **-21%** |
  | xtensor, xsimd | 3.25 ms | 2.85 ms | **-12%** |

- `py-rattler` and `js-rattler` (wasm32) lockfiles updated and build-checked.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Claude Code)

```plaintext
Can you update resolvo to 0.11.0, also perform benchmarks measuring main against our changes, also update the snapshot tool so we use the gateway to create the snapshot, this is required to capture conda-pypi
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
