### PR TITLE
fix(shell): preserve newlines in activation env vars

### DIFF
--- a/crates/rattler_shell/src/activation.rs
+++ b/crates/rattler_shell/src/activation.rs
@@ -1120,6 +1120,34 @@ mod tests {
         test_run_activation(crate::shell::Bash::default().into(), false);
     }
 
+    /// Regression test for prefix-dev/pixi#6575: a post-activation env
+    /// var whose value contains a newline must survive the env dump /
+    /// parse round-trip instead of being truncated at the newline.
+    #[test]
+    #[cfg(unix)]
+    fn test_run_activation_preserves_newline_in_env_var() {
+        let environment_dir = tempfile::TempDir::new().unwrap();
+        let mut activator = Activator::from_path(
+            environment_dir.path(),
+            shell::Bash::default(),
+            Platform::current(),
+        )
+        .unwrap();
+        activator.post_activation_env_vars = IndexMap::from_iter([(
+            String::from("ENV_WITH_NEWLINE"),
+            String::from("hello\nworld"),
+        )]);
+
+        let activation_env = activator
+            .run_activation(ActivationVariables::default(), None)
+            .unwrap();
+
+        assert_eq!(
+            activation_env.get("ENV_WITH_NEWLINE").map(String::as_str),
+            Some("hello\nworld")
+        );
+    }
+
     #[test]
     #[cfg(target_os = "macos")]
     fn test_run_activation_zsh() {

--- a/crates/rattler_shell/src/shell/mod.rs
+++ b/crates/rattler_shell/src/shell/mod.rs
@@ -142,8 +142,12 @@ pub trait Shell {
     }
 
     /// Emits writing all current environment variables to stdout.
+    ///
+    /// Records are NUL-separated (`env -0`) rather than newline-separated
+    /// so that values which themselves contain newlines survive the
+    /// round-trip through [`Shell::parse_env`].
     fn print_env(&self, f: &mut impl Write) -> std::fmt::Result {
-        writeln!(f, "/usr/bin/env")
+        writeln!(f, "/usr/bin/env -0")
     }
 
     /// Write the script to the writer and do some post-processing for
@@ -152,14 +156,18 @@ pub trait Shell {
         f.write_all(script.as_bytes())
     }
 
-    /// Parses environment variables emitted by the `Shell::env` command.
+    /// Parses environment variables emitted by [`Shell::print_env`].
+    ///
+    /// The default implementation expects NUL-separated `KEY=VALUE`
+    /// records (see [`Shell::print_env`]), so a value containing a
+    /// newline is kept intact instead of being cut at the newline.
     fn parse_env<'i>(&self, env: &'i str) -> HashMap<&'i str, &'i str> {
-        env.lines()
-            .filter_map(|line| {
-                line.split_once('=')
-                    // Trim " as CmdExe could add this to its variables.
-                    .map(|(key, value)| (key, value.trim_matches('"')))
-            })
+        env.split('\0')
+            .filter_map(|record| record.split_once('='))
+            // A record can carry a leading newline echoed just before the
+            // environment dump; variable names never do, so trimming the
+            // key is safe while the value is left untouched.
+            .map(|(key, value)| (key.trim_start_matches(['\n', '\r'].as_slice()), value))
             .collect()
     }
 
@@ -582,6 +590,19 @@ impl Shell for Xonsh {
     }
 }
 
+/// Parses newline-separated `KEY=VALUE` output, as emitted by the
+/// `print_env` of shells whose environment dump is line-based
+/// (cmd.exe's `@SET`, PowerShell's `dir env:`).
+fn parse_env_lines(env: &str) -> HashMap<&str, &str> {
+    env.lines()
+        .filter_map(|line| {
+            line.split_once('=')
+                // Trim " as CmdExe could add this to its variables.
+                .map(|(key, value)| (key, value.trim_matches('"')))
+        })
+        .collect()
+}
+
 /// A [`Shell`] implementation for the cmd.exe shell.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct CmdExe;
@@ -650,6 +671,10 @@ impl Shell for CmdExe {
 
     fn print_env(&self, f: &mut impl Write) -> std::fmt::Result {
         writeln!(f, "@SET")
+    }
+
+    fn parse_env<'i>(&self, env: &'i str) -> HashMap<&'i str, &'i str> {
+        parse_env_lines(env)
     }
 
     fn line_ending(&self) -> &str {
@@ -738,6 +763,10 @@ impl Shell for PowerShell {
     /// Emits writing all current environment variables to stdout.
     fn print_env(&self, f: &mut impl Write) -> std::fmt::Result {
         writeln!(f, r##"dir env: | %{{"{{0}}={{1}}" -f $_.Name,$_.Value}}"##)
+    }
+
+    fn parse_env<'i>(&self, env: &'i str) -> HashMap<&'i str, &'i str> {
+        parse_env_lines(env)
     }
 
     fn restore_env_var(&self, f: &mut impl Write, key: &str, backup_key: &str) -> ShellResult {


### PR DESCRIPTION
The activation env round-trip dumped the environment with /usr/bin/env (one KEY=VALUE per line) and parsed it back by splitting on lines, so any value containing a newline was truncated at the first newline.

Dump NUL-separated records with `env -0` and split the posix parse on NUL instead, keeping multi-line values intact. cmd.exe and PowerShell keep their line-based parsing via dedicated parse_env overrides.

Fixes prefix-dev/pixi#6575

### How Has This Been Tested?

A new test and via using this in pixi

### AI Disclosure

- [X] This PR contains AI-generated content.
  - [X] I have tested any AI-generated content in my PR.
  - [X] I take responsibility for any AI-generated content in my PR.

Tools: Claude

### Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.