### PR TITLE
feat(networking)!: challenge-reactive auth middleware + graceful OAuth expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,6 +884,8 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
+ "serde_json",
+ "serde_path_to_error",
  "sync_wrapper",
  "tokio",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5287,6 +5287,7 @@ dependencies = [
  "dbus-secret-service-keyring-store",
  "dirs",
  "fs-err",
+ "futures",
  "getrandom 0.4.2",
  "google-cloud-auth",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2776,6 +2776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5292,6 +5301,7 @@ dependencies = [
  "google-cloud-auth",
  "hex",
  "http 1.4.2",
+ "http-auth",
  "insta",
  "itertools 0.14.0",
  "keyring-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ hashbrown = "0.17"
 hex = "0.4.3"
 hex-literal = "1.0.0"
 http = "1.4"
+http-auth = { version = "0.1.10", default-features = false }
 http-cache-semantics = "3.0.0"
 humansize = "2.1.3"
 humantime = "2.2.0"

--- a/crates/rattler-bin/src/commands/client.rs
+++ b/crates/rattler-bin/src/commands/client.rs
@@ -70,7 +70,7 @@ pub fn create_client_with_middleware_for_channels(
         {
             continue;
         }
-        let Some(options) = TrustedPublishingOptions::for_host(url) else {
+        let Some(options) = TrustedPublishingOptions::for_server(url) else {
             continue;
         };
         let mut server = url.clone();

--- a/crates/rattler-bin/src/commands/client.rs
+++ b/crates/rattler-bin/src/commands/client.rs
@@ -1,13 +1,39 @@
 use std::{collections::HashMap, sync::Arc};
 
 use miette::{Context, IntoDiagnostic};
-use rattler_networking::{AuthenticationMiddleware, AuthenticationStorage};
+use rattler_conda_types::Channel;
+use rattler_networking::{
+    AuthChallengeMiddleware, AuthenticationMiddleware, AuthenticationStorage,
+    trusted_publishing::{TrustedPublishingFlow, TrustedPublishingOptions},
+};
 use reqwest::Client;
+use url::Url;
 
 pub const USER_AGENT: &str = concat!("rattler/", env!("CARGO_PKG_VERSION"));
 
+/// Hosts for which the CLI is willing to perform CI OIDC trusted publishing.
+/// Restricting this keeps the CLI from volunteering CI identity tokens to
+/// arbitrary channel hosts.
+fn is_prefix_dev_host(host: &str) -> bool {
+    host == "prefix.dev" || host.ends_with(".prefix.dev")
+}
+
 /// Creates an HTTP client with the middleware stack used by the CLI for remote fetches.
 pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
+    create_client_with_middleware_for_channels(&[])
+}
+
+/// Like [`create_client_with_middleware`], but additionally layers one
+/// [`AuthChallengeMiddleware`] per unique `https` channel host that matches
+/// the prefix.dev host policy. On a `WWW-Authenticate` challenge from such a
+/// host, the middleware acquires a token via CI OIDC trusted publishing
+/// (audience = the channel host) and replays the request.
+///
+/// This is the reference wiring for challenge-reactive private-channel
+/// reads (see prefix-dev/pixi#6318).
+pub fn create_client_with_middleware_for_channels(
+    channels: &[Channel],
+) -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
     let download_client = Client::builder()
         .no_gzip()
         .user_agent(USER_AGENT)
@@ -18,11 +44,40 @@ pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::Cli
     let authentication_storage =
         AuthenticationStorage::from_env_and_defaults().into_diagnostic()?;
 
-    let client = reqwest_middleware::ClientBuilder::new(download_client.clone())
-        .with_arc(Arc::new(AuthenticationMiddleware::from_auth_storage(
-            authentication_storage.clone(),
-        )))
-        .with(rattler_networking::OciMiddleware::new(download_client));
+    let mut client =
+        reqwest_middleware::ClientBuilder::new(download_client.clone()).with_arc(Arc::new(
+            AuthenticationMiddleware::from_auth_storage(authentication_storage.clone()),
+        ));
+
+    // The mint exchange must not itself go through AuthChallengeMiddleware
+    // (it would recurse), so it uses a plain client.
+    let mint_client = reqwest_middleware::ClientBuilder::new(download_client.clone()).build();
+
+    let mut seen_hosts = std::collections::HashSet::new();
+    for channel in channels {
+        let url: &Url = channel.base_url.as_ref();
+        if url.scheme() != "https" {
+            continue;
+        }
+        let Some(host) = url.host_str() else {
+            continue;
+        };
+        if !is_prefix_dev_host(host) || !seen_hosts.insert(host.to_string()) {
+            continue;
+        }
+        let Some(options) = TrustedPublishingOptions::for_host(url) else {
+            continue;
+        };
+        let mut server = url.clone();
+        server.set_path("/");
+        server.set_query(None);
+        client = client.with_arc(Arc::new(AuthChallengeMiddleware::new(
+            server,
+            Arc::new(TrustedPublishingFlow::new(options, mint_client.clone())),
+        )));
+    }
+
+    let client = client.with(rattler_networking::OciMiddleware::new(download_client));
     #[cfg(feature = "s3")]
     let client = client.with(rattler_networking::S3Middleware::new(
         HashMap::new(),
@@ -32,4 +87,20 @@ pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::Cli
     let client = client.with(rattler_networking::GCSMiddleware::default());
 
     Ok(client.build())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_dev_host_policy() {
+        assert!(is_prefix_dev_host("prefix.dev"));
+        assert!(is_prefix_dev_host("beta.prefix.dev"));
+        assert!(is_prefix_dev_host("staging.beta.prefix.dev"));
+        // not subdomains of prefix.dev:
+        assert!(!is_prefix_dev_host("evil-prefix.dev"));
+        assert!(!is_prefix_dev_host("prefix.dev.evil.com"));
+        assert!(!is_prefix_dev_host("conda.anaconda.org"));
+    }
 }

--- a/crates/rattler-bin/src/commands/client.rs
+++ b/crates/rattler-bin/src/commands/client.rs
@@ -1,42 +1,22 @@
 use std::{collections::HashMap, sync::Arc};
 
 use miette::{Context, IntoDiagnostic};
-use rattler_conda_types::Channel;
 use rattler_networking::{
     AuthChallengeMiddleware, AuthenticationMiddleware, AuthenticationStorage,
-    trusted_publishing::{TrustedPublishingFlow, TrustedPublishingOptions},
 };
 use reqwest::Client;
-use url::Url;
 
 pub const USER_AGENT: &str = concat!("rattler/", env!("CARGO_PKG_VERSION"));
 
-/// Hosts for which the CLI is willing to perform CI OIDC trusted publishing.
-/// Restricting this keeps the CLI from volunteering CI identity tokens to
-/// arbitrary channel hosts.
-fn is_prefix_dev_host(host: &str) -> bool {
-    host == "prefix.dev" || host.ends_with(".prefix.dev")
-}
-
 /// Creates an HTTP client with the middleware stack used by the CLI for remote fetches.
 ///
-/// This stack performs no challenge/trusted-publishing auth; commands that
-/// read channels should prefer [`create_client_with_middleware_for_channels`].
+/// The stack includes [`AuthChallengeMiddleware`] with its default flows: on
+/// a `WWW-Authenticate` challenge from a prefix.dev host, a token is minted
+/// via CI OIDC trusted publishing and the request is replayed — the
+/// zero-configuration wiring for challenge-reactive private-channel reads
+/// (see prefix-dev/pixi#6318). Stored credentials from
+/// [`AuthenticationMiddleware`] always take precedence.
 pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
-    create_client_with_middleware_for_channels(&[])
-}
-
-/// Like [`create_client_with_middleware`], but additionally layers one
-/// [`AuthChallengeMiddleware`] per unique `https` channel host that matches
-/// the prefix.dev host policy. On a `WWW-Authenticate` challenge from such a
-/// host, the middleware acquires a token via CI OIDC trusted publishing
-/// (audience = the channel host) and replays the request.
-///
-/// This is the reference wiring for challenge-reactive private-channel
-/// reads (see prefix-dev/pixi#6318).
-pub fn create_client_with_middleware_for_channels(
-    channels: &[Channel],
-) -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
     let download_client = Client::builder()
         .no_gzip()
         .user_agent(USER_AGENT)
@@ -47,42 +27,11 @@ pub fn create_client_with_middleware_for_channels(
     let authentication_storage =
         AuthenticationStorage::from_env_and_defaults().into_diagnostic()?;
 
-    let mut client =
-        reqwest_middleware::ClientBuilder::new(download_client.clone()).with_arc(Arc::new(
-            AuthenticationMiddleware::from_auth_storage(authentication_storage.clone()),
-        ));
-
-    // The mint exchange must not itself go through AuthChallengeMiddleware
-    // (it would recurse), so it uses a plain client.
-    let mint_client = reqwest_middleware::ClientBuilder::new(download_client.clone()).build();
-
-    let mut seen_hosts = std::collections::HashSet::new();
-    for channel in channels {
-        let url: &Url = channel.base_url.as_ref();
-        if url.scheme() != "https" {
-            continue;
-        }
-        let Some(host) = url.host_str() else {
-            continue;
-        };
-        if !is_prefix_dev_host(host)
-            || !seen_hosts.insert((host.to_string(), url.port_or_known_default()))
-        {
-            continue;
-        }
-        let Some(options) = TrustedPublishingOptions::for_server(url) else {
-            continue;
-        };
-        let mut server = url.clone();
-        // Cosmetic: the middleware scopes on scheme+host+port and ignores
-        // path/query; normalizing just keeps Debug output tidy.
-        server.set_path("/");
-        server.set_query(None);
-        client = client.with_arc(Arc::new(AuthChallengeMiddleware::new(
-            server,
-            Arc::new(TrustedPublishingFlow::new(options, mint_client.clone())),
-        )));
-    }
+    let client = reqwest_middleware::ClientBuilder::new(download_client.clone())
+        .with_arc(Arc::new(AuthenticationMiddleware::from_auth_storage(
+            authentication_storage.clone(),
+        )))
+        .with_arc(Arc::new(AuthChallengeMiddleware::default()));
 
     let client = client.with(rattler_networking::OciMiddleware::new(download_client));
     #[cfg(feature = "s3")]
@@ -94,23 +43,4 @@ pub fn create_client_with_middleware_for_channels(
     let client = client.with(rattler_networking::GCSMiddleware::default());
 
     Ok(client.build())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn prefix_dev_host_policy() {
-        assert!(is_prefix_dev_host("prefix.dev"));
-        assert!(is_prefix_dev_host("beta.prefix.dev"));
-        assert!(is_prefix_dev_host("staging.beta.prefix.dev"));
-        // not subdomains of prefix.dev:
-        assert!(!is_prefix_dev_host("evil-prefix.dev"));
-        assert!(!is_prefix_dev_host("prefix.dev.evil.com"));
-        assert!(!is_prefix_dev_host("conda.anaconda.org"));
-        // trailing-dot (DNS absolute) hosts are deliberately not matched:
-        // url::Url preserves the dot, so this fails closed.
-        assert!(!is_prefix_dev_host("beta.prefix.dev."));
-    }
 }

--- a/crates/rattler-bin/src/commands/client.rs
+++ b/crates/rattler-bin/src/commands/client.rs
@@ -8,14 +8,12 @@ use reqwest::Client;
 
 pub const USER_AGENT: &str = concat!("rattler/", env!("CARGO_PKG_VERSION"));
 
-/// Creates an HTTP client with the middleware stack used by the CLI for remote fetches.
+/// Creates the HTTP client with the middleware stack used by the CLI.
 ///
-/// The stack includes [`AuthChallengeMiddleware`] with its default flows: on
-/// a `WWW-Authenticate` challenge from a prefix.dev host, a token is minted
-/// via CI OIDC trusted publishing and the request is replayed — the
-/// zero-configuration wiring for challenge-reactive private-channel reads
-/// (see prefix-dev/pixi#6318). Stored credentials from
-/// [`AuthenticationMiddleware`] always take precedence.
+/// Includes [`AuthChallengeMiddleware`] with its default flows: a
+/// `WWW-Authenticate` challenge from a prefix.dev host mints a token via
+/// CI OIDC and replays the request (prefix-dev/pixi#6318). Stored
+/// credentials from [`AuthenticationMiddleware`] take precedence.
 pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
     let download_client = Client::builder()
         .no_gzip()

--- a/crates/rattler-bin/src/commands/client.rs
+++ b/crates/rattler-bin/src/commands/client.rs
@@ -19,6 +19,9 @@ fn is_prefix_dev_host(host: &str) -> bool {
 }
 
 /// Creates an HTTP client with the middleware stack used by the CLI for remote fetches.
+///
+/// This stack performs no challenge/trusted-publishing auth; commands that
+/// read channels should prefer [`create_client_with_middleware_for_channels`].
 pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
     create_client_with_middleware_for_channels(&[])
 }
@@ -62,13 +65,17 @@ pub fn create_client_with_middleware_for_channels(
         let Some(host) = url.host_str() else {
             continue;
         };
-        if !is_prefix_dev_host(host) || !seen_hosts.insert(host.to_string()) {
+        if !is_prefix_dev_host(host)
+            || !seen_hosts.insert((host.to_string(), url.port_or_known_default()))
+        {
             continue;
         }
         let Some(options) = TrustedPublishingOptions::for_host(url) else {
             continue;
         };
         let mut server = url.clone();
+        // Cosmetic: the middleware scopes on scheme+host+port and ignores
+        // path/query; normalizing just keeps Debug output tidy.
         server.set_path("/");
         server.set_query(None);
         client = client.with_arc(Arc::new(AuthChallengeMiddleware::new(
@@ -102,5 +109,8 @@ mod tests {
         assert!(!is_prefix_dev_host("evil-prefix.dev"));
         assert!(!is_prefix_dev_host("prefix.dev.evil.com"));
         assert!(!is_prefix_dev_host("conda.anaconda.org"));
+        // trailing-dot (DNS absolute) hosts are deliberately not matched:
+        // url::Url preserves the dot, so this fails closed.
+        assert!(!is_prefix_dev_host("beta.prefix.dev."));
     }
 }

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -179,7 +179,7 @@ pub async fn create(opt: Opt) -> miette::Result<()> {
     // `repodata.json` that should be available from the corresponding Url. The
     // code below also displays a nice CLI progress-bar to give users some more
     // information about what is going on.
-    let download_client = super::client::create_client_with_middleware()?;
+    let download_client = super::client::create_client_with_middleware_for_channels(&channels)?;
 
     // Get the package names from the matchspecs so we can only load the package
     // records that we need.

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -179,7 +179,7 @@ pub async fn create(opt: Opt) -> miette::Result<()> {
     // `repodata.json` that should be available from the corresponding Url. The
     // code below also displays a nice CLI progress-bar to give users some more
     // information about what is going on.
-    let download_client = super::client::create_client_with_middleware_for_channels(&channels)?;
+    let download_client = super::client::create_client_with_middleware()?;
 
     // Get the package names from the matchspecs so we can only load the package
     // records that we need.

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -86,7 +86,7 @@ anyhow = { workspace = true }
 insta = { workspace = true, features = ["json"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
-axum = { workspace = true }
+axum = { workspace = true, features = ["json"] }
 reqwest-retry = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -36,6 +36,7 @@ async-trait = { workspace = true }
 base64 = { workspace = true }
 dirs = { workspace = true, optional = true }
 fs-err = { workspace = true }
+futures = { workspace = true }
 google-cloud-auth = { workspace = true, optional = true }
 aws-config = { workspace = true, optional = true, features = [
     "rt-tokio",
@@ -85,7 +86,7 @@ windows-native-keyring-store = { workspace = true, optional = true }
 anyhow = { workspace = true }
 insta = { workspace = true, features = ["json"] }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "time"] }
 axum = { workspace = true, features = ["json"] }
 reqwest-retry = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -88,6 +88,9 @@ anyhow = { workspace = true }
 insta = { workspace = true, features = ["json"] }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "time"] }
+# `stream` (test-only) lets us build an unclonable streaming-body request to
+# exercise the challenge-middleware's no-replay path.
+reqwest = { workspace = true, features = ["json", "form", "stream"] }
 axum = { workspace = true, features = ["json"] }
 reqwest-retry = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -52,6 +52,7 @@ aws-sdk-s3 = { workspace = true, optional = true, features = [
 ] }
 aws-smithy-http-client = { workspace = true, optional = true, features = ["rustls-aws-lc"] }
 http = { workspace = true }
+http-auth = { workspace = true }
 itertools = { workspace = true }
 keyring-core = { workspace = true, optional = true }
 netrc-rs = { workspace = true, optional = true }

--- a/crates/rattler_networking/src/authentication_middleware.rs
+++ b/crates/rattler_networking/src/authentication_middleware.rs
@@ -15,6 +15,17 @@ use crate::{
     oauth_refresh,
 };
 
+/// Error returned when a request to `host` failed authentication while the
+/// stored OAuth credential for that host was expired and could not be
+/// refreshed. Surfaced so callers can tell the user to authenticate again
+/// (e.g. by re-running their login command).
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("authentication for '{host}' has expired; please re-authenticate")]
+pub struct AuthenticationExpired {
+    /// The host that requires re-authentication.
+    pub host: String,
+}
+
 /// `reqwest` middleware to authenticate requests
 #[derive(Clone)]
 pub struct AuthenticationMiddleware {
@@ -42,6 +53,15 @@ impl Middleware for AuthenticationMiddleware {
                 next.run(req, extensions).await
             }
             Ok((url, auth_with_key)) => {
+                // Remember whether we started with an OAuth credential for this
+                // host, so that if the refresh drops it (expired and not
+                // refreshable) and the request still fails authentication, we
+                // can tell the user to re-authenticate.
+                let oauth_host = match &auth_with_key {
+                    Some((_, Authentication::OAuth { .. })) => url.host_str().map(str::to_string),
+                    _ => None,
+                };
+
                 // If this is an OAuth token, attempt refresh if expired
                 let auth = match auth_with_key {
                     Some((matched_key, auth)) => {
@@ -51,13 +71,32 @@ impl Middleware for AuthenticationMiddleware {
                     None => None,
                 };
 
+                // An OAuth credential the refresh dropped (now `None`) means the
+                // request goes out unauthenticated and any auth-challenge
+                // middleware gets its turn; if the request still comes back
+                // unauthorized, the user needs to re-authenticate.
+                let reauth_host = match (&auth, oauth_host) {
+                    (None, Some(host)) => Some(host),
+                    _ => None,
+                };
+
                 let url = Self::authenticate_url(url, &auth);
 
                 let mut req = req;
                 *req.url_mut() = url;
 
                 let req = Self::authenticate_request(req, &auth).await?;
-                next.run(req, extensions).await
+                let response = next.run(req, extensions).await?;
+
+                if let Some(host) = reauth_host
+                    && matches!(response.status().as_u16(), 401 | 403)
+                {
+                    return Err(reqwest_middleware::Error::middleware(AuthenticationExpired {
+                        host,
+                    }));
+                }
+
+                Ok(response)
             }
         }
     }

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -1,8 +1,8 @@
 //! Host-scoped middleware that reacts to `WWW-Authenticate` challenges by
-//! acquiring a bearer token from a pluggable `AuthFlow` and replaying the
+//! acquiring a bearer token from a pluggable [`AuthFlow`] and replaying the
 //! request once.
 //!
-//! The first `AuthFlow` implementation will be
+//! The first [`AuthFlow`] implementation will be
 //! `crate::trusted_publishing::TrustedPublishingFlow` (added in a later task).
 
 use std::{
@@ -16,6 +16,8 @@ use base64::{
     engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
 };
 use serde::Deserialize;
+use thiserror::Error;
+use url::Url;
 
 /// One parsed challenge from a `WWW-Authenticate` response header.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -132,7 +134,7 @@ fn split_commas_respecting_quotes(s: &str) -> Vec<&str> {
 #[allow(dead_code)]
 const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
 
-/// A short-lived bearer token acquired by an auth flow (trait added in a later task).
+/// A short-lived bearer token acquired by an [`AuthFlow`] implementation.
 ///
 /// `Deserialize`-transparent (a raw JSON string body deserializes directly
 /// into it) and `Clone` so it can be shared between the cache and requests.
@@ -156,6 +158,45 @@ impl fmt::Debug for BearerToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("BearerToken").field(&"<redacted>").finish()
     }
+}
+
+/// Error produced by an [`AuthFlow`] implementation.
+///
+/// Boxed so custom flows can surface arbitrary failures. The middleware only
+/// logs this error and disables further attempts — it never propagates it,
+/// so the caller always observes the server's original response.
+#[derive(Debug, Error)]
+#[error("authentication flow failed: {source}")]
+pub struct AuthFlowError {
+    #[source]
+    source: Box<dyn std::error::Error + Send + Sync + 'static>,
+}
+
+impl AuthFlowError {
+    /// Wrap any error produced by an [`AuthFlow`] implementation.
+    pub fn new(err: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>) -> Self {
+        Self { source: err.into() }
+    }
+}
+
+/// A pluggable strategy that turns a `WWW-Authenticate` challenge into a
+/// bearer token.
+///
+/// Implementations decide which challenges they support (e.g. only scheme
+/// `Bearer`) and how to acquire the token (OIDC exchange, device flow, ...).
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+pub trait AuthFlow: Send + Sync + fmt::Debug {
+    /// Respond to `challenges` received from `url`.
+    ///
+    /// Return `Ok(None)` when this flow does not apply (e.g. unsupported
+    /// scheme, or not running in a CI environment) — the middleware caches
+    /// that negatively and stops asking for the lifetime of the process.
+    async fn acquire_token(
+        &self,
+        url: &Url,
+        challenges: &[Challenge],
+    ) -> Result<Option<BearerToken>, AuthFlowError>;
 }
 
 #[allow(dead_code)]

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -419,10 +419,7 @@ impl Middleware for AuthChallengeMiddleware {
         let url = req.url().clone();
 
         // We can only react to a challenge if the request can be cloned for
-        // replay. Cloning fails only for streaming bodies; such a request is
-        // sent once (with any cached token already attached) and its response
-        // returned as-is, warning if it turns out to be a challenge we could
-        // otherwise have satisfied.
+        // replay.
         let Some(mut retry_req) = req.try_clone() else {
             let response = next.run(req, extensions).await?;
             if !parse_challenges(response.headers()).is_empty() {

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -5,7 +5,17 @@
 //! The first `AuthFlow` implementation will be
 //! `crate::trusted_publishing::TrustedPublishingFlow` (added in a later task).
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    fmt,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use base64::{
+    Engine as _,
+    engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
+};
+use serde::Deserialize;
 
 /// One parsed challenge from a `WWW-Authenticate` response header.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -117,8 +127,104 @@ fn split_commas_respecting_quotes(s: &str) -> Vec<&str> {
     parts
 }
 
+/// Refresh tokens this long before their `exp` so a token does not become
+/// invalid while a request is in flight.
+#[allow(dead_code)]
+const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
+
+/// A short-lived bearer token acquired by an auth flow (trait added in a later task).
+///
+/// `Deserialize`-transparent (a raw JSON string body deserializes directly
+/// into it) and `Clone` so it can be shared between the cache and requests.
+#[derive(Clone, Deserialize)]
+#[serde(transparent)]
+pub struct BearerToken(String);
+
+impl BearerToken {
+    /// Wrap an existing token string.
+    pub fn new(token: String) -> Self {
+        Self(token)
+    }
+
+    /// The raw bearer token. Treat as sensitive; don't log it.
+    pub fn secret(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for BearerToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("BearerToken").field(&"<redacted>").finish()
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Deserialize)]
+struct JwtClaims {
+    exp: Option<u64>,
+}
+
+/// Best-effort extraction of the `exp` claim from a JWT-shaped token.
+/// Returns `None` for opaque tokens, which are then cached without expiry.
+#[allow(dead_code)]
+fn jwt_expiration(token: &str) -> Option<SystemTime> {
+    let mut parts = token.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    let _signature = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+
+    let payload = URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| URL_SAFE.decode(payload))
+        .ok()?;
+    let claims: JwtClaims = serde_json::from_slice(&payload).ok()?;
+    claims
+        .exp
+        .and_then(|exp| UNIX_EPOCH.checked_add(Duration::from_secs(exp)))
+}
+
+#[derive(Debug)]
+struct CachedToken {
+    #[allow(dead_code)]
+    token: BearerToken,
+    #[allow(dead_code)]
+    expires_at: Option<SystemTime>,
+}
+
+impl CachedToken {
+    #[allow(dead_code)]
+    fn new(token: BearerToken) -> Self {
+        let expires_at = jwt_expiration(token.secret());
+        Self { token, expires_at }
+    }
+
+    #[allow(dead_code)]
+    fn is_fresh(&self, now: SystemTime) -> bool {
+        self.expires_at
+            .is_none_or(|expires_at| now + TOKEN_REFRESH_MARGIN < expires_at)
+    }
+}
+
+/// Cache state shared by all clones of one middleware instance.
+#[derive(Debug, Default)]
+#[allow(dead_code)]
+enum TokenCache {
+    /// No acquisition attempted yet.
+    #[default]
+    Empty,
+    /// The flow reported "not applicable" or failed — stop asking.
+    Disabled,
+    /// A previously acquired token.
+    Token(CachedToken),
+}
+
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, UNIX_EPOCH};
+
     use super::*;
 
     fn header_map(values: &[&str]) -> http::HeaderMap {
@@ -192,5 +298,44 @@ mod tests {
         assert!(parse_challenges(&header_map(&[""])).is_empty());
         assert!(parse_challenges(&header_map(&["%%% ###"])).is_empty());
         assert!(parse_challenges(&http::HeaderMap::new()).is_empty());
+    }
+
+    #[test]
+    fn bearer_token_debug_is_redacted() {
+        let token = BearerToken::new("supersecret".to_string());
+        let formatted = format!("{token:?}");
+        assert!(!formatted.contains("supersecret"));
+        assert!(formatted.contains("redacted"));
+    }
+
+    fn unsigned_jwt_with_exp(exp: u64) -> String {
+        use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
+        format!("{header}.{payload}.")
+    }
+
+    #[test]
+    fn jwt_expiration_reads_exp_claim() {
+        let token = unsigned_jwt_with_exp(1_700_000_000);
+        assert_eq!(
+            jwt_expiration(&token),
+            UNIX_EPOCH.checked_add(Duration::from_secs(1_700_000_000))
+        );
+    }
+
+    #[test]
+    fn opaque_token_has_no_expiration() {
+        assert_eq!(jwt_expiration("not-a-jwt"), None);
+    }
+
+    #[test]
+    fn cached_jwt_is_stale_inside_refresh_margin() {
+        let token = BearerToken::new(unsigned_jwt_with_exp(1_700_000_000));
+        let cached = CachedToken::new(token);
+        let now = UNIX_EPOCH + Duration::from_secs(1_700_000_000 - 30);
+        assert!(!cached.is_fresh(now));
+        let earlier = UNIX_EPOCH + Duration::from_secs(1_700_000_000 - 3600);
+        assert!(cached.is_fresh(earlier));
     }
 }

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -730,7 +730,12 @@ mod tests {
             _challenges: &[Challenge],
         ) -> Result<Option<BearerToken>, AuthFlowError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
-            let token = self.tokens.lock().unwrap().remove(0);
+            let mut tokens = self.tokens.lock().unwrap();
+            assert!(
+                !tokens.is_empty(),
+                "SequenceFlow exhausted: middleware called acquire_token more times than expected"
+            );
+            let token = tokens.remove(0);
             Ok(Some(BearerToken::new(token.to_string())))
         }
     }
@@ -769,6 +774,7 @@ mod tests {
 
         assert_eq!(response.status(), 401);
         assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -789,6 +795,7 @@ mod tests {
 
         assert_eq!(response.status(), 401);
         assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -839,8 +846,40 @@ mod tests {
 
     #[tokio::test]
     async fn stale_cached_token_is_cleared_and_reacquired() {
-        let hits = Arc::new(AtomicUsize::new(0));
-        let server_url = spawn_protected_server("fresh", hits.clone()).await;
+        use axum::{http::StatusCode, response::IntoResponse, routing::get};
+
+        // Server accepting only "Bearer fresh", recording the Authorization
+        // header of every request it sees.
+        let seen: Arc<Mutex<Vec<Option<String>>>> = Arc::new(Mutex::new(Vec::new()));
+        let seen_in_handler = seen.clone();
+        let router = axum::Router::new().route(
+            "/channel/repodata.json",
+            get(move |headers: axum::http::HeaderMap| {
+                let seen = seen_in_handler.clone();
+                async move {
+                    let auth = headers
+                        .get("authorization")
+                        .and_then(|v| v.to_str().ok())
+                        .map(str::to_string);
+                    seen.lock().unwrap().push(auth.clone());
+                    if auth.as_deref() == Some("Bearer fresh") {
+                        (StatusCode::OK, "ok").into_response()
+                    } else {
+                        (
+                            StatusCode::UNAUTHORIZED,
+                            [("www-authenticate", r#"Bearer realm="test""#)],
+                            "unauthorized",
+                        )
+                            .into_response()
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        let server_url = Url::parse(&format!("http://{addr}")).unwrap();
+
         let flow = Arc::new(SequenceFlow {
             tokens: Mutex::new(vec!["old", "fresh"]),
             calls: AtomicUsize::new(0),
@@ -851,9 +890,8 @@ mod tests {
         ));
         let url = server_url.join("/channel/repodata.json").unwrap();
 
-        // Request 1: challenge -> flow mints "old" -> replay rejected (401).
-        // "old" is now cached even though the server already rejects it,
-        // simulating a token revoked after acquisition.
+        // Request 1: challenge -> flow mints "old" (cached before the replay
+        // proves it stale) -> replay rejected (401).
         assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
 
         // Request 2: cached "old" attached -> challenged -> cache cleared ->
@@ -861,7 +899,18 @@ mod tests {
         assert_eq!(client.get(url).send().await.unwrap().status(), 200);
 
         assert_eq!(flow.calls.load(Ordering::SeqCst), 2);
-        assert_eq!(hits.load(Ordering::SeqCst), 4);
+        // The header sequence proves the cached path: request 2's first leg
+        // carried the cached "old" token (a non-caching implementation would
+        // send no header there).
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![
+                None,
+                Some("Bearer old".to_string()),
+                Some("Bearer old".to_string()),
+                Some("Bearer fresh".to_string()),
+            ]
+        );
     }
 
     #[tokio::test]
@@ -881,6 +930,10 @@ mod tests {
         assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
         assert_eq!(client.get(url).send().await.unwrap().status(), 401);
         assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+        // Disabled = pass-through (next.run is still called), so both requests
+        // reach the server: request 1 triggers the challenge (1 hit), request 2
+        // is passed through unmodified and also reaches the server (1 hit).
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -222,9 +222,9 @@ pub trait AuthFlow: Send + Sync + fmt::Debug {
     ///
     /// Return `Ok(None)` when the flow does not apply (unsupported scheme,
     /// not in CI, untrusted origin); the origin is then negative-cached.
-    /// `url` is the full challenged URL, not just the origin. Flows may be
-    /// invoked concurrently; redundant invocations must be tolerated
-    /// (tokens are cached last-write-wins).
+    /// `url` is the full challenged URL, not just the origin. Acquisition
+    /// is single-flight per origin, but flows may still be invoked
+    /// concurrently for different origins.
     ///
     /// The middleware invokes flows for every challenged URL, so flows
     /// that forward credentials MUST validate `url`'s origin themselves;
@@ -301,6 +301,15 @@ enum TokenCache {
     Token(CachedToken),
 }
 
+/// Per-origin cache slot plus the gate serializing its acquisition.
+#[derive(Debug, Default)]
+struct OriginEntry {
+    state: TokenCache,
+    /// Single-flight gate: concurrent challenged requests queue here so
+    /// only one runs the flows; the rest reuse its token.
+    gate: Arc<futures::lock::Mutex<()>>,
+}
+
 /// Outcome of a cache lookup, decoupled from the lock.
 enum CacheLookup {
     Empty,
@@ -332,9 +341,11 @@ fn origin_key(url: &Url) -> Option<OriginKey> {
 ///
 /// Tokens are cached per origin (scheme, host, effective port) with
 /// JWT-expiry-aware refresh; a token for one origin is never replayed to
-/// another. An origin every flow declines is disabled for the process
-/// lifetime. Flow failures are logged, never propagated: the caller
-/// observes the server's original 401/403 response.
+/// another. Acquisition is single-flight per origin: concurrently
+/// challenged requests share one flow invocation. An origin every flow
+/// declines is disabled for the process lifetime. Flow failures are
+/// logged, never propagated: the caller observes the server's original
+/// 401/403 response.
 ///
 /// [`Self::default`] registers
 /// [`crate::trusted_publishing::PrefixAuthAmbientFlow`] for zero-config
@@ -342,7 +353,7 @@ fn origin_key(url: &Url) -> Option<OriginKey> {
 #[derive(Clone, Debug)]
 pub struct AuthChallengeMiddleware {
     flows: Vec<Arc<dyn AuthFlow>>,
-    caches: Arc<Mutex<HashMap<OriginKey, TokenCache>>>,
+    caches: Arc<Mutex<HashMap<OriginKey, OriginEntry>>>,
 }
 
 impl Default for AuthChallengeMiddleware {
@@ -368,7 +379,7 @@ impl AuthChallengeMiddleware {
             .caches
             .lock()
             .expect("auth challenge token cache poisoned");
-        match caches.get(origin) {
+        match caches.get(origin).map(|entry| &entry.state) {
             Some(TokenCache::Disabled) => CacheLookup::Disabled,
             Some(TokenCache::Token(cached)) if cached.is_fresh(SystemTime::now()) => {
                 CacheLookup::Fresh(cached.header.clone())
@@ -381,18 +392,62 @@ impl AuthChallengeMiddleware {
         self.caches
             .lock()
             .expect("auth challenge token cache poisoned")
-            .insert(origin, state);
+            .entry(origin)
+            .or_default()
+            .state = state;
     }
 
-    /// Consult flows in order and cache the outcome for `origin`. No
-    /// usable token from any flow disables the origin; failures are
-    /// logged.
-    async fn acquire_and_cache(
+    fn gate(&self, origin: &OriginKey) -> Arc<futures::lock::Mutex<()>> {
+        self.caches
+            .lock()
+            .expect("auth challenge token cache poisoned")
+            .entry(origin.clone())
+            .or_default()
+            .gate
+            .clone()
+    }
+
+    /// Single-flight token acquisition for `origin`: concurrent challenged
+    /// requests queue on the gate and reuse the winner's token instead of
+    /// minting again. `rejected` is the cached header the server just
+    /// rejected (if any), so only the request holding the stale token
+    /// clears it.
+    ///
+    /// Consults flows in order; no usable token from any flow disables the
+    /// origin. Failures are logged.
+    async fn acquire_serialized(
         &self,
         origin: OriginKey,
         url: &Url,
         challenges: &[Challenge],
+        rejected: Option<&reqwest::header::HeaderValue>,
     ) -> Option<reqwest::header::HeaderValue> {
+        let gate = self.gate(&origin);
+        let _guard = gate.lock().await;
+
+        // Re-check: another request may have settled this origin while we
+        // waited on the gate.
+        {
+            let mut caches = self
+                .caches
+                .lock()
+                .expect("auth challenge token cache poisoned");
+            let entry = caches.entry(origin.clone()).or_default();
+            match &entry.state {
+                TokenCache::Disabled => return None,
+                TokenCache::Token(cached) => {
+                    let ours = rejected.is_some_and(|header| *header == cached.header);
+                    if !ours && cached.is_fresh(SystemTime::now()) {
+                        return Some(cached.header.clone());
+                    }
+                    // The cached token is the one just rejected (or went
+                    // stale); drop it and re-acquire.
+                    entry.state = TokenCache::Empty;
+                }
+                TokenCache::Empty => {}
+            }
+        }
+
         for flow in &self.flows {
             match flow.acquire_token(url, challenges).await {
                 Ok(Some(token)) => match CachedToken::new(&token) {
@@ -458,11 +513,11 @@ impl Middleware for AuthChallengeMiddleware {
             return next.run(req, extensions).await;
         }
 
-        let used_cached_token = if let CacheLookup::Fresh(header) = cached {
-            attach_bearer(&mut req, header);
-            true
+        let used_header = if let CacheLookup::Fresh(header) = cached {
+            attach_bearer(&mut req, header.clone());
+            Some(header)
         } else {
-            false
+            None
         };
 
         // Clone before sending so we can replay on a challenge. Fails only
@@ -479,18 +534,13 @@ impl Middleware for AuthChallengeMiddleware {
             return Ok(response);
         };
 
-        if used_cached_token {
-            // The server rejected a token we believed fresh (revoked
-            // early). Drop it and its header on the clone, then re-acquire.
-            self.store_cache(origin.clone(), TokenCache::Empty);
-            retry_req
-                .headers_mut()
-                .remove(reqwest::header::AUTHORIZATION);
-        }
-
-        let Some(header) = self.acquire_and_cache(origin, &url, &challenges).await else {
+        let Some(header) = self
+            .acquire_serialized(origin, &url, &challenges, used_header.as_ref())
+            .await
+        else {
             return Ok(response);
         };
+        // Replaces a rejected cached header still on the clone, if any.
         attach_bearer(&mut retry_req, header);
         // Replay exactly once; the replayed response is returned as-is even
         // if it is another challenge.
@@ -1094,6 +1144,47 @@ mod tests {
         // Origin B is unaffected by A's negative entry.
         assert_eq!(client.get(b).send().await.unwrap().status(), 200);
         assert_eq!(flow.calls.load(Ordering::SeqCst), 2);
+    }
+
+    /// Flow slow enough that concurrent challenges overlap its acquisition.
+    #[derive(Debug)]
+    struct SlowFlow {
+        token: &'static str,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl AuthFlow for SlowFlow {
+        async fn acquire_token(
+            &self,
+            _url: &Url,
+            _challenges: &[Challenge],
+        ) -> Result<Option<BearerToken>, AuthFlowError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            Ok(Some(BearerToken::new(self.token.to_string())))
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_challenges_mint_once() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = Arc::new(SlowFlow {
+            token: "abc123",
+            calls: AtomicUsize::new(0),
+        });
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
+        let url = server_url.join("/channel/repodata.json").unwrap();
+
+        let responses =
+            futures::future::join_all((0..5).map(|_| client.get(url.clone()).send())).await;
+        for response in responses {
+            assert_eq!(response.unwrap().status(), 200);
+        }
+
+        // One acquisition serves every concurrently challenged request.
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -99,6 +99,11 @@ fn parse_param(s: &str) -> Option<(String, String)> {
     if key.is_empty() || value.is_empty() || !is_valid_scheme(&key) {
         return None;
     }
+    // A value consisting only of `=` characters is padding from a token68
+    // blob (e.g. `dGVzdA==` splits into key `dGVzdA`, value `=`). Skip it.
+    if value.chars().all(|c| c == '=') {
+        return None;
+    }
     let value = value
         .strip_prefix('"')
         .and_then(|v| v.strip_suffix('"'))
@@ -445,7 +450,7 @@ impl Middleware for AuthChallengeMiddleware {
 mod tests {
     use std::{
         sync::{
-            Arc,
+            Arc, Mutex,
             atomic::{AtomicUsize, Ordering},
         },
         time::{Duration, UNIX_EPOCH},
@@ -708,5 +713,181 @@ mod tests {
         assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
         assert_eq!(client.get(url).send().await.unwrap().status(), 401);
         assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// [`AuthFlow`] yielding a different token per call (for the stale-token test).
+    #[derive(Debug)]
+    struct SequenceFlow {
+        tokens: Mutex<Vec<&'static str>>,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl AuthFlow for SequenceFlow {
+        async fn acquire_token(
+            &self,
+            _url: &Url,
+            _challenges: &[Challenge],
+        ) -> Result<Option<BearerToken>, AuthFlowError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let token = self.tokens.lock().unwrap().remove(0);
+            Ok(Some(BearerToken::new(token.to_string())))
+        }
+    }
+
+    /// [`AuthFlow`] that always fails.
+    #[derive(Debug)]
+    struct FailingFlow {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl AuthFlow for FailingFlow {
+        async fn acquire_token(
+            &self,
+            _url: &Url,
+            _challenges: &[Challenge],
+        ) -> Result<Option<BearerToken>, AuthFlowError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Err(AuthFlowError::new(std::io::Error::other("mint exploded")))
+        }
+    }
+
+    #[tokio::test]
+    async fn non_matching_host_is_untouched() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(Some("abc123"));
+        let other_host = Url::parse("https://example.invalid").unwrap();
+        let client = client_with(AuthChallengeMiddleware::new(other_host, flow.clone()));
+
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 401);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn scheme_mismatch_is_untouched() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        // same host and port, but https configured vs the http test server
+        let mut https_url = server_url.clone();
+        https_url.set_scheme("https").unwrap();
+        let flow = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(https_url, flow.clone()));
+
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 401);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn existing_authorization_header_is_respected() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .header(reqwest::header::AUTHORIZATION, "Bearer user-supplied")
+            .send()
+            .await
+            .unwrap();
+
+        // wrong credentials stay wrong: no override, no replay
+        assert_eq!(response.status(), 401);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn replays_at_most_once() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        // server accepts a token the flow never produces -> always 401
+        let server_url = spawn_protected_server("never-issued", hits.clone()).await;
+        let flow = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 401);
+        // initial request + exactly one replay, nothing more
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn stale_cached_token_is_cleared_and_reacquired() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("fresh", hits.clone()).await;
+        let flow = Arc::new(SequenceFlow {
+            tokens: Mutex::new(vec!["old", "fresh"]),
+            calls: AtomicUsize::new(0),
+        });
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+        let url = server_url.join("/channel/repodata.json").unwrap();
+
+        // Request 1: challenge -> flow mints "old" -> replay rejected (401).
+        // "old" is now cached even though the server already rejects it,
+        // simulating a token revoked after acquisition.
+        assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
+
+        // Request 2: cached "old" attached -> challenged -> cache cleared ->
+        // flow mints "fresh" -> replay succeeds.
+        assert_eq!(client.get(url).send().await.unwrap().status(), 200);
+
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 2);
+        assert_eq!(hits.load(Ordering::SeqCst), 4);
+    }
+
+    #[tokio::test]
+    async fn flow_error_is_swallowed_and_negative_cached() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = Arc::new(FailingFlow {
+            calls: AtomicUsize::new(0),
+        });
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+        let url = server_url.join("/channel/repodata.json").unwrap();
+
+        // caller sees the server's 401, not the flow error
+        assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
+        assert_eq!(client.get(url).send().await.unwrap().status(), 401);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn token68_with_double_padding_is_skipped() {
+        let challenges = parse_challenges(&header_map(&["Negotiate dGVzdA=="]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].scheme, "Negotiate");
+        assert!(challenges[0].params.is_empty());
     }
 }

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -1,0 +1,196 @@
+//! Host-scoped middleware that reacts to `WWW-Authenticate` challenges by
+//! acquiring a bearer token from a pluggable `AuthFlow` and replaying the
+//! request once.
+//!
+//! The first `AuthFlow` implementation will be
+//! `crate::trusted_publishing::TrustedPublishingFlow` (added in a later task).
+
+use std::collections::HashMap;
+
+/// One parsed challenge from a `WWW-Authenticate` response header.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Challenge {
+    /// The authentication scheme, e.g. `Bearer` (case preserved as sent).
+    pub scheme: String,
+    /// Auth parameters with lowercased keys, e.g. `realm` -> `prefix.dev`.
+    /// `token68` payloads (e.g. base64 blobs after the scheme) are skipped.
+    pub params: HashMap<String, String>,
+}
+
+/// Parse all challenges from every `WWW-Authenticate` header in `headers`.
+///
+/// Tolerant by design: malformed input yields fewer (or no) challenges,
+/// never an error or panic. Handles multiple comma-separated challenges in
+/// one header value as well as the header appearing multiple times.
+pub fn parse_challenges(headers: &http::HeaderMap) -> Vec<Challenge> {
+    headers
+        .get_all(http::header::WWW_AUTHENTICATE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .flat_map(parse_header_value)
+        .collect()
+}
+
+/// An auth scheme is a token of ASCII alphanumerics plus a few safe symbols.
+/// Stricter than RFC 7235's `token` on purpose: it rejects line noise that
+/// would otherwise be misread as a scheme.
+fn is_valid_scheme(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+fn parse_header_value(value: &str) -> Vec<Challenge> {
+    let mut challenges: Vec<Challenge> = Vec::new();
+    for item in split_commas_respecting_quotes(value) {
+        let item = item.trim();
+        if item.is_empty() {
+            continue;
+        }
+        // A new challenge starts with a scheme token; a continuation item is
+        // a bare `key=value` auth-param belonging to the current challenge.
+        let (first, rest) = match item.split_once(char::is_whitespace) {
+            Some((first, rest)) => (first, Some(rest.trim())),
+            None => (item, None),
+        };
+        if !first.contains('=') {
+            if !is_valid_scheme(first) {
+                continue;
+            }
+            challenges.push(Challenge {
+                scheme: first.to_string(),
+                params: HashMap::new(),
+            });
+            if let (Some(rest), Some(challenge)) = (rest, challenges.last_mut()) {
+                if let Some((key, val)) = parse_param(rest) {
+                    challenge.params.insert(key, val);
+                }
+            }
+        } else if let Some(challenge) = challenges.last_mut() {
+            if let Some((key, val)) = parse_param(item) {
+                challenge.params.insert(key, val);
+            }
+        }
+    }
+    challenges
+}
+
+/// Parse one `key=value` or `key="quoted value"` auth-param. Returns `None`
+/// for non-params (e.g. token68 blobs like `YII=`, which have an empty
+/// "value" after the trailing `=`).
+fn parse_param(s: &str) -> Option<(String, String)> {
+    let (key, value) = s.split_once('=')?;
+    let key = key.trim().to_ascii_lowercase();
+    let value = value.trim();
+    if key.is_empty() || value.is_empty() || !is_valid_scheme(&key) {
+        return None;
+    }
+    let value = value
+        .strip_prefix('"')
+        .and_then(|v| v.strip_suffix('"'))
+        .unwrap_or(value);
+    Some((key, value.replace("\\\"", "\"")))
+}
+
+/// Split on commas that are not inside a double-quoted string.
+fn split_commas_respecting_quotes(s: &str) -> Vec<&str> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut in_quotes = false;
+    let mut escaped = false;
+    for (i, c) in s.char_indices() {
+        match c {
+            '\\' if in_quotes && !escaped => escaped = true,
+            '"' if !escaped => {
+                in_quotes = !in_quotes;
+                escaped = false;
+            }
+            ',' if !in_quotes => {
+                parts.push(&s[start..i]);
+                start = i + 1;
+                escaped = false;
+            }
+            _ => escaped = false,
+        }
+    }
+    parts.push(&s[start..]);
+    parts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn header_map(values: &[&str]) -> http::HeaderMap {
+        let mut headers = http::HeaderMap::new();
+        for v in values {
+            headers.append(
+                http::header::WWW_AUTHENTICATE,
+                http::HeaderValue::from_str(v).unwrap(),
+            );
+        }
+        headers
+    }
+
+    #[test]
+    fn parses_single_bearer_challenge() {
+        let challenges = parse_challenges(&header_map(&[r#"Bearer realm="prefix.dev""#]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].scheme, "Bearer");
+        assert_eq!(challenges[0].params["realm"], "prefix.dev");
+    }
+
+    #[test]
+    fn parses_multiple_challenges_in_one_header() {
+        let challenges = parse_challenges(&header_map(&[
+            r#"Bearer realm="prefix.dev", error="invalid_token", Basic realm="other""#,
+        ]));
+        assert_eq!(challenges.len(), 2);
+        assert_eq!(challenges[0].scheme, "Bearer");
+        assert_eq!(challenges[0].params["realm"], "prefix.dev");
+        assert_eq!(challenges[0].params["error"], "invalid_token");
+        assert_eq!(challenges[1].scheme, "Basic");
+        assert_eq!(challenges[1].params["realm"], "other");
+    }
+
+    #[test]
+    fn parses_multiple_headers() {
+        let challenges =
+            parse_challenges(&header_map(&[r#"Bearer realm="a""#, r#"Basic realm="b""#]));
+        assert_eq!(challenges.len(), 2);
+        assert_eq!(challenges[0].scheme, "Bearer");
+        assert_eq!(challenges[1].scheme, "Basic");
+    }
+
+    #[test]
+    fn quoted_commas_do_not_split_challenges() {
+        let challenges = parse_challenges(&header_map(&[r#"Bearer realm="a,b""#]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].params["realm"], "a,b");
+    }
+
+    #[test]
+    fn unquoted_params_and_case_insensitive_keys() {
+        let challenges = parse_challenges(&header_map(&["Bearer REALM=prefix.dev"]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].params["realm"], "prefix.dev");
+    }
+
+    #[test]
+    fn token68_payload_is_skipped_not_a_param() {
+        // e.g. `Negotiate YII=` — the trailing blob is not a key=value param
+        let challenges = parse_challenges(&header_map(&["Negotiate YII="]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].scheme, "Negotiate");
+        assert!(challenges[0].params.is_empty());
+    }
+
+    #[test]
+    fn garbage_yields_no_challenges_and_no_panic() {
+        assert!(parse_challenges(&header_map(&["= = ="])).is_empty());
+        assert!(parse_challenges(&header_map(&[",,,"])).is_empty());
+        assert!(parse_challenges(&header_map(&[""])).is_empty());
+        assert!(parse_challenges(&header_map(&["%%% ###"])).is_empty());
+        assert!(parse_challenges(&http::HeaderMap::new()).is_empty());
+    }
+}

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -654,7 +654,7 @@ mod tests {
     }
 
     #[test]
-    fn unparseable_header_value_does_not_hide_others() {
+    fn unparsable_header_value_does_not_hide_others() {
         // First value is malformed; the Bearer challenge in the second
         // must still surface (per-value tolerance).
         let challenges = parse_challenges(&header_map(&["%%% ###", r#"Bearer realm="x""#]));

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -8,6 +8,7 @@
 use std::{
     collections::HashMap,
     fmt,
+    sync::{Arc, Mutex},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
@@ -15,6 +16,7 @@ use base64::{
     Engine as _,
     engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
 };
+use reqwest_middleware::{Middleware, Next};
 use serde::Deserialize;
 use thiserror::Error;
 use url::Url;
@@ -131,7 +133,6 @@ fn split_commas_respecting_quotes(s: &str) -> Vec<&str> {
 
 /// Refresh tokens this long before their `exp` so a token does not become
 /// invalid while a request is in flight.
-#[allow(dead_code)]
 const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
 
 /// A short-lived bearer token acquired by an [`AuthFlow`] implementation.
@@ -192,6 +193,12 @@ pub trait AuthFlow: Send + Sync + fmt::Debug {
     /// Return `Ok(None)` when this flow does not apply (e.g. unsupported
     /// scheme, or not running in a CI environment) — the middleware caches
     /// that negatively and stops asking for the lifetime of the process.
+    ///
+    /// `url` is the full URL of the request that was challenged (path and
+    /// query included), not just the server origin. The flow may be invoked
+    /// concurrently by parallel requests racing on the first challenge;
+    /// implementations should tolerate redundant invocations (every returned
+    /// token is cached last-write-wins).
     async fn acquire_token(
         &self,
         url: &Url,
@@ -199,7 +206,6 @@ pub trait AuthFlow: Send + Sync + fmt::Debug {
     ) -> Result<Option<BearerToken>, AuthFlowError>;
 }
 
-#[allow(dead_code)]
 #[derive(Deserialize)]
 struct JwtClaims {
     exp: Option<u64>,
@@ -207,7 +213,6 @@ struct JwtClaims {
 
 /// Best-effort extraction of the `exp` claim from a JWT-shaped token.
 /// Returns `None` for opaque tokens, which are then cached without expiry.
-#[allow(dead_code)]
 fn jwt_expiration(token: &str) -> Option<SystemTime> {
     let mut parts = token.split('.');
     let _header = parts.next()?;
@@ -229,20 +234,16 @@ fn jwt_expiration(token: &str) -> Option<SystemTime> {
 
 #[derive(Debug)]
 struct CachedToken {
-    #[allow(dead_code)]
     token: BearerToken,
-    #[allow(dead_code)]
     expires_at: Option<SystemTime>,
 }
 
 impl CachedToken {
-    #[allow(dead_code)]
     fn new(token: BearerToken) -> Self {
         let expires_at = jwt_expiration(token.secret());
         Self { token, expires_at }
     }
 
-    #[allow(dead_code)]
     fn is_fresh(&self, now: SystemTime) -> bool {
         self.expires_at
             .is_none_or(|expires_at| now + TOKEN_REFRESH_MARGIN < expires_at)
@@ -251,7 +252,6 @@ impl CachedToken {
 
 /// Cache state shared by all clones of one middleware instance.
 #[derive(Debug, Default)]
-#[allow(dead_code)]
 enum TokenCache {
     /// No acquisition attempted yet.
     #[default]
@@ -262,11 +262,308 @@ enum TokenCache {
     Token(CachedToken),
 }
 
+/// Outcome of a cache lookup, decoupled from the lock.
+enum CacheLookup {
+    Empty,
+    Disabled,
+    Fresh(BearerToken),
+}
+
+/// Host-scoped `reqwest` middleware that acquires a bearer token via an
+/// [`AuthFlow`] when (and only when) the server answers with a
+/// `WWW-Authenticate` challenge, then replays the request once.
+///
+/// Construct one instance per server. A request is in scope when its scheme,
+/// host, and effective port match `server`; the path is ignored. Requests
+/// that already carry an `Authorization` header are never touched, so
+/// credentials from [`crate::AuthenticationMiddleware`] always win.
+///
+/// The first acquired token is cached (with JWT-expiry-aware refresh); a flow
+/// that reports "not applicable" or fails disables the middleware for the
+/// process lifetime. Acquisition failures are logged, never propagated: the
+/// caller then observes the server's original 401/403 response.
+#[derive(Clone, Debug)]
+pub struct AuthChallengeMiddleware {
+    server: Url,
+    flow: Arc<dyn AuthFlow>,
+    cache: Arc<Mutex<TokenCache>>,
+}
+
+impl AuthChallengeMiddleware {
+    /// Create a middleware guarding the server identified by `server`'s
+    /// scheme, host, and port. `server`'s path is ignored.
+    pub fn new(server: Url, flow: Arc<dyn AuthFlow>) -> Self {
+        Self {
+            server,
+            flow,
+            cache: Arc::new(Mutex::new(TokenCache::Empty)),
+        }
+    }
+
+    fn matches_host(&self, url: &Url) -> bool {
+        url.scheme() == self.server.scheme()
+            && url.host_str() == self.server.host_str()
+            && url.port_or_known_default() == self.server.port_or_known_default()
+    }
+
+    fn lookup_cache(&self) -> CacheLookup {
+        let cache = self
+            .cache
+            .lock()
+            .expect("auth challenge token cache poisoned");
+        match &*cache {
+            TokenCache::Disabled => CacheLookup::Disabled,
+            TokenCache::Token(cached) if cached.is_fresh(SystemTime::now()) => {
+                CacheLookup::Fresh(cached.token.clone())
+            }
+            TokenCache::Empty | TokenCache::Token(_) => CacheLookup::Empty,
+        }
+    }
+
+    /// Run the flow and record the outcome. `Ok(None)` and errors both
+    /// disable the middleware; errors are additionally logged.
+    async fn acquire_and_cache(&self, url: &Url, challenges: &[Challenge]) -> Option<BearerToken> {
+        let result = self.flow.acquire_token(url, challenges).await;
+        let mut cache = self
+            .cache
+            .lock()
+            .expect("auth challenge token cache poisoned");
+        match result {
+            Ok(Some(token)) => {
+                *cache = TokenCache::Token(CachedToken::new(token.clone()));
+                Some(token)
+            }
+            Ok(None) => {
+                tracing::debug!(
+                    "AuthChallengeMiddleware: flow not applicable for {url}, disabling"
+                );
+                *cache = TokenCache::Disabled;
+                None
+            }
+            Err(err) => {
+                tracing::warn!("AuthChallengeMiddleware: failed to acquire token for {url}: {err}");
+                *cache = TokenCache::Disabled;
+                None
+            }
+        }
+    }
+}
+
+fn attach_bearer(
+    req: &mut reqwest::Request,
+    token: &BearerToken,
+) -> reqwest_middleware::Result<()> {
+    let bearer = format!("Bearer {}", token.secret());
+    let mut value = reqwest::header::HeaderValue::from_str(&bearer)
+        .map_err(reqwest_middleware::Error::middleware)?;
+    value.set_sensitive(true);
+    req.headers_mut()
+        .insert(reqwest::header::AUTHORIZATION, value);
+    Ok(())
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Middleware for AuthChallengeMiddleware {
+    async fn handle(
+        &self,
+        mut req: reqwest::Request,
+        extensions: &mut http::Extensions,
+        next: Next<'_>,
+    ) -> reqwest_middleware::Result<reqwest::Response> {
+        if !self.matches_host(req.url())
+            || req.headers().contains_key(reqwest::header::AUTHORIZATION)
+        {
+            return next.run(req, extensions).await;
+        }
+
+        let cached = self.lookup_cache();
+        if matches!(cached, CacheLookup::Disabled) {
+            return next.run(req, extensions).await;
+        }
+
+        let used_cached_token = if let CacheLookup::Fresh(token) = &cached {
+            attach_bearer(&mut req, token)?;
+            true
+        } else {
+            false
+        };
+
+        // Clone before sending so we can replay on a challenge. Fails only
+        // for streaming bodies (absent on the GET-only read path) — then the
+        // response is passed through unmodified.
+        let retry_req = req.try_clone();
+        let url = req.url().clone();
+        let response = next.clone().run(req, extensions).await?;
+
+        let challenges = parse_challenges(response.headers());
+        if challenges.is_empty() {
+            return Ok(response);
+        }
+        let Some(mut retry_req) = retry_req else {
+            return Ok(response);
+        };
+
+        if used_cached_token {
+            // The server rejected a token we believed fresh (revoked early).
+            // Drop it — and its header on the clone — before re-acquiring.
+            *self
+                .cache
+                .lock()
+                .expect("auth challenge token cache poisoned") = TokenCache::Empty;
+            retry_req
+                .headers_mut()
+                .remove(reqwest::header::AUTHORIZATION);
+        }
+
+        let Some(token) = self.acquire_and_cache(&url, &challenges).await else {
+            return Ok(response);
+        };
+        attach_bearer(&mut retry_req, &token)?;
+        // Replay exactly once; the replayed response is returned as-is even
+        // if it is another challenge.
+        next.run(retry_req, extensions).await
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, UNIX_EPOCH};
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::{Duration, UNIX_EPOCH},
+    };
+
+    use reqwest_middleware::ClientBuilder;
 
     use super::*;
+
+    /// [`AuthFlow`] returning a fixed answer; counts invocations.
+    #[derive(Debug)]
+    struct StaticFlow {
+        token: Option<&'static str>,
+        calls: AtomicUsize,
+    }
+
+    impl StaticFlow {
+        fn new(token: Option<&'static str>) -> Arc<Self> {
+            Arc::new(Self {
+                token,
+                calls: AtomicUsize::new(0),
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AuthFlow for StaticFlow {
+        async fn acquire_token(
+            &self,
+            _url: &Url,
+            _challenges: &[Challenge],
+        ) -> Result<Option<BearerToken>, AuthFlowError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.token.map(|t| BearerToken::new(t.to_string())))
+        }
+    }
+
+    /// Axum server: requires `Bearer <accept>` on /channel/repodata.json,
+    /// answers 401 + WWW-Authenticate otherwise. Counts every request.
+    async fn spawn_protected_server(accept: &'static str, hits: Arc<AtomicUsize>) -> Url {
+        use axum::{http::StatusCode, response::IntoResponse, routing::get};
+        let router = axum::Router::new().route(
+            "/channel/repodata.json",
+            get(move |headers: axum::http::HeaderMap| {
+                let hits = hits.clone();
+                async move {
+                    hits.fetch_add(1, Ordering::SeqCst);
+                    let expected = format!("Bearer {accept}");
+                    match headers.get("authorization").and_then(|v| v.to_str().ok()) {
+                        Some(auth) if auth == expected => (StatusCode::OK, "ok").into_response(),
+                        _ => (
+                            StatusCode::UNAUTHORIZED,
+                            [("www-authenticate", r#"Bearer realm="test""#)],
+                            "unauthorized",
+                        )
+                            .into_response(),
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        Url::parse(&format!("http://{addr}")).unwrap()
+    }
+
+    fn client_with(
+        middleware: AuthChallengeMiddleware,
+    ) -> reqwest_middleware::ClientWithMiddleware {
+        ClientBuilder::new(reqwest::Client::new())
+            .with_arc(Arc::new(middleware))
+            .build()
+    }
+
+    #[tokio::test]
+    async fn challenge_triggers_mint_and_replay() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 200);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+        // one challenged request + one replay
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn second_request_reuses_cached_token_without_challenge() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+
+        let url = server_url.join("/channel/repodata.json").unwrap();
+        assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 200);
+        assert_eq!(client.get(url).send().await.unwrap().status(), 200);
+
+        // flow consulted exactly once; second request went straight through
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(hits.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn inapplicable_flow_is_negative_cached() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(None);
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+
+        let url = server_url.join("/channel/repodata.json").unwrap();
+        assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
+        assert_eq!(client.get(url).send().await.unwrap().status(), 401);
+
+        // flow consulted once, then disabled
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+    }
 
     fn header_map(values: &[&str]) -> http::HeaderMap {
         let mut headers = http::HeaderMap::new();

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -61,15 +61,15 @@ fn parse_header_value(value: &str) -> Vec<Challenge> {
                 scheme: first.to_string(),
                 params: HashMap::new(),
             });
-            if let (Some(rest), Some(challenge)) = (rest, challenges.last_mut()) {
-                if let Some((key, val)) = parse_param(rest) {
-                    challenge.params.insert(key, val);
-                }
-            }
-        } else if let Some(challenge) = challenges.last_mut() {
-            if let Some((key, val)) = parse_param(item) {
+            if let (Some(rest), Some(challenge)) = (rest, challenges.last_mut())
+                && let Some((key, val)) = parse_param(rest)
+            {
                 challenge.params.insert(key, val);
             }
+        } else if let Some(challenge) = challenges.last_mut()
+            && let Some((key, val)) = parse_param(item)
+        {
+            challenge.params.insert(key, val);
         }
     }
     challenges

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -234,14 +234,22 @@ fn jwt_expiration(token: &str) -> Option<SystemTime> {
 
 #[derive(Debug)]
 struct CachedToken {
-    token: BearerToken,
+    /// Pre-validated `Bearer <secret>` header value, marked sensitive.
+    header: reqwest::header::HeaderValue,
     expires_at: Option<SystemTime>,
 }
 
 impl CachedToken {
-    fn new(token: BearerToken) -> Self {
-        let expires_at = jwt_expiration(token.secret());
-        Self { token, expires_at }
+    /// Fails when the token cannot be encoded as an HTTP header value —
+    /// callers must treat that like a failed acquisition, not cache it.
+    fn new(token: &BearerToken) -> Result<Self, reqwest::header::InvalidHeaderValue> {
+        let mut header =
+            reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token.secret()))?;
+        header.set_sensitive(true);
+        Ok(Self {
+            header,
+            expires_at: jwt_expiration(token.secret()),
+        })
     }
 
     fn is_fresh(&self, now: SystemTime) -> bool {
@@ -266,7 +274,7 @@ enum TokenCache {
 enum CacheLookup {
     Empty,
     Disabled,
-    Fresh(BearerToken),
+    Fresh(reqwest::header::HeaderValue),
 }
 
 /// Host-scoped `reqwest` middleware that acquires a bearer token via an
@@ -314,7 +322,7 @@ impl AuthChallengeMiddleware {
         match &*cache {
             TokenCache::Disabled => CacheLookup::Disabled,
             TokenCache::Token(cached) if cached.is_fresh(SystemTime::now()) => {
-                CacheLookup::Fresh(cached.token.clone())
+                CacheLookup::Fresh(cached.header.clone())
             }
             TokenCache::Empty | TokenCache::Token(_) => CacheLookup::Empty,
         }
@@ -322,17 +330,32 @@ impl AuthChallengeMiddleware {
 
     /// Run the flow and record the outcome. `Ok(None)` and errors both
     /// disable the middleware; errors are additionally logged.
-    async fn acquire_and_cache(&self, url: &Url, challenges: &[Challenge]) -> Option<BearerToken> {
+    async fn acquire_and_cache(
+        &self,
+        url: &Url,
+        challenges: &[Challenge],
+    ) -> Option<reqwest::header::HeaderValue> {
         let result = self.flow.acquire_token(url, challenges).await;
         let mut cache = self
             .cache
             .lock()
             .expect("auth challenge token cache poisoned");
         match result {
-            Ok(Some(token)) => {
-                *cache = TokenCache::Token(CachedToken::new(token.clone()));
-                Some(token)
-            }
+            Ok(Some(token)) => match CachedToken::new(&token) {
+                Ok(cached) => {
+                    let header = cached.header.clone();
+                    *cache = TokenCache::Token(cached);
+                    Some(header)
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        "AuthChallengeMiddleware: flow returned a token for {url} that is \
+                         not a valid header value ({err}), disabling"
+                    );
+                    *cache = TokenCache::Disabled;
+                    None
+                }
+            },
             Ok(None) => {
                 tracing::debug!(
                     "AuthChallengeMiddleware: flow not applicable for {url}, disabling"
@@ -349,17 +372,9 @@ impl AuthChallengeMiddleware {
     }
 }
 
-fn attach_bearer(
-    req: &mut reqwest::Request,
-    token: &BearerToken,
-) -> reqwest_middleware::Result<()> {
-    let bearer = format!("Bearer {}", token.secret());
-    let mut value = reqwest::header::HeaderValue::from_str(&bearer)
-        .map_err(reqwest_middleware::Error::middleware)?;
-    value.set_sensitive(true);
+fn attach_bearer(req: &mut reqwest::Request, header: reqwest::header::HeaderValue) {
     req.headers_mut()
-        .insert(reqwest::header::AUTHORIZATION, value);
-    Ok(())
+        .insert(reqwest::header::AUTHORIZATION, header);
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
@@ -382,8 +397,8 @@ impl Middleware for AuthChallengeMiddleware {
             return next.run(req, extensions).await;
         }
 
-        let used_cached_token = if let CacheLookup::Fresh(token) = &cached {
-            attach_bearer(&mut req, token)?;
+        let used_cached_token = if let CacheLookup::Fresh(header) = cached {
+            attach_bearer(&mut req, header);
             true
         } else {
             false
@@ -416,10 +431,10 @@ impl Middleware for AuthChallengeMiddleware {
                 .remove(reqwest::header::AUTHORIZATION);
         }
 
-        let Some(token) = self.acquire_and_cache(&url, &challenges).await else {
+        let Some(header) = self.acquire_and_cache(&url, &challenges).await else {
             return Ok(response);
         };
-        attach_bearer(&mut retry_req, &token)?;
+        attach_bearer(&mut retry_req, header);
         // Replay exactly once; the replayed response is returned as-is even
         // if it is another challenge.
         next.run(retry_req, extensions).await
@@ -670,10 +685,28 @@ mod tests {
     #[test]
     fn cached_jwt_is_stale_inside_refresh_margin() {
         let token = BearerToken::new(unsigned_jwt_with_exp(1_700_000_000));
-        let cached = CachedToken::new(token);
+        let cached = CachedToken::new(&token).unwrap();
         let now = UNIX_EPOCH + Duration::from_secs(1_700_000_000 - 30);
         assert!(!cached.is_fresh(now));
         let earlier = UNIX_EPOCH + Duration::from_secs(1_700_000_000 - 3600);
         assert!(cached.is_fresh(earlier));
+    }
+
+    #[tokio::test]
+    async fn header_invalid_token_is_not_cached_and_does_not_error() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(Some("bad\ntoken"));
+        let client = client_with(AuthChallengeMiddleware::new(
+            server_url.clone(),
+            flow.clone(),
+        ));
+        let url = server_url.join("/channel/repodata.json").unwrap();
+
+        // The caller sees the server's original 401, not a middleware error,
+        // and the middleware disables itself instead of caching the bad token.
+        assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
+        assert_eq!(client.get(url).send().await.unwrap().status(), 401);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -3,8 +3,8 @@
 //! request once. Tokens are cached per origin (scheme, host, port).
 //!
 //! [`AuthChallengeMiddleware::default`] registers
-//! [`crate::trusted_publishing::PrefixAuthAmbientFlow`], making the zero
-//! configuration stack authenticate to prefix.dev servers from CI.
+//! [`crate::trusted_publishing::PrefixAuthAmbientFlow`] for zero-config
+//! prefix.dev auth from CI.
 
 use std::{
     collections::HashMap,
@@ -34,9 +34,8 @@ pub struct Challenge {
 
 /// Parse all challenges from every `WWW-Authenticate` header in `headers`.
 ///
-/// Tolerant by design: malformed input yields fewer (or no) challenges,
-/// never an error or panic. Handles multiple comma-separated challenges in
-/// one header value as well as the header appearing multiple times.
+/// Tolerant: malformed input yields fewer challenges, never an error or
+/// panic. Handles multiple challenges per header and repeated headers.
 pub fn parse_challenges(headers: &http::HeaderMap) -> Vec<Challenge> {
     headers
         .get_all(http::header::WWW_AUTHENTICATE)
@@ -46,9 +45,8 @@ pub fn parse_challenges(headers: &http::HeaderMap) -> Vec<Challenge> {
         .collect()
 }
 
-/// An auth scheme is a token of ASCII alphanumerics plus a few safe symbols.
-/// Stricter than RFC 7235's `token` on purpose: it rejects line noise that
-/// would otherwise be misread as a scheme.
+/// Schemes are ASCII alphanumerics plus `-`, `_`, `.`. Stricter than RFC
+/// 7235's `token` to avoid misreading line noise as a scheme.
 fn is_valid_scheme(s: &str) -> bool {
     !s.is_empty()
         && s.chars()
@@ -106,10 +104,9 @@ fn parse_param(s: &str) -> Option<(String, String)> {
         return None;
     }
     let value = if let Some(rest) = value.strip_prefix('"') {
-        // Quoted string: require a clean closing quote with nothing after it
-        // and no unescaped quotes inside; anything else (unterminated, or
-        // trailing garbage like a second space-separated param) is malformed
-        // and yields no param rather than a wrong value.
+        // Quoted string: require a clean closing quote and no unescaped
+        // quotes inside; anything else yields no param rather than a
+        // wrong value.
         let inner = rest.strip_suffix('"')?;
         if malformed_quoted_interior(inner) {
             return None;
@@ -125,11 +122,9 @@ fn parse_param(s: &str) -> Option<(String, String)> {
     Some((key, value))
 }
 
-/// Returns `true` when `s` (the interior of a quoted string, outer quotes
-/// already stripped) contains an unescaped `"` — e.g. two space-separated
-/// quoted params mashed into one value — or ends with a dangling escape,
-/// which means the stripped closing quote was actually escaped (i.e. the
-/// quoted string was never terminated).
+/// True when the quoted-string interior `s` (outer quotes stripped)
+/// contains an unescaped `"` or ends with a dangling escape, i.e. the
+/// stripped closing quote was escaped and the string never terminated.
 fn malformed_quoted_interior(s: &str) -> bool {
     let mut escaped = false;
     for c in s.chars() {
@@ -171,10 +166,9 @@ fn split_commas_respecting_quotes(s: &str) -> Vec<&str> {
 /// invalid while a request is in flight.
 const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
 
-/// A short-lived bearer token acquired by an [`AuthFlow`] implementation.
+/// A short-lived bearer token acquired by an [`AuthFlow`].
 ///
-/// `Deserialize`-transparent (a raw JSON string body deserializes directly
-/// into it) and `Clone` so it can be shared between the cache and requests.
+/// `Deserialize`-transparent: a raw JSON string deserializes into it.
 #[derive(Clone, Deserialize)]
 #[serde(transparent)]
 pub struct BearerToken(String);
@@ -197,11 +191,11 @@ impl fmt::Debug for BearerToken {
     }
 }
 
-/// Error produced by an [`AuthFlow`] implementation.
+/// Error produced by an [`AuthFlow`].
 ///
-/// Boxed so custom flows can surface arbitrary failures. The middleware only
-/// logs this error and disables further attempts — it never propagates it,
-/// so the caller always observes the server's original response.
+/// Boxed so custom flows can surface arbitrary failures. The middleware
+/// logs it and never propagates it; the caller observes the server's
+/// original response.
 #[derive(Debug, Error)]
 #[error("authentication flow failed: {source}")]
 pub struct AuthFlowError {
@@ -226,22 +220,16 @@ impl AuthFlowError {
 pub trait AuthFlow: Send + Sync + fmt::Debug {
     /// Respond to `challenges` received from `url`.
     ///
-    /// Return `Ok(None)` when this flow does not apply (e.g. unsupported
-    /// scheme, or not running in a CI environment) — the middleware caches
-    /// that negatively and stops asking for the lifetime of the process.
+    /// Return `Ok(None)` when the flow does not apply (unsupported scheme,
+    /// not in CI, untrusted origin); the origin is then negative-cached.
+    /// `url` is the full challenged URL, not just the origin. Flows may be
+    /// invoked concurrently; redundant invocations must be tolerated
+    /// (tokens are cached last-write-wins).
     ///
-    /// `url` is the full URL of the request that was challenged (path and
-    /// query included), not just the server origin. The flow may be invoked
-    /// concurrently by parallel requests racing on the first challenge;
-    /// implementations should tolerate redundant invocations (every returned
-    /// token is cached last-write-wins).
-    ///
-    /// [`crate::AuthChallengeMiddleware`] invokes flows for *every*
-    /// challenged URL, so implementations that forward credentials (CI OIDC
-    /// tokens, ...) MUST validate `url`'s origin themselves before treating
-    /// it as a credential sink — see
-    /// [`crate::trusted_publishing::PrefixAuthAmbientFlow`] for the pattern.
-    /// Return `Ok(None)` for origins outside the flow's trust gate.
+    /// The middleware invokes flows for every challenged URL, so flows
+    /// that forward credentials MUST validate `url`'s origin themselves;
+    /// see [`crate::trusted_publishing::PrefixAuthAmbientFlow`] for the
+    /// pattern.
     async fn acquire_token(
         &self,
         url: &Url,
@@ -283,8 +271,8 @@ struct CachedToken {
 }
 
 impl CachedToken {
-    /// Fails when the token cannot be encoded as an HTTP header value —
-    /// callers must treat that like a failed acquisition, not cache it.
+    /// Fails when the token cannot be encoded as a header value; callers
+    /// must treat that as a failed acquisition, not cache it.
     fn new(token: &BearerToken) -> Result<Self, reqwest::header::InvalidHeaderValue> {
         let mut header =
             reqwest::header::HeaderValue::from_str(&format!("Bearer {}", token.secret()))?;
@@ -301,14 +289,13 @@ impl CachedToken {
     }
 }
 
-/// Cache state for one origin, shared by all clones of one middleware
-/// instance.
+/// Cache state for one origin.
 #[derive(Debug, Default)]
 enum TokenCache {
     /// No acquisition attempted yet.
     #[default]
     Empty,
-    /// Every flow reported "not applicable" or failed — stop asking.
+    /// Every flow declined or failed; stop asking.
     Disabled,
     /// A previously acquired token.
     Token(CachedToken),
@@ -321,9 +308,8 @@ enum CacheLookup {
     Fresh(reqwest::header::HeaderValue),
 }
 
-/// Cache key: one token per (scheme, host, effective port). `None` for URLs
-/// without a host or known port (`data:`, `file:`, ...), which the
-/// middleware passes through untouched.
+/// Cache key: (scheme, host, effective port). `None` for URLs without a
+/// host or known port (`data:`, `file:`), which pass through untouched.
 type OriginKey = (String, String, u16);
 
 fn origin_key(url: &Url) -> Option<OriginKey> {
@@ -334,31 +320,25 @@ fn origin_key(url: &Url) -> Option<OriginKey> {
     ))
 }
 
-/// `reqwest` middleware that acquires a bearer token via its registered
-/// [`AuthFlow`]s when (and only when) a server answers with a
-/// `WWW-Authenticate` challenge, then replays the request once.
+/// `reqwest` middleware that reacts to a `WWW-Authenticate` challenge by
+/// acquiring a bearer token from its registered [`AuthFlow`]s (consulted
+/// in order, first token wins) and replaying the request once.
 ///
-/// On a challenge, the flows are consulted in registration order; the first
-/// one yielding a token wins. Flows decide for themselves whether a URL is
-/// within their trust gate (see the [`AuthFlow`] contract), so one middleware
-/// instance serves every host on the client. Requests that already carry an
-/// `Authorization` header are never touched, so credentials from
-/// [`crate::AuthenticationMiddleware`] always win. (Credentials embedded in
-/// the URL path or query — e.g. conda `/t/<token>` tokens — are not
-/// detected; a challenged request carrying such credentials will still be
-/// replayed with a bearer token.)
+/// Flows gate their own origins (see [`AuthFlow`]), so one instance serves
+/// every host. Requests already carrying `Authorization` are never
+/// touched: credentials from [`crate::AuthenticationMiddleware`] win.
+/// Credentials in the URL path or query (conda `/t/<token>`) are not
+/// detected; such requests are still replayed with a bearer token.
 ///
-/// Acquired tokens are cached per origin — scheme, host, effective port —
-/// with JWT-expiry-aware refresh; a token minted for one origin is never
-/// replayed to another. When no flow yields a token for an origin, that
-/// origin is disabled for the process lifetime. Acquisition failures are
-/// logged, never propagated: the caller then observes the server's original
-/// 401/403 response.
+/// Tokens are cached per origin (scheme, host, effective port) with
+/// JWT-expiry-aware refresh; a token for one origin is never replayed to
+/// another. An origin every flow declines is disabled for the process
+/// lifetime. Flow failures are logged, never propagated: the caller
+/// observes the server's original 401/403 response.
 ///
-/// [`AuthChallengeMiddleware::default`] registers
-/// [`crate::trusted_publishing::PrefixAuthAmbientFlow`], which mints tokens
-/// via CI OIDC for prefix.dev servers — the zero-configuration wiring for
-/// challenge-reactive private-channel reads.
+/// [`Self::default`] registers
+/// [`crate::trusted_publishing::PrefixAuthAmbientFlow`] for zero-config
+/// prefix.dev auth from CI.
 #[derive(Clone, Debug)]
 pub struct AuthChallengeMiddleware {
     flows: Vec<Arc<dyn AuthFlow>>,
@@ -374,12 +354,8 @@ impl Default for AuthChallengeMiddleware {
 }
 
 impl AuthChallengeMiddleware {
-    /// Create a middleware consulting `flows` in order on every
-    /// `WWW-Authenticate` challenge.
-    ///
-    /// Flows are responsible for their own origin gating: a flow that
-    /// forwards credentials must only do so for origins it trusts (see
-    /// [`AuthFlow::acquire_token`]).
+    /// Create a middleware consulting `flows` in order on every challenge.
+    /// Flows gate their own origins (see [`AuthFlow::acquire_token`]).
     pub fn new(flows: Vec<Arc<dyn AuthFlow>>) -> Self {
         Self {
             flows,
@@ -408,8 +384,8 @@ impl AuthChallengeMiddleware {
             .insert(origin, state);
     }
 
-    /// Consult each flow in order and record the outcome for `origin`. The
-    /// origin is disabled when no flow yields a usable token; failures are
+    /// Consult flows in order and cache the outcome for `origin`. No
+    /// usable token from any flow disables the origin; failures are
     /// logged.
     async fn acquire_and_cache(
         &self,
@@ -490,8 +466,7 @@ impl Middleware for AuthChallengeMiddleware {
         };
 
         // Clone before sending so we can replay on a challenge. Fails only
-        // for streaming bodies (absent on the GET-only read path) — then the
-        // response is passed through unmodified.
+        // for streaming bodies; then the response passes through as-is.
         let retry_req = req.try_clone();
         let url = req.url().clone();
         let response = next.clone().run(req, extensions).await?;
@@ -505,8 +480,8 @@ impl Middleware for AuthChallengeMiddleware {
         };
 
         if used_cached_token {
-            // The server rejected a token we believed fresh (revoked early).
-            // Drop it — and its header on the clone — before re-acquiring.
+            // The server rejected a token we believed fresh (revoked
+            // early). Drop it and its header on the clone, then re-acquire.
             self.store_cache(origin.clone(), TokenCache::Empty);
             retry_req
                 .headers_mut()
@@ -725,7 +700,7 @@ mod tests {
 
     #[test]
     fn token68_payload_is_skipped_not_a_param() {
-        // e.g. `Negotiate YII=` — the trailing blob is not a key=value param
+        // `Negotiate YII=`: the trailing blob is not a key=value param
         let challenges = parse_challenges(&header_map(&["Negotiate YII="]));
         assert_eq!(challenges.len(), 1);
         assert_eq!(challenges[0].scheme, "Negotiate");
@@ -976,9 +951,7 @@ mod tests {
         assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
         assert_eq!(client.get(url).send().await.unwrap().status(), 401);
         assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
-        // Disabled = pass-through (next.run is still called), so both requests
-        // reach the server: request 1 triggers the challenge (1 hit), request 2
-        // is passed through unmodified and also reaches the server (1 hit).
+        // Disabled = pass-through: both requests still reach the server.
         assert_eq!(hits.load(Ordering::SeqCst), 2);
     }
 

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -416,19 +416,31 @@ impl Middleware for AuthChallengeMiddleware {
             None
         };
 
-        // Clone before sending so we can replay on a challenge. Fails only
-        // for streaming bodies; then the response passes through as-is.
-        let retry_req = req.try_clone();
         let url = req.url().clone();
+
+        // We can only react to a challenge if the request can be cloned for
+        // replay. Cloning fails only for streaming bodies; such a request is
+        // sent once (with any cached token already attached) and its response
+        // returned as-is, warning if it turns out to be a challenge we could
+        // otherwise have satisfied.
+        let Some(mut retry_req) = req.try_clone() else {
+            let response = next.run(req, extensions).await?;
+            if !parse_challenges(response.headers()).is_empty() {
+                tracing::warn!(
+                    "AuthChallengeMiddleware: {url} responded with a challenge but the \
+                     request body could not be cloned for replay; returning the \
+                     challenge response unmodified"
+                );
+            }
+            return Ok(response);
+        };
+
         let response = next.clone().run(req, extensions).await?;
 
         let challenges = parse_challenges(response.headers());
         if challenges.is_empty() {
             return Ok(response);
         }
-        let Some(mut retry_req) = retry_req else {
-            return Ok(response);
-        };
 
         let Some(header) = self
             .acquire_serialized(origin, &url, &challenges, used_header.as_ref())
@@ -881,6 +893,34 @@ mod tests {
         assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
         // Disabled = pass-through: both requests still reach the server.
         assert_eq!(hits.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    #[tracing_test::traced_test]
+    async fn unclonable_challenged_request_is_returned_unreplayed_with_warning() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let flow = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
+
+        // A streaming body cannot be cloned, so a challenge cannot be replayed.
+        let body = reqwest::Body::wrap_stream(futures::stream::once(async {
+            Ok::<_, std::io::Error>(b"x".to_vec())
+        }));
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .body(body)
+            .send()
+            .await
+            .unwrap();
+
+        // The original challenge is returned: one request, no replay, the
+        // flow never consulted.
+        assert_eq!(response.status(), 401);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
+        // The dropped replay is surfaced, not silent.
+        assert!(logs_contain("could not be cloned for replay"));
     }
 
     /// Flow minting a token tied to the challenged URL's port; pairs with

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -1,9 +1,10 @@
-//! Host-scoped middleware that reacts to `WWW-Authenticate` challenges by
-//! acquiring a bearer token from a pluggable [`AuthFlow`] and replaying the
-//! request once.
+//! Middleware that reacts to `WWW-Authenticate` challenges by acquiring a
+//! bearer token from one of its registered [`AuthFlow`]s and replaying the
+//! request once. Tokens are cached per origin (scheme, host, port).
 //!
-//! The first [`AuthFlow`] implementation is
-//! [`crate::trusted_publishing::TrustedPublishingFlow`].
+//! [`AuthChallengeMiddleware::default`] registers
+//! [`crate::trusted_publishing::PrefixAuthAmbientFlow`], making the zero
+//! configuration stack authenticate to prefix.dev servers from CI.
 
 use std::{
     collections::HashMap,
@@ -235,9 +236,12 @@ pub trait AuthFlow: Send + Sync + fmt::Debug {
     /// implementations should tolerate redundant invocations (every returned
     /// token is cached last-write-wins).
     ///
-    /// Implementations may treat `url`'s origin as a trusted credential sink;
-    /// dispatchers must therefore only invoke flows for URLs on the host they
-    /// are scoped to.
+    /// [`crate::AuthChallengeMiddleware`] invokes flows for *every*
+    /// challenged URL, so implementations that forward credentials (CI OIDC
+    /// tokens, ...) MUST validate `url`'s origin themselves before treating
+    /// it as a credential sink — see
+    /// [`crate::trusted_publishing::PrefixAuthAmbientFlow`] for the pattern.
+    /// Return `Ok(None)` for origins outside the flow's trust gate.
     async fn acquire_token(
         &self,
         url: &Url,
@@ -297,13 +301,14 @@ impl CachedToken {
     }
 }
 
-/// Cache state shared by all clones of one middleware instance.
+/// Cache state for one origin, shared by all clones of one middleware
+/// instance.
 #[derive(Debug, Default)]
 enum TokenCache {
     /// No acquisition attempted yet.
     #[default]
     Empty,
-    /// The flow reported "not applicable" or failed — stop asking.
+    /// Every flow reported "not applicable" or failed — stop asking.
     Disabled,
     /// A previously acquired token.
     Token(CachedToken),
@@ -316,101 +321,137 @@ enum CacheLookup {
     Fresh(reqwest::header::HeaderValue),
 }
 
-/// Host-scoped `reqwest` middleware that acquires a bearer token via an
-/// [`AuthFlow`] when (and only when) the server answers with a
+/// Cache key: one token per (scheme, host, effective port). `None` for URLs
+/// without a host or known port (`data:`, `file:`, ...), which the
+/// middleware passes through untouched.
+type OriginKey = (String, String, u16);
+
+fn origin_key(url: &Url) -> Option<OriginKey> {
+    Some((
+        url.scheme().to_string(),
+        url.host_str()?.to_string(),
+        url.port_or_known_default()?,
+    ))
+}
+
+/// `reqwest` middleware that acquires a bearer token via its registered
+/// [`AuthFlow`]s when (and only when) a server answers with a
 /// `WWW-Authenticate` challenge, then replays the request once.
 ///
-/// Construct one instance per server. A request is in scope when its scheme,
-/// host, and effective port match `server`; the path is ignored. Requests
-/// that already carry an `Authorization` header are never touched, so
-/// credentials from [`crate::AuthenticationMiddleware`] always win.
-/// (Credentials embedded in the URL path or query — e.g. conda `/t/<token>`
-/// tokens — are not detected; a challenged request carrying such credentials
-/// will still be replayed with a bearer token.)
+/// On a challenge, the flows are consulted in registration order; the first
+/// one yielding a token wins. Flows decide for themselves whether a URL is
+/// within their trust gate (see the [`AuthFlow`] contract), so one middleware
+/// instance serves every host on the client. Requests that already carry an
+/// `Authorization` header are never touched, so credentials from
+/// [`crate::AuthenticationMiddleware`] always win. (Credentials embedded in
+/// the URL path or query — e.g. conda `/t/<token>` tokens — are not
+/// detected; a challenged request carrying such credentials will still be
+/// replayed with a bearer token.)
 ///
-/// The first acquired token is cached (with JWT-expiry-aware refresh); a flow
-/// that reports "not applicable" or fails disables the middleware for the
-/// process lifetime. Acquisition failures are logged, never propagated: the
-/// caller then observes the server's original 401/403 response.
+/// Acquired tokens are cached per origin — scheme, host, effective port —
+/// with JWT-expiry-aware refresh; a token minted for one origin is never
+/// replayed to another. When no flow yields a token for an origin, that
+/// origin is disabled for the process lifetime. Acquisition failures are
+/// logged, never propagated: the caller then observes the server's original
+/// 401/403 response.
+///
+/// [`AuthChallengeMiddleware::default`] registers
+/// [`crate::trusted_publishing::PrefixAuthAmbientFlow`], which mints tokens
+/// via CI OIDC for prefix.dev servers — the zero-configuration wiring for
+/// challenge-reactive private-channel reads.
 #[derive(Clone, Debug)]
 pub struct AuthChallengeMiddleware {
-    server: Url,
-    flow: Arc<dyn AuthFlow>,
-    cache: Arc<Mutex<TokenCache>>,
+    flows: Vec<Arc<dyn AuthFlow>>,
+    caches: Arc<Mutex<HashMap<OriginKey, TokenCache>>>,
+}
+
+impl Default for AuthChallengeMiddleware {
+    fn default() -> Self {
+        Self::new(vec![Arc::new(
+            crate::trusted_publishing::PrefixAuthAmbientFlow::default(),
+        )])
+    }
 }
 
 impl AuthChallengeMiddleware {
-    /// Create a middleware guarding the server identified by `server`'s
-    /// scheme, host, and port. `server`'s path is ignored.
-    pub fn new(server: Url, flow: Arc<dyn AuthFlow>) -> Self {
+    /// Create a middleware consulting `flows` in order on every
+    /// `WWW-Authenticate` challenge.
+    ///
+    /// Flows are responsible for their own origin gating: a flow that
+    /// forwards credentials must only do so for origins it trusts (see
+    /// [`AuthFlow::acquire_token`]).
+    pub fn new(flows: Vec<Arc<dyn AuthFlow>>) -> Self {
         Self {
-            server,
-            flow,
-            cache: Arc::new(Mutex::new(TokenCache::Empty)),
+            flows,
+            caches: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
-    fn matches_host(&self, url: &Url) -> bool {
-        url.scheme() == self.server.scheme()
-            && url.host_str() == self.server.host_str()
-            && url.port_or_known_default() == self.server.port_or_known_default()
-    }
-
-    fn lookup_cache(&self) -> CacheLookup {
-        let cache = self
-            .cache
+    fn lookup_cache(&self, origin: &OriginKey) -> CacheLookup {
+        let caches = self
+            .caches
             .lock()
             .expect("auth challenge token cache poisoned");
-        match &*cache {
-            TokenCache::Disabled => CacheLookup::Disabled,
-            TokenCache::Token(cached) if cached.is_fresh(SystemTime::now()) => {
+        match caches.get(origin) {
+            Some(TokenCache::Disabled) => CacheLookup::Disabled,
+            Some(TokenCache::Token(cached)) if cached.is_fresh(SystemTime::now()) => {
                 CacheLookup::Fresh(cached.header.clone())
             }
-            TokenCache::Empty | TokenCache::Token(_) => CacheLookup::Empty,
+            None | Some(TokenCache::Empty | TokenCache::Token(_)) => CacheLookup::Empty,
         }
     }
 
-    /// Run the flow and record the outcome. `Ok(None)` and errors both
-    /// disable the middleware; errors are additionally logged.
+    fn store_cache(&self, origin: OriginKey, state: TokenCache) {
+        self.caches
+            .lock()
+            .expect("auth challenge token cache poisoned")
+            .insert(origin, state);
+    }
+
+    /// Consult each flow in order and record the outcome for `origin`. The
+    /// origin is disabled when no flow yields a usable token; failures are
+    /// logged.
     async fn acquire_and_cache(
         &self,
+        origin: OriginKey,
         url: &Url,
         challenges: &[Challenge],
     ) -> Option<reqwest::header::HeaderValue> {
-        let result = self.flow.acquire_token(url, challenges).await;
-        let mut cache = self
-            .cache
-            .lock()
-            .expect("auth challenge token cache poisoned");
-        match result {
-            Ok(Some(token)) => match CachedToken::new(&token) {
-                Ok(cached) => {
-                    let header = cached.header.clone();
-                    *cache = TokenCache::Token(cached);
-                    Some(header)
+        for flow in &self.flows {
+            match flow.acquire_token(url, challenges).await {
+                Ok(Some(token)) => match CachedToken::new(&token) {
+                    Ok(cached) => {
+                        let header = cached.header.clone();
+                        self.store_cache(origin, TokenCache::Token(cached));
+                        return Some(header);
+                    }
+                    Err(err) => {
+                        tracing::warn!(
+                            "AuthChallengeMiddleware: {flow:?} returned a token for {url} \
+                             that is not a valid header value ({err}), trying next flow"
+                        );
+                    }
+                },
+                Ok(None) => {
+                    tracing::debug!(
+                        "AuthChallengeMiddleware: {flow:?} not applicable for {url}, \
+                         trying next flow"
+                    );
                 }
                 Err(err) => {
                     tracing::warn!(
-                        "AuthChallengeMiddleware: flow returned a token for {url} that is \
-                         not a valid header value ({err}), disabling"
+                        "AuthChallengeMiddleware: {flow:?} failed to acquire a token \
+                         for {url}: {err}, trying next flow"
                     );
-                    *cache = TokenCache::Disabled;
-                    None
                 }
-            },
-            Ok(None) => {
-                tracing::debug!(
-                    "AuthChallengeMiddleware: flow not applicable for {url}, disabling"
-                );
-                *cache = TokenCache::Disabled;
-                None
-            }
-            Err(err) => {
-                tracing::warn!("AuthChallengeMiddleware: failed to acquire token for {url}: {err}");
-                *cache = TokenCache::Disabled;
-                None
             }
         }
+        tracing::debug!(
+            "AuthChallengeMiddleware: no flow produced a token for {url}, \
+             disabling its origin"
+        );
+        self.store_cache(origin, TokenCache::Disabled);
+        None
     }
 }
 
@@ -428,13 +469,15 @@ impl Middleware for AuthChallengeMiddleware {
         extensions: &mut http::Extensions,
         next: Next<'_>,
     ) -> reqwest_middleware::Result<reqwest::Response> {
-        if !self.matches_host(req.url())
-            || req.headers().contains_key(reqwest::header::AUTHORIZATION)
-        {
+        let origin = origin_key(req.url());
+        let Some(origin) = origin else {
+            return next.run(req, extensions).await;
+        };
+        if req.headers().contains_key(reqwest::header::AUTHORIZATION) {
             return next.run(req, extensions).await;
         }
 
-        let cached = self.lookup_cache();
+        let cached = self.lookup_cache(&origin);
         if matches!(cached, CacheLookup::Disabled) {
             return next.run(req, extensions).await;
         }
@@ -464,16 +507,13 @@ impl Middleware for AuthChallengeMiddleware {
         if used_cached_token {
             // The server rejected a token we believed fresh (revoked early).
             // Drop it — and its header on the clone — before re-acquiring.
-            *self
-                .cache
-                .lock()
-                .expect("auth challenge token cache poisoned") = TokenCache::Empty;
+            self.store_cache(origin.clone(), TokenCache::Empty);
             retry_req
                 .headers_mut()
                 .remove(reqwest::header::AUTHORIZATION);
         }
 
-        let Some(header) = self.acquire_and_cache(&url, &challenges).await else {
+        let Some(header) = self.acquire_and_cache(origin, &url, &challenges).await else {
             return Ok(response);
         };
         attach_bearer(&mut retry_req, header);
@@ -525,17 +565,17 @@ mod tests {
         }
     }
 
-    /// Axum server: requires `Bearer <accept>` on /channel/repodata.json,
-    /// answers 401 + WWW-Authenticate otherwise. Counts every request.
-    async fn spawn_protected_server(accept: &'static str, hits: Arc<AtomicUsize>) -> Url {
+    /// Router requiring `Bearer <accept>` on /channel/repodata.json,
+    /// answering 401 + WWW-Authenticate otherwise. Counts every request.
+    fn protected_router(accept: String, hits: Arc<AtomicUsize>) -> axum::Router {
         use axum::{http::StatusCode, response::IntoResponse, routing::get};
-        let router = axum::Router::new().route(
+        axum::Router::new().route(
             "/channel/repodata.json",
             get(move |headers: axum::http::HeaderMap| {
                 let hits = hits.clone();
+                let expected = format!("Bearer {accept}");
                 async move {
                     hits.fetch_add(1, Ordering::SeqCst);
-                    let expected = format!("Bearer {accept}");
                     match headers.get("authorization").and_then(|v| v.to_str().ok()) {
                         Some(auth) if auth == expected => (StatusCode::OK, "ok").into_response(),
                         _ => (
@@ -547,9 +587,24 @@ mod tests {
                     }
                 }
             }),
-        );
+        )
+    }
+
+    async fn spawn_protected_server(accept: &str, hits: Arc<AtomicUsize>) -> Url {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
+        let router = protected_router(accept.to_string(), hits);
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        Url::parse(&format!("http://{addr}")).unwrap()
+    }
+
+    /// Like [`spawn_protected_server`], but the accepted token is derived
+    /// from the server's own port (`token-<port>`), pairing with
+    /// [`PortTokenFlow`] to make per-origin cache mix-ups observable.
+    async fn spawn_port_token_server(hits: Arc<AtomicUsize>) -> Url {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let router = protected_router(format!("token-{}", addr.port()), hits);
         tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
         Url::parse(&format!("http://{addr}")).unwrap()
     }
@@ -567,10 +622,7 @@ mod tests {
         let hits = Arc::new(AtomicUsize::new(0));
         let server_url = spawn_protected_server("abc123", hits.clone()).await;
         let flow = StaticFlow::new(Some("abc123"));
-        let client = client_with(AuthChallengeMiddleware::new(
-            server_url.clone(),
-            flow.clone(),
-        ));
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
 
         let response = client
             .get(server_url.join("/channel/repodata.json").unwrap())
@@ -589,10 +641,7 @@ mod tests {
         let hits = Arc::new(AtomicUsize::new(0));
         let server_url = spawn_protected_server("abc123", hits.clone()).await;
         let flow = StaticFlow::new(Some("abc123"));
-        let client = client_with(AuthChallengeMiddleware::new(
-            server_url.clone(),
-            flow.clone(),
-        ));
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
 
         let url = server_url.join("/channel/repodata.json").unwrap();
         assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 200);
@@ -608,10 +657,7 @@ mod tests {
         let hits = Arc::new(AtomicUsize::new(0));
         let server_url = spawn_protected_server("abc123", hits.clone()).await;
         let flow = StaticFlow::new(None);
-        let client = client_with(AuthChallengeMiddleware::new(
-            server_url.clone(),
-            flow.clone(),
-        ));
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
 
         let url = server_url.join("/channel/repodata.json").unwrap();
         assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 401);
@@ -757,10 +803,7 @@ mod tests {
         let hits = Arc::new(AtomicUsize::new(0));
         let server_url = spawn_protected_server("abc123", hits.clone()).await;
         let flow = StaticFlow::new(Some("bad\ntoken"));
-        let client = client_with(AuthChallengeMiddleware::new(
-            server_url.clone(),
-            flow.clone(),
-        ));
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
         let url = server_url.join("/channel/repodata.json").unwrap();
 
         // The caller sees the server's original 401, not a middleware error,
@@ -814,54 +857,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn non_matching_host_is_untouched() {
-        let hits = Arc::new(AtomicUsize::new(0));
-        let server_url = spawn_protected_server("abc123", hits.clone()).await;
-        let flow = StaticFlow::new(Some("abc123"));
-        let other_host = Url::parse("https://example.invalid").unwrap();
-        let client = client_with(AuthChallengeMiddleware::new(other_host, flow.clone()));
-
-        let response = client
-            .get(server_url.join("/channel/repodata.json").unwrap())
-            .send()
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), 401);
-        assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
-        assert_eq!(hits.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn scheme_mismatch_is_untouched() {
-        let hits = Arc::new(AtomicUsize::new(0));
-        let server_url = spawn_protected_server("abc123", hits.clone()).await;
-        // same host and port, but https configured vs the http test server
-        let mut https_url = server_url.clone();
-        https_url.set_scheme("https").unwrap();
-        let flow = StaticFlow::new(Some("abc123"));
-        let client = client_with(AuthChallengeMiddleware::new(https_url, flow.clone()));
-
-        let response = client
-            .get(server_url.join("/channel/repodata.json").unwrap())
-            .send()
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), 401);
-        assert_eq!(flow.calls.load(Ordering::SeqCst), 0);
-        assert_eq!(hits.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
     async fn existing_authorization_header_is_respected() {
         let hits = Arc::new(AtomicUsize::new(0));
         let server_url = spawn_protected_server("abc123", hits.clone()).await;
         let flow = StaticFlow::new(Some("abc123"));
-        let client = client_with(AuthChallengeMiddleware::new(
-            server_url.clone(),
-            flow.clone(),
-        ));
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
 
         let response = client
             .get(server_url.join("/channel/repodata.json").unwrap())
@@ -882,10 +882,7 @@ mod tests {
         // server accepts a token the flow never produces -> always 401
         let server_url = spawn_protected_server("never-issued", hits.clone()).await;
         let flow = StaticFlow::new(Some("abc123"));
-        let client = client_with(AuthChallengeMiddleware::new(
-            server_url.clone(),
-            flow.clone(),
-        ));
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
 
         let response = client
             .get(server_url.join("/channel/repodata.json").unwrap())
@@ -939,10 +936,7 @@ mod tests {
             tokens: Mutex::new(vec!["old", "fresh"]),
             calls: AtomicUsize::new(0),
         });
-        let client = client_with(AuthChallengeMiddleware::new(
-            server_url.clone(),
-            flow.clone(),
-        ));
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
         let url = server_url.join("/channel/repodata.json").unwrap();
 
         // Request 1: challenge -> flow mints "old" (cached before the replay
@@ -975,10 +969,7 @@ mod tests {
         let flow = Arc::new(FailingFlow {
             calls: AtomicUsize::new(0),
         });
-        let client = client_with(AuthChallengeMiddleware::new(
-            server_url.clone(),
-            flow.clone(),
-        ));
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
         let url = server_url.join("/channel/repodata.json").unwrap();
 
         // caller sees the server's 401, not the flow error
@@ -997,5 +988,156 @@ mod tests {
         assert_eq!(challenges.len(), 1);
         assert_eq!(challenges[0].scheme, "Negotiate");
         assert!(challenges[0].params.is_empty());
+    }
+
+    /// Flow minting a token tied to the challenged URL's port; pairs with
+    /// [`spawn_port_token_server`] to prove per-origin cache scoping.
+    #[derive(Debug)]
+    struct PortTokenFlow {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl AuthFlow for PortTokenFlow {
+        async fn acquire_token(
+            &self,
+            url: &Url,
+            _challenges: &[Challenge],
+        ) -> Result<Option<BearerToken>, AuthFlowError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let port = url.port().expect("test URLs always carry a port");
+            Ok(Some(BearerToken::new(format!("token-{port}"))))
+        }
+    }
+
+    #[tokio::test]
+    async fn tokens_are_cached_per_origin() {
+        let hits_a = Arc::new(AtomicUsize::new(0));
+        let hits_b = Arc::new(AtomicUsize::new(0));
+        let url_a = spawn_port_token_server(hits_a.clone()).await;
+        let url_b = spawn_port_token_server(hits_b.clone()).await;
+        let flow = Arc::new(PortTokenFlow {
+            calls: AtomicUsize::new(0),
+        });
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
+
+        let a = url_a.join("/channel/repodata.json").unwrap();
+        let b = url_b.join("/channel/repodata.json").unwrap();
+
+        // Each origin mints its own token; the repeat request on origin A
+        // must be served from A's cache entry (a single shared slot would
+        // attach B's token and fail).
+        assert_eq!(client.get(a.clone()).send().await.unwrap().status(), 200);
+        assert_eq!(client.get(b).send().await.unwrap().status(), 200);
+        assert_eq!(client.get(a).send().await.unwrap().status(), 200);
+
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 2); // once per origin
+        assert_eq!(hits_a.load(Ordering::SeqCst), 3); // challenge + replay + cached
+        assert_eq!(hits_b.load(Ordering::SeqCst), 2); // challenge + replay
+    }
+
+    #[tokio::test]
+    async fn flows_are_consulted_in_order_until_one_yields() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let inapplicable = StaticFlow::new(None);
+        let minting = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(vec![
+            inapplicable.clone(),
+            minting.clone(),
+        ]));
+
+        let url = server_url.join("/channel/repodata.json").unwrap();
+        assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 200);
+        // The token is cached: a second request consults no flow at all.
+        assert_eq!(client.get(url).send().await.unwrap().status(), 200);
+
+        assert_eq!(inapplicable.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(minting.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn failing_flow_falls_through_to_next() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let failing = Arc::new(FailingFlow {
+            calls: AtomicUsize::new(0),
+        });
+        let minting = StaticFlow::new(Some("abc123"));
+        let client = client_with(AuthChallengeMiddleware::new(vec![
+            failing.clone(),
+            minting.clone(),
+        ]));
+
+        let url = server_url.join("/channel/repodata.json").unwrap();
+        assert_eq!(client.get(url).send().await.unwrap().status(), 200);
+        assert_eq!(failing.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(minting.calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// Flow applicable to exactly one origin (matched by port).
+    #[derive(Debug)]
+    struct SinglePortFlow {
+        port: u16,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl AuthFlow for SinglePortFlow {
+        async fn acquire_token(
+            &self,
+            url: &Url,
+            _challenges: &[Challenge],
+        ) -> Result<Option<BearerToken>, AuthFlowError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if url.port() == Some(self.port) {
+                Ok(Some(BearerToken::new(format!("token-{}", self.port))))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn negative_cache_is_scoped_per_origin() {
+        let hits_a = Arc::new(AtomicUsize::new(0));
+        let hits_b = Arc::new(AtomicUsize::new(0));
+        let url_a = spawn_port_token_server(hits_a.clone()).await;
+        let url_b = spawn_port_token_server(hits_b.clone()).await;
+        let flow = Arc::new(SinglePortFlow {
+            port: url_b.port().unwrap(),
+            calls: AtomicUsize::new(0),
+        });
+        let client = client_with(AuthChallengeMiddleware::new(vec![flow.clone()]));
+
+        let a = url_a.join("/channel/repodata.json").unwrap();
+        let b = url_b.join("/channel/repodata.json").unwrap();
+
+        // Origin A: flow inapplicable -> negative-cached, asked exactly once.
+        assert_eq!(client.get(a.clone()).send().await.unwrap().status(), 401);
+        assert_eq!(client.get(a).send().await.unwrap().status(), 401);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
+
+        // Origin B is unaffected by A's negative entry.
+        assert_eq!(client.get(b).send().await.unwrap().status(), 200);
+        assert_eq!(flow.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn default_middleware_is_inert_for_untrusted_origins() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let server_url = spawn_protected_server("abc123", hits.clone()).await;
+        let client = client_with(AuthChallengeMiddleware::default());
+
+        let response = client
+            .get(server_url.join("/channel/repodata.json").unwrap())
+            .send()
+            .await
+            .unwrap();
+
+        // A loopback http origin is outside every default flow's trust gate:
+        // the caller sees the original 401 and there is no replay.
+        assert_eq!(response.status(), 401);
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -2,8 +2,8 @@
 //! acquiring a bearer token from a pluggable [`AuthFlow`] and replaying the
 //! request once.
 //!
-//! The first [`AuthFlow`] implementation will be
-//! `crate::trusted_publishing::TrustedPublishingFlow` (added in a later task).
+//! The first [`AuthFlow`] implementation is
+//! [`crate::trusted_publishing::TrustedPublishingFlow`].
 
 use std::{
     collections::HashMap,
@@ -204,6 +204,10 @@ pub trait AuthFlow: Send + Sync + fmt::Debug {
     /// concurrently by parallel requests racing on the first challenge;
     /// implementations should tolerate redundant invocations (every returned
     /// token is cached last-write-wins).
+    ///
+    /// Implementations may treat `url`'s origin as a trusted credential sink;
+    /// dispatchers must therefore only invoke flows for URLs on the host they
+    /// are scoped to.
     async fn acquire_token(
         &self,
         url: &Url,

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -324,6 +324,9 @@ enum CacheLookup {
 /// host, and effective port match `server`; the path is ignored. Requests
 /// that already carry an `Authorization` header are never touched, so
 /// credentials from [`crate::AuthenticationMiddleware`] always win.
+/// (Credentials embedded in the URL path or query — e.g. conda `/t/<token>`
+/// tokens — are not detected; a challenged request carrying such credentials
+/// will still be replayed with a bearer token.)
 ///
 /// The first acquired token is cached (with JWT-expiry-aware refresh); a flow
 /// that reports "not applicable" or fails disables the middleware for the

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -104,11 +104,41 @@ fn parse_param(s: &str) -> Option<(String, String)> {
     if value.chars().all(|c| c == '=') {
         return None;
     }
-    let value = value
-        .strip_prefix('"')
-        .and_then(|v| v.strip_suffix('"'))
-        .unwrap_or(value);
-    Some((key, value.replace("\\\"", "\"")))
+    let value = if let Some(rest) = value.strip_prefix('"') {
+        // Quoted string: require a clean closing quote with nothing after it
+        // and no unescaped quotes inside; anything else (unterminated, or
+        // trailing garbage like a second space-separated param) is malformed
+        // and yields no param rather than a wrong value.
+        let inner = rest.strip_suffix('"')?;
+        if malformed_quoted_interior(inner) {
+            return None;
+        }
+        inner.replace("\\\"", "\"")
+    } else {
+        // Unquoted token: any stray quote means a mangled quoted string.
+        if value.contains('"') {
+            return None;
+        }
+        value.to_string()
+    };
+    Some((key, value))
+}
+
+/// Returns `true` when `s` (the interior of a quoted string, outer quotes
+/// already stripped) contains an unescaped `"` — e.g. two space-separated
+/// quoted params mashed into one value — or ends with a dangling escape,
+/// which means the stripped closing quote was actually escaped (i.e. the
+/// quoted string was never terminated).
+fn malformed_quoted_interior(s: &str) -> bool {
+    let mut escaped = false;
+    for c in s.chars() {
+        match c {
+            '\\' if !escaped => escaped = true,
+            '"' if !escaped => return true,
+            _ => escaped = false,
+        }
+    }
+    escaped
 }
 
 /// Split on commas that are not inside a double-quoted string.
@@ -650,6 +680,24 @@ mod tests {
         let challenges = parse_challenges(&header_map(&["Negotiate YII="]));
         assert_eq!(challenges.len(), 1);
         assert_eq!(challenges[0].scheme, "Negotiate");
+        assert!(challenges[0].params.is_empty());
+    }
+
+    #[test]
+    fn space_separated_params_yield_no_wrong_values() {
+        // Non-RFC space-separated params: scheme parsed, malformed param dropped
+        let challenges = parse_challenges(&header_map(&[
+            r#"Bearer realm="prefix.dev" error="invalid_token""#,
+        ]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].scheme, "Bearer");
+        assert!(challenges[0].params.is_empty());
+    }
+
+    #[test]
+    fn unbalanced_quote_yields_no_param() {
+        let challenges = parse_challenges(&header_map(&[r#"Bearer realm="unterminated"#]));
+        assert_eq!(challenges.len(), 1);
         assert!(challenges[0].params.is_empty());
     }
 

--- a/crates/rattler_networking/src/challenge_middleware.rs
+++ b/crates/rattler_networking/src/challenge_middleware.rs
@@ -25,141 +25,37 @@ use url::Url;
 /// One parsed challenge from a `WWW-Authenticate` response header.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Challenge {
-    /// The authentication scheme, e.g. `Bearer` (case preserved as sent).
+    /// The authentication scheme, e.g. `Bearer` (case preserved as sent;
+    /// compare case-insensitively).
     pub scheme: String,
-    /// Auth parameters with lowercased keys, e.g. `realm` -> `prefix.dev`.
-    /// `token68` payloads (e.g. base64 blobs after the scheme) are skipped.
+    /// Auth parameters with lowercased keys and unescaped values, e.g.
+    /// `realm` -> `prefix.dev`.
     pub params: HashMap<String, String>,
 }
 
 /// Parse all challenges from every `WWW-Authenticate` header in `headers`.
 ///
-/// Tolerant: malformed input yields fewer challenges, never an error or
-/// panic. Handles multiple challenges per header and repeated headers.
+/// RFC 7235 parsing is delegated to the `http-auth` crate. Tolerant: a
+/// header value `http-auth` cannot parse contributes no challenges instead
+/// of failing the whole set, so one malformed header never hides the
+/// others. (`http-auth` does not support the apocryphal `token68` challenge
+/// form; no scheme we react to uses it.)
 pub fn parse_challenges(headers: &http::HeaderMap) -> Vec<Challenge> {
     headers
         .get_all(http::header::WWW_AUTHENTICATE)
         .iter()
         .filter_map(|value| value.to_str().ok())
-        .flat_map(parse_header_value)
+        .filter_map(|value| http_auth::parse_challenges(value).ok())
+        .flatten()
+        .map(|challenge| Challenge {
+            scheme: challenge.scheme.to_string(),
+            params: challenge
+                .params
+                .iter()
+                .map(|(key, value)| (key.to_ascii_lowercase(), value.to_unescaped()))
+                .collect(),
+        })
         .collect()
-}
-
-/// Schemes are ASCII alphanumerics plus `-`, `_`, `.`. Stricter than RFC
-/// 7235's `token` to avoid misreading line noise as a scheme.
-fn is_valid_scheme(s: &str) -> bool {
-    !s.is_empty()
-        && s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
-}
-
-fn parse_header_value(value: &str) -> Vec<Challenge> {
-    let mut challenges: Vec<Challenge> = Vec::new();
-    for item in split_commas_respecting_quotes(value) {
-        let item = item.trim();
-        if item.is_empty() {
-            continue;
-        }
-        // A new challenge starts with a scheme token; a continuation item is
-        // a bare `key=value` auth-param belonging to the current challenge.
-        let (first, rest) = match item.split_once(char::is_whitespace) {
-            Some((first, rest)) => (first, Some(rest.trim())),
-            None => (item, None),
-        };
-        if !first.contains('=') {
-            if !is_valid_scheme(first) {
-                continue;
-            }
-            challenges.push(Challenge {
-                scheme: first.to_string(),
-                params: HashMap::new(),
-            });
-            if let (Some(rest), Some(challenge)) = (rest, challenges.last_mut())
-                && let Some((key, val)) = parse_param(rest)
-            {
-                challenge.params.insert(key, val);
-            }
-        } else if let Some(challenge) = challenges.last_mut()
-            && let Some((key, val)) = parse_param(item)
-        {
-            challenge.params.insert(key, val);
-        }
-    }
-    challenges
-}
-
-/// Parse one `key=value` or `key="quoted value"` auth-param. Returns `None`
-/// for non-params (e.g. token68 blobs like `YII=`, which have an empty
-/// "value" after the trailing `=`).
-fn parse_param(s: &str) -> Option<(String, String)> {
-    let (key, value) = s.split_once('=')?;
-    let key = key.trim().to_ascii_lowercase();
-    let value = value.trim();
-    if key.is_empty() || value.is_empty() || !is_valid_scheme(&key) {
-        return None;
-    }
-    // A value consisting only of `=` characters is padding from a token68
-    // blob (e.g. `dGVzdA==` splits into key `dGVzdA`, value `=`). Skip it.
-    if value.chars().all(|c| c == '=') {
-        return None;
-    }
-    let value = if let Some(rest) = value.strip_prefix('"') {
-        // Quoted string: require a clean closing quote and no unescaped
-        // quotes inside; anything else yields no param rather than a
-        // wrong value.
-        let inner = rest.strip_suffix('"')?;
-        if malformed_quoted_interior(inner) {
-            return None;
-        }
-        inner.replace("\\\"", "\"")
-    } else {
-        // Unquoted token: any stray quote means a mangled quoted string.
-        if value.contains('"') {
-            return None;
-        }
-        value.to_string()
-    };
-    Some((key, value))
-}
-
-/// True when the quoted-string interior `s` (outer quotes stripped)
-/// contains an unescaped `"` or ends with a dangling escape, i.e. the
-/// stripped closing quote was escaped and the string never terminated.
-fn malformed_quoted_interior(s: &str) -> bool {
-    let mut escaped = false;
-    for c in s.chars() {
-        match c {
-            '\\' if !escaped => escaped = true,
-            '"' if !escaped => return true,
-            _ => escaped = false,
-        }
-    }
-    escaped
-}
-
-/// Split on commas that are not inside a double-quoted string.
-fn split_commas_respecting_quotes(s: &str) -> Vec<&str> {
-    let mut parts = Vec::new();
-    let mut start = 0;
-    let mut in_quotes = false;
-    let mut escaped = false;
-    for (i, c) in s.char_indices() {
-        match c {
-            '\\' if in_quotes && !escaped => escaped = true,
-            '"' if !escaped => {
-                in_quotes = !in_quotes;
-                escaped = false;
-            }
-            ',' if !in_quotes => {
-                parts.push(&s[start..i]);
-                start = i + 1;
-                escaped = false;
-            }
-            _ => escaped = false,
-        }
-    }
-    parts.push(&s[start..]);
-    parts
 }
 
 /// Refresh tokens this long before their `exp` so a token does not become
@@ -749,39 +645,21 @@ mod tests {
     }
 
     #[test]
-    fn token68_payload_is_skipped_not_a_param() {
-        // `Negotiate YII=`: the trailing blob is not a key=value param
-        let challenges = parse_challenges(&header_map(&["Negotiate YII="]));
-        assert_eq!(challenges.len(), 1);
-        assert_eq!(challenges[0].scheme, "Negotiate");
-        assert!(challenges[0].params.is_empty());
-    }
-
-    #[test]
-    fn space_separated_params_yield_no_wrong_values() {
-        // Non-RFC space-separated params: scheme parsed, malformed param dropped
-        let challenges = parse_challenges(&header_map(&[
-            r#"Bearer realm="prefix.dev" error="invalid_token""#,
-        ]));
-        assert_eq!(challenges.len(), 1);
-        assert_eq!(challenges[0].scheme, "Bearer");
-        assert!(challenges[0].params.is_empty());
-    }
-
-    #[test]
-    fn unbalanced_quote_yields_no_param() {
-        let challenges = parse_challenges(&header_map(&[r#"Bearer realm="unterminated"#]));
-        assert_eq!(challenges.len(), 1);
-        assert!(challenges[0].params.is_empty());
-    }
-
-    #[test]
     fn garbage_yields_no_challenges_and_no_panic() {
         assert!(parse_challenges(&header_map(&["= = ="])).is_empty());
         assert!(parse_challenges(&header_map(&[",,,"])).is_empty());
         assert!(parse_challenges(&header_map(&[""])).is_empty());
         assert!(parse_challenges(&header_map(&["%%% ###"])).is_empty());
         assert!(parse_challenges(&http::HeaderMap::new()).is_empty());
+    }
+
+    #[test]
+    fn unparseable_header_value_does_not_hide_others() {
+        // First value is malformed; the Bearer challenge in the second
+        // must still surface (per-value tolerance).
+        let challenges = parse_challenges(&header_map(&["%%% ###", r#"Bearer realm="x""#]));
+        assert_eq!(challenges.len(), 1);
+        assert_eq!(challenges[0].scheme, "Bearer");
     }
 
     #[test]
@@ -1003,14 +881,6 @@ mod tests {
         assert_eq!(flow.calls.load(Ordering::SeqCst), 1);
         // Disabled = pass-through: both requests still reach the server.
         assert_eq!(hits.load(Ordering::SeqCst), 2);
-    }
-
-    #[test]
-    fn token68_with_double_padding_is_skipped() {
-        let challenges = parse_challenges(&header_map(&["Negotiate dGVzdA=="]));
-        assert_eq!(challenges.len(), 1);
-        assert_eq!(challenges[0].scheme, "Negotiate");
-        assert!(challenges[0].params.is_empty());
     }
 
     /// Flow minting a token tied to the challenged URL's port; pairs with

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 
 //! Networking utilities for Rattler, specifically authenticating requests
-pub use authentication_middleware::AuthenticationMiddleware;
+pub use authentication_middleware::{AuthenticationExpired, AuthenticationMiddleware};
 pub use authentication_storage::{authentication::Authentication, storage::AuthenticationStorage};
 pub use challenge_middleware::{
     AuthChallengeMiddleware, AuthFlow, AuthFlowError, BearerToken, Challenge,

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -3,7 +3,9 @@
 //! Networking utilities for Rattler, specifically authenticating requests
 pub use authentication_middleware::AuthenticationMiddleware;
 pub use authentication_storage::{authentication::Authentication, storage::AuthenticationStorage};
-pub use challenge_middleware::{AuthFlow, AuthFlowError, BearerToken};
+pub use challenge_middleware::{
+    AuthChallengeMiddleware, AuthFlow, AuthFlowError, BearerToken, Challenge,
+};
 pub use lazy_client::LazyClient;
 pub use mirror_middleware::MirrorMiddleware;
 pub use oci_middleware::OciMiddleware;

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -19,6 +19,7 @@ pub use s3_middleware::S3Middleware;
 
 pub mod authentication_middleware;
 pub mod authentication_storage;
+pub mod challenge_middleware;
 pub mod oauth_refresh;
 
 mod lazy_client;

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -3,6 +3,7 @@
 //! Networking utilities for Rattler, specifically authenticating requests
 pub use authentication_middleware::AuthenticationMiddleware;
 pub use authentication_storage::{authentication::Authentication, storage::AuthenticationStorage};
+pub use challenge_middleware::{AuthFlow, AuthFlowError, BearerToken};
 pub use lazy_client::LazyClient;
 pub use mirror_middleware::MirrorMiddleware;
 pub use oci_middleware::OciMiddleware;

--- a/crates/rattler_networking/src/oauth_refresh.rs
+++ b/crates/rattler_networking/src/oauth_refresh.rs
@@ -1,5 +1,10 @@
 //! Refresh logic for `Authentication::OAuth` credentials.
 
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, LazyLock, Mutex},
+};
+
 use serde::Deserialize;
 
 use crate::{Authentication, AuthenticationStorage};
@@ -16,8 +21,70 @@ struct TokenRefreshResponse {
 /// "about to expire"
 const EXPIRY_SKEW_SECONDS: i64 = 300;
 
+/// Single-flight gates keyed by the storage key, so concurrent requests for
+/// the same credential share one refresh attempt instead of each hitting the
+/// token endpoint (and logging) independently.
+static REFRESH_GATES: LazyLock<Mutex<HashMap<String, Arc<futures::lock::Mutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Refresh attempts that already failed this process, keyed by
+/// `<storage key>\0<refresh token>` (or a `<no-refresh>` sentinel when there
+/// is no refresh token). We neither retry nor re-log these, so a dead
+/// credential produces a single warning per process rather than one per
+/// request.
+static FAILED_REFRESHES: LazyLock<Mutex<HashSet<String>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+/// Whether an `OAuth` credential is expired (or within the refresh skew).
+/// Non-OAuth credentials are never considered expired here.
+fn oauth_is_expired(auth: &Authentication) -> bool {
+    match auth {
+        Authentication::OAuth { expires_at, .. } => {
+            expires_at.is_some_and(|exp| exp - now_secs() < EXPIRY_SKEW_SECONDS)
+        }
+        _ => false,
+    }
+}
+
+/// Record `key` as a failed refresh. Returns `true` only the first time the
+/// key is seen this process, so callers log at most once.
+fn record_failure_once(key: &str) -> bool {
+    FAILED_REFRESHES
+        .lock()
+        .expect("OAuth refresh failure cache poisoned")
+        .insert(key.to_string())
+}
+
+fn is_failed(key: &str) -> bool {
+    FAILED_REFRESHES
+        .lock()
+        .expect("OAuth refresh failure cache poisoned")
+        .contains(key)
+}
+
 /// Refresh an OAuth token if it is expired (or close to expiring) and
 /// store the refreshed credential back to `storage`.
+///
+/// Returns:
+/// - `Some(credential)` for a non-OAuth credential, an OAuth credential that
+///   is still valid, or a successfully refreshed one;
+/// - `None` when an OAuth credential is expired and could **not** be refreshed
+///   (no refresh token, network error, or the server rejected it). In that
+///   case the request is sent unauthenticated so downstream middleware (e.g.
+///   the auth-challenge middleware) can take over; if it still fails, the
+///   caller can tell the user to re-authenticate.
+///
+/// Concurrent calls for the same credential are coalesced: only one performs
+/// the refresh, the rest wait and reuse its result. A refresh that fails is
+/// recorded so it is neither retried nor re-logged for the rest of the
+/// process.
 pub async fn maybe_refresh_oauth(
     storage: &AuthenticationStorage,
     auth: Authentication,
@@ -26,7 +93,7 @@ pub async fn maybe_refresh_oauth(
     let Authentication::OAuth {
         access_token: _,
         ref refresh_token,
-        expires_at,
+        expires_at: _,
         ref token_endpoint,
         ref revocation_endpoint,
         ref client_id,
@@ -35,22 +102,47 @@ pub async fn maybe_refresh_oauth(
         return Some(auth);
     };
 
-    let is_expired = expires_at.is_some_and(|exp| {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64;
-        exp - now < EXPIRY_SKEW_SECONDS
-    });
-
-    if !is_expired {
+    if !oauth_is_expired(&auth) {
         return Some(auth);
     }
 
     let Some(refresh_token_val) = refresh_token.as_deref() else {
-        tracing::warn!("OAuth token is expired but no refresh token is available");
-        return Some(auth);
+        if record_failure_once(&format!("{matched_key}\0<no-refresh>")) {
+            tracing::warn!("OAuth token is expired but no refresh token is available");
+        }
+        return None;
     };
+
+    let failed_key = format!("{matched_key}\0{refresh_token_val}");
+
+    // Fast path: this exact refresh token already failed this process.
+    if is_failed(&failed_key) {
+        return None;
+    }
+
+    // Single-flight: concurrent requests for the same credential coalesce on
+    // one gate so only the first performs the refresh.
+    let gate = {
+        let mut gates = REFRESH_GATES
+            .lock()
+            .expect("OAuth refresh gate map poisoned");
+        gates
+            .entry(matched_key.to_string())
+            .or_insert_with(|| Arc::new(futures::lock::Mutex::new(())))
+            .clone()
+    };
+    let _guard = gate.lock().await;
+
+    // Re-check now that we hold the gate: a sibling may have refreshed the
+    // credential (use its fresh result) or already failed (drop it).
+    if let Ok(Some(current)) = storage.get(matched_key)
+        && !oauth_is_expired(&current)
+    {
+        return Some(current);
+    }
+    if is_failed(&failed_key) {
+        return None;
+    }
 
     tracing::debug!("OAuth token expired, attempting refresh");
 
@@ -69,8 +161,10 @@ pub async fn maybe_refresh_oauth(
     {
         Ok(resp) => resp,
         Err(e) => {
-            tracing::warn!("Failed to refresh OAuth token: {e}");
-            return Some(auth);
+            if record_failure_once(&failed_key) {
+                tracing::warn!("Failed to refresh OAuth token: {e}");
+            }
+            return None;
         }
     };
 
@@ -90,25 +184,23 @@ pub async fn maybe_refresh_oauth(
             }
             Err(_) => format!("HTTP {status}"),
         };
-        tracing::warn!("OAuth token refresh failed ({hint})");
-        return Some(auth);
+        if record_failure_once(&failed_key) {
+            tracing::warn!("OAuth token refresh failed ({hint})");
+        }
+        return None;
     }
 
     let token_response: TokenRefreshResponse = match response.json().await {
         Ok(body) => body,
         Err(e) => {
-            tracing::warn!("Failed to read OAuth refresh response body: {e}");
-            return Some(auth);
+            if record_failure_once(&failed_key) {
+                tracing::warn!("Failed to read OAuth refresh response body: {e}");
+            }
+            return None;
         }
     };
 
-    let new_expires_at = token_response.expires_in.map(|secs| {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs() as i64
-            + secs
-    });
+    let new_expires_at = token_response.expires_in.map(|secs| now_secs() + secs);
 
     let refreshed = Authentication::OAuth {
         access_token: token_response.access_token,

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -83,6 +83,24 @@ impl TrustedPublishingOptions {
             mint_path: DEFAULT_MINT_PATH.to_string(),
         })
     }
+
+    /// Options for `server` following the deployed prefix.dev ecosystem
+    /// convention: every prefix.dev deployment (`prefix.dev` and
+    /// `*.prefix.dev`, e.g. `beta.prefix.dev`) validates GitHub OIDC tokens
+    /// against the shared audience `prefix.dev`, while tokens are minted at
+    /// the deployment's own host. Hosts outside that family fall back to
+    /// [`Self::for_host`] (host-derived audience).
+    ///
+    /// Returns `None` when `server` has no host. The caveats on
+    /// [`Self::for_host`] (scheme validation, allow-listing) apply here too.
+    pub fn for_server(server: &Url) -> Option<Self> {
+        let host = server.host_str()?;
+        if host == "prefix.dev" || host.ends_with(".prefix.dev") {
+            Some(Self::for_prefix_dev())
+        } else {
+            Self::for_host(server)
+        }
+    }
 }
 
 /// Outcome of an optional trusted-publishing attempt.
@@ -518,5 +536,33 @@ mod tests {
         )
         .unwrap();
         assert_eq!(options.audience, "beta.prefix.dev");
+    }
+
+    #[test]
+    fn for_server_uses_shared_audience_for_prefix_dev_family() {
+        // prefix.dev deployments share the audience "prefix.dev"
+        let beta = TrustedPublishingOptions::for_server(
+            &Url::parse("https://beta.prefix.dev/some-channel").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(beta.audience, "prefix.dev");
+
+        let prod = TrustedPublishingOptions::for_server(&Url::parse("https://prefix.dev").unwrap())
+            .unwrap();
+        assert_eq!(prod.audience, "prefix.dev");
+
+        // hosts outside the family keep the host-derived audience
+        let other = TrustedPublishingOptions::for_server(
+            &Url::parse("https://conda.example.com/channel").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(other.audience, "conda.example.com");
+
+        // ...and lookalike hosts are not part of the family
+        let evil = TrustedPublishingOptions::for_server(
+            &Url::parse("https://evil-prefix.dev/channel").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(evil.audience, "evil-prefix.dev");
     }
 }

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -41,9 +41,10 @@ pub struct TrustedPublishingOptions {
     /// Path on the server where the ID token is exchanged for a bearer token.
     ///
     /// This path is joined onto arbitrary URLs of the challenged server using
-    /// [`Url::join`]. It must start with `/` so that it replaces the full URL
-    /// path; a relative path would resolve against the challenged URL's path
-    /// and could target an unintended endpoint.
+    /// [`Url::join`]. It should start with `/` so that it replaces the full
+    /// URL path; a relative path would resolve against the challenged URL's
+    /// path and could target an unintended endpoint.
+    /// [`TrustedPublishingFlow::new`] normalizes a missing leading slash.
     pub mint_path: String,
 }
 
@@ -205,8 +206,12 @@ pub struct TrustedPublishingFlow {
 }
 
 impl TrustedPublishingFlow {
-    /// Create a flow with custom [`TrustedPublishingOptions`].
-    pub fn new(options: TrustedPublishingOptions, client: ClientWithMiddleware) -> Self {
+    /// Create a flow with custom [`TrustedPublishingOptions`]. A missing
+    /// leading `/` on [`TrustedPublishingOptions::mint_path`] is normalized.
+    pub fn new(mut options: TrustedPublishingOptions, client: ClientWithMiddleware) -> Self {
+        if !options.mint_path.starts_with('/') {
+            options.mint_path.insert(0, '/');
+        }
         Self { options, client }
     }
 
@@ -316,6 +321,133 @@ mod tests {
             token.expect("expected a minted token").secret(),
             "pfx-jwt.minted"
         );
+    }
+
+    #[tokio::test]
+    async fn mint_path_without_leading_slash_is_normalized() {
+        use axum::routing::post;
+
+        // Mint endpoint at the absolute path /api/x. Without normalization,
+        // a relative mint_path of "api/x" would resolve against the
+        // challenged URL's path (/channel/api/x) and miss this route.
+        let router = axum::Router::new().route("/api/x", post(|| async { "pfx-jwt.minted" }));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        let server_url = Url::parse(&format!("http://{addr}")).unwrap();
+
+        let token = temp_env::async_with_vars(
+            [
+                ("GITLAB_CI", Some("true")),
+                ("PREFIX_DEV_ID_TOKEN", Some("fake.oidc.token")),
+                ("GITHUB_ACTIONS", None),
+                ("BUILDKITE", None),
+                ("CIRCLECI", None),
+            ],
+            async {
+                let flow = TrustedPublishingFlow::new(
+                    TrustedPublishingOptions {
+                        audience: "prefix.dev".to_string(),
+                        mint_path: "api/x".to_string(),
+                    },
+                    plain_client(),
+                );
+                flow.acquire_token(
+                    &server_url.join("/channel/repodata.json").unwrap(),
+                    &bearer_challenge(),
+                )
+                .await
+                .unwrap()
+            },
+        )
+        .await;
+
+        assert_eq!(
+            token.expect("expected a minted token").secret(),
+            "pfx-jwt.minted"
+        );
+    }
+
+    #[tokio::test]
+    async fn middleware_with_trusted_publishing_flow_end_to_end() {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        use axum::{
+            Json,
+            http::StatusCode,
+            response::IntoResponse,
+            routing::{get, post},
+        };
+
+        use crate::AuthChallengeMiddleware;
+
+        // One server hosting both the protected resource and the mint
+        // endpoint, like a real prefix.dev instance.
+        let mints = Arc::new(AtomicUsize::new(0));
+        let mints_in_handler = mints.clone();
+        let router = axum::Router::new()
+            .route(
+                "/channel/repodata.json",
+                get(|headers: axum::http::HeaderMap| async move {
+                    match headers.get("authorization").and_then(|v| v.to_str().ok()) {
+                        Some("Bearer pfx-jwt.minted") => (StatusCode::OK, "ok").into_response(),
+                        _ => (
+                            StatusCode::UNAUTHORIZED,
+                            [("www-authenticate", r#"Bearer realm="test""#)],
+                            "unauthorized",
+                        )
+                            .into_response(),
+                    }
+                }),
+            )
+            .route(
+                "/api/oidc/mint_token",
+                post(move |Json(body): Json<serde_json::Value>| {
+                    let mints = mints_in_handler.clone();
+                    async move {
+                        assert_eq!(body["token"], "fake.oidc.token");
+                        mints.fetch_add(1, Ordering::SeqCst);
+                        "pfx-jwt.minted"
+                    }
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        let server_url = Url::parse(&format!("http://{addr}")).unwrap();
+
+        temp_env::async_with_vars(
+            [
+                ("GITLAB_CI", Some("true")),
+                ("PREFIX_DEV_ID_TOKEN", Some("fake.oidc.token")),
+                ("GITHUB_ACTIONS", None),
+                ("BUILDKITE", None),
+                ("CIRCLECI", None),
+            ],
+            async {
+                // The mint client must not itself carry the challenge
+                // middleware (it would recurse), so it stays plain.
+                let flow = TrustedPublishingFlow::for_prefix_dev(plain_client());
+                let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
+                    .with_arc(std::sync::Arc::new(AuthChallengeMiddleware::new(
+                        server_url.clone(),
+                        std::sync::Arc::new(flow),
+                    )))
+                    .build();
+                let url = server_url.join("/channel/repodata.json").unwrap();
+
+                // First request: challenge -> OIDC detect -> mint -> replay.
+                assert_eq!(client.get(url.clone()).send().await.unwrap().status(), 200);
+                // Second request: cached token, no second mint.
+                assert_eq!(client.get(url).send().await.unwrap().status(), 200);
+            },
+        )
+        .await;
+
+        assert_eq!(mints.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -22,6 +22,9 @@ use url::Url;
 
 use crate::challenge_middleware::{AuthFlow, AuthFlowError, BearerToken, Challenge};
 
+/// Default path of the prefix.dev-convention mint endpoint.
+const DEFAULT_MINT_PATH: &str = "/api/oidc/mint_token";
+
 /// Knobs for the trusted-publishing flow. Use
 /// [`for_prefix_dev`](Self::for_prefix_dev) for the prefix.dev defaults, or
 /// construct directly to point at a different server.
@@ -54,7 +57,7 @@ impl TrustedPublishingOptions {
     pub fn for_prefix_dev() -> Self {
         Self {
             audience: "prefix.dev".to_string(),
-            mint_path: "/api/oidc/mint_token".to_string(),
+            mint_path: DEFAULT_MINT_PATH.to_string(),
         }
     }
 
@@ -67,10 +70,17 @@ impl TrustedPublishingOptions {
     /// Deriving the audience from the host scopes each OIDC ID token to the
     /// server it is sent to: a token minted with `aud = <host>` is only
     /// redeemable at that host.
+    ///
+    /// This constructor does not validate the scheme or host. Callers
+    /// handling ambient CI credentials must ensure `server` uses `https`
+    /// and apply their own host allow-list before attaching this flow.
+    /// The audience is the URL-normalized host: lowercased, IDN hosts in
+    /// punycode, and without any port. See the struct-level docs for how
+    /// the audience determines the GitLab CI env-var name.
     pub fn for_host(server: &Url) -> Option<Self> {
         Some(Self {
             audience: server.host_str()?.to_string(),
-            mint_path: "/api/oidc/mint_token".to_string(),
+            mint_path: DEFAULT_MINT_PATH.to_string(),
         })
     }
 }
@@ -499,5 +509,14 @@ mod tests {
         // data: URLs have no host component
         let url = Url::parse("data:text/plain,hello").unwrap();
         assert!(TrustedPublishingOptions::for_host(&url).is_none());
+    }
+
+    #[test]
+    fn for_host_normalizes_case_and_drops_default_port() {
+        let options = TrustedPublishingOptions::for_host(
+            &Url::parse("https://Beta.PREFIX.dev:443/some-channel").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(options.audience, "beta.prefix.dev");
     }
 }

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -57,6 +57,22 @@ impl TrustedPublishingOptions {
             mint_path: "/api/oidc/mint_token".to_string(),
         }
     }
+
+    /// Options for any trusted-publishing server following the prefix.dev
+    /// convention: the OIDC audience is the server's host name and tokens
+    /// are minted at `/api/oidc/mint_token`.
+    ///
+    /// Returns `None` when `server` has no host (e.g. `data:` URLs).
+    ///
+    /// Deriving the audience from the host scopes each OIDC ID token to the
+    /// server it is sent to: a token minted with `aud = <host>` is only
+    /// redeemable at that host.
+    pub fn for_host(server: &Url) -> Option<Self> {
+        Some(Self {
+            audience: server.host_str()?.to_string(),
+            mint_path: "/api/oidc/mint_token".to_string(),
+        })
+    }
 }
 
 /// Outcome of an optional trusted-publishing attempt.
@@ -455,5 +471,33 @@ mod tests {
         let opts = TrustedPublishingOptions::for_prefix_dev();
         assert_eq!(opts.audience, "prefix.dev");
         assert_eq!(opts.mint_path, "/api/oidc/mint_token");
+    }
+
+    #[test]
+    fn for_host_derives_audience_from_host() {
+        let options = TrustedPublishingOptions::for_host(
+            &Url::parse("https://beta.prefix.dev/some-channel/noarch/repodata.json").unwrap(),
+        )
+        .unwrap();
+        assert_eq!(options.audience, "beta.prefix.dev");
+        assert_eq!(options.mint_path, "/api/oidc/mint_token");
+
+        let prod =
+            TrustedPublishingOptions::for_host(&Url::parse("https://prefix.dev").unwrap()).unwrap();
+        assert_eq!(
+            prod.audience,
+            TrustedPublishingOptions::for_prefix_dev().audience
+        );
+        assert_eq!(
+            prod.mint_path,
+            TrustedPublishingOptions::for_prefix_dev().mint_path
+        );
+    }
+
+    #[test]
+    fn for_host_returns_none_without_host() {
+        // data: URLs have no host component
+        let url = Url::parse("data:text/plain,hello").unwrap();
+        assert!(TrustedPublishingOptions::for_host(&url).is_none());
     }
 }

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -23,6 +23,8 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use url::Url;
 
+use crate::challenge_middleware::{AuthFlow, AuthFlowError, Challenge};
+
 /// Refresh minted JWT tokens before they expire to avoid sending a token that
 /// becomes invalid while a request is in flight.
 const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
@@ -229,6 +231,61 @@ async fn get_publish_token(
     }
 }
 
+/// [`AuthFlow`] implementation backed by trusted publishing (CI OIDC).
+///
+/// Responds only to `Bearer` challenges. On a challenge it asks `ambient-id`
+/// for an OIDC ID token (returns `Ok(None)` outside supported CI providers)
+/// and exchanges it at the challenged host's mint endpoint
+/// ([`TrustedPublishingOptions::mint_path`]). Because the surrounding
+/// [`crate::AuthChallengeMiddleware`] is host-scoped, the challenged URL is
+/// always the right host to mint against.
+///
+/// `client` is used only for the mint exchange; it must not itself layer in
+/// [`crate::AuthChallengeMiddleware`] or the mint call will recurse.
+#[derive(Debug, Clone)]
+pub struct TrustedPublishingFlow {
+    options: TrustedPublishingOptions,
+    client: ClientWithMiddleware,
+}
+
+impl TrustedPublishingFlow {
+    /// Create a flow with custom [`TrustedPublishingOptions`].
+    pub fn new(options: TrustedPublishingOptions, client: ClientWithMiddleware) -> Self {
+        Self { options, client }
+    }
+
+    /// Create a flow preconfigured for prefix.dev.
+    pub fn for_prefix_dev(client: ClientWithMiddleware) -> Self {
+        Self::new(TrustedPublishingOptions::for_prefix_dev(), client)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl AuthFlow for TrustedPublishingFlow {
+    async fn acquire_token(
+        &self,
+        url: &Url,
+        challenges: &[Challenge],
+    ) -> Result<Option<crate::challenge_middleware::BearerToken>, AuthFlowError> {
+        if !challenges
+            .iter()
+            .any(|challenge| challenge.scheme.eq_ignore_ascii_case("bearer"))
+        {
+            return Ok(None);
+        }
+        // `get_token` still returns the old `TrustedPublishingToken` until
+        // Task 7 swaps it to `BearerToken`; convert explicitly for now.
+        match get_token(&self.client, url, &self.options).await {
+            Ok(Some(token)) => Ok(Some(crate::challenge_middleware::BearerToken::new(
+                token.secret().to_string(),
+            ))),
+            Ok(None) => Ok(None),
+            Err(err) => Err(AuthFlowError::new(err)),
+        }
+    }
+}
+
 /// `reqwest` middleware that injects a [`TrustedPublishingToken`] as a
 /// `Bearer` `Authorization` header for requests targeting a specific channel.
 ///
@@ -407,7 +464,85 @@ impl Middleware for TrustedPublishingMiddleware {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
+    use crate::challenge_middleware::{AuthFlow, Challenge};
+
+    fn bearer_challenge() -> Vec<Challenge> {
+        vec![Challenge {
+            scheme: "Bearer".to_string(),
+            params: HashMap::new(),
+        }]
+    }
+
+    fn plain_client() -> reqwest_middleware::ClientWithMiddleware {
+        reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build()
+    }
+
+    #[tokio::test]
+    async fn flow_ignores_non_bearer_challenges() {
+        let flow = TrustedPublishingFlow::for_prefix_dev(plain_client());
+        let challenges = vec![Challenge {
+            scheme: "Basic".to_string(),
+            params: HashMap::new(),
+        }];
+        let result = flow
+            .acquire_token(
+                &Url::parse("https://prefix.dev/channel/repodata.json").unwrap(),
+                &challenges,
+            )
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn flow_mints_token_via_gitlab_env() {
+        use axum::{Json, routing::post};
+
+        // Mint endpoint: verifies it receives the CI-provided OIDC token and
+        // returns the minted bearer token as the raw response body.
+        let router = axum::Router::new().route(
+            "/api/oidc/mint_token",
+            post(|Json(body): Json<serde_json::Value>| async move {
+                assert_eq!(body["token"], "fake.oidc.token");
+                "pfx-jwt.minted"
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+        let server_url = Url::parse(&format!("http://{addr}")).unwrap();
+
+        // Force the GitLab detector: GITLAB_CI on, every other provider off.
+        // (rattler's own CI runs on GitHub Actions, so GITHUB_ACTIONS must be
+        // explicitly unset.)
+        let token = temp_env::async_with_vars(
+            [
+                ("GITLAB_CI", Some("true")),
+                ("PREFIX_DEV_ID_TOKEN", Some("fake.oidc.token")),
+                ("GITHUB_ACTIONS", None),
+                ("BUILDKITE", None),
+                ("CIRCLECI", None),
+            ],
+            async {
+                let flow = TrustedPublishingFlow::for_prefix_dev(plain_client());
+                flow.acquire_token(
+                    &server_url.join("/channel/repodata.json").unwrap(),
+                    &bearer_challenge(),
+                )
+                .await
+                .unwrap()
+            },
+        )
+        .await;
+
+        assert_eq!(
+            token.expect("expected a minted token").secret(),
+            "pfx-jwt.minted"
+        );
+    }
 
     #[test]
     fn for_prefix_dev_matches_prefix_dev() {

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -14,6 +14,8 @@
 //!    bearer token usable against the server (read or write, depending on
 //!    server policy).
 
+use std::sync::Arc;
+
 use reqwest::StatusCode;
 use reqwest_middleware::ClientWithMiddleware;
 use serde::Serialize;
@@ -228,9 +230,7 @@ async fn get_publish_token(
 /// Responds only to `Bearer` challenges. On a challenge it asks `ambient-id`
 /// for an OIDC ID token (returns `Ok(None)` outside supported CI providers)
 /// and exchanges it at the challenged host's mint endpoint
-/// ([`TrustedPublishingOptions::mint_path`]). Because the surrounding
-/// [`crate::AuthChallengeMiddleware`] is host-scoped, the challenged URL is
-/// always the right host to mint against.
+/// ([`TrustedPublishingOptions::mint_path`]).
 ///
 /// `client` is used only for the mint exchange; it must not itself layer in
 /// [`crate::AuthChallengeMiddleware`] or the mint call will recurse.
@@ -239,10 +239,11 @@ async fn get_publish_token(
 ///
 /// `acquire_token` sends the CI provider's OIDC ID token — a live
 /// credential — to `url`'s origin (joined with
-/// [`TrustedPublishingOptions::mint_path`]). Only drive this flow from a
-/// dispatcher that is scoped to a single trusted host, such as
-/// [`crate::AuthChallengeMiddleware`]; never pass it URLs derived from
-/// untrusted input.
+/// [`TrustedPublishingOptions::mint_path`]) **without any origin
+/// validation of its own**. [`crate::AuthChallengeMiddleware`] invokes
+/// flows for every challenged URL, so never register this flow there
+/// directly: wrap it in an origin gate such as [`PrefixAuthAmbientFlow`],
+/// or only drive it with URLs for a single host you trust.
 #[derive(Debug, Clone)]
 pub struct TrustedPublishingFlow {
     options: TrustedPublishingOptions,
@@ -282,6 +283,69 @@ impl AuthFlow for TrustedPublishingFlow {
         get_token(&self.client, url, &self.options)
             .await
             .map_err(AuthFlowError::new)
+    }
+}
+
+/// Returns `true` for `prefix.dev` and any true subdomain (`*.prefix.dev`).
+/// Lookalikes (`evil-prefix.dev`, `prefix.dev.evil.com`) and trailing-dot
+/// hosts (`beta.prefix.dev.`, preserved as-is by [`Url`]) fail closed.
+fn is_prefix_dev_host(host: &str) -> bool {
+    host == "prefix.dev" || host.ends_with(".prefix.dev")
+}
+
+/// Origin-gated [`AuthFlow`] for the prefix.dev family, safe to register in
+/// an unscoped [`crate::AuthChallengeMiddleware`]: it forwards the ambient
+/// CI identity only to origins it trusts.
+///
+/// On a challenge it delegates to an inner flow (by default a
+/// [`TrustedPublishingFlow`] with [`TrustedPublishingOptions::for_prefix_dev`]
+/// options) if and only if the challenged URL is `https` and its host is
+/// `prefix.dev` or a true subdomain. The gate keys on the request URL alone —
+/// server-controlled challenge parameters such as `realm` cannot open it.
+/// Outside CI the inner flow finds no ambient OIDC identity and the flow
+/// reports "not applicable".
+///
+/// This is the default flow behind [`crate::AuthChallengeMiddleware::default`].
+#[derive(Debug, Clone)]
+pub struct PrefixAuthAmbientFlow {
+    inner: Arc<dyn AuthFlow>,
+}
+
+impl PrefixAuthAmbientFlow {
+    /// Create the flow with `client` used for the mint exchange. The client
+    /// must not itself layer in [`crate::AuthChallengeMiddleware`] or the
+    /// mint call will recurse.
+    pub fn new(client: ClientWithMiddleware) -> Self {
+        Self::wrapping(Arc::new(TrustedPublishingFlow::for_prefix_dev(client)))
+    }
+
+    /// Apply the prefix.dev origin gate to an arbitrary `inner` flow:
+    /// `inner` is only consulted for `https` URLs on the prefix.dev family.
+    pub fn wrapping(inner: Arc<dyn AuthFlow>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Default for PrefixAuthAmbientFlow {
+    /// The flow with a plain (middleware-free) HTTP client for the mint
+    /// exchange.
+    fn default() -> Self {
+        Self::new(reqwest_middleware::ClientBuilder::new(reqwest::Client::new()).build())
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl AuthFlow for PrefixAuthAmbientFlow {
+    async fn acquire_token(
+        &self,
+        url: &Url,
+        challenges: &[Challenge],
+    ) -> Result<Option<BearerToken>, AuthFlowError> {
+        if url.scheme() != "https" || !url.host_str().is_some_and(is_prefix_dev_host) {
+            return Ok(None);
+        }
+        self.inner.acquire_token(url, challenges).await
     }
 }
 
@@ -476,10 +540,9 @@ mod tests {
                 // middleware (it would recurse), so it stays plain.
                 let flow = TrustedPublishingFlow::for_prefix_dev(plain_client());
                 let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
-                    .with_arc(std::sync::Arc::new(AuthChallengeMiddleware::new(
-                        server_url.clone(),
+                    .with_arc(std::sync::Arc::new(AuthChallengeMiddleware::new(vec![
                         std::sync::Arc::new(flow),
-                    )))
+                    ])))
                     .build();
                 let url = server_url.join("/channel/repodata.json").unwrap();
 
@@ -564,5 +627,71 @@ mod tests {
         )
         .unwrap();
         assert_eq!(evil.audience, "evil-prefix.dev");
+    }
+
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use crate::challenge_middleware::{AuthFlowError, BearerToken};
+
+    /// Inner flow recording invocations; stands in for the trusted-publishing
+    /// delegate so the gate can be observed without any network traffic.
+    #[derive(Debug)]
+    struct SpyFlow {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl AuthFlow for SpyFlow {
+        async fn acquire_token(
+            &self,
+            _url: &Url,
+            _challenges: &[Challenge],
+        ) -> Result<Option<BearerToken>, AuthFlowError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(BearerToken::new("spy-token".to_string())))
+        }
+    }
+
+    #[tokio::test]
+    async fn ambient_flow_delegates_for_prefix_dev_family_hosts() {
+        let spy = Arc::new(SpyFlow {
+            calls: AtomicUsize::new(0),
+        });
+        let flow = PrefixAuthAmbientFlow::wrapping(spy.clone());
+        for host in ["prefix.dev", "beta.prefix.dev", "staging.beta.prefix.dev"] {
+            let url = Url::parse(&format!("https://{host}/channel/repodata.json")).unwrap();
+            let token = flow.acquire_token(&url, &bearer_challenge()).await.unwrap();
+            assert!(token.is_some(), "{host} should pass the trust gate");
+        }
+        assert_eq!(spy.calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn ambient_flow_never_delegates_for_untrusted_origins() {
+        let spy = Arc::new(SpyFlow {
+            calls: AtomicUsize::new(0),
+        });
+        let flow = PrefixAuthAmbientFlow::wrapping(spy.clone());
+        // The gate must key on the request URL alone: a server-controlled
+        // realm claiming "prefix.dev" must not open it.
+        let challenges = vec![Challenge {
+            scheme: "Bearer".to_string(),
+            params: HashMap::from([("realm".to_string(), "prefix.dev".to_string())]),
+        }];
+        for url in [
+            "https://evil-prefix.dev/channel/repodata.json",
+            "https://prefix.dev.evil.com/channel/repodata.json",
+            "https://conda.anaconda.org/conda-forge/noarch/repodata.json",
+            "http://prefix.dev/channel/repodata.json", // https only
+            "https://beta.prefix.dev./channel/repodata.json", // trailing dot fails closed
+        ] {
+            let url = Url::parse(url).unwrap();
+            let token = flow.acquire_token(&url, &challenges).await.unwrap();
+            assert!(token.is_none(), "{url} must be rejected by the trust gate");
+        }
+        assert_eq!(spy.calls.load(Ordering::SeqCst), 0);
     }
 }

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -2,7 +2,7 @@
 //!
 //! This module owns the OIDC exchange with the server's mint endpoint and
 //! provides [`TrustedPublishingFlow`], an [`AuthFlow`] implementation that
-//! plugs into [`crate::challenge_middleware`]. Challenge-reactive read
+//! plugs into [`crate::challenge_middleware`]. Challenge-reactive HTTP
 //! authentication (reacting to `WWW-Authenticate` responses) lives in
 //! [`crate::challenge_middleware`].
 //!

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -1,18 +1,14 @@
 //! Trusted publishing (via OIDC).
 //!
-//! This module owns the OIDC exchange with the server's mint endpoint and
-//! provides [`TrustedPublishingFlow`], an [`AuthFlow`] implementation that
-//! plugs into [`crate::challenge_middleware`]. Challenge-reactive HTTP
-//! authentication (reacting to `WWW-Authenticate` responses) lives in
+//! Owns the OIDC exchange with the server's mint endpoint and provides
+//! [`TrustedPublishingFlow`] and [`PrefixAuthAmbientFlow`] for
 //! [`crate::challenge_middleware`].
 //!
 //! The flow:
 //! 1. Ask `ambient-id` for an OIDC ID token with the configured `audience`
-//!    claim. It owns CI-provider detection and returns `None` when no
-//!    supported provider is present.
-//! 2. Exchange that ID token at the server's mint endpoint for a short-lived
-//!    bearer token usable against the server (read or write, depending on
-//!    server policy).
+//!    claim (`None` outside supported CI providers).
+//! 2. Exchange it at the server's mint endpoint for a short-lived bearer
+//!    token.
 
 use std::sync::Arc;
 
@@ -28,14 +24,12 @@ use crate::challenge_middleware::{AuthFlow, AuthFlowError, BearerToken, Challeng
 const DEFAULT_MINT_PATH: &str = "/api/oidc/mint_token";
 
 /// Knobs for the trusted-publishing flow. Use
-/// [`for_prefix_dev`](Self::for_prefix_dev) for the prefix.dev defaults, or
-/// construct directly to point at a different server.
+/// [`for_prefix_dev`](Self::for_prefix_dev) for the prefix.dev defaults.
 ///
-/// On GitLab CI, the OIDC ID token must be populated by the runner under an
-/// env var whose name is derived from [`audience`](Self::audience) by
-/// `ambient-id` (uppercasing the audience and replacing non-alphanumeric
-/// characters with `_`, then suffixing `_ID_TOKEN`). For audience
-/// `prefix.dev`, that resolves to `PREFIX_DEV_ID_TOKEN` — set this via the
+/// On GitLab CI the runner must populate the OIDC ID token under an env
+/// var that `ambient-id` derives from [`audience`](Self::audience)
+/// (uppercased, non-alphanumerics to `_`, suffixed `_ID_TOKEN`; audience
+/// `prefix.dev` resolves to `PREFIX_DEV_ID_TOKEN`). Set it via the
 /// `id_tokens` block in `.gitlab-ci.yml`.
 #[derive(Debug, Clone)]
 pub struct TrustedPublishingOptions {
@@ -45,10 +39,8 @@ pub struct TrustedPublishingOptions {
     pub audience: String,
     /// Path on the server where the ID token is exchanged for a bearer token.
     ///
-    /// This path is joined onto arbitrary URLs of the challenged server using
-    /// [`Url::join`]. It should start with `/` so that it replaces the full
-    /// URL path; a relative path would resolve against the challenged URL's
-    /// path and could target an unintended endpoint.
+    /// Joined onto challenged URLs with [`Url::join`]; it must start with
+    /// `/` or it would resolve relative to the challenged URL's path.
     /// [`TrustedPublishingFlow::new`] normalizes a missing leading slash.
     pub mint_path: String,
 }
@@ -63,22 +55,15 @@ impl TrustedPublishingOptions {
         }
     }
 
-    /// Options for any trusted-publishing server following the prefix.dev
-    /// convention: the OIDC audience is the server's host name and tokens
-    /// are minted at `/api/oidc/mint_token`.
+    /// Options for a server following the prefix.dev convention: the OIDC
+    /// audience is the server's host name (scoping each ID token to the
+    /// server it is sent to) and tokens are minted at
+    /// `/api/oidc/mint_token`.
     ///
-    /// Returns `None` when `server` has no host (e.g. `data:` URLs).
-    ///
-    /// Deriving the audience from the host scopes each OIDC ID token to the
-    /// server it is sent to: a token minted with `aud = <host>` is only
-    /// redeemable at that host.
-    ///
-    /// This constructor does not validate the scheme or host. Callers
-    /// handling ambient CI credentials must ensure `server` uses `https`
-    /// and apply their own host allow-list before attaching this flow.
-    /// The audience is the URL-normalized host: lowercased, IDN hosts in
-    /// punycode, and without any port. See the struct-level docs for how
-    /// the audience determines the GitLab CI env-var name.
+    /// Returns `None` when `server` has no host. Does not validate scheme
+    /// or host; callers handling ambient CI credentials must enforce
+    /// `https` and an allow-list themselves. The audience is the
+    /// URL-normalized host: lowercased, punycode, no port.
     pub fn for_host(server: &Url) -> Option<Self> {
         Some(Self {
             audience: server.host_str()?.to_string(),
@@ -86,15 +71,13 @@ impl TrustedPublishingOptions {
         })
     }
 
-    /// Options for `server` following the deployed prefix.dev ecosystem
-    /// convention: every prefix.dev deployment (`prefix.dev` and
-    /// `*.prefix.dev`, e.g. `beta.prefix.dev`) validates GitHub OIDC tokens
-    /// against the shared audience `prefix.dev`, while tokens are minted at
-    /// the deployment's own host. Hosts outside that family fall back to
-    /// [`Self::for_host`] (host-derived audience).
+    /// Like [`Self::for_host`], except prefix.dev deployments
+    /// (`prefix.dev` and `*.prefix.dev`) get the shared audience
+    /// `prefix.dev`, which is what they validate GitHub OIDC tokens
+    /// against; tokens are still minted at the deployment's own host.
     ///
-    /// Returns `None` when `server` has no host. The caveats on
-    /// [`Self::for_host`] (scheme validation, allow-listing) apply here too.
+    /// Returns `None` when `server` has no host. The [`Self::for_host`]
+    /// caveats apply.
     pub fn for_server(server: &Url) -> Option<Self> {
         let host = server.host_str()?;
         if host == "prefix.dev" || host.ends_with(".prefix.dev") {
@@ -225,25 +208,23 @@ async fn get_publish_token(
     }
 }
 
-/// [`AuthFlow`] implementation backed by trusted publishing (CI OIDC).
+/// [`AuthFlow`] backed by trusted publishing (CI OIDC).
 ///
-/// Responds only to `Bearer` challenges. On a challenge it asks `ambient-id`
-/// for an OIDC ID token (returns `Ok(None)` outside supported CI providers)
-/// and exchanges it at the challenged host's mint endpoint
-/// ([`TrustedPublishingOptions::mint_path`]).
+/// Responds only to `Bearer` challenges: asks `ambient-id` for an OIDC ID
+/// token (`Ok(None)` outside supported CI providers) and exchanges it at
+/// the challenged host's mint endpoint.
 ///
-/// `client` is used only for the mint exchange; it must not itself layer in
-/// [`crate::AuthChallengeMiddleware`] or the mint call will recurse.
+/// `client` is used only for the mint exchange; it must not itself layer
+/// in [`crate::AuthChallengeMiddleware`] or the mint call will recurse.
 ///
 /// # Security
 ///
-/// `acquire_token` sends the CI provider's OIDC ID token — a live
-/// credential — to `url`'s origin (joined with
-/// [`TrustedPublishingOptions::mint_path`]) **without any origin
-/// validation of its own**. [`crate::AuthChallengeMiddleware`] invokes
-/// flows for every challenged URL, so never register this flow there
-/// directly: wrap it in an origin gate such as [`PrefixAuthAmbientFlow`],
-/// or only drive it with URLs for a single host you trust.
+/// `acquire_token` sends the CI provider's OIDC ID token (a live
+/// credential) to `url`'s origin **without any origin validation of its
+/// own**. Never register this flow directly in the unscoped
+/// [`crate::AuthChallengeMiddleware`]; wrap it in an origin gate such as
+/// [`PrefixAuthAmbientFlow`], or only drive it with URLs of a single
+/// trusted host.
 #[derive(Debug, Clone)]
 pub struct TrustedPublishingFlow {
     options: TrustedPublishingOptions,
@@ -293,19 +274,15 @@ fn is_prefix_dev_host(host: &str) -> bool {
     host == "prefix.dev" || host.ends_with(".prefix.dev")
 }
 
-/// Origin-gated [`AuthFlow`] for the prefix.dev family, safe to register in
-/// an unscoped [`crate::AuthChallengeMiddleware`]: it forwards the ambient
-/// CI identity only to origins it trusts.
+/// Origin-gated [`AuthFlow`] for the prefix.dev family, safe to register
+/// in an unscoped [`crate::AuthChallengeMiddleware`]; the default flow
+/// behind [`crate::AuthChallengeMiddleware::default`].
 ///
-/// On a challenge it delegates to an inner flow (by default a
-/// [`TrustedPublishingFlow`] with [`TrustedPublishingOptions::for_prefix_dev`]
-/// options) if and only if the challenged URL is `https` and its host is
-/// `prefix.dev` or a true subdomain. The gate keys on the request URL alone —
-/// server-controlled challenge parameters such as `realm` cannot open it.
-/// Outside CI the inner flow finds no ambient OIDC identity and the flow
-/// reports "not applicable".
-///
-/// This is the default flow behind [`crate::AuthChallengeMiddleware::default`].
+/// Delegates to an inner flow (by default [`TrustedPublishingFlow`] with
+/// [`TrustedPublishingOptions::for_prefix_dev`]) only for `https` URLs on
+/// `prefix.dev` or a true subdomain. The gate keys on the request URL
+/// alone; server-controlled challenge params such as `realm` cannot open
+/// it. Outside CI the inner flow reports "not applicable".
 #[derive(Debug, Clone)]
 pub struct PrefixAuthAmbientFlow {
     inner: Arc<dyn AuthFlow>,

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -45,8 +45,12 @@ pub struct TrustedPublishingOptions {
     /// this against the trusted-publisher configuration before minting a
     /// token.
     pub audience: String,
-    /// Path on the server (joined onto `server_url`) where the ID token is
-    /// exchanged for a bearer token.
+    /// Path on the server where the ID token is exchanged for a bearer token.
+    ///
+    /// This path is joined onto arbitrary URLs of the challenged server using
+    /// [`Url::join`]. It must start with `/` so that it replaces the full URL
+    /// path; a relative path would resolve against the challenged URL's path
+    /// and could target an unintended endpoint.
     pub mint_path: String,
 }
 
@@ -242,6 +246,15 @@ async fn get_publish_token(
 ///
 /// `client` is used only for the mint exchange; it must not itself layer in
 /// [`crate::AuthChallengeMiddleware`] or the mint call will recurse.
+///
+/// # Security
+///
+/// `acquire_token` sends the CI provider's OIDC ID token — a live
+/// credential — to `url`'s origin (joined with
+/// [`TrustedPublishingOptions::mint_path`]). Only drive this flow from a
+/// dispatcher that is scoped to a single trusted host, such as
+/// [`crate::AuthChallengeMiddleware`]; never pass it URLs derived from
+/// untrusted input.
 #[derive(Debug, Clone)]
 pub struct TrustedPublishingFlow {
     options: TrustedPublishingOptions,

--- a/crates/rattler_networking/src/trusted_publishing.rs
+++ b/crates/rattler_networking/src/trusted_publishing.rs
@@ -1,5 +1,11 @@
 //! Trusted publishing (via OIDC).
 //!
+//! This module owns the OIDC exchange with the server's mint endpoint and
+//! provides [`TrustedPublishingFlow`], an [`AuthFlow`] implementation that
+//! plugs into [`crate::challenge_middleware`]. Challenge-reactive read
+//! authentication (reacting to `WWW-Authenticate` responses) lives in
+//! [`crate::challenge_middleware`].
+//!
 //! The flow:
 //! 1. Ask `ambient-id` for an OIDC ID token with the configured `audience`
 //!    claim. It owns CI-provider detection and returns `None` when no
@@ -8,26 +14,13 @@
 //!    bearer token usable against the server (read or write, depending on
 //!    server policy).
 
-use std::{
-    sync::{Arc, Mutex},
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
-
-use base64::{
-    Engine as _,
-    engine::general_purpose::{URL_SAFE, URL_SAFE_NO_PAD},
-};
 use reqwest::StatusCode;
-use reqwest_middleware::{ClientWithMiddleware, Middleware, Next};
-use serde::{Deserialize, Serialize};
+use reqwest_middleware::ClientWithMiddleware;
+use serde::Serialize;
 use thiserror::Error;
 use url::Url;
 
-use crate::challenge_middleware::{AuthFlow, AuthFlowError, Challenge};
-
-/// Refresh minted JWT tokens before they expire to avoid sending a token that
-/// becomes invalid while a request is in flight.
-const TOKEN_REFRESH_MARGIN: Duration = Duration::from_secs(60);
+use crate::challenge_middleware::{AuthFlow, AuthFlowError, BearerToken, Challenge};
 
 /// Knobs for the trusted-publishing flow. Use
 /// [`for_prefix_dev`](Self::for_prefix_dev) for the prefix.dev defaults, or
@@ -70,7 +63,7 @@ pub enum TrustedPublishResult {
     /// We didn't check for trusted publishing (no CI provider detected).
     Skipped,
     /// We checked for trusted publishing and got a token.
-    Configured(TrustedPublishingToken),
+    Configured(BearerToken),
     /// We checked for optional trusted publishing, but it didn't succeed.
     Ignored(TrustedPublishingError),
 }
@@ -97,62 +90,14 @@ pub enum TrustedPublishingError {
     OidcToken(#[from] ambient_id::Error),
 }
 
-/// A short-lived bearer token minted by the server. The inner string is
-/// `Deserialize`-friendly (the mint endpoint returns the raw token as a JSON
-/// string body) and `Clone` so the same token can be shared across middleware
-/// and stored in auth state.
-#[derive(Clone, Deserialize)]
-#[serde(transparent)]
-pub struct TrustedPublishingToken(String);
-
-impl TrustedPublishingToken {
-    /// Wrap an already-minted token (mostly for tests).
-    pub fn new(token: String) -> Self {
-        Self(token)
-    }
-
-    /// The raw bearer token. Treat as sensitive; don't log it.
-    pub fn secret(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Debug for TrustedPublishingToken {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("TrustedPublishingToken")
-            .field(&"<redacted>")
-            .finish()
-    }
-}
+/// Deprecated alias kept for backwards compatibility.
+#[deprecated(note = "use `rattler_networking::BearerToken` instead")]
+pub type TrustedPublishingToken = BearerToken;
 
 /// The body sent to the server's mint endpoint.
 #[derive(Serialize)]
 struct MintTokenRequest {
     token: String,
-}
-
-#[derive(Deserialize)]
-struct JwtClaims {
-    exp: Option<u64>,
-}
-
-fn jwt_expiration(token: &str) -> Option<SystemTime> {
-    let mut parts = token.split('.');
-    let _header = parts.next()?;
-    let payload = parts.next()?;
-    let _signature = parts.next()?;
-    if parts.next().is_some() {
-        return None;
-    }
-
-    let payload = URL_SAFE_NO_PAD
-        .decode(payload)
-        .or_else(|_| URL_SAFE.decode(payload))
-        .ok()?;
-    let claims: JwtClaims = serde_json::from_slice(&payload).ok()?;
-    claims
-        .exp
-        .and_then(|exp| UNIX_EPOCH.checked_add(Duration::from_secs(exp)))
 }
 
 /// If applicable, attempt to obtain a bearer token via trusted publishing.
@@ -185,7 +130,7 @@ pub async fn get_token(
     client: &ClientWithMiddleware,
     server_url: &Url,
     options: &TrustedPublishingOptions,
-) -> Result<Option<TrustedPublishingToken>, TrustedPublishingError> {
+) -> Result<Option<BearerToken>, TrustedPublishingError> {
     let detector = ambient_id::Detector::new_with_client(client.clone());
     let Some(oidc_token) = detector.detect(&options.audience).await? else {
         return Ok(None);
@@ -203,7 +148,7 @@ async fn get_publish_token(
     server_url: &Url,
     client: &ClientWithMiddleware,
     options: &TrustedPublishingOptions,
-) -> Result<TrustedPublishingToken, TrustedPublishingError> {
+) -> Result<BearerToken, TrustedPublishingError> {
     let mint_token_url = server_url.join(&options.mint_path)?;
     tracing::info!("Querying the trusted publishing token from {mint_token_url}");
     let mint_token_payload = MintTokenRequest {
@@ -224,9 +169,7 @@ async fn get_publish_token(
         .map_err(|err| TrustedPublishingError::Reqwest(mint_token_url.clone(), err))?;
 
     if status.is_success() {
-        Ok(TrustedPublishingToken(
-            String::from_utf8_lossy(&body).to_string(),
-        ))
+        Ok(BearerToken::new(String::from_utf8_lossy(&body).to_string()))
     } else {
         Err(TrustedPublishingError::MintToken(
             status,
@@ -280,198 +223,16 @@ impl AuthFlow for TrustedPublishingFlow {
         &self,
         url: &Url,
         challenges: &[Challenge],
-    ) -> Result<Option<crate::challenge_middleware::BearerToken>, AuthFlowError> {
+    ) -> Result<Option<BearerToken>, AuthFlowError> {
         if !challenges
             .iter()
             .any(|challenge| challenge.scheme.eq_ignore_ascii_case("bearer"))
         {
             return Ok(None);
         }
-        // `get_token` still returns the old `TrustedPublishingToken` until
-        // Task 7 swaps it to `BearerToken`; convert explicitly for now.
-        match get_token(&self.client, url, &self.options).await {
-            Ok(Some(token)) => Ok(Some(crate::challenge_middleware::BearerToken::new(
-                token.secret().to_string(),
-            ))),
-            Ok(None) => Ok(None),
-            Err(err) => Err(AuthFlowError::new(err)),
-        }
-    }
-}
-
-/// `reqwest` middleware that injects a [`TrustedPublishingToken`] as a
-/// `Bearer` `Authorization` header for requests targeting a specific channel.
-///
-/// Layered alongside [`crate::AuthenticationMiddleware`]: it only sets the
-/// header when no `Authorization` is already present and only when the
-/// request URL's host and path prefix match the configured channel. This
-/// keeps the minted token scoped to the channel it was issued for, instead
-/// of leaking it to unrelated channels (which may share a host, e.g.
-/// `https://prefix.dev/my-channel/` vs `https://prefix.dev/other-channel/`).
-#[derive(Clone, Debug)]
-pub struct TrustedPublishingMiddleware {
-    channel_url: Url,
-    state: TrustedPublishingState,
-}
-
-#[derive(Clone, Debug)]
-enum TrustedPublishingState {
-    /// Caller supplied an already-minted token.
-    Token(TrustedPublishingToken),
-    /// Token will be minted on the first matching request.
-    Lazy {
-        server_url: Url,
-        options: TrustedPublishingOptions,
-        client: ClientWithMiddleware,
-        cache: Arc<Mutex<TrustedPublishingCache>>,
-    },
-}
-
-#[derive(Debug, Default)]
-enum TrustedPublishingCache {
-    #[default]
-    Empty,
-    Disabled,
-    Token(CachedTrustedPublishingToken),
-}
-
-#[derive(Clone, Debug)]
-struct CachedTrustedPublishingToken {
-    token: TrustedPublishingToken,
-    expires_at: Option<SystemTime>,
-}
-
-impl CachedTrustedPublishingToken {
-    fn new(token: TrustedPublishingToken) -> Self {
-        let expires_at = jwt_expiration(token.secret());
-        Self { token, expires_at }
-    }
-
-    fn is_fresh(&self, now: SystemTime) -> bool {
-        self.expires_at
-            .is_none_or(|expires_at| now + TOKEN_REFRESH_MARGIN < expires_at)
-    }
-}
-
-impl TrustedPublishingMiddleware {
-    /// Create a middleware that will mint a token lazily on the first
-    /// matching request using `options`. `client` is used only for the OIDC
-    /// mint exchange; it must not itself layer in `TrustedPublishingMiddleware`
-    /// or the mint call will recurse.
-    pub fn new(
-        server_url: Url,
-        options: TrustedPublishingOptions,
-        client: ClientWithMiddleware,
-    ) -> Self {
-        let channel_url = normalize_channel_url(&server_url);
-        Self {
-            channel_url,
-            state: TrustedPublishingState::Lazy {
-                server_url,
-                options,
-                client,
-                cache: Arc::new(Mutex::new(TrustedPublishingCache::Empty)),
-            },
-        }
-    }
-
-    /// Create a middleware that injects an already-minted `token` on
-    /// requests whose URL host and path prefix match `server_url`.
-    pub fn with_token(server_url: &Url, token: TrustedPublishingToken) -> Self {
-        Self {
-            channel_url: normalize_channel_url(server_url),
-            state: TrustedPublishingState::Token(token),
-        }
-    }
-
-    /// Resolve the token to inject, performing (and caching) the OIDC
-    /// exchange on demand for the `Lazy` variant.
-    async fn token(&self) -> Option<TrustedPublishingToken> {
-        match &self.state {
-            TrustedPublishingState::Token(token) => Some(token.clone()),
-            TrustedPublishingState::Lazy {
-                server_url,
-                options,
-                client,
-                cache,
-            } => {
-                {
-                    let cache = cache.lock().expect("trusted publishing cache poisoned");
-                    match &*cache {
-                        TrustedPublishingCache::Token(token)
-                            if token.is_fresh(SystemTime::now()) =>
-                        {
-                            return Some(token.token.clone());
-                        }
-                        TrustedPublishingCache::Disabled => return None,
-                        TrustedPublishingCache::Empty | TrustedPublishingCache::Token(_) => {}
-                    }
-                }
-
-                let token = match check_trusted_publishing(client, server_url, options).await {
-                    TrustedPublishResult::Configured(token) => Some(token),
-                    TrustedPublishResult::Skipped => {
-                        tracing::debug!(
-                            "TrustedPublishingMiddleware: no CI provider detected, skipping OIDC token exchange"
-                        );
-                        None
-                    }
-                    TrustedPublishResult::Ignored(err) => {
-                        tracing::warn!(
-                            "TrustedPublishingMiddleware: trusted publishing failed: {err}"
-                        );
-                        None
-                    }
-                };
-
-                let mut cache = cache.lock().expect("trusted publishing cache poisoned");
-                if let Some(token) = token {
-                    let token = CachedTrustedPublishingToken::new(token);
-                    let result = token.token.clone();
-                    *cache = TrustedPublishingCache::Token(token);
-                    Some(result)
-                } else {
-                    *cache = TrustedPublishingCache::Disabled;
-                    None
-                }
-            }
-        }
-    }
-}
-
-/// Normalize a channel URL so its path always ends with `/`. This avoids a
-/// prefix-collision bug where `/my-channel` would also match `/my-channel-evil`.
-fn normalize_channel_url(url: &Url) -> Url {
-    let mut url = url.clone();
-    if !url.path().ends_with('/') {
-        let new_path = format!("{}/", url.path());
-        url.set_path(&new_path);
-    }
-    url
-}
-
-#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
-#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
-impl Middleware for TrustedPublishingMiddleware {
-    async fn handle(
-        &self,
-        mut req: reqwest::Request,
-        extensions: &mut http::Extensions,
-        next: Next<'_>,
-    ) -> reqwest_middleware::Result<reqwest::Response> {
-        if req.headers().get(reqwest::header::AUTHORIZATION).is_none()
-            && req.url().host_str() == self.channel_url.host_str()
-            && req.url().path().starts_with(self.channel_url.path())
-            && let Some(token) = self.token().await
-        {
-            let bearer_auth = format!("Bearer {}", token.secret());
-            let mut header_value = reqwest::header::HeaderValue::from_str(&bearer_auth)
-                .map_err(reqwest_middleware::Error::middleware)?;
-            header_value.set_sensitive(true);
-            req.headers_mut()
-                .insert(reqwest::header::AUTHORIZATION, header_value);
-        }
-        next.run(req, extensions).await
+        get_token(&self.client, url, &self.options)
+            .await
+            .map_err(AuthFlowError::new)
     }
 }
 
@@ -562,233 +323,5 @@ mod tests {
         let opts = TrustedPublishingOptions::for_prefix_dev();
         assert_eq!(opts.audience, "prefix.dev");
         assert_eq!(opts.mint_path, "/api/oidc/mint_token");
-    }
-
-    #[test]
-    fn token_debug_is_redacted() {
-        let token = TrustedPublishingToken::new("supersecret".to_string());
-        let formatted = format!("{token:?}");
-        assert!(!formatted.contains("supersecret"));
-        assert!(formatted.contains("redacted"));
-    }
-
-    fn unsigned_jwt_with_exp(exp: u64) -> String {
-        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
-        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{exp}}}"#));
-        format!("{header}.{payload}.")
-    }
-
-    #[test]
-    fn jwt_expiration_reads_exp_claim() {
-        let token = unsigned_jwt_with_exp(1_700_000_000);
-        assert_eq!(
-            jwt_expiration(&token),
-            UNIX_EPOCH.checked_add(Duration::from_secs(1_700_000_000))
-        );
-    }
-
-    #[test]
-    fn cached_jwt_is_stale_inside_refresh_margin() {
-        let token = TrustedPublishingToken::new(unsigned_jwt_with_exp(1_700_000_000));
-        let cached = CachedTrustedPublishingToken::new(token);
-        let now = UNIX_EPOCH + Duration::from_secs(1_700_000_000 - 30);
-        assert!(!cached.is_fresh(now));
-    }
-
-    #[tokio::test]
-    async fn middleware_injects_bearer_for_matching_host() {
-        use reqwest_middleware::ClientBuilder;
-        use std::sync::Arc;
-
-        let server = axum::Router::new().route(
-            "/check",
-            axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                headers
-                    .get("authorization")
-                    .map(|v| v.to_str().unwrap().to_string())
-                    .unwrap_or_default()
-            }),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move { axum::serve(listener, server).await.unwrap() });
-
-        let server_url = Url::parse(&format!("http://{addr}")).unwrap();
-        let token = TrustedPublishingToken::new("abc123".to_string());
-        let middleware = TrustedPublishingMiddleware::with_token(&server_url, token);
-
-        let client = ClientBuilder::new(reqwest::Client::new())
-            .with_arc(Arc::new(middleware))
-            .build();
-
-        let body = client
-            .get(server_url.join("/check").unwrap())
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "Bearer abc123");
-    }
-
-    #[tokio::test]
-    async fn middleware_skips_same_host_different_channel() {
-        use reqwest_middleware::ClientBuilder;
-        use std::sync::Arc;
-
-        let server = axum::Router::new()
-            .route(
-                "/my-channel/check",
-                axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                    if headers.contains_key("authorization") {
-                        "has-auth".to_string()
-                    } else {
-                        "no-auth".to_string()
-                    }
-                }),
-            )
-            .route(
-                "/other-channel/check",
-                axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                    if headers.contains_key("authorization") {
-                        "has-auth".to_string()
-                    } else {
-                        "no-auth".to_string()
-                    }
-                }),
-            )
-            .route(
-                "/my-channel-evil/check",
-                axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                    if headers.contains_key("authorization") {
-                        "has-auth".to_string()
-                    } else {
-                        "no-auth".to_string()
-                    }
-                }),
-            )
-            .route(
-                "/my-channel/subdir/check",
-                axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                    if headers.contains_key("authorization") {
-                        "has-auth".to_string()
-                    } else {
-                        "no-auth".to_string()
-                    }
-                }),
-            );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move { axum::serve(listener, server).await.unwrap() });
-
-        // Middleware scoped to /my-channel/ on the test host.
-        let channel_url = Url::parse(&format!("http://{addr}/my-channel/")).unwrap();
-        let token = TrustedPublishingToken::new("abc123".to_string());
-        let middleware = TrustedPublishingMiddleware::with_token(&channel_url, token);
-
-        let client = ClientBuilder::new(reqwest::Client::new())
-            .with_arc(Arc::new(middleware))
-            .build();
-
-        // Same host, different channel: token must NOT be injected.
-        let body = client
-            .get(format!("http://{addr}/other-channel/check"))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "no-auth");
-
-        // Prefix collision: /my-channel-evil must NOT match /my-channel/.
-        let body = client
-            .get(format!("http://{addr}/my-channel-evil/check"))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "no-auth");
-
-        // Same channel: token IS injected.
-        let body = client
-            .get(format!("http://{addr}/my-channel/check"))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "has-auth");
-
-        // Sub-path under the same channel: token IS injected.
-        let body = client
-            .get(format!("http://{addr}/my-channel/subdir/check"))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "has-auth");
-    }
-
-    #[test]
-    fn normalize_channel_url_adds_trailing_slash() {
-        let with_path = Url::parse("https://prefix.dev/my-channel").unwrap();
-        assert_eq!(normalize_channel_url(&with_path).path(), "/my-channel/");
-
-        let already_trailing = Url::parse("https://prefix.dev/my-channel/").unwrap();
-        assert_eq!(
-            normalize_channel_url(&already_trailing).path(),
-            "/my-channel/"
-        );
-
-        // The url crate normalizes a host-only URL to path "/".
-        let host_only = Url::parse("https://prefix.dev").unwrap();
-        assert_eq!(host_only.path(), "/");
-        assert_eq!(normalize_channel_url(&host_only).path(), "/");
-    }
-
-    #[tokio::test]
-    async fn middleware_skips_non_matching_host() {
-        use reqwest_middleware::ClientBuilder;
-        use std::sync::Arc;
-
-        let server = axum::Router::new().route(
-            "/check",
-            axum::routing::get(|headers: axum::http::HeaderMap| async move {
-                if headers.contains_key("authorization") {
-                    "has-auth".to_string()
-                } else {
-                    "no-auth".to_string()
-                }
-            }),
-        );
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move { axum::serve(listener, server).await.unwrap() });
-
-        // Middleware is configured for a different host than the one we hit.
-        let other_url = Url::parse("https://example.invalid").unwrap();
-        let token = TrustedPublishingToken::new("abc123".to_string());
-        let middleware = TrustedPublishingMiddleware::with_token(&other_url, token);
-
-        let client = ClientBuilder::new(reqwest::Client::new())
-            .with_arc(Arc::new(middleware))
-            .build();
-
-        let body = client
-            .get(format!("http://{addr}/check"))
-            .send()
-            .await
-            .unwrap()
-            .text()
-            .await
-            .unwrap();
-        assert_eq!(body, "no-auth");
     }
 }

--- a/crates/rattler_upload/src/upload/prefix.rs
+++ b/crates/rattler_upload/src/upload/prefix.rs
@@ -214,7 +214,7 @@ pub async fn upload_package_to_prefix(
         None => match check_trusted_publishing(
             &client,
             &prefix_data.url,
-            &TrustedPublishingOptions::for_host(&prefix_data.url)
+            &TrustedPublishingOptions::for_server(&prefix_data.url)
                 .unwrap_or_else(TrustedPublishingOptions::for_prefix_dev),
         )
         .await
@@ -252,7 +252,7 @@ pub async fn upload_package_to_prefix(
         None => match check_trusted_publishing(
             &client,
             &prefix_data.url,
-            &TrustedPublishingOptions::for_host(&prefix_data.url)
+            &TrustedPublishingOptions::for_server(&prefix_data.url)
                 .unwrap_or_else(TrustedPublishingOptions::for_prefix_dev),
         )
         .await

--- a/crates/rattler_upload/src/upload/prefix.rs
+++ b/crates/rattler_upload/src/upload/prefix.rs
@@ -214,7 +214,8 @@ pub async fn upload_package_to_prefix(
         None => match check_trusted_publishing(
             &client,
             &prefix_data.url,
-            &TrustedPublishingOptions::for_prefix_dev(),
+            &TrustedPublishingOptions::for_host(&prefix_data.url)
+                .unwrap_or_else(TrustedPublishingOptions::for_prefix_dev),
         )
         .await
         {
@@ -251,7 +252,8 @@ pub async fn upload_package_to_prefix(
         None => match check_trusted_publishing(
             &client,
             &prefix_data.url,
-            &TrustedPublishingOptions::for_prefix_dev(),
+            &TrustedPublishingOptions::for_host(&prefix_data.url)
+                .unwrap_or_else(TrustedPublishingOptions::for_prefix_dev),
         )
         .await
         {


### PR DESCRIPTION
### Description

This PR reworks how `rattler_networking` authenticates to channel servers,
moving from a **proactive credential-push** model to a **challenge-reactive**
model, and makes expired OAuth credentials degrade gracefully into that path.

**The architectural shift**

- Adds `AuthChallengeMiddleware` (`challenge_middleware.rs`): the middleware
  does nothing until a server replies `401`/`403` with a `WWW-Authenticate`
  header. It then parses the challenge (RFC 7235, via the `http-auth` crate),
  picks a registered `AuthFlow` that can satisfy it, acquires a bearer token,
  and **replays the request once**. Tokens are cached **per origin**
  (scheme + host + port), with single-flight acquisition so concurrent
  requests to the same origin don't each mint a token.
- Introduces the `AuthFlow` trait as a pluggable strategy for answering
  challenges. `TrustedPublishingFlow` / `PrefixAuthAmbientFlow` reimplements
  trusted publishing as an `AuthFlow` for zero-config prefix.dev auth from CI.
- **Breaking:** removes the old `TrustedPublishingMiddleware` in favor of the
  challenge-reactive middleware. `trusted_publishing.rs` is substantially
  rewritten; `TrustedPublishingOptions::for_host` / `for_server` derive the
  audience from the upload/channel host.
- Wires `AuthChallengeMiddleware` into `rattler-bin` for prefix.dev channel
  hosts, with port-aware middleware dedup.

**Graceful OAuth expiry** (the `oauth-expired-reauth` commit on top)

- `oauth_refresh` now coalesces concurrent refreshes (single-flight) and
  negatively caches failures, so a dead credential logs and hits the token
  endpoint **once per process** instead of once per request.
- `maybe_refresh_oauth` returns `None` when an OAuth token is expired and
  cannot be refreshed, so the request is sent unauthenticated and the
  auth-challenge middleware can take over.
- If such a request still returns `401`/`403`, `AuthenticationMiddleware`
  surfaces a typed `AuthenticationExpired { host }` error so callers can
  prompt the user to re-authenticate.

Motivation/context: enables zero-config prefix.dev OIDC/trusted-publishing
auth and a clean re-auth signal for expired credentials (relates to the
prefix.dev OIDC work, pixi#6318).

### How Has This Been Tested?

Automated tests are included in the branch:

- Unit tests pinning `AuthChallengeMiddleware` behavior and edge cases
  (challenge parsing, token validation before caching, per-origin caching,
  single-flight, replay guards, malformed auth-params).
- A self-discriminating stale-token test asserting cache hit counts.
- An e2e test for the trusted-publishing mint path.

Run locally with:

```
pixi run -- cargo nextest run -p rattler_networking
```

> Note: opened as a **draft** — CI on the full stack should be green before
> marking ready for review.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Claude Code, Opus 4.8)

```plaintext
what we have done in this branch?
can you create a draft pr?
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.
