### PR TITLE
fix: make the Windows package-cache rename retry actually fire

### DIFF
--- a/crates/rattler_cache/Cargo.toml
+++ b/crates/rattler_cache/Cargo.toml
@@ -33,7 +33,7 @@ rattler_networking = { workspace = true, default-features = false }
 rattler_package_streaming = { workspace = true, default-features = false, features = ["reqwest"] }
 reqwest = { workspace = true, features = ["stream"] }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "fs"] }
 tracing = { workspace = true }
 url = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -660,9 +660,12 @@ async fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
 async fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
     use rattler_networking::retry_policies::ExponentialBackoff;
 
+    // Roughly 25s of total wait: AV scans of large freshly-extracted packages
+    // (e.g. python, openssl) can hold handles for well over the ~5s the
+    // previous 5x100ms..2s policy allowed.
     let retry_policy = ExponentialBackoff::builder()
-        .retry_bounds(Duration::from_millis(100), Duration::from_secs(2))
-        .build_with_max_retries(5);
+        .retry_bounds(Duration::from_millis(100), Duration::from_secs(5))
+        .build_with_max_retries(10);
     retry_io_on_transient(
         || tokio::fs::rename(from, to),
         is_transient_rename_error,

--- a/crates/rattler_cache/src/package_cache/mod.rs
+++ b/crates/rattler_cache/src/package_cache/mod.rs
@@ -649,6 +649,13 @@ async fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
 /// Antivirus scanners and the search indexer hold short-lived handles to
 /// freshly-extracted files, breaking `MoveFileEx`.
 /// See <https://github.com/prefix-dev/pixi/issues/5660>.
+///
+/// This deliberately uses `tokio::fs::rename` instead of the `fs_err` wrapper:
+/// `fs_err` wraps the OS error in a custom `io::Error` whose `raw_os_error()`
+/// returns `None` (and which exposes no `source()`), so the transient-error
+/// check below would never match and the rename would fail on the first
+/// attempt. The caller adds both paths to the error message, so no context is
+/// lost. See <https://github.com/prefix-dev/rattler-build/issues/2474>.
 #[cfg(windows)]
 async fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
     use rattler_networking::retry_policies::ExponentialBackoff;
@@ -657,7 +664,7 @@ async fn rename_with_retry(from: &Path, to: &Path) -> std::io::Result<()> {
         .retry_bounds(Duration::from_millis(100), Duration::from_secs(2))
         .build_with_max_retries(5);
     retry_io_on_transient(
-        || tokio_fs::rename(from, to),
+        || tokio::fs::rename(from, to),
         is_transient_rename_error,
         retry_policy,
     )
@@ -1031,6 +1038,25 @@ mod test {
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     }
 
+    /// Canary for the constraint documented on `rename_with_retry`: `fs_err`
+    /// wraps errors in a custom `io::Error` whose `raw_os_error()` is `None`,
+    /// so `is_transient_rename_error` never matches it and no retry happens
+    /// (see prefix-dev/rattler-build#2474). If this test starts failing,
+    /// `fs_err` began propagating the OS error code and `rename_with_retry`
+    /// could switch back to the wrapper for richer error messages.
+    #[tokio::test]
+    async fn test_fs_err_rename_error_loses_raw_os_error() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        let to = dir.path().join("dst");
+
+        let std_err = tokio::fs::rename(&missing, &to).await.unwrap_err();
+        assert!(std_err.raw_os_error().is_some());
+
+        let wrapped_err = super::tokio_fs::rename(&missing, &to).await.unwrap_err();
+        assert_eq!(wrapped_err.raw_os_error(), None);
+    }
+
     #[cfg(windows)]
     #[test]
     fn test_is_transient_rename_error() {
@@ -1204,7 +1230,10 @@ mod test {
                     let release_request = release_request.clone();
                     let release_done = release_done.clone();
                     async move {
-                        let result = super::tokio_fs::rename(from, to).await;
+                        // Use the same rename op as `rename_with_retry`; the
+                        // fs_err wrapper would strip `raw_os_error()` and make
+                        // the transient check below never match.
+                        let result = tokio::fs::rename(from, to).await;
                         if result.is_err() && !signaled.swap(true, Ordering::SeqCst) {
                             release_request.add_permits(1);
                             let _ = release_done.acquire().await;
@@ -1212,7 +1241,7 @@ mod test {
                         result
                     }
                 },
-                |_| true,
+                super::is_transient_rename_error,
                 policy,
             )
             .await


### PR DESCRIPTION
### Description

The transient-error retry added in #2453 for the Windows `Access is denied. (os error 5)` package-cache rename failure never actually triggered. `rename_with_retry` performed the rename through the `fs_err` wrapper, which converts the OS error into a custom `io::Error` whose `raw_os_error()` returns `None` (and which exposes no `source()` to recover it from). `is_transient_rename_error` therefore never matched `ERROR_ACCESS_DENIED` (5) or `ERROR_SHARING_VIOLATION` (32), and the very first failure was fatal — which is why users on rattler-build ≥ 0.66 (rattler_cache ≥ 0.9.0) kept reporting `failed to interact with the package cache layer` / `failed to rename temp directory ... Access is denied` with no "transient I/O error; retry" warnings in their logs (see prefix-dev/rattler-build#2474 and the Windows CI failures in mantidproject/mantid#41300).

Changes:

- `rename_with_retry` now calls `tokio::fs::rename` directly so the OS error code survives; a comment documents why `fs_err` must not be used there. No error context is lost: the caller already wraps the error with both paths.
- The retry budget is bumped from 5 retries within 100ms..2s (~5s total) to 10 retries within 100ms..5s (~25s total), since antivirus scans of large freshly-extracted packages (python, openssl, tk, ...) can hold handles for longer than the old budget.
- The Windows share-lock integration test now drives the real `is_transient_rename_error` predicate and the same rename op as production, instead of bypassing the predicate with `|_| true` — this is the gap that let the bug ship.
- A new canary test asserts that `fs_err`'s rename error loses `raw_os_error()`, so a future "use fs_err everywhere" cleanup cannot silently reintroduce the bug.

Fixes prefix-dev/rattler-build#2474

### How Has This Been Tested?

- `cargo test -p rattler_cache --lib` — all rename/retry tests pass, including the new canary test that empirically verifies the fs_err error wrapping behavior this fix depends on.
- The existing Windows share-lock test (`test_retry_io_on_transient_recovers_from_share_lock`) now exercises the production predicate against a real `ERROR_SHARING_VIOLATION`/`ERROR_ACCESS_DENIED` from a `share_mode(0)` handle; it runs on Windows CI.
- Cross-checked that the Windows-gated code compiles: `cargo check -p rattler_cache --lib --tests --target x86_64-pc-windows-gnu`.
- `cargo fmt --check` and `cargo clippy -p rattler_cache --lib --tests` are clean.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

```plaintext
Can you double check if you find any clues about this issue?
https://github.com/prefix-dev/rattler-build/issues/2474 It seems to affect the
folks here: https://github.com/mantidproject/mantid/pull/41300 ... for reasons
I don't quite understand. Also not sure who creates these `.foo` files before
renaming?! Is that in rattler?

Please increase the budget to something higher then and make the PR
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMMSLZ253ZnsHCcMVAa8hf

---
_Generated by [Claude Code](https://claude.ai/code/session_01WMMSLZ253ZnsHCcMVAa8hf)_