### PR TITLE
feat(networking): surface AuthenticationExpired for unrecoverable OAuth logins

### DIFF
--- a/crates/rattler_networking/src/authentication_middleware.rs
+++ b/crates/rattler_networking/src/authentication_middleware.rs
@@ -11,9 +11,21 @@ use reqwest_middleware::{Middleware, Next};
 use url::Url;
 
 use crate::{
-    Authentication, AuthenticationStorage, authentication_storage::AuthenticationStorageError,
-    oauth_refresh,
+    Authentication, AuthenticationStorage,
+    authentication_storage::AuthenticationStorageError,
+    oauth_refresh::{self, OAuthRefreshFailure},
 };
+
+/// Error returned when a request to `host` failed authentication while the
+/// stored OAuth credential for that host was expired and could not be
+/// refreshed. Surfaced so callers can tell the user to authenticate again
+/// (e.g. by re-running their login command).
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("authentication for '{host}' has expired; please re-authenticate")]
+pub struct AuthenticationExpired {
+    /// The host that requires re-authentication.
+    pub host: String,
+}
 
 /// `reqwest` middleware to authenticate requests
 #[derive(Clone)]
@@ -43,7 +55,7 @@ impl Middleware for AuthenticationMiddleware {
             }
             Ok((url, auth_with_key)) => {
                 // If this is an OAuth token, attempt refresh if expired
-                let auth = match auth_with_key {
+                let (auth, reauth_host) = match auth_with_key {
                     Some((matched_key, auth)) => {
                         let refresh_result = oauth_refresh::maybe_refresh_oauth(
                             &self.auth_storage,
@@ -51,14 +63,33 @@ impl Middleware for AuthenticationMiddleware {
                             &matched_key,
                         )
                         .await;
+                        // A failure that means the stored login itself is no
+                        // longer usable (vs. a transient refresh problem).
+                        let needs_reauth = matches!(
+                            refresh_result.failure(),
+                            Some(
+                                OAuthRefreshFailure::MissingRefreshToken
+                                    | OAuthRefreshFailure::ReauthenticationRequired { .. }
+                            )
+                        );
                         if let Some(failure) = refresh_result.failure() {
                             tracing::warn!(
                                 "OAuth refresh for '{matched_key}' did not produce fresh credentials: {failure}"
                             );
                         }
-                        refresh_result.into_authentication()
+                        let auth = refresh_result.into_authentication();
+                        // Only when the dead credential was actually dropped does
+                        // the request go out unauthenticated; remember the host
+                        // so we can prompt for re-authentication if it still
+                        // fails.
+                        let reauth_host = if needs_reauth && auth.is_none() {
+                            url.host_str().map(str::to_string)
+                        } else {
+                            None
+                        };
+                        (auth, reauth_host)
                     }
-                    None => None,
+                    None => (None, None),
                 };
 
                 let url = Self::authenticate_url(url, &auth);
@@ -67,7 +98,20 @@ impl Middleware for AuthenticationMiddleware {
                 *req.url_mut() = url;
 
                 let req = Self::authenticate_request(req, &auth).await?;
-                next.run(req, extensions).await
+                let response = next.run(req, extensions).await?;
+
+                // The stored login expired, could not be refreshed, and the
+                // request still came back unauthorized: surface a typed error so
+                // callers can tell the user to re-authenticate.
+                if let Some(host) = reauth_host
+                    && matches!(response.status().as_u16(), 401 | 403)
+                {
+                    return Err(reqwest_middleware::Error::middleware(
+                        AuthenticationExpired { host },
+                    ));
+                }
+
+                Ok(response)
             }
         }
     }

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(missing_docs)]
 
 //! Networking utilities for Rattler, specifically authenticating requests
-pub use authentication_middleware::AuthenticationMiddleware;
+pub use authentication_middleware::{AuthenticationExpired, AuthenticationMiddleware};
 pub use authentication_storage::{authentication::Authentication, storage::AuthenticationStorage};
 pub use challenge_middleware::{
     AuthChallengeMiddleware, AuthFlow, AuthFlowError, BearerToken, Challenge,


### PR DESCRIPTION
### Description

Builds on the OAuth refresh handling already in `main` (`OAuthRefreshOutcome` /
`OAuthRefreshFailure`, which drops an expired access token when it cannot be
refreshed and sends the request unauthenticated so the auth-challenge
middleware can take over).

This adds a typed **`AuthenticationExpired { host }`** error for the case where
the stored login itself is no longer usable. In `AuthenticationMiddleware`:

- after a refresh attempt, inspect `refresh_result.failure()` and treat only
  `MissingRefreshToken` and `ReauthenticationRequired` as "the login is dead"
  (transient refresh problems keep the existing log-and-continue behavior);
- only when the dead credential was actually dropped (so the request goes out
  unauthenticated) remember the host;
- if that request still comes back `401`/`403`, return
  `AuthenticationExpired { host }` so callers can prompt the user to
  re-authenticate (e.g. re-run their login command).

`AuthenticationExpired` is re-exported from the crate root.

### How Has This Been Tested?

- `pixi run cargo-fmt` and `pixi run -- cargo clippy -p rattler_networking --all-targets` are clean.
- Relies on the existing `oauth_refresh` / `authentication_middleware` unit
  tests in `main` for the refresh-outcome paths.

```
pixi run -- cargo nextest run -p rattler_networking
```

> Opened as a **draft**: no test yet asserts the new `AuthenticationExpired`
> path end to end — happy to add one before marking ready.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude (Claude Code, Opus 4.8)

```plaintext
what we have done in this branch?
can you create a draft pr?
ok, just make this branch to be exactly the same as main for now
can you push it again? I've made some changes there
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
