### PR TITLE
feat(channel): add non-panicking Channel::try_from_directory

### DIFF
--- a/crates/rattler_conda_types/src/channel/mod.rs
+++ b/crates/rattler_conda_types/src/channel/mod.rs
@@ -317,27 +317,45 @@ impl Channel {
 
     /// Constructs a channel from a directory path.
     ///
+    /// A relative path is canonicalized, so it must point to an existing
+    /// directory. Use [`Channel::try_from_directory`] for a variant that
+    /// returns an error instead of panicking.
+    ///
     /// # Panics
     ///
     /// Panics if the path is not an absolute path or could not be
     /// canonicalized.
     #[cfg(not(target_arch = "wasm32"))]
+    #[deprecated(
+        since = "0.47.3",
+        note = "this function panics on invalid paths; use `Channel::try_from_directory` instead"
+    )]
     pub fn from_directory(path: &Path) -> Self {
+        Self::try_from_directory(path).expect("could not create channel from directory")
+    }
+
+    /// Constructs a channel from a directory path.
+    ///
+    /// This is the non-panicking variant of [`Channel::from_directory`]. A
+    /// relative path is canonicalized, so it must point to an existing
+    /// directory; otherwise a [`ParseChannelError::InvalidPath`] is returned.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn try_from_directory(path: &Path) -> Result<Self, ParseChannelError> {
         let path = if path.is_absolute() {
             Cow::Borrowed(path)
         } else {
-            Cow::Owned(
-                path.canonicalize()
-                    .expect("path is a not a valid absolute path"),
-            )
+            Cow::Owned(path.canonicalize().map_err(|err| {
+                ParseChannelError::InvalidPath(format!("{}: {err}", path.display()))
+            })?)
         };
 
-        let url = Url::from_directory_path(path).expect("path is a valid url");
-        Self {
+        let url = Url::from_directory_path(&path)
+            .map_err(|()| ParseChannelError::InvalidPath(path.display().to_string()))?;
+        Ok(Self {
             platforms: None,
             base_url: url.into(),
             name: None,
-        }
+        })
     }
 
     /// Returns the name of the channel
@@ -658,6 +676,24 @@ mod tests {
             channel.base_url.url().to_file_path().unwrap(),
             current_dir.join("dir/does/not_exist")
         );
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn try_from_directory() {
+        // An existing absolute directory succeeds.
+        let current_dir = std::env::current_dir().expect("no current dir?");
+        let channel = Channel::try_from_directory(&current_dir).unwrap();
+        assert_eq!(channel.base_url.url().to_file_path().unwrap(), current_dir);
+
+        // A relative path to a directory that does not exist cannot be
+        // canonicalized and returns an error instead of panicking.
+        let missing = Path::new("this/directory/does/not/exist");
+        assert!(!missing.is_absolute());
+        assert!(matches!(
+            Channel::try_from_directory(missing),
+            Err(ParseChannelError::InvalidPath(_))
+        ));
     }
 
     #[test]

--- a/crates/rattler_repodata_gateway/src/gateway/mod.rs
+++ b/crates/rattler_repodata_gateway/src/gateway/mod.rs
@@ -403,9 +403,10 @@ mod test {
             tools::fetch_test_conda_forge_repodata_async("linux-64")
         )
         .unwrap();
-        Channel::from_directory(
+        Channel::try_from_directory(
             &Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-data/channels/conda-forge"),
         )
+        .unwrap()
     }
 
     async fn remote_conda_forge() -> SimpleChannelServer {
@@ -514,7 +515,7 @@ mod test {
 
         let reporter = Arc::new(RevisionReporter::default());
         let gateway = Gateway::new();
-        let channel = Channel::from_directory(tempdir.path());
+        let channel = Channel::try_from_directory(tempdir.path()).unwrap();
         let records = gateway
             .query(
                 vec![channel.clone()],
@@ -604,7 +605,7 @@ mod test {
         let reporter = Arc::new(RevisionReporter::default());
         let records = Gateway::new()
             .query(
-                vec![Channel::from_directory(tempdir.path())],
+                vec![Channel::try_from_directory(tempdir.path()).unwrap()],
                 vec![Platform::NoArch],
                 vec![PackageName::from_str("demo").unwrap()],
             )

--- a/crates/rattler_solve/benches/sorting_bench.rs
+++ b/crates/rattler_solve/benches/sorting_bench.rs
@@ -73,7 +73,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         .join("channels")
         .join("conda-forge");
     let repodata_json_path = channel_path.join("linux-64").join("repodata.json");
-    let channel = Channel::from_directory(&channel_path);
+    let channel = Channel::try_from_directory(&channel_path).unwrap();
 
     let sparse_repo_data = SparseRepoData::from_file(channel, "linux-64", repodata_json_path, None)
         .expect("failed to load sparse repodata");

--- a/crates/rattler_solve/tests/sorting.rs
+++ b/crates/rattler_solve/tests/sorting.rs
@@ -22,7 +22,7 @@ fn load_repodata(package_name: &PackageName) -> Vec<Vec<RepoDataRecord>> {
         .join("channels")
         .join("conda-forge");
     let repodata_json_path = channel_path.join("linux-64").join("repodata.json");
-    let channel = Channel::from_directory(&channel_path);
+    let channel = Channel::try_from_directory(&channel_path).unwrap();
 
     let sparse_repo_data = SparseRepoData::from_file(channel, "linux-64", repodata_json_path, None)
         .expect("failed to load sparse repodata");


### PR DESCRIPTION
### Description

`Channel::from_directory` canonicalizes relative paths and panics with `path is a not a valid absolute path` when the directory does not exist. It also contains a second hidden panic (`Url::from_directory_path(...).expect("path is a valid url")`). Because the input is caller-supplied, this makes it easy to hit an opaque panic.

A concrete example is rattler-build's `rattler-build build --render-only --with-solve`, which registers the output directory as a local channel; when the (default `./output`) directory doesn't exist, the whole command panics (prefix-dev/rattler-build#2611).

This PR:

- Adds `Channel::try_from_directory(path) -> Result<Self, ParseChannelError>`, a non-panicking variant that returns `ParseChannelError::InvalidPath` for paths that can't be canonicalized or turned into a file URL.
- Reimplements `from_directory` on top of `try_from_directory` (behavior unchanged: it still panics on invalid input).
- Deprecates `from_directory` in favor of the fallible variant, keeping the existing signature to avoid a breaking change for downstream consumers.
- Updates internal callers (gateway/solve tests and a bench) to the new API.

### How Has This Been Tested?

- Added a unit test `channel::tests::try_from_directory` covering both the success case (existing absolute directory) and the error case (relative path to a missing directory returns `Err(ParseChannelError::InvalidPath)`) instead of panicking.
- `cargo test -p rattler_conda_types --lib channel::` passes.
- `cargo clippy` (affected crates, all targets) and `cargo fmt --check` are clean.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude Code

```plaintext
Fix https://github.com/prefix-dev/rattler-build/issues/2611
> We could also make a Channel::try_from ... or similar function (or even totally change signature). wdyt? panic sucks
> Do it make PR to rattler and also deprecate the old API
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdUcxD9DpTXdw86Y7HX4jL)_