### PR TITLE
chore(py-rattler): upgrade pyo3 to 0.29

### DIFF
--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -3757,9 +3757,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "inventory",
  "jiff",
@@ -3773,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
+checksum = "b3ef68daa7316a3fac65e5e18b2203f010346de1c1c53456811a2624673ab046"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -3787,18 +3787,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3806,18 +3806,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-file"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5adcebc53e144e7a27305c3586df7f0f09ceea9db34769a243291f9d6b20f"
+checksum = "8e873dd65f93e8766fa1238a3b45eb6e5b09cf72bed4b6861bf8fe740b00b50d"
 dependencies = [
  "pyo3",
 ]
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3827,22 +3827,21 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "pythonize"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b79f670c9626c8b651c0581011b57b6ba6970bb69faf01a7c4c0cfc81c43f95"
+checksum = "6ec376e1216e0c929a74964ce2020012a1a39f32d80e78aa688721219ea7fb89"
 dependencies = [
  "pyo3",
  "serde",

--- a/py-rattler/Cargo.toml
+++ b/py-rattler/Cargo.toml
@@ -55,14 +55,14 @@ rattler_solve = { path = "../crates/rattler_solve", default-features = false, fe
 rattler_index = { path = "../crates/rattler_index" }
 rattler_lock = { path = "../crates/rattler_lock", default-features = false }
 rattler_package_streaming = { path = "../crates/rattler_package_streaming", default-features = false }
-pyo3 = { version = "0.28.0", features = [
+pyo3 = { version = "0.29.0", features = [
   "abi3-py310",
   "extension-module",
   "multiple-pymethods",
   "jiff-02",
 ] }
-pyo3-async-runtimes = { version = "0.28.0", features = ["tokio-runtime"] }
-pythonize = "0.28.0"
+pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
+pythonize = "0.29.0"
 tokio = { version = "1.46.1" }
 
 reqwest = { version = "0.13.3", default-features = false }
@@ -78,11 +78,11 @@ openssl = { version = "0.10", optional = true }
 pep440_rs = "0.7.3"
 pep508_rs = "0.9.2"
 serde_json = "1.0.140"
-pyo3-file = "0.16.0"
+pyo3-file = "0.17.0"
 nix = { version = "0.30.1", features = ["process"], optional = true }
 
 [build-dependencies]
-pyo3-build-config = "0.28.0"
+pyo3-build-config = "0.29.0"
 
 
 [patch.crates-io]


### PR DESCRIPTION
### Description

Follow-up to #2545, which upgraded PyO3 to 0.28. That PR was capped at 0.28 because `pyo3-file` had no 0.29-compatible release at the time.

`pyo3-file` 0.17.0 has now been released with `pyo3 ^0.29` support, so this bumps the remaining PyO3 ecosystem dependencies to 0.29:

- `pyo3`: 0.28 → 0.29
- `pyo3-async-runtimes`: 0.28 → 0.29
- `pythonize`: 0.28 → 0.29
- `pyo3-build-config`: 0.28 → 0.29
- `pyo3-file`: 0.16 → 0.17

No source changes are required for the 0.28 → 0.29 transition; only `Cargo.toml` and `Cargo.lock` change.

### How Has This Been Tested?

`cargo check`, `cargo clippy --all`, and a full `cargo build` of the extension module all pass with no new warnings. The Python test suite runs in CI (the bindings build through pixi/maturin).

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

```plaintext
pyo3-file was released now and we can make a follow up PR
```

### Checklist:
- [x] I have performed a self-review of my own code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUkyco85casQUVRqoDUfPn)_