### PR TITLE
fix: add `ptsname_r` on Android compilation

### DIFF
--- a/crates/rattler_pty/src/unix/pty_process.rs
+++ b/crates/rattler_pty/src/unix/pty_process.rs
@@ -24,7 +24,7 @@ use tokio::{
     time::{Duration, Instant, sleep},
 };
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use nix::pty::ptsname_r;
 
 #[cfg(target_os = "netbsd")]


### PR DESCRIPTION
### Description

The `rattler_pty` package is being used in `mise`, and in order to port
it to Android/Termux it required a trivial patch to expose `ptsname_r`

https://github.com/termux/termux-packages/blob/d4967a3307cc8386052ec3f395f9deef18f9544d/packages/mise/rattler_pty-android-target.diff

This commit upstreams the patch to remove the need to vender/patch the
dependency on Termux package respositories.

This is Similar to https://github.com/conda/rattler/pull/2524

Kudos for @igorgatis on the [discussion](https://github.com/jdx/mise/discussions/7026) for reporting the patch.


### How Has This Been Tested?

Running with cross:

```sh
git clone github.com/conda/rattler.git
cd crates/rattler_pty
cross build --target aarch64-linux-android
```

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
