### PR TITLE
fix: rename auth status --verbose to --details to avoid clap clash

### DIFF
--- a/crates/rattler/src/cli/auth.rs
+++ b/crates/rattler/src/cli/auth.rs
@@ -127,8 +127,13 @@ struct LogoutArgs {
 struct StatusArgs {
     /// Show endpoint URLs, client ID, and other IdP-introspection fields
     /// that are only useful for debugging.
-    #[clap(short, long)]
-    verbose: bool,
+    // NOTE: this intentionally avoids the `--verbose`/`-v` name. `Args` is
+    // embedded as a subcommand in larger CLIs (pixi, the `rattler` binary, ...)
+    // that define their own global `--verbose` logging flag. Sharing the name
+    // makes clap either merge the two args (panicking on a type mismatch) or
+    // reject them as duplicate long names — see prefix-dev/pixi#6466.
+    #[clap(long)]
+    details: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -1083,7 +1088,7 @@ async fn status(
             entry.active,
             account.as_deref(),
             now,
-            args.verbose,
+            args.details,
         );
     }
 
@@ -1162,6 +1167,45 @@ mod tests {
             URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap()),
             URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap())
         )
+    }
+
+    // Auth `Args` must be embeddable as a subcommand of a larger CLI that
+    // defines its own `global = true` `--verbose` flag, without clashing.
+    // pixi uses a `u8` (count) flag, the `rattler` binary a `bool` one — both
+    // previously broke `auth status` (panic on type mismatch or a duplicate
+    // long-name assertion). See prefix-dev/pixi#6466.
+    #[test]
+    fn auth_embeds_under_global_verbose_flag() {
+        #[derive(Parser, Debug)]
+        struct CountParent {
+            #[clap(short, long, action = clap::ArgAction::Count, global = true)]
+            verbose: u8,
+            #[clap(subcommand)]
+            command: ParentCommand,
+        }
+
+        #[derive(Parser, Debug)]
+        struct BoolParent {
+            #[clap(short, long, global = true)]
+            verbose: bool,
+            #[clap(subcommand)]
+            command: ParentCommand,
+        }
+
+        #[derive(Parser, Debug)]
+        enum ParentCommand {
+            Auth(super::Args),
+        }
+
+        // `try_parse_from` panics (rather than returning `Err`) on the clashing
+        // definitions, so reaching an `Ok`/`Err` at all proves the clash is gone.
+        assert!(CountParent::try_parse_from(["prog", "auth", "status"]).is_ok());
+        assert!(BoolParent::try_parse_from(["prog", "auth", "status"]).is_ok());
+
+        // The parent's global `--verbose` is still accepted after the subcommand.
+        assert!(CountParent::try_parse_from(["prog", "auth", "status", "--verbose"]).is_ok());
+        // And our renamed detail flag works on its own.
+        assert!(CountParent::try_parse_from(["prog", "auth", "status", "--details"]).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
### Description

`rattler::cli::auth::Args` is embedded as a subcommand in larger CLIs (pixi, the `rattler` binary, ...) that define their own `global = true` `--verbose` logging flag. Because a global flag propagates into every leaf subcommand, `auth status` ended up with two args clap identified as `verbose`:

- pixi's global flag is a `u8` count while our flag was a `bool`, so clap panics at runtime: `Mismatch between definition and access of 'verbose'. Could not downcast...` (this is prefix-dev/pixi#6466).
- The `rattler` binary itself has the same structure (global `verbose: bool` + `Auth(auth::Args)`). It only escaped the panic because both were `bool` and clap silently merged them.

Giving our flag a distinct clap `id` (the workaround attempted on the pixi side) doesn't help — clap then trips its duplicate-long-name assertion because two args both claim `--verbose`/`-v`. The name has to differ.

This PR renames the `auth status` flag from `--verbose`/`-v` to `--details`. `--verbose` is the canonical global logging flag, and this flag's actual job is showing extra IdP/introspection debug fields, so `--details` is both non-colliding and more descriptive. `rattler auth status` now cleanly exposes both `-v, --verbose` (the embedder's logging flag) and `--details`.

> [!NOTE]
> This is a user-facing rename: `rattler auth status --verbose`/`-v` for the detail view must now use `--details`. The flag was only added recently (#2457), so the blast radius is small.

Fixes prefix-dev/pixi#6466

### How Has This Been Tested?

- Added a regression test (`auth_embeds_under_global_verbose_flag`) that embeds `auth::Args` under both a `u8`-count global `--verbose` (pixi's shape) and a `bool` global `--verbose` (the `rattler` binary's shape), asserting no clash and that both `--verbose` and `--details` still parse.
- `cargo nextest run -p rattler --features cli-tools cli::auth` — all 28 auth tests pass.
- Built with `--features cli-tools,auth-interactive,oauth`; clippy clean; `cargo fmt` applied.
- Verified `rattler auth status --help` now lists `--details` and `-v, --verbose` as distinct options.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus 4.8)

Prompt:
```plaintext
This PR tried to fix something in Pixi which we might want to fix in rattler
instead: https://github.com/prefix-dev/pixi/pull/6468
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
