### PR TITLE
fix: make shard creation deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5094,6 +5094,7 @@ dependencies = [
  "rattler_redaction",
  "rayon",
  "regex",
+ "rmp-serde",
  "rstest",
  "serde",
  "serde-untagged",

--- a/crates/rattler_conda_types/Cargo.toml
+++ b/crates/rattler_conda_types/Cargo.toml
@@ -81,6 +81,7 @@ hex-literal = { workspace = true }
 criterion = { workspace = true, features = ["html_reports"] }
 pathdiff = { workspace = true }
 dunce = { workspace = true }
+rmp-serde = { workspace = true }
 tools = { path = "../tools" }
 
 [[bench]]

--- a/crates/rattler_conda_types/src/repo_data/mod.rs
+++ b/crates/rattler_conda_types/src/repo_data/mod.rs
@@ -36,6 +36,7 @@ use crate::{
         TimestampMs, UrlWithTrailingSlash,
         serde::{
             DeserializeFromStrUnchecked, sort_index_map_alphabetically, sort_map_alphabetically,
+            sort_set_alphabetically,
         },
     },
 };
@@ -1071,13 +1072,6 @@ impl PackageRecord {
             run_exports: None,
         })
     }
-}
-
-fn sort_set_alphabetically<K: Ord + Serialize, S: serde::Serializer>(
-    value: &ahash::HashSet<K>,
-    serializer: S,
-) -> Result<S::Ok, S::Error> {
-    value.iter().collect::<BTreeSet<_>>().serialize(serializer)
 }
 
 #[cfg(test)]

--- a/crates/rattler_conda_types/src/repo_data/sharded.rs
+++ b/crates/rattler_conda_types/src/repo_data/sharded.rs
@@ -3,6 +3,7 @@
 use crate::PackageRecord;
 use crate::package::DistArchiveIdentifier;
 use crate::repo_data::{ChannelRelations, RepodataRevisions, V3Packages};
+use crate::utils::serde::{sort_index_map_alphabetically, sort_set_alphabetically};
 use indexmap::IndexMap;
 use jiff::Timestamp;
 use rattler_digest::{Sha256, Sha256Hash, serde::SerializableHash};
@@ -64,6 +65,44 @@ pub struct ShardedSubdirInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{PackageName, Version};
+
+    /// Shards are content-addressed (stored under the hash of their bytes), so
+    /// serialization must not depend on the insertion order of the underlying
+    /// maps and sets — otherwise every producer run writes a fresh shard file
+    /// and orphans the previous one.
+    #[test]
+    fn test_shard_serialization_is_insertion_order_independent() {
+        let entry = |n: u64| {
+            let key =
+                DistArchiveIdentifier::try_from_filename(&format!("multi-1.0.0-h_{n}.tar.bz2"))
+                    .unwrap();
+            let record = PackageRecord::new(
+                PackageName::new_unchecked("multi"),
+                Version::major(1),
+                format!("h_{n}"),
+            );
+            (key, record)
+        };
+
+        let shard_with_order = |order: &mut dyn Iterator<Item = u64>| {
+            let mut shard = Shard::default();
+            for n in order {
+                let (key, record) = entry(n);
+                shard.conda_packages.insert(key.clone(), record.clone());
+                shard.packages.insert(key.clone(), record);
+                shard.removed.insert(key);
+            }
+            rmp_serde::to_vec_named(&shard).unwrap()
+        };
+
+        let ascending = shard_with_order(&mut (0..10));
+        let descending = shard_with_order(&mut (0..10).rev());
+        assert_eq!(
+            ascending, descending,
+            "shard bytes must be independent of insertion order"
+        );
+    }
 
     // See https://github.com/conda/ceps/blob/main/cep-0042.md
     #[test]
@@ -100,13 +139,22 @@ mod tests {
 }
 
 /// An individual shard that contains repodata for a single package name.
+///
+/// Shards are content-addressed by the hash of their serialized bytes, so all
+/// maps and sets are sorted during serialization to keep the output
+/// deterministic regardless of insertion order.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Shard {
     /// The records for all `.tar.bz2` packages
