### PR TITLE
fix: coalesce concurrent OAuth token refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http 1.4.2",
  "http-body 1.0.1",
@@ -875,6 +876,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -91,7 +91,7 @@ tokio = { workspace = true, features = ["macros", "time"] }
 # `stream` (test-only) lets us build an unclonable streaming-body request to
 # exercise the challenge-middleware's no-replay path.
 reqwest = { workspace = true, features = ["json", "form", "stream"] }
-axum = { workspace = true, features = ["json"] }
+axum = { workspace = true, features = ["json", "form"] }
 reqwest-retry = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }

--- a/crates/rattler_networking/src/authentication_middleware.rs
+++ b/crates/rattler_networking/src/authentication_middleware.rs
@@ -45,8 +45,18 @@ impl Middleware for AuthenticationMiddleware {
                 // If this is an OAuth token, attempt refresh if expired
                 let auth = match auth_with_key {
                     Some((matched_key, auth)) => {
-                        oauth_refresh::maybe_refresh_oauth(&self.auth_storage, auth, &matched_key)
-                            .await
+                        let refresh_result = oauth_refresh::maybe_refresh_oauth(
+                            &self.auth_storage,
+                            auth,
+                            &matched_key,
+                        )
+                        .await;
+                        if let Some(failure) = refresh_result.failure() {
+                            tracing::warn!(
+                                "OAuth refresh for '{matched_key}' did not produce fresh credentials: {failure}"
+                            );
+                        }
+                        refresh_result.into_authentication()
                     }
                     None => None,
                 };
@@ -171,14 +181,25 @@ pub fn default_auth_store_fallback_directory() -> &'static Path {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    };
 
     #[cfg(feature = "keyring")]
     use anyhow::anyhow;
+    use axum::{
+        Json, Router,
+        extract::State,
+        http::{HeaderMap, StatusCode},
+        routing::post,
+    };
+    use futures::future::join_all;
+    use serde_json::json;
     use tempfile::tempdir;
 
     use super::*;
-    use crate::authentication_storage::backends::file::FileStorage;
+    use crate::authentication_storage::backends::{file::FileStorage, memory::MemoryStorage};
 
     #[cfg(feature = "keyring")]
     // Requests are only authenticated when executed, so we need to capture and
@@ -441,6 +462,151 @@ mod tests {
                 assert_eq!(retrieved.1, None);
             }
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn concurrent_oauth_refresh_is_coalesced_by_authentication_middleware()
+    -> anyhow::Result<()> {
+        #[derive(Clone)]
+        struct TestState {
+            refresh_count: Arc<AtomicUsize>,
+            seen_authorization: Arc<Mutex<Vec<Option<String>>>>,
+        }
+
+        async fn token(State(state): State<TestState>) -> (StatusCode, Json<serde_json::Value>) {
+            state.refresh_count.fetch_add(1, Ordering::SeqCst);
+            (
+                StatusCode::OK,
+                Json(json!({
+                    "access_token": "fresh-access-token",
+                    "refresh_token": "rotated-refresh-token",
+                    "expires_in": 3600,
+                })),
+            )
+        }
+
+        async fn repo(State(state): State<TestState>, headers: HeaderMap) -> &'static str {
+            let authorization = headers
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .map(ToOwned::to_owned);
+            state.seen_authorization.lock().unwrap().push(authorization);
+            "ok"
+        }
+
+        let state = TestState {
+            refresh_count: Arc::new(AtomicUsize::new(0)),
+            seen_authorization: Arc::new(Mutex::new(Vec::new())),
+        };
+        let router = Router::new()
+            .route("/token", post(token))
+            .route("/repo", post(repo))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+
+        let host = "127.0.0.1";
+        let mut storage = AuthenticationStorage::empty();
+        storage.add_backend(Arc::new(MemoryStorage::new()));
+        storage.store(
+            host,
+            &Authentication::OAuth {
+                access_token: "expired-access-token".to_string(),
+                refresh_token: Some("refresh-token".to_string()),
+                expires_at: Some(0),
+                token_endpoint: format!("http://{addr}/token"),
+                revocation_endpoint: None,
+                client_id: "client-id".to_string(),
+            },
+        )?;
+
+        let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::default())
+            .with(AuthenticationMiddleware::from_auth_storage(storage))
+            .build();
+        let repo_url = format!("http://{addr}/repo");
+
+        let responses = join_all((0..8).map(|_| client.post(&repo_url).send())).await;
+        for response in responses {
+            assert_eq!(response?.status(), StatusCode::OK);
+        }
+
+        assert_eq!(state.refresh_count.load(Ordering::SeqCst), 1);
+        let seen_authorization = state.seen_authorization.lock().unwrap();
+        assert_eq!(seen_authorization.len(), 8);
+        assert!(
+            seen_authorization
+                .iter()
+                .all(|auth| { auth.as_deref() == Some("Bearer fresh-access-token") })
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn expired_oauth_with_failed_refresh_sends_no_authorization_header() -> anyhow::Result<()>
+    {
+        #[derive(Clone)]
+        struct TestState {
+            seen_authorization: Arc<Mutex<Vec<Option<String>>>>,
+        }
+
+        // A rotating server that has already invalidated this refresh token.
+        async fn token() -> (StatusCode, Json<serde_json::Value>) {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "invalid_grant" })),
+            )
+        }
+
+        async fn repo(State(state): State<TestState>, headers: HeaderMap) -> &'static str {
+            let authorization = headers
+                .get(reqwest::header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                .map(ToOwned::to_owned);
+            state.seen_authorization.lock().unwrap().push(authorization);
+            "ok"
+        }
+
+        let state = TestState {
+            seen_authorization: Arc::new(Mutex::new(Vec::new())),
+        };
+        let router = Router::new()
+            .route("/token", post(token))
+            .route("/repo", post(repo))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+
+        let host = "127.0.0.1";
+        let mut storage = AuthenticationStorage::empty();
+        storage.add_backend(Arc::new(MemoryStorage::new()));
+        storage.store(
+            host,
+            &Authentication::OAuth {
+                access_token: "expired-access-token".to_string(),
+                refresh_token: Some("refresh-token".to_string()),
+                expires_at: Some(0),
+                token_endpoint: format!("http://{addr}/token"),
+                revocation_endpoint: None,
+                client_id: "client-id".to_string(),
+            },
+        )?;
+
+        let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::default())
+            .with(AuthenticationMiddleware::from_auth_storage(storage))
+            .build();
+
+        let response = client.post(format!("http://{addr}/repo")).send().await?;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Refresh failed and the access token is expired, so no expired bearer
+        // token should leak to the backend.
+        let seen_authorization = state.seen_authorization.lock().unwrap();
+        assert_eq!(seen_authorization.as_slice(), &[None]);
 
         Ok(())
     }

