### PR TITLE
ci(py): bump ppc64le/ppc64 test wheel distro to ubuntu22.04

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -212,7 +212,7 @@ jobs:
         name: Test wheel
         with:
           arch: ${{ matrix.platform.arch }}
-          distro: ubuntu20.04
+          distro: ubuntu22.04
           githubToken: ${{ github.token }}
           install: |
             apt-get update


### PR DESCRIPTION
The linux-cross-native-tls job (ppc64le/ppc64) still tested wheels inside
ubuntu20.04, which ships Python 3.8. Since py-rattler now builds abi3-py310
wheels (requires-python >=3.10), pip on Python 3.8 cannot find a matching
distribution, failing the "Test wheel" step. Bump the distro to ubuntu22.04
(Python 3.10) to match the linux-cross job.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UkiWG7oGNJemHp57FHeAvb