+    #[serde(serialize_with = "sort_index_map_alphabetically")]
     pub packages: IndexMap<DistArchiveIdentifier, PackageRecord, ahash::RandomState>,
 
     /// The records for all `.conda` packages
-    #[serde(rename = "packages.conda", default)]
+    #[serde(
+        rename = "packages.conda",
+        default,
+        serialize_with = "sort_index_map_alphabetically"
+    )]
     pub conda_packages: IndexMap<DistArchiveIdentifier, PackageRecord, ahash::RandomState>,
 
     /// Packages stored under the `v3` top-level key.
@@ -114,6 +162,6 @@ pub struct Shard {
     pub v3: V3Packages,
 
     /// The file names of all removed for this shard
-    #[serde(default)]
+    #[serde(default, serialize_with = "sort_set_alphabetically")]
     pub removed: ahash::HashSet<DistArchiveIdentifier>,
 }

--- a/crates/rattler_conda_types/src/utils/serde.rs
+++ b/crates/rattler_conda_types/src/utils/serde.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _, ser::Error};
 use serde_with::{DeserializeAs, SerializeAs};
 use std::borrow::Cow;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::{
     marker::PhantomData,
     path::{Path, PathBuf},
@@ -254,6 +254,14 @@ pub(crate) fn sort_index_map_alphabetically<
         .iter()
         .collect::<BTreeMap<_, _>>()
         .serialize(serializer)
+}
+
+/// A helper function used to sort a set alphabetically when serializing.
+pub(crate) fn sort_set_alphabetically<K: Ord + Serialize, S: serde::Serializer>(
+    value: &ahash::HashSet<K>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    value.iter().collect::<BTreeSet<_>>().serialize(serializer)
 }
 
 /// A helper to serialize and deserialize `track_features` in repodata. Track

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -911,12 +911,6 @@ async fn index_subdir_inner(
         IndexMap::default();
     let mut v3 = V3Packages::default();
     let latest_revision = latest_repodata_revision(&repodata_revisions);
-    // Sort by filename so shards serialize deterministically: the
-    // `registered_packages` HashMap's random iteration order would otherwise
-    // leak into each shard's bytes, orphaning content-addressed shards on every
-    // reindex.
-    let mut registered_packages: Vec<_> = registered_packages.into_iter().collect();
-    registered_packages.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
     for (filename, package) in registered_packages {
         let revision =
             package_revision_assignment.assign(package.repodata_revision, latest_revision);

--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -911,6 +911,12 @@ async fn index_subdir_inner(
         IndexMap::default();
     let mut v3 = V3Packages::default();
     let latest_revision = latest_repodata_revision(&repodata_revisions);
+    // Sort by filename so shards serialize deterministically: the
+    // `registered_packages` HashMap's random iteration order would otherwise
+    // leak into each shard's bytes, orphaning content-addressed shards on every
+    // reindex.
+    let mut registered_packages: Vec<_> = registered_packages.into_iter().collect();
+    registered_packages.sort_unstable_by(|(a, _), (b, _)| a.cmp(b));
     for (filename, package) in registered_packages {
         let revision =
             package_revision_assignment.assign(package.repodata_revision, latest_revision);

--- a/crates/rattler_index/tests/integration/basic_indexing.rs
+++ b/crates/rattler_index/tests/integration/basic_indexing.rs
@@ -459,3 +459,78 @@ async fn test_index_writes_channel_metadata() {
         Some(0)
     );
 }
+
+/// Regression test: sharded repodata must be reproducible.
+///
+/// Shard records were serialized in the random iteration order of an ahash
+/// `HashMap`, so every index run produced a different shard digest for any
+/// package name with more than one build. Since shards are content-addressed
+/// and written `if_not_exists`, each reindex wrote a fresh shard file and
+/// orphaned the old one — unbounded `shards/` growth with no package changes.
+#[tokio::test]
+async fn test_sharded_repodata_is_deterministic() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let subdir_path = temp_dir.path().join("noarch");
+    fs::create_dir(&subdir_path).unwrap();
+
+    // One package name with many builds => a single shard holding N records.
+    // Two independent random orderings coincide with probability 1/N!, so
+    // N = 10 (~3e-7) makes a non-deterministic indexer reliably write a fresh
+    // shard file on reindex.
+    let build_dir = temp_dir.path().join("build");
+    for n in 0..10 {
+        let info_dir = build_dir.join("info");
+        fs::create_dir_all(&info_dir).unwrap();
+        fs::write(
+            info_dir.join("index.json"),
+            format!(
+                r#"{{"build":"h_{n}","build_number":{n},"name":"multi","noarch":"generic","subdir":"noarch","timestamp":1710000000000,"version":"1.0.0"}}"#
+            ),
+        )
+        .unwrap();
+        let pkg = subdir_path.join(format!("multi-1.0.0-h_{n}.tar.bz2"));
+        write_tar_bz2_package(
+            File::create(&pkg).unwrap(),
+            &build_dir,
+            &[info_dir.join("index.json")],
+            CompressionLevel::Default,
+            None,
+            None,
+        )
+        .unwrap();
+        fs::remove_dir_all(&build_dir).unwrap();
+    }
+
+    let config = |force| IndexFsConfig {
+        channel: temp_dir.path().into(),
+        target_platform: Some(Platform::NoArch),
+        repodata_patch: None,
+        write_zst: false,
+        write_shards: true,
+        repodata_revisions: Vec::new(),
+        package_revision_assignment: PackageRevisionAssignment::default(),
+        force,
+        max_parallel: 1,
+        multi_progress: None,
+    };
+
+    // Build the index, then reindex the unchanged channel several times.
+    index_fs(config(true)).await.unwrap();
+    for _ in 0..3 {
+        index_fs(config(false)).await.unwrap();
+    }
+
+    // Exactly one package name => exactly one live shard. A deterministic
+    // indexer rewrites the same content-addressed file, so `shards/` holds a
+    // single file; the bug leaves one new orphan per reshuffled reindex.
+    let shard_files = fs::read_dir(subdir_path.join("shards"))
+        .unwrap()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_name().to_string_lossy().ends_with(".msgpack.zst"))
+        .count();
+    assert_eq!(
+        shard_files, 1,
+        "sharded repodata is non-deterministic: {shard_files} shard files after \
+         reindexing an unchanged channel (expected 1)"
+    );
+}


### PR DESCRIPTION
### Description

Sharded repodata (`repodata_shards.msgpack.zst` + the `shards/` directory) is written non-deterministically.

`index_subdir_inner` iterates the `registered_packages` map — an `ahash::HashMap`, seeded with a random `RandomState` per process — to build the per-shard `IndexMap`s. That random iteration order is preserved as each shard's serialization order, so a package name with more than one build serializes to a **different shard digest on every index run**. Because shards are content-addressed and written with `if_not_exists`, each reindex writes a fresh shard file and orphans the previous one, so `shards/` grows without bound even when no packages changed.

(`repodata.json` is unaffected — its packages are sorted at serialization time. Only the shards are order-sensitive.)

**Impact:** reindexing an unchanged channel churns shards. On a real channel we saw a `shards/` directory bloated to ~10–40× the live shard count, with every reindex adding a fresh batch of orphans (nothing GCs unreferenced shards). The new-orphans-per-run count closely matches `Σ (1 − 1/n!)` over multi-build names: single-build names never reshuffle, two-build names ~50% of the time, larger ones almost always.

**Fix:** sort `registered_packages` by filename before building the shards, using the `sort_unstable_by` idiom already present elsewhere in the file. Shard digests are now reproducible across runs.

### How Has This Been Tested?

Added `test_sharded_repodata_is_deterministic`. It synthesizes one package name with 10 builds (a single shard holding 10 records), indexes the channel, then reindexes the unchanged channel 3 times and asserts that `shards/` contains exactly one file. With 10 records, two independent random orderings coincide with probability 1/10! (~3e-7), so the test reliably catches the bug rather than flaking.

- **Before the fix:** fails — `4 shard files after reindexing an unchanged channel (expected 1)`.
- **After the fix:** passes.
- Full `rattler_index` integration suite: 16 passed, 0 failed. `cargo fmt` clean.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code (Opus 4.8)

Prompt (paraphrased): investigated non-deterministic sharded-repodata output on a private channel, then asked Claude Code to locate the root cause in `rattler_index`, write a reproducing regression test, and implement the fix.

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
