### PR TITLE
chore(py-rattler): upgrade pyo3 to 0.28

### DIFF
--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -888,12 +888,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
-name = "bytecount"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,37 +926,6 @@ name = "cache_control"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2a5fb3207c12b5d208ebc145f967fea5cac41a021c37417ccc31ba40f39ee"
-
-[[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "cbc"
@@ -1715,15 +1678,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -2679,15 +2633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3063,15 +3008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -3766,17 +3702,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulldown-cmark"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
-dependencies = [
- "bitflags",
- "memchr",
- "unicase",
-]
-
-[[package]]
 name = "purl"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3832,30 +3757,28 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "indoc",
  "inventory",
  "jiff",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.25.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73cc6b1b7d8b3cef02101d37390dbdfe7e450dfea14921cae80a9534ba59ef2"
+checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "once_cell",
  "pin-project-lite",
  "pyo3",
@@ -3864,19 +3787,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3884,19 +3806,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-file"
-version = "0.13.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75916300df50dbfa6958ec05fe53473e69474542dac7fd1275aa6869a18a241a"
+checksum = "bfa5adcebc53e144e7a27305c3586df7f0f09ceea9db34769a243291f9d6b20f"
 dependencies = [
  "pyo3",
- "skeptic",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3906,9 +3827,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3919,9 +3840,9 @@ dependencies = [
 
 [[package]]
 name = "pythonize"
-version = "0.25.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597907139a488b22573158793aa7539df36ae863eba300c75f3a0d65fc475e27"
+checksum = "0b79f670c9626c8b651c0581011b57b6ba6970bb69faf01a7c4c0cfc81c43f95"
 dependencies = [
  "pyo3",
  "serde",
@@ -5215,10 +5136,6 @@ name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -5508,21 +5425,6 @@ name = "simple_spawn_blocking"
 version = "1.1.0"
 dependencies = [
  "tokio",
-]
-
-[[package]]
-name = "skeptic"
-version = "0.13.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
-dependencies = [
- "bytecount",
- "cargo_metadata",
- "error-chain",
- "glob",
- "pulldown-cmark",
- "tempfile",
- "walkdir",
 ]
 
 [[package]]
@@ -6085,12 +5987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6116,12 +6012,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "unit-prefix"

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -55,14 +55,14 @@ rattler_solve = { path = "../crates/rattler_solve", default-features = false, fe
 rattler_index = { path = "../crates/rattler_index" }
 rattler_lock = { path = "../crates/rattler_lock", default-features = false }
 rattler_package_streaming = { path = "../crates/rattler_package_streaming", default-features = false }
-pyo3 = { version = "0.25.1", features = [
+pyo3 = { version = "0.28.0", features = [
   "abi3-py310",
   "extension-module",
   "multiple-pymethods",
   "jiff-02",
 ] }
-pyo3-async-runtimes = { version = "0.25.0", features = ["tokio-runtime"] }
-pythonize = "0.25.0"
+pyo3-async-runtimes = { version = "0.28.0", features = ["tokio-runtime"] }
+pythonize = "0.28.0"
 tokio = { version = "1.46.1" }
 
 reqwest = { version = "0.13.3", default-features = false }
@@ -78,11 +78,11 @@ openssl = { version = "0.10", optional = true }
 pep440_rs = "0.7.3"
 pep508_rs = "0.9.2"
 serde_json = "1.0.140"
-pyo3-file = "0.13.0"
+pyo3-file = "0.16.0"
 nix = { version = "0.30.1", features = ["process"], optional = true }
 
 [build-dependencies]
-pyo3-build-config = "0.25.1"
+pyo3-build-config = "0.28.0"
 
 
 [patch.crates-io]

--- a/py-rattler/src/about_json.rs
+++ b/py-rattler/src/about_json.rs
@@ -10,7 +10,7 @@ use url::Url;
 use crate::{error::PyRattlerError, networking::client::PyClientWithMiddleware};
 
 /// The `about.json` file contains metadata about the package
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyAboutJson {
@@ -87,7 +87,7 @@ impl PyAboutJson {
                 >(client.into(), url)
                 .await;
 
-            Python::with_gil(|py| match about_json {
+            Python::attach(|py| match about_json {
                 Ok(r) => Ok(Some(Py::new(py, PyAboutJson::from(r))?.into_any())),
                 Err(rattler_package_streaming::ExtractError::MissingComponent) => Ok(None),
                 Err(e) => Err(PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string())),

--- a/py-rattler/src/channel/mod.rs
+++ b/py-rattler/src/channel/mod.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use crate::{error::PyRattlerError, platform::PyPlatform};
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyChannelConfig {
@@ -37,7 +37,7 @@ impl PyChannelConfig {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone, Hash, Eq, PartialEq)]
 pub struct PyChannel {
@@ -83,7 +83,7 @@ impl PyChannel {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Clone, PartialEq, Eq)]
 pub enum PyChannelPriority {
     /// The channel that the package is first found in will be used as the only channel

--- a/py-rattler/src/explicit_environment_spec.rs
+++ b/py-rattler/src/explicit_environment_spec.rs
@@ -7,7 +7,7 @@ use crate::{error::PyRattlerError, platform::PyPlatform};
 
 /// The explicit environment (e.g. env.txt) file that contains a list of
 /// all URLs in a environment
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyExplicitEnvironmentSpec {
@@ -66,7 +66,7 @@ impl PyExplicitEnvironmentSpec {
 }
 
 /// A Python wrapper around an explicit environment entry which represents a URL to a package
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyExplicitEnvironmentEntry(pub(crate) ExplicitEnvironmentEntry);
 

--- a/py-rattler/src/generic_virtual_package.rs
+++ b/py-rattler/src/generic_virtual_package.rs
@@ -5,7 +5,7 @@ use crate::package_name::PyPackageName;
 use crate::version::PyVersion;
 use crate::virtual_package::PyVirtualPackage;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyGenericVirtualPackage {

--- a/py-rattler/src/index_json.rs
+++ b/py-rattler/src/index_json.rs
@@ -17,7 +17,7 @@ use crate::{
     version::PyVersion,
 };
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyIndexJson {
@@ -100,7 +100,7 @@ impl PyIndexJson {
                 >(client.into(), url)
                 .await;
 
-            Python::with_gil(|py| match index_json {
+            Python::attach(|py| match index_json {
                 Ok(r) => Ok(Some(Py::new(py, PyIndexJson::from(r))?.into_any())),
                 Err(rattler_package_streaming::ExtractError::MissingComponent) => Ok(None),
                 Err(e) => Err(PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string())),

--- a/py-rattler/src/installer.rs
+++ b/py-rattler/src/installer.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use pyo3::{Bound, PyAny, PyObject, PyResult, Python, exceptions::PyTypeError, pyfunction};
+use pyo3::{Bound, Py, PyAny, PyResult, Python, exceptions::PyTypeError, pyfunction};
 use pyo3_async_runtimes::tokio::future_into_py;
 use rattler::{
     install::{IndicatifReporter, Installer, Reporter, Transaction},
@@ -18,13 +18,13 @@ use crate::{
 
 /// A [`Reporter`] implementation that delegates progress events to a Python object. The Python object should implement the following methods:
 struct PyReporter {
-    py_obj: Arc<PyObject>,
+    py_obj: Arc<Py<PyAny>>,
 }
 
 impl Reporter for PyReporter {
     fn on_transaction_start(&self, transaction: &Transaction<PrefixRecord, RepoDataRecord>) {
         let total = transaction.operations.len();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self
                 .py_obj
                 .call_method1(py, "on_transaction_start", (total,));
@@ -32,7 +32,7 @@ impl Reporter for PyReporter {
     }
 
     fn on_transaction_operation_start(&self, operation: usize) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self
                 .py_obj
                 .call_method1(py, "on_transaction_operation_start", (operation,));
@@ -41,7 +41,7 @@ impl Reporter for PyReporter {
 
     fn on_populate_cache_start(&self, operation: usize, record: &RepoDataRecord) -> usize {
         let name = record.package_record.name.as_normalized().to_string();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             match self
                 .py_obj
                 .call_method1(py, "on_populate_cache_start", (operation, name))
@@ -53,7 +53,7 @@ impl Reporter for PyReporter {
     }
 
     fn on_validate_start(&self, cache_entry: usize) -> usize {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             match self
                 .py_obj
                 .call_method1(py, "on_validate_start", (cache_entry,))
@@ -65,7 +65,7 @@ impl Reporter for PyReporter {
     }
 
     fn on_validate_complete(&self, validate_idx: usize) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self
                 .py_obj
                 .call_method1(py, "on_validate_complete", (validate_idx,));
@@ -73,7 +73,7 @@ impl Reporter for PyReporter {
     }
 
     fn on_download_start(&self, cache_entry: usize) -> usize {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             match self
                 .py_obj
                 .call_method1(py, "on_download_start", (cache_entry,))
@@ -85,7 +85,7 @@ impl Reporter for PyReporter {
     }
 
     fn on_download_progress(&self, download_idx: usize, progress: u64, total: Option<u64>) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self.py_obj.call_method1(
                 py,
                 "on_download_progress",
@@ -95,7 +95,7 @@ impl Reporter for PyReporter {
     }
 
     fn on_download_completed(&self, download_idx: usize) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self
                 .py_obj
                 .call_method1(py, "on_download_completed", (download_idx,));
@@ -103,7 +103,7 @@ impl Reporter for PyReporter {
     }
 
     fn on_populate_cache_complete(&self, cache_entry: usize) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self
                 .py_obj
                 .call_method1(py, "on_populate_cache_complete", (cache_entry,));
@@ -117,7 +117,7 @@ impl Reporter for PyReporter {
             .name
             .as_normalized()
             .to_string();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             match self
                 .py_obj
                 .call_method1(py, "on_unlink_start", (operation, name))
@@ -129,14 +129,14 @@ impl Reporter for PyReporter {
     }
 
     fn on_unlink_complete(&self, index: usize) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self.py_obj.call_method1(py, "on_unlink_complete", (index,));
         });
     }
 
     fn on_link_start(&self, operation: usize, record: &RepoDataRecord) -> usize {
         let name = record.package_record.name.as_normalized().to_string();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             match self
                 .py_obj
                 .call_method1(py, "on_link_start", (operation, name))
@@ -148,13 +148,13 @@ impl Reporter for PyReporter {
     }
 
     fn on_link_complete(&self, index: usize) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self.py_obj.call_method1(py, "on_link_complete", (index,));
         });
     }
 
     fn on_transaction_operation_complete(&self, operation: usize) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self
                 .py_obj
                 .call_method1(py, "on_transaction_operation_complete", (operation,));
@@ -162,7 +162,7 @@ impl Reporter for PyReporter {
     }
 
     fn on_transaction_complete(&self) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self.py_obj.call_method0(py, "on_transaction_complete");
         });
     }
@@ -170,7 +170,7 @@ impl Reporter for PyReporter {
     fn on_post_link_start(&self, package_name: &str, script_path: &str) -> usize {
         let pkg = package_name.to_string();
         let path = script_path.to_string();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             match self
                 .py_obj
                 .call_method1(py, "on_post_link_start", (pkg, path))
@@ -182,7 +182,7 @@ impl Reporter for PyReporter {
     }
 
     fn on_post_link_complete(&self, index: usize, success: bool) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self
                 .py_obj
                 .call_method1(py, "on_post_link_complete", (index, success));
@@ -192,7 +192,7 @@ impl Reporter for PyReporter {
     fn on_pre_unlink_start(&self, package_name: &str, script_path: &str) -> usize {
         let pkg = package_name.to_string();
         let path = script_path.to_string();
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             match self
                 .py_obj
                 .call_method1(py, "on_pre_unlink_start", (pkg, path))
@@ -204,7 +204,7 @@ impl Reporter for PyReporter {
     }
 
     fn on_pre_unlink_complete(&self, index: usize, success: bool) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let _ = self
                 .py_obj
                 .call_method1(py, "on_pre_unlink_complete", (index, success));
@@ -228,7 +228,7 @@ pub fn py_install<'a>(
     reinstall_packages: Option<HashSet<String>>,
     ignored_packages: Option<HashSet<String>>,
     requested_specs: Option<Vec<PyMatchSpec>>,
-    reporter: Option<PyObject>,
+    reporter: Option<Py<PyAny>>,
     alternative_target_prefix: Option<PathBuf>,
 ) -> PyResult<Bound<'a, PyAny>> {
     let dependencies = records

--- a/py-rattler/src/lock/mod.rs
+++ b/py-rattler/src/lock/mod.rs
@@ -62,7 +62,7 @@ enum LockFileState {
 ///
 /// Lock-files can store information for multiple platforms and for multiple
 /// environments.
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct PyLockFile {
     state: Mutex<LockFileState>,
 }
@@ -296,7 +296,7 @@ enum LockPlatformInner {
 ///
 /// This provides access to the platform name, the underlying conda subdir,
 /// and any virtual packages associated with the platform.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyLockPlatform {
     inner: LockPlatformInner,
@@ -424,7 +424,7 @@ impl PyLockPlatform {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyEnvironment {
     environment: OwnedEnvironment,
@@ -600,7 +600,7 @@ impl PyEnvironment {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyLockChannel {
@@ -641,7 +641,7 @@ impl PyLockChannel {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyLockedPackage {
@@ -788,7 +788,7 @@ impl PyLockedPackage {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyPypiPackageData {
@@ -876,7 +876,7 @@ impl PyPypiPackageData {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyPackageHashes {

--- a/py-rattler/src/match_spec.rs
+++ b/py-rattler/src/match_spec.rs
@@ -9,7 +9,7 @@ use crate::{
     package_name_matcher::PyPackageNameMatcher, record::PyRecord,
 };
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyMatchSpec {

--- a/py-rattler/src/nameless_match_spec.rs
+++ b/py-rattler/src/nameless_match_spec.rs
@@ -5,7 +5,7 @@ use rattler_conda_types::{Channel, MatchSpec, Matches, NamelessMatchSpec, ParseM
 
 use crate::{channel::PyChannel, error::PyRattlerError, match_spec::PyMatchSpec, record::PyRecord};
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyNamelessMatchSpec {

--- a/py-rattler/src/networking/cached_repo_data.rs
+++ b/py-rattler/src/networking/cached_repo_data.rs
@@ -2,7 +2,7 @@ use pyo3::{pyclass, pymethods};
 use rattler_repodata_gateway::fetch::CachedRepoData;
 use std::sync::Arc;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyCachedRepoData {

--- a/py-rattler/src/networking/client.rs
+++ b/py-rattler/src/networking/client.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 
 static RATTLER_USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyClientWithMiddleware {

--- a/py-rattler/src/networking/middleware.rs
+++ b/py-rattler/src/networking/middleware.rs
@@ -24,7 +24,7 @@ pub enum PyMiddleware {
     AddHeaders(PyAddHeadersMiddleware),
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyMirrorMiddleware {
@@ -64,7 +64,7 @@ impl From<PyMirrorMiddleware> for MirrorMiddleware {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyAuthenticationMiddleware {}
@@ -77,7 +77,7 @@ impl PyAuthenticationMiddleware {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyRetryMiddleware {
     pub(crate) max_retries: u32,
@@ -92,7 +92,7 @@ impl PyRetryMiddleware {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyOciMiddleware {}
@@ -105,7 +105,7 @@ impl PyOciMiddleware {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyGCSMiddleware {}
@@ -125,7 +125,7 @@ impl From<PyGCSMiddleware> for GCSMiddleware {
 }
 
 #[derive(Clone)]
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct PyS3Config {
     // non-trivial enums are not supported by pyo3 as pyclasses
     pub(crate) custom: Option<PyS3ConfigCustom>,
@@ -174,7 +174,7 @@ impl From<PyS3Config> for S3Config {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyS3Middleware {
     pub(crate) s3_config: HashMap<String, PyS3Config>,
@@ -192,14 +192,14 @@ impl PyS3Middleware {
 ///
 /// The callback receives (host, path) and should return a dict of headers to add,
 /// or None to add no headers.
-#[pyclass]
+#[pyclass(from_py_object)]
 pub struct PyAddHeadersMiddleware {
     pub(crate) callback: Py<PyAny>,
 }
 
 impl Clone for PyAddHeadersMiddleware {
     fn clone(&self) -> Self {
-        Python::with_gil(|py| Self {
+        Python::attach(|py| Self {
             callback: self.callback.clone_ref(py),
         })
     }
@@ -250,7 +250,7 @@ impl Middleware for AddHeadersMiddleware {
 
         // Call the Python callback with host and path
         let callback = self.callback.clone();
-        let headers_to_add: Option<HashMap<String, String>> = Python::with_gil(
+        let headers_to_add: Option<HashMap<String, String>> = Python::attach(
             |py| -> reqwest_middleware::Result<Option<HashMap<String, String>>> {
                 let result = callback
                     .call1(py, (host.as_str(), path.as_str()))
@@ -266,7 +266,7 @@ impl Middleware for AddHeadersMiddleware {
                 }
 
                 // Try to extract as a dictionary
-                let dict = result.downcast_bound::<PyDict>(py).map_err(|_e| {
+                let dict = result.cast_bound::<PyDict>(py).map_err(|_e| {
                     let type_name = result
                         .bind(py)
                         .get_type()

--- a/py-rattler/src/networking/mod.rs
+++ b/py-rattler/src/networking/mod.rs
@@ -91,7 +91,7 @@ impl DownloadReporter for ProgressReporter {
         bytes_downloaded: usize,
         total_bytes: Option<usize>,
     ) {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let args = PyTuple::new(py, [Some(bytes_downloaded), total_bytes])
                 .expect("Failed to create tuple");
             self.callback.call1(py, args).expect("Callback failed!");

--- a/py-rattler/src/no_arch_type.rs
+++ b/py-rattler/src/no_arch_type.rs
@@ -6,7 +6,7 @@ use std::{
 use pyo3::{basic::CompareOp, pyclass, pymethods};
 use rattler_conda_types::NoArchType;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyNoArchType {
     pub inner: NoArchType,

--- a/py-rattler/src/package_name.rs
+++ b/py-rattler/src/package_name.rs
@@ -8,7 +8,7 @@ use rattler_conda_types::PackageName;
 
 use crate::error::PyRattlerError;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone, Debug)]
 pub struct PyPackageName {

--- a/py-rattler/src/package_name_matcher.rs
+++ b/py-rattler/src/package_name_matcher.rs
@@ -9,7 +9,7 @@ use rattler_conda_types::PackageNameMatcher;
 
 use crate::{error::PyRattlerError, package_name::PyPackageName};
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyPackageNameMatcher {
     pub(crate) inner: PackageNameMatcher,

--- a/py-rattler/src/package_streaming/mod.rs
+++ b/py-rattler/src/package_streaming/mod.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 use crate::{networking::client::PyClientWithMiddleware, utils::sha256_from_pybytes};
 
-fn convert_result(py: Python<'_>, result: ExtractResult) -> (PyObject, PyObject) {
+fn convert_result(py: Python<'_>, result: ExtractResult) -> (Py<PyAny>, Py<PyAny>) {
     let sha256_bytes = PyBytes::new(py, &result.sha256);
     let md5_bytes = PyBytes::new(py, &result.md5);
 
@@ -28,9 +28,9 @@ fn io_error<E: std::fmt::Display>(error: E) -> PyErr {
 #[pyfunction]
 pub fn extract_tar_bz2(
     py: Python<'_>,
-    reader: PyObject,
+    reader: Py<PyAny>,
     destination: String,
-) -> PyResult<(PyObject, PyObject)> {
+) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
     // Convert Python file-like object to Read implementation
     let reader = PyFileLikeObject::new(reader)?;
     let destination = Path::new(&destination);
@@ -47,7 +47,7 @@ pub fn extract(
     py: Python<'_>,
     source: PathBuf,
     destination: PathBuf,
-) -> PyResult<(PyObject, PyObject)> {
+) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
     match rattler_package_streaming::fs::extract(&source, &destination) {
         Ok(result) => Ok(convert_result(py, result)),
         Err(e) => Err(PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string())),
@@ -84,7 +84,7 @@ pub fn download_and_extract<'a>(
             None,
         )
         .await
-        .map(|result| Python::with_gil(|py| convert_result(py, result)))
+        .map(|result| Python::attach(|py| convert_result(py, result)))
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))
     };
 
@@ -116,7 +116,7 @@ pub fn fetch_raw_package_file_from_url<'a>(
             ))
         })?;
 
-        Python::with_gil(|py| Ok(PyBytes::new(py, &bytes).into_any().unbind()))
+        Python::attach(|py| Ok(PyBytes::new(py, &bytes).into_any().unbind()))
     };
 
     future_into_py(py, future)
@@ -182,7 +182,7 @@ pub fn download_bytes<'a>(
             .await
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
-        Python::with_gil(|py| Ok(PyBytes::new(py, &bytes).into_any().unbind()))
+        Python::attach(|py| Ok(PyBytes::new(py, &bytes).into_any().unbind()))
     };
 
     future_into_py(py, future)
@@ -209,7 +209,7 @@ pub fn download_to_writer<'a>(
         let mut stream = response.bytes_stream();
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(io_error)?;
-            Python::with_gil(|py| {
+            Python::attach(|py| {
                 writer
                     .bind(py)
                     .call_method1("write", (PyBytes::new(py, &chunk),))

--- a/py-rattler/src/paths_json.rs
+++ b/py-rattler/src/paths_json.rs
@@ -18,7 +18,7 @@ use crate::{
 /// A representation of the `paths.json` file found in package archives.
 ///
 /// The `paths.json` file contains information about every file included with the package.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyPathsJson {
@@ -106,7 +106,7 @@ impl PyPathsJson {
                 >(client.into(), url)
                 .await;
 
-            Python::with_gil(|py| match paths_json {
+            Python::attach(|py| match paths_json {
                 Ok(r) => Ok(Some(Py::new(py, PyPathsJson::from(r))?.into_any())),
                 Err(rattler_package_streaming::ExtractError::MissingComponent) => Ok(None),
                 Err(e) => Err(PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string())),
@@ -178,7 +178,7 @@ impl PyPathsJson {
 }
 
 /// A single entry in the `paths.json` file.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyPathsEntry {
@@ -306,7 +306,7 @@ impl PyPathsEntry {
 
 /// The path type of the path entry
 // TODO: Expose this properly later.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyPathType {
@@ -367,7 +367,7 @@ impl PyPathType {
 
 /// Description off a placeholder text found in a file that must be replaced when installing the
 /// file into the prefix.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyPrefixPlaceholder {
@@ -427,7 +427,7 @@ impl PyPrefixPlaceholder {
 }
 
 /// The file mode of the entry
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyFileMode {

--- a/py-rattler/src/platform.rs
+++ b/py-rattler/src/platform.rs
@@ -9,7 +9,7 @@ use crate::error::PyRattlerError;
 /// Arch                ///
 ///////////////////////////
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyArch {
     pub inner: Arch,
@@ -52,7 +52,7 @@ impl PyArch {
 /// Platform            ///
 ///////////////////////////
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct PyPlatform {

--- a/py-rattler/src/prefix_paths.rs
+++ b/py-rattler/src/prefix_paths.rs
@@ -50,7 +50,7 @@ impl PyPrefixPathsEntry {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyPrefixPaths {
@@ -72,7 +72,7 @@ impl From<PrefixPaths> for PyPrefixPaths {
 /// An entry in the `paths_data` attribute of the `PrefixRecord`
 /// This is similar to `PathsEntry` from `paths_json` but refers
 /// to an entry for an installed package
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyPrefixPathsEntry {
@@ -94,7 +94,7 @@ impl From<PyPrefixPathsEntry> for PathsEntry {
 /// The path type of the path entry
 /// This is similar to `PathType` from `paths_json`; however, it contains additional enum fields
 /// since it represents a file that's installed
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyPrefixPathType {

--- a/py-rattler/src/record.rs
+++ b/py-rattler/src/record.rs
@@ -8,8 +8,8 @@ use pyo3::basic::CompareOp;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::PyAnyMethods;
 use pyo3::{
-    Bound, FromPyObject, PyAny, PyErr, PyResult, Python, exceptions::PyTypeError, intern, pyclass,
-    pymethods, types::PyBytes,
+    Bound, PyAny, PyErr, PyResult, Python, exceptions::PyTypeError, intern, pyclass, pymethods,
+    types::PyBytes,
 };
 use rattler_conda_types::{
     Flag, NoArchType, PackageRecord, PrefixRecord, RepoDataRecord, UrlOrPath, VersionWithSource,
@@ -38,7 +38,7 @@ use crate::{
 ///
 /// `PyO3` cannot expose tagged enums directly, to achieve this we use the
 /// `PyRecord` wrapper pyclass on top of `RecordInner`.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyRecord {
@@ -137,7 +137,7 @@ impl PyRecord {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyLink {
     #[pyo3(get, set)]
@@ -846,7 +846,7 @@ impl<'a> TryFrom<Bound<'a, PyAny>> for PyRecord {
             return Err(PyTypeError::new_err("'_record' is invalid"));
         }
 
-        PyRecord::extract_bound(&inner)
+        Ok(inner.extract::<PyRecord>()?)
     }
 }
 

--- a/py-rattler/src/repo_data/gateway.rs
+++ b/py-rattler/src/repo_data/gateway.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::pybacked::PyBackedStr;
 use pyo3::types::PyAnyMethods;
-use pyo3::{Bound, FromPyObject, PyAny, PyResult, Python, pyclass, pymethods};
+use pyo3::{Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python, pyclass, pymethods};
 use pyo3_async_runtimes::tokio::future_into_py;
 use rattler_repodata_gateway::fetch::{CacheAction, FetchRepoDataOptions, Variant};
 use rattler_repodata_gateway::{
@@ -22,7 +22,7 @@ use crate::record::PyRecord;
 use crate::repo_data::source::PyRepoDataSource;
 use crate::{PyChannel, Wrap};
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[derive(Clone)]
 pub struct PyGateway {
     pub(crate) inner: Gateway,
@@ -44,9 +44,10 @@ impl From<Gateway> for PyGateway {
     }
 }
 
-impl<'source> FromPyObject<'source> for Wrap<SubdirSelection> {
-    fn extract_bound(ob: &Bound<'source, PyAny>) -> PyResult<Self> {
-        let parsed = match <Option<HashSet<PyPlatform>>>::extract_bound(ob)? {
+impl<'a, 'source> FromPyObject<'a, 'source> for Wrap<SubdirSelection> {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'source, PyAny>) -> PyResult<Self> {
+        let parsed = match ob.extract::<Option<HashSet<PyPlatform>>>()? {
             Some(platforms) => SubdirSelection::Some(
                 platforms
                     .into_iter()
@@ -255,7 +256,7 @@ impl PyGateway {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PySourceConfig {
@@ -274,8 +275,9 @@ impl From<SourceConfig> for PySourceConfig {
     }
 }
 
-impl<'py> FromPyObject<'py> for Wrap<CacheAction> {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Wrap<CacheAction> {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let as_py_str: PyBackedStr = ob.extract()?;
         let parsed = match as_py_str.as_ref() {
             "cache-or-fetch" => CacheAction::CacheOrFetch,
@@ -313,7 +315,7 @@ impl PySourceConfig {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyFetchRepoDataOptions {
@@ -332,8 +334,9 @@ impl From<FetchRepoDataOptions> for PyFetchRepoDataOptions {
     }
 }
 
-impl<'py> FromPyObject<'py> for Wrap<Variant> {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Wrap<Variant> {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let as_py_str: PyBackedStr = ob.extract()?;
         let parsed = match as_py_str.as_ref() {
             "after-patches" => Variant::AfterPatches,

--- a/py-rattler/src/repo_data/mod.rs
+++ b/py-rattler/src/repo_data/mod.rs
@@ -12,7 +12,7 @@ pub mod patch_instructions;
 pub mod source;
 pub mod sparse;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyRepoData {
@@ -80,7 +80,7 @@ impl PyRepoData {
 
 /// Python wrapper around [`ChannelInfo`] — the `info` section of a
 /// `repodata.json` file.
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyChannelInfo {
@@ -121,7 +121,7 @@ impl PyChannelInfo {
 
 /// Python wrapper around [`ChannelRelations`] — see
 /// [CEP-42](https://github.com/conda/ceps/blob/main/cep-0042.md).
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyChannelRelations {

--- a/py-rattler/src/repo_data/patch_instructions.rs
+++ b/py-rattler/src/repo_data/patch_instructions.rs
@@ -1,7 +1,7 @@
 use pyo3::pyclass;
 use rattler_conda_types::PatchInstructions;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyPatchInstructions {

--- a/py-rattler/src/repo_data/source.rs
+++ b/py-rattler/src/repo_data/source.rs
@@ -59,7 +59,7 @@ impl RepoDataSource for PyRepoDataSource {
         let name_clone = name.clone();
 
         // Get the Python coroutine and convert to future
-        let future = Python::with_gil(|py| {
+        let future = Python::attach(|py| {
             let py_platform = PyPlatform::from(platform);
             let py_name = PyPackageName::from(name_clone);
 
@@ -87,7 +87,7 @@ impl RepoDataSource for PyRepoDataSource {
         //
         // Iterating via `try_iter` avoids materializing an intermediate
         // `Vec<Bound<PyAny>>` first; we hit each Python item once.
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let bound = result.bind(py);
             let mut rust_records: Vec<Arc<RepoDataRecord>> =
                 Vec::with_capacity(bound.len().unwrap_or(0));
@@ -109,7 +109,7 @@ impl RepoDataSource for PyRepoDataSource {
     }
 
     fn package_names(&self, platform: Platform) -> Vec<String> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             let py_platform = PyPlatform::from(platform);
 
             self.inner

--- a/py-rattler/src/repo_data/sparse.rs
+++ b/py-rattler/src/repo_data/sparse.rs
@@ -44,7 +44,7 @@ impl From<SparseRepoData> for PySparseRepoData {
     }
 }
 
-#[pyclass(eq)]
+#[pyclass(eq, from_py_object)]
 #[derive(Copy, Clone, PartialEq)]
 pub enum PyPackageFormatSelection {
     OnlyTarBz2,
@@ -104,7 +104,7 @@ impl PySparseRepoData {
         subdir: String,
         path: PathBuf,
     ) -> PyResult<Self> {
-        py.allow_threads(move || Self::from_args(channel, subdir, path))
+        py.detach(move || Self::from_args(channel, subdir, path))
     }
 
     pub fn package_names(
@@ -113,7 +113,7 @@ impl PySparseRepoData {
         package_format_selection: PyPackageFormatSelection,
     ) -> PyResult<Vec<String>> {
         let inner = self.inner.clone();
-        py.allow_threads(move || {
+        py.detach(move || {
             let lock = inner.read();
             let Some(sparse) = lock.as_ref() else {
                 return Err(PyValueError::new_err("I/O operation on closed file."));
@@ -131,7 +131,7 @@ impl PySparseRepoData {
         package_format_selection: PyPackageFormatSelection,
     ) -> PyResult<usize> {
         let inner = self.inner.clone();
-        py.allow_threads(move || {
+        py.detach(move || {
             let lock = inner.read();
             let Some(sparse) = lock.as_ref() else {
                 return Err(PyValueError::new_err("I/O operation on closed file."));
@@ -148,7 +148,7 @@ impl PySparseRepoData {
     ) -> PyResult<Vec<PyRecord>> {
         let inner = self.inner.clone();
         let name = package_name.inner.clone();
-        py.allow_threads(move || {
+        py.detach(move || {
             let lock = inner.read();
             let Some(sparse) = lock.as_ref() else {
                 return Err(PyValueError::new_err("I/O operation on closed file."));
@@ -167,7 +167,7 @@ impl PySparseRepoData {
         package_format_selection: PyPackageFormatSelection,
     ) -> PyResult<Vec<PyRecord>> {
         let inner = self.inner.clone();
-        py.allow_threads(move || {
+        py.detach(move || {
             let lock = inner.read();
             let Some(sparse) = lock.as_ref() else {
                 return Err(PyValueError::new_err("I/O operation on closed file."));
@@ -188,7 +188,7 @@ impl PySparseRepoData {
     ) -> PyResult<Vec<PyRecord>> {
         let inner = self.inner.clone();
         let owned_specs: Vec<_> = specs.iter().map(|s| s.inner.clone()).collect();
-        py.allow_threads(move || {
+        py.detach(move || {
             let lock = inner.read();
             let Some(sparse) = lock.as_ref() else {
                 return Err(PyValueError::new_err("I/O operation on closed file."));
@@ -233,7 +233,7 @@ impl PySparseRepoData {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        py.allow_threads(move || {
+        py.detach(move || {
             let package_names = package_names.into_iter().map(Into::into);
             Ok(SparseRepoData::load_records_recursive(
                 repo_data_refs,

--- a/py-rattler/src/run_exports_json.rs
+++ b/py-rattler/src/run_exports_json.rs
@@ -10,7 +10,7 @@ use crate::{error::PyRattlerError, networking::client::PyClientWithMiddleware};
 /// A representation of the `run_exports.json` file found in package archives.
 ///
 /// The `run_exports.json` file contains information about the run exports of a package
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyRunExportsJson {
@@ -117,7 +117,7 @@ impl PyRunExportsJson {
                 >(client.into(), url)
                 .await;
 
-            Python::with_gil(|py| match run_exports_json {
+            Python::attach(|py| match run_exports_json {
                 Ok(r) => Ok(Some(Py::new(py, PyRunExportsJson::from(r))?.into_any())),
                 Err(rattler_package_streaming::ExtractError::MissingComponent) => Ok(None),
                 Err(e) => Err(PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string())),

--- a/py-rattler/src/shell.rs
+++ b/py-rattler/src/shell.rs
@@ -1,8 +1,8 @@
 use crate::error::PyRattlerError;
 use crate::platform::PyPlatform;
 use pyo3::{
-    Bound, FromPyObject, PyAny, PyResult, exceptions::PyValueError, pybacked::PyBackedStr, pyclass,
-    pymethods, types::PyAnyMethods,
+    Borrowed, FromPyObject, PyAny, PyErr, PyResult, exceptions::PyValueError,
+    pybacked::PyBackedStr, pyclass, pymethods,
 };
 use rattler_shell::{
     activation::{ActivationResult, ActivationVariables, Activator, PathModificationBehavior},
@@ -11,7 +11,7 @@ use rattler_shell::{
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyActivationVariables {
@@ -27,8 +27,9 @@ impl From<ActivationVariables> for PyActivationVariables {
 #[repr(transparent)]
 pub struct Wrap<T>(pub T);
 
-impl<'py> FromPyObject<'py> for Wrap<PathModificationBehavior> {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Wrap<PathModificationBehavior> {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let as_py_str: PyBackedStr = ob.extract()?;
         let parsed = match as_py_str.as_ref() {
             "prepend" => PathModificationBehavior::Prepend,
@@ -104,7 +105,7 @@ impl PyActivationResult {
     }
 }
 
-#[pyclass(eq, eq_int)]
+#[pyclass(eq, eq_int, from_py_object)]
 #[derive(Clone, Eq, PartialEq)]
 pub enum PyShellEnum {
     Bash,

--- a/py-rattler/src/solver.rs
+++ b/py-rattler/src/solver.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use jiff::Timestamp;
 use pyo3::{
-    Bound, FromPyObject, PyAny, PyErr, PyResult, Python, exceptions::PyValueError,
-    pybacked::PyBackedStr, pyfunction, types::PyAnyMethods,
+    Borrowed, Bound, FromPyObject, PyAny, PyErr, PyResult, Python, exceptions::PyValueError,
+    pybacked::PyBackedStr, pyfunction,
 };
 use pyo3_async_runtimes::tokio::future_into_py;
 use rattler_conda_types::RepoDataRecord;
@@ -24,8 +24,9 @@ use crate::{
     repo_data::gateway::{PyGateway, py_object_to_source},
 };
 
-impl<'py> FromPyObject<'py> for Wrap<SolveStrategy> {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl<'a, 'py> FromPyObject<'a, 'py> for Wrap<SolveStrategy> {
+    type Error = PyErr;
+    fn extract(ob: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
         let parsed: PyBackedStr = ob.extract()?;
         let parsed = match parsed.as_ref() {
             "highest" => SolveStrategy::Highest,

--- a/py-rattler/src/version/mod.rs
+++ b/py-rattler/src/version/mod.rs
@@ -12,7 +12,7 @@ use std::{
 };
 pub use version_spec::PyVersionSpec;
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyVersion {

--- a/py-rattler/src/version/version_spec.rs
+++ b/py-rattler/src/version/version_spec.rs
@@ -6,7 +6,7 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyVersionSpec {

--- a/py-rattler/src/virtual_package.rs
+++ b/py-rattler/src/virtual_package.rs
@@ -3,7 +3,7 @@ use rattler_virtual_packages::{Override, VirtualPackage, VirtualPackageOverrides
 
 use crate::{error::PyRattlerError, generic_virtual_package::PyGenericVirtualPackage};
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone, Default, PartialEq)]
 pub struct PyOverride {
@@ -54,7 +54,7 @@ impl PyOverride {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyVirtualPackageOverrides {
@@ -135,7 +135,7 @@ impl PyVirtualPackageOverrides {
     }
 }
 
-#[pyclass]
+#[pyclass(from_py_object)]
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyVirtualPackage {


### PR DESCRIPTION
### Description

This PR upgrades PyO3 and related dependencies to version 0.28.0, which includes breaking API changes that require updates throughout the py-rattler bindings.

**Key changes:**

1. **Dependency upgrades:**
   - PyO3: 0.25.1 → 0.28.0
   - pyo3-async-runtimes: 0.25.0 → 0.28.0
   - pythonize: 0.25.0 → 0.28.0
   - pyo3-file: 0.13.0 → 0.16.0
   - pyo3-build-config: 0.25.1 → 0.28.0

2. **API migration updates:**
   - Replaced `Python::with_gil()` with `Python::attach()` throughout the codebase (async-compatible alternative)
   - Replaced `py.allow_threads()` with `py.detach()` for thread-safe operations
   - Updated `FromPyObject` trait implementations to use new signature: `extract(Borrowed<'a, 'source, PyAny>)` instead of `extract_bound(&Bound<'source, PyAny>)`
   - Added `type Error = PyErr;` to `FromPyObject` implementations
   - Updated type annotations: `PyObject` → `Py<PyAny>` for better type safety
   - Replaced `downcast_bound()` with `cast_bound()` for type casting
   - Added `from_py_object` attribute to `#[pyclass]` macros to enable automatic `FromPyObject` implementation

3. **Import updates:**
   - Added `Borrowed` import from pyo3 for new `FromPyObject` signature
   - Removed unused `PyObject` imports where replaced with `Py<PyAny>`
   - Removed unused `FromPyObject` imports where no longer needed

These changes maintain backward compatibility with the Python API while updating to the latest PyO3 version, which provides better async support and improved type safety.

### How Has This Been Tested?

The changes are primarily mechanical API updates required by the PyO3 0.28.0 upgrade. Existing test suites should validate that the bindings continue to work correctly with the updated APIs. CI will verify compilation and test execution.

### Checklist:
- [x] I have performed a self-review of my own code
- [x] Changes follow the repository's conventional commit style

https://claude.ai/code/session_01MUkyco85casQUVRqoDUfPn