--- a/crates/rattler_networking/src/authentication_storage/storage.rs
+++ b/crates/rattler_networking/src/authentication_storage/storage.rs
@@ -6,6 +6,8 @@ use std::{
     collections::{BTreeMap, HashMap},
     sync::{Arc, Mutex},
 };
+
+use futures::lock::Mutex as AsyncMutex;
 use url::Url;
 
 use crate::authentication_storage::{AuthenticationStorageError, backends::file::FileStorage};
@@ -20,6 +22,8 @@ use crate::authentication_storage::backends::keyring::KeyringAuthenticationStora
 
 #[cfg(feature = "keyring")]
 use super::backends::keyring::KeyringAuthenticationStorage;
+
+type OAuthRefreshLocks = Arc<Mutex<HashMap<String, Arc<AsyncMutex<()>>>>>;
 
 /// A single entry returned by [`AuthenticationStorage::list_keys_with_sources`].
 /// Carries host metadata without the stored credential, so callers can build
@@ -65,6 +69,7 @@ pub struct AuthenticationStorage {
     /// Authentication backends
     pub backends: Vec<Arc<dyn StorageBackend + Send + Sync>>,
     cache: Arc<Mutex<HashMap<String, Option<Authentication>>>>,
+    oauth_refresh_locks: OAuthRefreshLocks,
 }
 
 impl AuthenticationStorage {
@@ -73,6 +78,7 @@ impl AuthenticationStorage {
         Self {
             backends: vec![],
             cache: Arc::new(Mutex::new(HashMap::new())),
+            oauth_refresh_locks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -112,6 +118,22 @@ impl AuthenticationStorage {
     /// (backends are tried in the order they are added)
     pub fn add_backend(&mut self, backend: Arc<dyn StorageBackend + Send + Sync>) {
         self.backends.push(backend);
+    }
+
+    /// Returns the per-key OAuth refresh gate.
+    ///
+    /// The gate only coalesces concurrent refresh attempts. Refreshed tokens
+    /// are still stored in and read from the configured authentication
+    /// backends/cache; the gate itself never caches credentials.
+    pub(crate) fn oauth_refresh_lock(&self, key: &str) -> Arc<AsyncMutex<()>> {
+        let mut locks = self
+            .oauth_refresh_locks
+            .lock()
+            .expect("OAuth refresh lock map poisoned");
+        locks
+            .entry(key.to_string())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
     }
 
     /// Store the given authentication information for the given host
@@ -356,7 +378,9 @@ impl AuthenticationStorage {
             // `maybe_refresh_oauth` is a no-op for non-OAuth variants and
             // returns them as-is, so this branch covers every auth type.
             Some((matched_key, auth)) => {
-                crate::oauth_refresh::maybe_refresh_oauth(self, auth, &matched_key).await
+                crate::oauth_refresh::maybe_refresh_oauth(self, auth, &matched_key)
+                    .await
+                    .into_authentication()
             }
             None => None,
         };

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -23,7 +23,7 @@ pub use s3_middleware::S3Middleware;
 pub mod authentication_middleware;
 pub mod authentication_storage;
 pub mod challenge_middleware;
-pub mod oauth_refresh;
+pub(crate) mod oauth_refresh;
 
 mod lazy_client;
 pub mod mirror_middleware;

--- a/crates/rattler_networking/src/oauth_refresh.rs
+++ b/crates/rattler_networking/src/oauth_refresh.rs
@@ -1,5 +1,7 @@
 //! Refresh logic for `Authentication::OAuth` credentials.
 
+use std::fmt;
+
 use serde::Deserialize;
 
 use crate::{Authentication, AuthenticationStorage};
@@ -16,40 +18,150 @@ struct TokenRefreshResponse {
 /// "about to expire"
 const EXPIRY_SKEW_SECONDS: i64 = 300;
 
+/// Maximum time to wait for the token endpoint to respond to a refresh request.
+/// Without this, a hung authorization server would stall the request that
+/// triggered the refresh indefinitely.
+const REFRESH_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+fn now_unix_timestamp() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+fn oauth_expires_at(auth: &Authentication) -> Option<i64> {
+    match auth {
+        Authentication::OAuth { expires_at, .. } => *expires_at,
+        _ => None,
+    }
+}
+
+fn needs_refresh(auth: &Authentication) -> bool {
+    oauth_expires_at(auth).is_some_and(|exp| exp - now_unix_timestamp() < EXPIRY_SKEW_SECONDS)
+}
+
+fn is_expired(auth: &Authentication) -> bool {
+    oauth_expires_at(auth).is_some_and(|exp| exp <= now_unix_timestamp())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum OAuthRefreshFailure {
+    MissingRefreshToken,
+    ReauthenticationRequired { reason: String },
+    Transient { reason: String },
+    InvalidResponse { reason: String },
+}
+
+impl fmt::Display for OAuthRefreshFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OAuthRefreshFailure::MissingRefreshToken => {
+                write!(
+                    f,
+                    "OAuth token is expired but no refresh token is available"
+                )
+            }
+            OAuthRefreshFailure::ReauthenticationRequired { reason }
+            | OAuthRefreshFailure::Transient { reason }
+            | OAuthRefreshFailure::InvalidResponse { reason } => write!(f, "{reason}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OAuthRefreshOutcome {
+    authentication: Option<Authentication>,
+    failure: Option<OAuthRefreshFailure>,
+}
+
+impl OAuthRefreshOutcome {
+    pub(crate) fn into_authentication(self) -> Option<Authentication> {
+        self.authentication
+    }
+
+    pub(crate) fn failure(&self) -> Option<&OAuthRefreshFailure> {
+        self.failure.as_ref()
+    }
+}
+
+fn auth_outcome(auth: Authentication) -> OAuthRefreshOutcome {
+    OAuthRefreshOutcome {
+        authentication: Some(auth),
+        failure: None,
+    }
+}
+
+fn stale_auth_fallback(auth: Authentication, failure: OAuthRefreshFailure) -> OAuthRefreshOutcome {
+    if is_expired(&auth) {
+        tracing::warn!(
+            "OAuth access token is expired and could not be refreshed; not attaching it"
+        );
+        OAuthRefreshOutcome {
+            authentication: None,
+            failure: Some(failure),
+        }
+    } else {
+        OAuthRefreshOutcome {
+            authentication: Some(auth),
+            failure: Some(failure),
+        }
+    }
+}
+
 /// Refresh an OAuth token if it is expired (or close to expiring) and
 /// store the refreshed credential back to `storage`.
-pub async fn maybe_refresh_oauth(
+pub(crate) async fn maybe_refresh_oauth(
     storage: &AuthenticationStorage,
     auth: Authentication,
     matched_key: &str,
-) -> Option<Authentication> {
+) -> OAuthRefreshOutcome {
+    if !matches!(auth, Authentication::OAuth { .. }) {
+        return auth_outcome(auth);
+    }
+
+    if !needs_refresh(&auth) {
+        return auth_outcome(auth);
+    }
+
+    let refresh_lock = storage.oauth_refresh_lock(matched_key);
+    let _refresh_guard = refresh_lock.lock().await;
+
+    // Another request may have refreshed and stored credentials for this key
+    // while we were waiting for the per-key refresh lock. Re-read storage so we
+    // don't reuse a refresh token that has already been rotated.
+    let auth = match storage.get(matched_key) {
+        Ok(Some(current_auth)) => {
+            if !matches!(current_auth, Authentication::OAuth { .. })
+                || !needs_refresh(&current_auth)
+            {
+                return auth_outcome(current_auth);
+            }
+            current_auth
+        }
+        Ok(None) => auth,
+        Err(e) => {
+            tracing::warn!("Failed to re-read OAuth credentials before refresh: {e}");
+            auth
+        }
+    };
+
     let Authentication::OAuth {
         access_token: _,
         ref refresh_token,
-        expires_at,
+        expires_at: _,
         ref token_endpoint,
         ref revocation_endpoint,
         ref client_id,
     } = auth
     else {
-        return Some(auth);
+        return auth_outcome(auth);
     };
 
-    let is_expired = expires_at.is_some_and(|exp| {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
-        exp - now < EXPIRY_SKEW_SECONDS
-    });
-
-    if !is_expired {
-        return Some(auth);
-    }
-
     let Some(refresh_token_val) = refresh_token.as_deref() else {
-        tracing::warn!("OAuth token is expired but no refresh token is available");
-        return Some(auth);
+        let failure = OAuthRefreshFailure::MissingRefreshToken;
+        tracing::warn!("{failure}");
+        return stale_auth_fallback(auth, failure);
     };
 
     tracing::debug!("OAuth token expired, attempting refresh");
@@ -64,41 +176,55 @@ pub async fn maybe_refresh_oauth(
     let response = match client
         .post(token_endpoint.as_str())
         .form(&params)
+        .timeout(REFRESH_REQUEST_TIMEOUT)
         .send()
         .await
     {
         Ok(resp) => resp,
         Err(e) => {
-            tracing::warn!("Failed to refresh OAuth token: {e}");
-            return Some(auth);
+            let failure = OAuthRefreshFailure::Transient {
+                reason: format!("Failed to refresh OAuth token: {e}"),
+            };
+            tracing::warn!("{failure}");
+            return stale_auth_fallback(auth, failure);
         }
     };
 
     if !response.status().is_success() {
         let status = response.status();
-        let hint = match response.json::<serde_json::Value>().await {
+        let failure = match response.json::<serde_json::Value>().await {
             Ok(body) => {
                 let error_code = body
                     .get("error")
                     .and_then(|v| v.as_str())
                     .unwrap_or("unknown");
                 if error_code == "invalid_grant" {
-                    "refresh token is expired or revoked — please re-authenticate".to_string()
+                    OAuthRefreshFailure::ReauthenticationRequired {
+                        reason: "refresh token is expired or revoked — please re-authenticate"
+                            .to_string(),
+                    }
                 } else {
-                    format!("error code: {error_code}")
+                    OAuthRefreshFailure::Transient {
+                        reason: format!("OAuth token refresh failed with error code: {error_code}"),
+                    }
                 }
             }
-            Err(_) => format!("HTTP {status}"),
+            Err(_) => OAuthRefreshFailure::Transient {
+                reason: format!("OAuth token refresh failed with HTTP {status}"),
+            },
         };
-        tracing::warn!("OAuth token refresh failed ({hint})");
-        return Some(auth);
+        tracing::warn!("OAuth token refresh failed ({failure})");
+        return stale_auth_fallback(auth, failure);
     }
 
     let token_response: TokenRefreshResponse = match response.json().await {
         Ok(body) => body,
         Err(e) => {
-            tracing::warn!("Failed to read OAuth refresh response body: {e}");
-            return Some(auth);
+            let failure = OAuthRefreshFailure::InvalidResponse {
+                reason: format!("Failed to read OAuth refresh response body: {e}"),
+            };
+            tracing::warn!("{failure}");
+            return stale_auth_fallback(auth, failure);
         }
     };
 
@@ -125,5 +251,295 @@ pub async fn maybe_refresh_oauth(
         tracing::warn!("Failed to store refreshed OAuth token: {e}");
     }
 
-    Some(refreshed)
+    auth_outcome(refreshed)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::HashMap,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    use axum::{Json, Router, extract::Form, http::StatusCode, routing::post};
+    use futures::future::join_all;
+    use serde_json::json;
+
+    use super::*;
+    use crate::authentication_storage::backends::memory::MemoryStorage;
+
+    fn expired_oauth(token_endpoint: String) -> Authentication {
+        Authentication::OAuth {
+            access_token: "expired-access-token".to_string(),
+            refresh_token: Some("refresh-token".to_string()),
+            expires_at: Some(now_unix_timestamp() - 60),
+            token_endpoint,
+            revocation_endpoint: None,
+            client_id: "client-id".to_string(),
+        }
+    }
+
+    /// An OAuth token inside the refresh skew window (so `needs_refresh` is true)
+    /// but not yet expired (so `is_expired` is false).
+    fn near_expiry_oauth(token_endpoint: String) -> Authentication {
+        Authentication::OAuth {
+            access_token: "near-expiry-access-token".to_string(),
+            refresh_token: Some("refresh-token".to_string()),
+            expires_at: Some(now_unix_timestamp() + 60),
+            token_endpoint,
+            revocation_endpoint: None,
+            client_id: "client-id".to_string(),
+        }
+    }
+
+    fn auth_storage(host: &str, auth: &Authentication) -> AuthenticationStorage {
+        let mut storage = AuthenticationStorage::empty();
+        storage.add_backend(Arc::new(MemoryStorage::new()));
+        storage.store(host, auth).unwrap();
+        storage
+    }
+
+    /// Spawn a token endpoint whose handler receives the posted form parameters,
+    /// so tests can assert on (and react to) the `refresh_token` that was sent.
+    async fn spawn_token_endpoint_with_form(
+        handler: impl Fn(HashMap<String, String>) -> (StatusCode, Json<serde_json::Value>)
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    ) -> String {
+        let router = Router::new().route(
+            "/token",
+            post({
+                let handler = handler.clone();
+                move |Form(form): Form<HashMap<String, String>>| {
+                    let handler = handler.clone();
+                    async move { handler(form) }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        format!("http://{addr}/token")
+    }
+
+    async fn spawn_token_endpoint(
+        handler: impl Fn() -> (StatusCode, Json<serde_json::Value>) + Clone + Send + Sync + 'static,
+    ) -> String {
+        let router = Router::new().route(
+            "/token",
+            post({
+                let handler = handler.clone();
+                move || {
+                    let handler = handler.clone();
+                    async move { handler() }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        format!("http://{addr}/token")
+    }
+
+    #[tokio::test]
+    async fn concurrent_refresh_is_single_flight() {
+        let refresh_count = Arc::new(AtomicUsize::new(0));
+        let token_endpoint = spawn_token_endpoint({
+            let refresh_count = refresh_count.clone();
+            move || {
+                refresh_count.fetch_add(1, Ordering::SeqCst);
+                (
+                    StatusCode::OK,
+                    Json(json!({
+                        "access_token": "fresh-access-token",
+                        "refresh_token": "rotated-refresh-token",
+                        "expires_in": 3600,
+                    })),
+                )
+            }
+        })
+        .await;
+
+        let host = "repo.prefix.dev";
+        let expired = expired_oauth(token_endpoint);
+        let storage = auth_storage(host, &expired);
+
+        let results =
+            join_all((0..8).map(|_| maybe_refresh_oauth(&storage, expired.clone(), host))).await;
+
+        assert_eq!(refresh_count.load(Ordering::SeqCst), 1);
+        for result in results {
+            assert_eq!(result.failure, None);
+            assert!(matches!(
+                result.authentication,
+                Some(Authentication::OAuth { access_token, .. }) if access_token == "fresh-access-token"
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn expired_token_is_not_returned_after_refresh_failure() {
+        let token_endpoint = spawn_token_endpoint(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(json!({ "error": "invalid_grant" })),
+            )
+        })
+        .await;
+
+        let host = "repo.prefix.dev";
+        let expired = expired_oauth(token_endpoint);
+        let storage = auth_storage(host, &expired);
+
+        let result = maybe_refresh_oauth(&storage, expired, host).await;
+
+        assert_eq!(result.authentication, None);
+        assert!(matches!(
+            result.failure,
+            Some(OAuthRefreshFailure::ReauthenticationRequired { .. })
+        ));
+    }
+
+    /// The core property the coalescing gate protects: with refresh-token
+    /// rotation enabled, concurrent refreshes must never send a stale refresh
+    /// token to the authorization server. The endpoint here rotates its single
+    /// valid refresh token on every successful refresh and rejects any other
+    /// token with `invalid_grant` — exactly how a rotating server behaves. If
+    /// two requests both refreshed (the bug), the second would arrive with the
+    /// now-stale original token and be rejected.
+    #[tokio::test]
+    async fn concurrent_refresh_never_reuses_rotated_token() {
+        let valid_refresh_token = Arc::new(Mutex::new("refresh-token".to_string()));
+        let success_count = Arc::new(AtomicUsize::new(0));
+        let invalid_grant_count = Arc::new(AtomicUsize::new(0));
+
+        let token_endpoint = spawn_token_endpoint_with_form({
+            let valid_refresh_token = valid_refresh_token.clone();
+            let success_count = success_count.clone();
+            let invalid_grant_count = invalid_grant_count.clone();
+            move |form| {
+                let presented = form.get("refresh_token").cloned().unwrap_or_default();
+                let mut valid = valid_refresh_token.lock().unwrap();
+                if presented == *valid {
+                    // Rotate: the presented token is now spent.
+                    let rotated =
+                        format!("rotated-{}", success_count.fetch_add(1, Ordering::SeqCst));
+                    *valid = rotated.clone();
+                    (
+                        StatusCode::OK,
+                        Json(json!({
+                            "access_token": "fresh-access-token",
+                            "refresh_token": rotated,
+                            "expires_in": 3600,
+                        })),
+                    )
+                } else {
+                    invalid_grant_count.fetch_add(1, Ordering::SeqCst);
+                    (
+                        StatusCode::BAD_REQUEST,
+                        Json(json!({ "error": "invalid_grant" })),
+                    )
+                }
+            }
+        })
+        .await;
+
+        let host = "repo.prefix.dev";
+        let expired = expired_oauth(token_endpoint);
+        let storage = auth_storage(host, &expired);
+
+        let results =
+            join_all((0..8).map(|_| maybe_refresh_oauth(&storage, expired.clone(), host))).await;
+
+        // Exactly one refresh hit the server and no stale token was ever presented.
+        assert_eq!(success_count.load(Ordering::SeqCst), 1);
+        assert_eq!(invalid_grant_count.load(Ordering::SeqCst), 0);
+        for result in results {
+            assert_eq!(result.failure, None);
+            assert!(matches!(
+                result.authentication,
+                Some(Authentication::OAuth { access_token, .. }) if access_token == "fresh-access-token"
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_refresh_token_yields_unauthenticated() {
+        let host = "repo.prefix.dev";
+        let expired = Authentication::OAuth {
+            access_token: "expired-access-token".to_string(),
+            refresh_token: None,
+            expires_at: Some(now_unix_timestamp() - 60),
+            token_endpoint: "http://127.0.0.1:0/token".to_string(),
+            revocation_endpoint: None,
+            client_id: "client-id".to_string(),
+        };
+        let storage = auth_storage(host, &expired);
+
+        let result = maybe_refresh_oauth(&storage, expired, host).await;
+
+        assert_eq!(result.authentication, None);
+        assert!(matches!(
+            result.failure,
+            Some(OAuthRefreshFailure::MissingRefreshToken)
+        ));
+    }
+
+    #[tokio::test]
+    async fn transient_failure_on_expired_token_yields_unauthenticated() {
+        let token_endpoint = spawn_token_endpoint(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "server_error" })),
+            )
+        })
+        .await;
+
+        let host = "repo.prefix.dev";
+        let expired = expired_oauth(token_endpoint);
+        let storage = auth_storage(host, &expired);
+
+        let result = maybe_refresh_oauth(&storage, expired, host).await;
+
+        // The token is expired, so a transient failure must not attach it.
+        assert_eq!(result.authentication, None);
+        assert!(matches!(
+            result.failure,
+            Some(OAuthRefreshFailure::Transient { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn transient_failure_keeps_unexpired_token() {
+        let token_endpoint = spawn_token_endpoint(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "server_error" })),
+            )
+        })
+        .await;
+
+        let host = "repo.prefix.dev";
+        let near_expiry = near_expiry_oauth(token_endpoint);
+        let storage = auth_storage(host, &near_expiry);
+
+        let result = maybe_refresh_oauth(&storage, near_expiry, host).await;
+
+        // The token is within the refresh-skew window but not yet expired, so a
+        // transient failure should still attach the existing token and surface
+        // the failure as non-fatal.
+        assert!(matches!(
+            result.authentication,
+            Some(Authentication::OAuth { access_token, .. }) if access_token == "near-expiry-access-token"
+        ));
+        assert!(matches!(
+            result.failure,
+            Some(OAuthRefreshFailure::Transient { .. })
+        ));
+    }
 }


### PR DESCRIPTION
### Description

This PR makes OAuth token refresh in `rattler_networking` coalesce concurrent refresh attempts for the same stored credential.

The motivation is a somewhat theoretical / hard-to-reproduce failure mode we suspect can happen when multiple requests start at the same time with an expired OAuth access token. For example, pixi may request both `noarch/repodata_shards.msgpack.zst` and `<platform>/repodata_shards.msgpack.zst` for a single channel. If both requests notice that the access token is expired, they can both try to use the same refresh token.

That is problematic when the authorization server rotates refresh tokens: the first refresh succeeds and stores the rotated token, while the second refresh can fail with `invalid_grant` because it is still using the old refresh token. Before this change, that failure path could still attach the expired access token to the original request.

I do not have a reliable reproducer for the actual pixi failure, but this matches the kind of occasional 401-on-repodata behavior we have seen. Although I suspect a server-side change (prefix.dev) is required as well, probably when the refresh token TTL has also passed.

This PR:
- adds a per-`AuthenticationStorage` / per-auth-key refresh gate
- re-reads the stored credential after waiting for the refresh gate, so concurrent requests can reuse a freshly stored token
- avoids attaching an expired access token when refresh failed
- adds a timeout to refresh requests so a stuck token endpoint does not block indefinitely
- keeps the refresh outcome internal to `rattler_networking` instead of adding new public API
- adds tests for rotating refresh tokens, failed refresh, and middleware-level behavior

No linked issue.

### How Has This Been Tested?

```shell
pixi run cargo-fmt
pixi run -- cargo nextest run -p rattler_networking oauth_refresh authentication_middleware::tests::expired_oauth_with_failed_refresh_sends_no_authorization_header authentication_middleware::tests::concurrent_oauth_refresh_is_coalesced_by_authentication_middleware
pixi run -- cargo nextest run -p rattler_networking
```

All rattler_networking tests pass locally.

### AI Disclosure

- [x] This PR contains AI-generated content.
    - [x] I have tested any AI-generated content in my PR.
    - [x] I take responsibility for any AI-generated content in my PR.

Tools: pi / ChatGPT / Opus

Prompt:

```plaintext
Investigate a suspected pixi/rattler OAuth refresh race that can lead to 401s on public prefix.dev repodata shard index requests, then implement a rattler-side fix. Use jj for the checkout. Keep the change focused, add tests, and avoid adding speculative public API.
```

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
