### PR TITLE
fix: make Windows keyring credential search use a valid regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5327,6 +5327,7 @@ dependencies = [
  "keyring-core",
  "netrc-rs",
  "rattler_config",
+ "regex",
  "reqwest",
  "retry-policies",
  "rstest",

--- a/crates/rattler_networking/Cargo.toml
+++ b/crates/rattler_networking/Cargo.toml
@@ -23,6 +23,7 @@ keyring = [
     "dep:apple-native-keyring-store",
     "dep:dbus-secret-service-keyring-store",
     "dep:windows-native-keyring-store",
+    "dep:regex",
 ]
 
 [package.metadata.docs.rs]
@@ -82,6 +83,7 @@ dbus-secret-service-keyring-store = { workspace = true, optional = true, feature
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-native-keyring-store = { workspace = true, optional = true }
+regex = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -98,3 +100,7 @@ hex = { workspace = true }
 temp-env = { workspace = true }
 rstest = { workspace = true }
 tracing-test = { workspace = true }
+# Compiles the Windows keyring search pattern in tests on every platform —
+# the pattern is only *used* on Windows, but a bad pattern should fail CI
+# everywhere.
+regex = { workspace = true }

--- a/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
+++ b/crates/rattler_networking/src/authentication_storage/backends/keyring.rs
@@ -63,10 +63,20 @@ fn search_spec(store_key: &str) -> HashMap<String, String> {
 
 #[cfg(target_os = "windows")]
 fn search_spec(store_key: &str) -> HashMap<String, String> {
-    // `\Q...\E` quotes the store_key as a literal so any future caller using a
-    // custom (possibly regex-meaningful) store key still gets the expected
-    // entries back.
-    HashMap::from([("pattern".to_string(), format!(r"\.\Q{store_key}\E\z"))])
+    HashMap::from([("pattern".to_string(), windows_search_pattern(store_key))])
+}
+
+/// The regex handed to the Windows store's `pattern` search filter, matching
+/// every credential target this storage writes (`{host}.{store_key}`).
+///
+/// The store compiles it with the Rust `regex` crate, so the store key must be
+/// escaped with [`regex::escape`] — PCRE-style `\Q...\E` quoting is rejected as
+/// an invalid pattern, which silently empties `list()`/`list_keys()` and broke
+/// `auth logout` on Windows. Compiled (and tested) on every platform so a bad
+/// pattern fails CI everywhere, not just on Windows.
+#[cfg(any(target_os = "windows", test))]
+fn windows_search_pattern(store_key: &str) -> String {
+    format!(r"\.{}\z", regex::escape(store_key))
 }
 
 #[cfg(not(any(
@@ -420,6 +430,31 @@ mod tests {
         fn as_any(&self) -> &dyn std::any::Any {
             self
         }
+    }
+
+    /// The Windows store compiles the search pattern with the Rust `regex`
+    /// crate. An invalid pattern (like the `\Q...\E` quoting this used to
+    /// emit) makes every `search()` fail, which empties `list()`/`list_keys()`
+    /// and made `auth logout` report "No stored credentials found" for
+    /// credentials that were right there in the Windows Credential Manager.
+    #[test]
+    fn windows_search_pattern_is_a_valid_regex_matching_target_names() {
+        let pattern = windows_search_pattern("rattler");
+        let re = regex::Regex::new(&pattern).expect("search pattern must compile");
+
+        // Targets are written as `{host}.{store_key}`.
+        assert!(re.is_match("*.example.org.rattler"));
+        assert!(re.is_match("repo.prefix.dev.rattler"));
+        // The store key must terminate the target...
+        assert!(!re.is_match("*.example.org.rattler-build"));
+        // ...and be preceded by a delimiter, not embedded in another word.
+        assert!(!re.is_match("rattler.example.org"));
+
+        // Regex metacharacters in a custom store key are matched literally.
+        let pattern = windows_search_pattern("my+key");
+        let re = regex::Regex::new(&pattern).expect("search pattern must compile");
+        assert!(re.is_match("example.org.my+key"));
+        assert!(!re.is_match("example.org.myyykey"));
     }
 
     /// The whole point of `list_keys` is to enumerate hosts without reading

--- a/py-rattler/Cargo.lock
+++ b/py-rattler/Cargo.lock
@@ -4322,6 +4322,7 @@ dependencies = [
  "itertools 0.14.0",
  "keyring-core",
  "netrc-rs",
+ "regex",
  "reqwest",
  "retry-policies",
  "serde",


### PR DESCRIPTION
### Description

Fixes a bug in the Windows keyring authentication storage backend where the search pattern used PCRE-style `\Q...\E` quoting, which is not supported by the Rust `regex` crate. This caused the pattern to be invalid, making all `search()` calls fail silently, which emptied `list()`/`list_keys()` results and broke `auth logout` on Windows.

**Changes:**
- Replaced `\Q...\E` quoting with proper `regex::escape()` to correctly escape regex metacharacters in store keys
- Extracted the pattern generation into a new `windows_search_pattern()` function for clarity and testability
- Added `regex` as a dependency for the keyring feature (Windows-specific in production, but available in tests on all platforms)
- Added comprehensive unit tests that verify:
  - The pattern compiles as valid regex on all platforms (not just Windows)
  - The pattern correctly matches credential target names (`{host}.{store_key}`)
  - Regex metacharacters in custom store keys are matched literally

The pattern is now compiled and tested on every platform during CI, ensuring a bad pattern fails everywhere rather than only manifesting as a silent bug on Windows.

### How Has This Been Tested?

Added `windows_search_pattern_is_a_valid_regex_matching_target_names()` test that:
- Verifies the generated pattern compiles as valid regex
- Tests matching behavior for typical credential targets
- Validates boundary conditions (store key must terminate the target, not be embedded)
- Confirms regex metacharacters in store keys are escaped and matched literally

The test runs on all platforms during CI, catching any regressions in pattern generation.

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes

https://claude.ai/code/session_01G3NFZniotieJW159vX7ZA5