### PR TITLE
feat: add offline mode to rattler CLI

### DIFF
--- a/crates/rattler-bin/src/commands/auth.rs
+++ b/crates/rattler-bin/src/commands/auth.rs
@@ -3,6 +3,8 @@ use rattler::cli::auth;
 
 pub type Opt = auth::Args;
 
-pub async fn auth(opt: Opt) -> miette::Result<()> {
-    auth::execute(opt).await.into_diagnostic()
+pub async fn auth(opt: Opt, offline: bool) -> miette::Result<()> {
+    auth::execute_with_offline(opt, offline)
+        .await
+        .into_diagnostic()
 }

--- a/crates/rattler-bin/src/commands/client.rs
+++ b/crates/rattler-bin/src/commands/client.rs
@@ -2,11 +2,21 @@ use std::{collections::HashMap, sync::Arc};
 
 use miette::{Context, IntoDiagnostic};
 use rattler_networking::{
-    AuthChallengeMiddleware, AuthenticationMiddleware, AuthenticationStorage,
+    AuthChallengeMiddleware, AuthenticationMiddleware, AuthenticationStorage, OfflineMiddleware,
 };
+use rattler_repodata_gateway::fetch::CacheAction;
 use reqwest::Client;
 
 pub const USER_AGENT: &str = concat!("rattler/", env!("CARGO_PKG_VERSION"));
+
+/// Returns the cache action to use for repodata queries in the CLI.
+pub fn repodata_cache_action(offline: bool) -> CacheAction {
+    if offline {
+        CacheAction::ForceCacheOnly
+    } else {
+        CacheAction::default()
+    }
+}
 
 /// Creates the HTTP client with the middleware stack used by the CLI.
 ///
@@ -14,7 +24,9 @@ pub const USER_AGENT: &str = concat!("rattler/", env!("CARGO_PKG_VERSION"));
 /// `WWW-Authenticate` challenge from a prefix.dev host mints a token via
 /// CI OIDC and replays the request (prefix-dev/pixi#6318). Stored
 /// credentials from [`AuthenticationMiddleware`] take precedence.
-pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
+pub fn create_client_with_middleware(
+    offline: bool,
+) -> miette::Result<reqwest_middleware::ClientWithMiddleware> {
     let download_client = Client::builder()
         .no_gzip()
         .user_agent(USER_AGENT)
@@ -25,7 +37,13 @@ pub fn create_client_with_middleware() -> miette::Result<reqwest_middleware::Cli
     let authentication_storage =
         AuthenticationStorage::from_env_and_defaults().into_diagnostic()?;
 
-    let client = reqwest_middleware::ClientBuilder::new(download_client.clone())
+    let client = reqwest_middleware::ClientBuilder::new(download_client.clone());
+    let client = if offline {
+        client.with(OfflineMiddleware)
+    } else {
+        client
+    };
+    let client = client
         .with_arc(Arc::new(AuthenticationMiddleware::from_auth_storage(
             authentication_storage.clone(),
         )))

--- a/crates/rattler-bin/src/commands/create.rs
+++ b/crates/rattler-bin/src/commands/create.rs
@@ -125,7 +125,7 @@ impl From<SolveStrategy> for rattler_solve::SolveStrategy {
     }
 }
 
-pub async fn create(opt: Opt) -> miette::Result<()> {
+pub async fn create(opt: Opt, offline: bool) -> miette::Result<()> {
     let channel_config =
         ChannelConfig::default_with_root_dir(env::current_dir().into_diagnostic()?);
     // Make the target prefix absolute
@@ -175,7 +175,7 @@ pub async fn create(opt: Opt) -> miette::Result<()> {
     // `repodata.json` that should be available from the corresponding Url. The
     // code below also displays a nice CLI progress-bar to give users some more
     // information about what is going on.
-    let download_client = super::client::create_client_with_middleware()?;
+    let download_client = super::client::create_client_with_middleware(offline)?;
 
     // Get the package names from the matchspecs so we can only load the package
     // records that we need.
@@ -188,6 +188,7 @@ pub async fn create(opt: Opt) -> miette::Result<()> {
         .with_channel_config(rattler_repodata_gateway::ChannelConfig {
             default: SourceConfig {
                 sharded_enabled: true,
+                cache_action: super::client::repodata_cache_action(offline),
                 ..SourceConfig::default()
             },
             per_channel: HashMap::new(),

--- a/crates/rattler-bin/src/commands/download.rs
+++ b/crates/rattler-bin/src/commands/download.rs
@@ -27,14 +27,14 @@ fn default_output_path(url: &Url) -> miette::Result<PathBuf> {
     Ok(PathBuf::from(file_name))
 }
 
-pub async fn download(opt: Opt) -> miette::Result<()> {
+pub async fn download(opt: Opt, offline: bool) -> miette::Result<()> {
     let output = match opt.output {
         Some(output) => output,
         None => default_output_path(&opt.url)?,
     };
     let write_to_stdout = output.as_os_str() == "-";
 
-    let client = super::client::create_client_with_middleware()?;
+    let client = super::client::create_client_with_middleware(offline)?;
 
     let response = client
         .get(opt.url.clone())

--- a/crates/rattler-bin/src/commands/exec.rs
+++ b/crates/rattler-bin/src/commands/exec.rs
@@ -115,16 +115,16 @@ pub async fn exec(opt: Opt, offline: bool) -> miette::Result<()> {
     let dir_prefix = exec_dir_prefix(&install_specs, Some(command), should_guess);
 
     // Solve + install (or reuse) the cached environment
-    let prefix = create_exec_prefix(
-        &install_specs,
-        &channels,
-        opt.platform,
+    let prefix = create_exec_prefix(CreateExecPrefixOptions {
+        specs: &install_specs,
+        channels: &channels,
+        platform: opt.platform,
         dir_prefix,
-        opt.force_reinstall,
-        opt.list.as_deref(),
-        &cache_dir,
+        force_reinstall: opt.force_reinstall,
+        list: opt.list.as_deref(),
+        cache_dir: &cache_dir,
         offline,
-    )
+    })
     .await?;
 
     // Build extra environment variables
@@ -179,17 +179,29 @@ pub async fn exec(opt: Opt, offline: bool) -> miette::Result<()> {
     std::process::exit(status.code().unwrap_or(1));
 }
 
-/// Creates a prefix for the `rattler exec` command.
-async fn create_exec_prefix(
-    specs: &[MatchSpec],
-    channels: &[Channel],
+struct CreateExecPrefixOptions<'a> {
+    specs: &'a [MatchSpec],
+    channels: &'a [Channel],
     platform: Platform,
     dir_prefix: Option<String>,
     force_reinstall: bool,
-    list: Option<&str>,
-    cache_dir: &Path,
+    list: Option<&'a str>,
+    cache_dir: &'a Path,
     offline: bool,
-) -> miette::Result<PathBuf> {
+}
+
+/// Creates a prefix for the `rattler exec` command.
+async fn create_exec_prefix(options: CreateExecPrefixOptions<'_>) -> miette::Result<PathBuf> {
+    let CreateExecPrefixOptions {
+        specs,
+        channels,
+        platform,
+        dir_prefix,
+        force_reinstall,
+        list,
+        cache_dir,
+        offline,
+    } = options;
     let channel_urls: Vec<String> = channels.iter().map(|c| c.base_url.to_string()).collect();
     let env_hash = compute_env_hash(specs, &channel_urls, platform);
 

--- a/crates/rattler-bin/src/commands/exec.rs
+++ b/crates/rattler-bin/src/commands/exec.rs
@@ -25,7 +25,7 @@ use tokio;
 
 use crate::{
     commands::{
-        client::create_client_with_middleware,
+        client::{create_client_with_middleware, repodata_cache_action},
         progress::{wrap_in_async_progress, wrap_in_progress},
     },
     global_multi_progress,
@@ -72,7 +72,7 @@ pub struct Opt {
 }
 
 /// CLI entry point for `rattler exec`.
-pub async fn exec(opt: Opt) -> miette::Result<()> {
+pub async fn exec(opt: Opt, offline: bool) -> miette::Result<()> {
     let channel_config =
         ChannelConfig::default_with_root_dir(env::current_dir().into_diagnostic()?);
 
@@ -123,6 +123,7 @@ pub async fn exec(opt: Opt) -> miette::Result<()> {
         opt.force_reinstall,
         opt.list.as_deref(),
         &cache_dir,
+        offline,
     )
     .await?;
 
@@ -187,6 +188,7 @@ async fn create_exec_prefix(
     force_reinstall: bool,
     list: Option<&str>,
     cache_dir: &Path,
+    offline: bool,
 ) -> miette::Result<PathBuf> {
     let channel_urls: Vec<String> = channels.iter().map(|c| c.base_url.to_string()).collect();
     let env_hash = compute_env_hash(specs, &channel_urls, platform);
@@ -207,7 +209,7 @@ async fn create_exec_prefix(
         return Ok(prefix);
     }
 
-    let download_client = create_client_with_middleware()?;
+    let download_client = create_client_with_middleware(offline)?;
 
     let gateway = Gateway::builder()
         .with_cache_dir(cache_dir.join(rattler_cache::REPODATA_CACHE_DIR))
@@ -218,6 +220,7 @@ async fn create_exec_prefix(
         .with_channel_config(rattler_repodata_gateway::ChannelConfig {
             default: SourceConfig {
                 sharded_enabled: true,
+                cache_action: repodata_cache_action(offline),
                 ..SourceConfig::default()
             },
             per_channel: HashMap::new(),

--- a/crates/rattler-bin/src/commands/extract.rs
+++ b/crates/rattler-bin/src/commands/extract.rs
@@ -44,6 +44,7 @@ async fn extract_from_url(
     url: Url,
     destination: Option<PathBuf>,
     package_display: &str,
+    offline: bool,
 ) -> miette::Result<(PathBuf, rattler_package_streaming::ExtractResult)> {
     let destination = destination.map_or_else(|| determine_destination_from_url(&url), Ok)?;
 
@@ -53,7 +54,7 @@ async fn extract_from_url(
         destination.display()
     );
 
-    let client = super::client::create_client_with_middleware()?;
+    let client = super::client::create_client_with_middleware(offline)?;
 
     let result =
         rattler_package_streaming::reqwest::tokio::extract(client, url, &destination, None, None)
@@ -93,10 +94,10 @@ fn extract_from_path(
     Ok((destination, result))
 }
 
-pub async fn extract(opt: Opt) -> miette::Result<()> {
+pub async fn extract(opt: Opt, offline: bool) -> miette::Result<()> {
     // Try to parse as URL, otherwise treat as file path
     let (destination, result) = if let Ok(url) = Url::parse(&opt.package) {
-        extract_from_url(url, opt.destination, &opt.package).await?
+        extract_from_url(url, opt.destination, &opt.package, offline).await?
     } else {
         extract_from_path(&opt.package, opt.destination)?
     };

--- a/crates/rattler-bin/src/commands/fetch_file.rs
+++ b/crates/rattler-bin/src/commands/fetch_file.rs
@@ -17,10 +17,10 @@ pub struct Opt {
     path: String,
 }
 
-pub async fn fetch_file(opt: Opt) -> miette::Result<()> {
+pub async fn fetch_file(opt: Opt, offline: bool) -> miette::Result<()> {
     let Opt { url, path } = opt;
 
-    let client = super::client::create_client_with_middleware()?;
+    let client = super::client::create_client_with_middleware(offline)?;
 
     let target_path = Path::new(&path);
 

--- a/crates/rattler-bin/src/commands/inspect.rs
+++ b/crates/rattler-bin/src/commands/inspect.rs
@@ -15,8 +15,8 @@ pub struct Opt {
     limit: usize,
 }
 
-pub async fn inspect(opt: Opt) -> miette::Result<()> {
-    let client = super::client::create_client_with_middleware()?;
+pub async fn inspect(opt: Opt, offline: bool) -> miette::Result<()> {
+    let client = super::client::create_client_with_middleware(offline)?;
 
     let index_json: IndexJson = fetch_package_file_from_remote_url(client.clone(), opt.url.clone())
         .await

--- a/crates/rattler-bin/src/commands/search.rs
+++ b/crates/rattler-bin/src/commands/search.rs
@@ -52,7 +52,7 @@ pub struct Opt {
     json: bool,
 }
 
-pub async fn search(opt: Opt) -> miette::Result<()> {
+pub async fn search(opt: Opt, offline: bool) -> miette::Result<()> {
     let channel_config =
         ChannelConfig::default_with_root_dir(env::current_dir().into_diagnostic()?);
 
@@ -83,7 +83,7 @@ pub async fn search(opt: Opt) -> miette::Result<()> {
     );
 
     // Create HTTP client
-    let download_client = super::client::create_client_with_middleware()?;
+    let download_client = super::client::create_client_with_middleware(offline)?;
 
     // Create gateway
     let gateway = Gateway::builder()
@@ -91,6 +91,7 @@ pub async fn search(opt: Opt) -> miette::Result<()> {
         .with_channel_config(rattler_repodata_gateway::ChannelConfig {
             default: SourceConfig {
                 sharded_enabled: opt.sharded,
+                cache_action: super::client::repodata_cache_action(offline),
                 ..SourceConfig::default()
             },
             per_channel: HashMap::new(),

--- a/crates/rattler-bin/src/commands/solve.rs
+++ b/crates/rattler-bin/src/commands/solve.rs
@@ -108,7 +108,7 @@ impl From<SolveStrategy> for rattler_solve::SolveStrategy {
     }
 }
 
-pub async fn solve(opt: Opt) -> miette::Result<()> {
+pub async fn solve(opt: Opt, offline: bool) -> miette::Result<()> {
     let channel_config =
         ChannelConfig::default_with_root_dir(env::current_dir().into_diagnostic()?);
 
@@ -139,7 +139,7 @@ pub async fn solve(opt: Opt) -> miette::Result<()> {
         .collect::<Result<Vec<_>, _>>()
         .into_diagnostic()?;
 
-    let download_client = super::client::create_client_with_middleware()?;
+    let download_client = super::client::create_client_with_middleware(offline)?;
 
     let gateway = Gateway::builder()
         .with_cache_dir(cache_dir.join(rattler_cache::REPODATA_CACHE_DIR))
@@ -150,6 +150,7 @@ pub async fn solve(opt: Opt) -> miette::Result<()> {
         .with_channel_config(rattler_repodata_gateway::ChannelConfig {
             default: SourceConfig {
                 sharded_enabled: true,
+                cache_action: super::client::repodata_cache_action(offline),
                 ..SourceConfig::default()
             },
             per_channel: HashMap::new(),

--- a/crates/rattler-bin/src/main.rs
+++ b/crates/rattler-bin/src/main.rs
@@ -36,6 +36,10 @@ struct Opt {
     /// Log verbose
     #[clap(short, long, global = true)]
     verbose: bool,
+
+    /// Disable network access and use only locally cached data.
+    #[clap(long, global = true)]
+    offline: bool,
 }
 
 /// Different commands supported by `rattler`.
@@ -106,27 +110,36 @@ async fn async_main() -> miette::Result<()> {
         .try_init()
         .into_diagnostic()?;
 
+    let offline = opt.offline;
+
     // Dispatch the selected comment
     match opt.command {
-        Command::Auth(opts) => commands::auth::auth(*opts).await,
+        Command::Auth(opts) => commands::auth::auth(*opts, offline).await,
         Command::Completion(opts) => commands::completion::completion(opts),
-        Command::Create(opts) => commands::create::create(opts).await,
-        Command::Download(opts) => commands::download::download(opts).await,
-        Command::FetchFile(opts) => commands::fetch_file::fetch_file(opts).await,
-        Command::Inspect(opts) => commands::inspect::inspect(opts).await,
-        Command::Search(opts) => commands::search::search(opts).await,
-        Command::Solve(opts) => commands::solve::solve(opts).await,
+        Command::Create(opts) => commands::create::create(opts, offline).await,
+        Command::Download(opts) => commands::download::download(opts, offline).await,
+        Command::FetchFile(opts) => commands::fetch_file::fetch_file(opts, offline).await,
+        Command::Inspect(opts) => commands::inspect::inspect(opts, offline).await,
+        Command::Search(opts) => commands::search::search(opts, offline).await,
+        Command::Solve(opts) => commands::solve::solve(opts, offline).await,
         Command::List(opts) => commands::list::list(opts).await,
         Command::ShellHook(opts) => commands::shell_hook::shell_hook(opts).await,
         Command::VirtualPackages(opts) => commands::virtual_packages::virtual_packages(opts),
         Command::InstallMenu(opts) => commands::menu::install_menu(opts).await,
         Command::RemoveMenu(opts) => commands::menu::remove_menu(opts).await,
         Command::Run(opts) => commands::run::run(opts).await,
-        Command::Extract(opts) => commands::extract::extract(opts).await,
+        Command::Extract(opts) => commands::extract::extract(opts, offline).await,
         Command::Link(opts) => commands::link::link(opts).await,
         Command::InjectIntoPrefix(opts) => commands::prefix::inject(opts).await,
         Command::RemoveFromPrefix(opts) => commands::prefix::remove_from_prefix(opts).await,
-        Command::Upload(opts) => rattler_upload::upload_from_args(*opts).await,
-        Command::Exec(opts) => exec::exec(opts).await,
+        Command::Upload(opts) => {
+            if offline {
+                return Err(miette::miette!(
+                    "upload cannot run because network access is disabled by --offline"
+                ));
+            }
+            rattler_upload::upload_from_args(*opts).await
+        }
+        Command::Exec(opts) => exec::exec(opts, offline).await,
     }
 }

--- a/crates/rattler/src/cli/auth.rs
+++ b/crates/rattler/src/cli/auth.rs
@@ -196,6 +196,10 @@ pub enum AuthenticationCLIError {
     #[error("General http request error")]
     ReqwestError(#[from] reqwest::Error),
 
+    /// Network access was requested while offline mode was enabled.
+    #[error("network access is disabled by offline mode")]
+    Offline,
+
     /// JSON parsing failed
     #[error("Failed to parse JSON: {0}")]
     JsonParseError(String),
@@ -350,15 +354,27 @@ pub enum ValidationResult {
 /// This function validates the authentication method based on the host and
 /// stores the credentials if successful. For prefix.dev hosts, it validates the
 /// token by making a GraphQL API call.
+#[cfg(test)]
 async fn login(
     args: LoginArgs,
     storage: AuthenticationStorage,
+) -> Result<(), AuthenticationCLIError> {
+    login_with_offline(args, storage, false).await
+}
+
+async fn login_with_offline(
+    args: LoginArgs,
+    storage: AuthenticationStorage,
+    offline: bool,
 ) -> Result<(), AuthenticationCLIError> {
     // explicit `--oauth` *or* no explicit method on an OAuth-capable host
     #[cfg(feature = "oauth")]
     {
         let auto_default = default_oauth_for_login(&args);
         if args.oauth || auto_default.is_some() {
+            if offline {
+                return Err(AuthenticationCLIError::Offline);
+            }
             if !args.oauth {
                 eprintln!(
                     "No credentials provided; using OAuth device code login for {}.",
@@ -463,6 +479,10 @@ async fn login(
 
     // Only validate token for prefix.dev
     if args.host.contains("prefix.dev") {
+        if offline {
+            return Err(AuthenticationCLIError::Offline);
+        }
+
         // Extract the token from BearerToken
         let token = match &auth {
             Authentication::BearerToken(t) => t,
@@ -652,9 +672,18 @@ fn logout_candidate_keys(host: &str) -> Result<Vec<String>, AuthenticationCLIErr
     Ok(keys)
 }
 
+#[cfg(test)]
 async fn logout(
     args: LogoutArgs,
     storage: AuthenticationStorage,
+) -> Result<(), AuthenticationCLIError> {
+    logout_with_offline(args, storage, false).await
+}
+
+async fn logout_with_offline(
+    args: LogoutArgs,
+    storage: AuthenticationStorage,
+    offline: bool,
 ) -> Result<(), AuthenticationCLIError> {
     // Enumerate hosts without reading secrets — important on macOS where each
     // keychain read prompts the user. We fetch credentials lazily, once per
@@ -721,18 +750,25 @@ async fn logout(
             ..
         } = &auth
         {
-            eprintln!(
-                "Revoking OAuth tokens for {} ({})",
-                entry.host, entry.source
-            );
-            oauth::revoke_tokens(
-                revocation_endpoint,
-                access_token,
-                refresh_token.as_deref(),
-                client_id,
-                None,
-            )
-            .await;
+            if offline {
+                eprintln!(
+                    "Skipping OAuth token revocation for {} ({}) because offline mode is enabled",
+                    entry.host, entry.source
+                );
+            } else {
+                eprintln!(
+                    "Revoking OAuth tokens for {} ({})",
+                    entry.host, entry.source
+                );
+                oauth::revoke_tokens(
+                    revocation_endpoint,
+                    access_token,
+                    refresh_token.as_deref(),
+                    client_id,
+                    None,
+                )
+                .await;
+            }
         }
         // Silence unused-variable warning when oauth is off.
         let _ = auth;
@@ -1056,11 +1092,16 @@ async fn status(
 
 /// CLI entrypoint for authentication
 pub async fn execute(args: Args) -> Result<(), AuthenticationCLIError> {
+    execute_with_offline(args, false).await
+}
+
+/// CLI entrypoint for authentication with optional offline mode.
+pub async fn execute_with_offline(args: Args, offline: bool) -> Result<(), AuthenticationCLIError> {
     let storage = AuthenticationStorage::from_env_and_defaults()?;
 
     match args.subcommand {
-        Subcommand::Login(args) => login(args, storage).await,
-        Subcommand::Logout(args) => logout(args, storage).await,
+        Subcommand::Login(args) => login_with_offline(args, storage, offline).await,
+        Subcommand::Logout(args) => logout_with_offline(args, storage, offline).await,
         Subcommand::Status(args) => status(args, storage).await,
     }
 }

--- a/crates/rattler_networking/src/lib.rs
+++ b/crates/rattler_networking/src/lib.rs
@@ -9,6 +9,7 @@ pub use challenge_middleware::{
 pub use lazy_client::LazyClient;
 pub use mirror_middleware::MirrorMiddleware;
 pub use oci_middleware::OciMiddleware;
+pub use offline_middleware::{OfflineError, OfflineMiddleware};
 
 #[cfg(feature = "gcs")]
 pub mod gcs_middleware;
@@ -28,5 +29,6 @@ pub(crate) mod oauth_refresh;
 mod lazy_client;
 pub mod mirror_middleware;
 pub mod oci_middleware;
+pub mod offline_middleware;
 pub mod retry_policies;
 pub mod trusted_publishing;

--- a/crates/rattler_networking/src/offline_middleware.rs
+++ b/crates/rattler_networking/src/offline_middleware.rs
@@ -1,0 +1,54 @@
+//! Middleware that rejects network requests when offline mode is enabled.
+
+use reqwest::{Request, Response};
+use reqwest_middleware::{Middleware, Next};
+
+/// Middleware that immediately rejects every outgoing request.
+///
+/// This can be installed as the first middleware in a client stack to ensure
+/// that offline mode prevents all network access before authentication,
+/// transport-specific URL rewriting, or retry middleware can run.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OfflineMiddleware;
+
+/// Error returned when [`OfflineMiddleware`] blocks a request.
+#[derive(Debug, thiserror::Error)]
+#[error("network access is disabled by offline mode")]
+pub struct OfflineError;
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait::async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait::async_trait(?Send))]
+impl Middleware for OfflineMiddleware {
+    async fn handle(
+        &self,
+        req: Request,
+        _extensions: &mut http::Extensions,
+        _next: Next<'_>,
+    ) -> reqwest_middleware::Result<Response> {
+        tracing::debug!(url = %req.url(), "blocking request because offline mode is enabled");
+        Err(reqwest_middleware::Error::Middleware(OfflineError.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OfflineMiddleware;
+
+    #[tokio::test]
+    async fn rejects_requests_before_network_access() {
+        let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
+            .with(OfflineMiddleware)
+            .build();
+
+        let err = client
+            .get("https://example.com/repodata.json")
+            .send()
+            .await
+            .expect_err("offline middleware should reject the request");
+
+        assert!(
+            err.to_string().contains("offline mode"),
+            "unexpected error: {err}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add an offline middleware in `rattler_networking` that rejects outgoing requests before they reach the rest of the client stack.
- Add a global `--offline` flag to the `rattler` CLI and pass it explicitly into commands that create HTTP clients.
- Use cached repodata only for solve/create/search/exec while offline, and avoid auth/upload network calls.

## Validation

- `cargo fmt --all`
- `cargo check -p rattler_networking -p rattler-bin`
- `cargo test -p rattler_networking offline_middleware --lib`
- `git diff --check`

## AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: pi coding agent
