### PR TITLE
fix: add openbsd `ptsname_r` shim to `rattler_pty`

### DIFF
--- a/crates/rattler_pty/src/unix/pty_process.rs
+++ b/crates/rattler_pty/src/unix/pty_process.rs
@@ -75,6 +75,24 @@ fn ptsname_r(fd: &PtyMaster) -> nix::Result<String> {
     }
 }
 
+#[cfg(target_os = "openbsd")]
+/// OpenBSD has neither `nix::pty::ptsname_r` nor `libc::ptsname_r` — only the
+/// POSIX `ptsname(3)`, which returns a pointer into a static buffer and is
+/// not thread-safe. Safe here because `PtyProcess::new` calls this once,
+/// synchronously, before forking.
+fn ptsname_r(fd: &PtyMaster) -> nix::Result<String> {
+    use std::ffi::CStr;
+
+    unsafe {
+        let ptr = libc::ptsname(fd.as_raw_fd());
+        if ptr.is_null() {
+            Err(nix::Error::last())
+        } else {
+            Ok(CStr::from_ptr(ptr).to_string_lossy().into_owned())
+        }
+    }
+}
+
 #[cfg(target_os = "freebsd")]
 /// FreeBSD implementation using FIODGNAME ioctl to get the slave pty name
 fn ptsname_r(fd: &PtyMaster) -> nix::Result<String> {


### PR DESCRIPTION
## Summary

`rattler_pty` has hand-written `ptsname_r` shims for `linux`, `macos`, `freebsd`, and `netbsd` in `crates/rattler_pty/src/unix/pty_process.rs`, but none for `openbsd`. Since `nix::pty::ptsname_r` is only implemented upstream for Linux/Android, and `libc::ptsname_r` isn't available on OpenBSD either, the crate currently fails to compile there with:

```
error[E0425]: cannot find function `ptsname_r` in this scope
   --> crates/rattler_pty/src/unix/pty_process.rs:130:26
    |
130 |         let slave_name = ptsname_r(&master_fd)?;
    |                          ^^^^^^^^^ not found in this scope
```

This adds an `openbsd` arm using the POSIX `ptsname(3)` (available on all unix targets via `libc::ptsname`, just not the `_r` variant). It returns a pointer into a static buffer and isn't thread-safe, but that's fine here since `PtyProcess::new` calls it once, synchronously, before forking — the same constraint the existing macOS shim already relies on (its doc comment notes the same trade-off).

Found this while getting [mise](https://github.com/jdx/mise) (a transitive consumer via `rattler` → `rattler_shell` → `rattler_pty`) building on OpenBSD.

## Test plan

- [x] Diffed against the `freebsd`/`netbsd`/`macos` shims for the same pattern (ioctl vs. direct libc call) — this one mirrors the macOS shim's structure most closely since both use a single non-reentrant call.
- [ ] Maintainers: I don't have an OpenBSD CI runner to confirm in this repo's own CI; happy to share local build output from an OpenBSD box if useful, but didn't want to assume your CI matrix has one.

*This PR description was generated with AI assistance.*