### PR TITLE
feat(rattler_upload): support basic Artifactory auth again

### DIFF
--- a/crates/rattler_upload/src/upload/mod.rs
+++ b/crates/rattler_upload/src/upload/mod.rs
@@ -566,11 +566,8 @@ mod test {
         let router = Router::new().fallback(ok_with_bearer);
         let url = start_test_server(router).await;
         let storage = AuthenticationStorage::empty();
-        let artifactory_data = ArtifactoryData::new(
-            url,
-            "test-channel".to_string(),
-            Some("test-token".to_string()),
-        );
+        let artifactory_data = ArtifactoryData::new(url, "test-channel".to_string())
+            .with_bearer_auth("test-token".to_string());
         let result = super::upload_package_to_artifactory(
             &storage,
             &vec![test_package_path()],
@@ -585,7 +582,7 @@ mod test {
         let router = Router::new().fallback(ok_with_basic);
         let url = start_test_server(router).await;
         let storage = AuthenticationStorage::empty();
-        let artifactory_data = ArtifactoryData::new(url, "test-channel".to_string(), None)
+        let artifactory_data = ArtifactoryData::new(url, "test-channel".to_string())
             .with_basic_auth("test-user".to_string(), "test-password".to_string());
         let result = super::upload_package_to_artifactory(
             &storage,
@@ -611,7 +608,7 @@ mod test {
                 },
             )
             .unwrap();
-        let artifactory_data = ArtifactoryData::new(url, "test-channel".to_string(), None);
+        let artifactory_data = ArtifactoryData::new(url, "test-channel".to_string());
         let result = super::upload_package_to_artifactory(
             &storage,
             &vec![test_package_path()],
@@ -626,11 +623,8 @@ mod test {
         let router = Router::new().fallback(unauthorized);
         let url = start_test_server(router).await;
         let storage = AuthenticationStorage::empty();
-        let artifactory_data = ArtifactoryData::new(
-            url,
-            "test-channel".to_string(),
-            Some("bad-token".to_string()),
-        );
+        let artifactory_data = ArtifactoryData::new(url, "test-channel".to_string())
+            .with_bearer_auth("bad-token".to_string());
         let result = super::upload_package_to_artifactory(
             &storage,
             &vec![test_package_path()],

--- a/crates/rattler_upload/src/upload/mod.rs
+++ b/crates/rattler_upload/src/upload/mod.rs
@@ -159,12 +159,12 @@ pub async fn upload_package_to_artifactory(
             )) => authentication,
             Ok((_, Some(_))) => {
                 return Err(miette::miette!(
-                    "Authentication information found in the keychain / auth file, but it was neither a bearer token nor HTTP Basic credentials"
+                    "Authentication information found in the keychain / auth file, but it was neither a bearer token nor HTTP basic credentials"
                 ));
             }
             Ok((_, None)) => {
                 return Err(miette::miette!(
-                    "No bearer token or HTTP Basic credentials were given or found in the keychain / auth file"
+                    "No bearer token or HTTP basic credentials were given or found in the keychain / auth file"
                 ));
             }
             Err(e) => {

--- a/crates/rattler_upload/src/upload/mod.rs
+++ b/crates/rattler_upload/src/upload/mod.rs
@@ -1,5 +1,6 @@
 //! The upload module provides the package upload functionality.
 
+use self::opt::ArtifactoryAuthentication;
 use crate::{
     AnacondaData, ArtifactoryData, CloudsmithData, QuetzData, tool_configuration::APP_USER_AGENT,
 };
@@ -143,34 +144,32 @@ pub async fn upload_package_to_artifactory(
     package_files: &Vec<PathBuf>,
     artifactory_data: ArtifactoryData,
 ) -> miette::Result<()> {
-    let token = match artifactory_data.token {
-        Some(t) => t,
-        _ => match storage.get_by_url(Url::from(artifactory_data.url.clone())) {
-            Ok((_, Some(Authentication::BearerToken(token)))) => token,
+    let authentication = match artifactory_data.authentication {
+        Some(ArtifactoryAuthentication::Token(token)) => Authentication::BearerToken(token),
+        Some(ArtifactoryAuthentication::Basic { username, password }) => {
+            Authentication::BasicHTTP { username, password }
+        }
+        None => match storage.get_by_url(Url::from(artifactory_data.url.clone())) {
             Ok((
                 _,
-                Some(Authentication::BasicHTTP {
-                    username: _,
-                    password,
-                }),
-            )) => {
-                warn!(
-                    "A bearer token is required for authentication with artifactory. Using the password from the keychain / auth file to authenticate. Consider switching to a bearer token instead for Artifactory."
-                );
-                password
-            }
+                Some(
+                    authentication @ (Authentication::BearerToken(_)
+                    | Authentication::BasicHTTP { .. }),
+                ),
+            )) => authentication,
             Ok((_, Some(_))) => {
-                return Err(miette::miette!("A bearer token is required for authentication with artifactory.
-                            Authentication information found in the keychain / auth file, but it was not a bearer token"));
+                return Err(miette::miette!(
+                    "Authentication information found in the keychain / auth file, but it was neither a bearer token nor HTTP Basic credentials"
+                ));
             }
             Ok((_, None)) => {
                 return Err(miette::miette!(
-                    "No bearer token was given and none was found in the keychain / auth file"
+                    "No bearer token or HTTP Basic credentials were given or found in the keychain / auth file"
                 ));
             }
             Err(e) => {
                 return Err(miette::miette!(
-                    "Failed to get authentication information form keychain: {e}"
+                    "Failed to get authentication information from keychain: {e}"
                 ));
             }
         },
@@ -201,9 +200,14 @@ pub async fn upload_package_to_artifactory(
             ))
             .into_diagnostic()?;
 
-        let prepared_request = client
-            .request(Method::PUT, upload_url)
-            .bearer_auth(token.clone());
+        let prepared_request = client.request(Method::PUT, upload_url);
+        let prepared_request = match &authentication {
+            Authentication::BearerToken(token) => prepared_request.bearer_auth(token),
+            Authentication::BasicHTTP { username, password } => {
+                prepared_request.basic_auth(username, Some(password))
+            }
+            _ => unreachable!("Artifactory authentication was validated above"),
+        };
 
         send_request_with_retry(prepared_request, package_file).await?;
     }
@@ -472,8 +476,13 @@ async fn send_request(
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use axum::{Router, http::StatusCode};
-    use rattler_networking::AuthenticationStorage;
+    use rattler_networking::{
+        Authentication, AuthenticationStorage,
+        authentication_storage::backends::memory::MemoryStorage,
+    };
 
     use crate::upload::opt::{ArtifactoryData, QuetzData};
     use crate::upload::test_utils::{start_test_server, test_package_path};
@@ -492,6 +501,13 @@ mod test {
     ) -> StatusCode {
         let auth = headers.get("authorization").unwrap().to_str().unwrap();
         assert!(auth.starts_with("Bearer "));
+        StatusCode::OK
+    }
+
+    async fn ok_with_basic(headers: axum::http::HeaderMap, _body: axum::body::Bytes) -> StatusCode {
+        let auth = headers.get("authorization").unwrap().to_str().unwrap();
+        // Base64 encoding of `test-user:test-password`, as required by HTTP Basic auth.
+        assert_eq!(auth, "Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=");
         StatusCode::OK
     }
 
@@ -546,7 +562,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_artifactory_upload_success() {
+    async fn test_artifactory_bearer_upload_success() {
         let router = Router::new().fallback(ok_with_bearer);
         let url = start_test_server(router).await;
         let storage = AuthenticationStorage::empty();
@@ -555,6 +571,47 @@ mod test {
             "test-channel".to_string(),
             Some("test-token".to_string()),
         );
+        let result = super::upload_package_to_artifactory(
+            &storage,
+            &vec![test_package_path()],
+            artifactory_data,
+        )
+        .await;
+        assert!(result.is_ok(), "{:?}", result.unwrap_err());
+    }
+
+    #[tokio::test]
+    async fn test_artifactory_basic_upload_success() {
+        let router = Router::new().fallback(ok_with_basic);
+        let url = start_test_server(router).await;
+        let storage = AuthenticationStorage::empty();
+        let artifactory_data = ArtifactoryData::new(url, "test-channel".to_string(), None)
+            .with_basic_auth("test-user".to_string(), "test-password".to_string());
+        let result = super::upload_package_to_artifactory(
+            &storage,
+            &vec![test_package_path()],
+            artifactory_data,
+        )
+        .await;
+        assert!(result.is_ok(), "{:?}", result.unwrap_err());
+    }
+
+    #[tokio::test]
+    async fn test_artifactory_basic_upload_from_auth_storage() {
+        let router = Router::new().fallback(ok_with_basic);
+        let url = start_test_server(router).await;
+        let mut storage = AuthenticationStorage::empty();
+        storage.add_backend(Arc::new(MemoryStorage::new()));
+        storage
+            .store(
+                url.host_str().unwrap(),
+                &Authentication::BasicHTTP {
+                    username: "test-user".to_string(),
+                    password: "test-password".to_string(),
+                },
+            )
+            .unwrap();
+        let artifactory_data = ArtifactoryData::new(url, "test-channel".to_string(), None);
         let result = super::upload_package_to_artifactory(
             &storage,
             &vec![test_package_path()],

--- a/crates/rattler_upload/src/upload/mod.rs
+++ b/crates/rattler_upload/src/upload/mod.rs
@@ -159,12 +159,12 @@ pub async fn upload_package_to_artifactory(
             )) => authentication,
             Ok((_, Some(_))) => {
                 return Err(miette::miette!(
-                    "Authentication information found in the keychain / auth file, but it was neither a bearer token nor HTTP basic credentials"
+                    "Authentication information found in the keychain / auth file, but it was neither a bearer token nor HTTP basic auth credentials"
                 ));
             }
             Ok((_, None)) => {
                 return Err(miette::miette!(
-                    "No bearer token or HTTP basic credentials were given or found in the keychain / auth file"
+                    "No bearer token or HTTP basic auth credentials were given or found in the keychain / auth file"
                 ));
             }
             Err(e) => {

--- a/crates/rattler_upload/src/upload/mod.rs
+++ b/crates/rattler_upload/src/upload/mod.rs
@@ -506,7 +506,7 @@ mod test {
 
     async fn ok_with_basic(headers: axum::http::HeaderMap, _body: axum::body::Bytes) -> StatusCode {
         let auth = headers.get("authorization").unwrap().to_str().unwrap();
-        // Base64 encoding of `test-user:test-password`, as required by HTTP Basic auth.
+        // Base64 encoding of `test-user:test-password`, as required by HTTP basic auth.
         assert_eq!(auth, "Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=");
         StatusCode::OK
     }

--- a/crates/rattler_upload/src/upload/opt.rs
+++ b/crates/rattler_upload/src/upload/opt.rs
@@ -185,16 +185,16 @@ pub struct ArtifactoryOpts {
     #[arg(short, long = "channel", env = "ARTIFACTORY_CHANNEL")]
     pub channels: String,
 
-    /// Your Artifactory username for HTTP basic authentication. Requires a password.
-    #[arg(long, env = "ARTIFACTORY_USERNAME")]
+    /// Your Artifactory username for HTTP basic authentication.
+    #[arg(long, env = "ARTIFACTORY_USERNAME", requires = "password")]
     pub username: Option<String>,
 
-    /// Your Artifactory password for HTTP basic authentication. Requires a username.
-    #[arg(long, env = "ARTIFACTORY_PASSWORD")]
+    /// Your Artifactory password for HTTP basic authentication.
+    #[arg(long, env = "ARTIFACTORY_PASSWORD", requires = "username")]
     pub password: Option<String>,
 
-    /// Your Artifactory bearer token. Takes precedence over username/password authentication.
-    #[arg(short, long, env = "ARTIFACTORY_TOKEN")]
+    /// Your Artifactory token for bearer authentication.
+    #[arg(short, long, env = "ARTIFACTORY_TOKEN", conflicts_with_all = ["username", "password"])]
     pub token: Option<String>,
 }
 
@@ -204,12 +204,7 @@ pub enum ArtifactoryAuthentication {
     /// Authenticate with a bearer token.
     Token(String),
     /// Authenticate with HTTP basic authentication.
-    Basic {
-        /// The username to use for basic authentication.
-        username: String,
-        /// The password to use for basic authentication.
-        password: String,
-    },
+    Basic { username: String, password: String },
 }
 
 #[derive(Debug)]
@@ -224,38 +219,37 @@ impl TryFrom<ArtifactoryOpts> for ArtifactoryData {
     type Error = miette::Error;
 
     fn try_from(value: ArtifactoryOpts) -> Result<Self, Self::Error> {
-        let ArtifactoryOpts {
-            url,
-            channels,
-            username,
-            password,
-            token,
-        } = value;
+        let data = Self::new(value.url, value.channels);
 
-        match (username, password, token) {
-            (_, _, Some(token)) => Ok(Self::new(url, channels, Some(token))),
-            (Some(username), Some(password), None) => {
-                Ok(Self::new(url, channels, None).with_basic_auth(username, password))
-            }
-            (Some(_), None, None) => Err(miette::miette!(
-                "Artifactory username provided without a password"
-            )),
-            (None, Some(_), None) => Err(miette::miette!(
-                "Artifactory password provided without a username"
-            )),
-            (None, None, None) => Ok(Self::new(url, channels, None)),
+        if let Some(username) = value.username {
+            let password = value
+                .password
+                .expect("clap guarantees that password is present if username is present");
+            return Ok(data.with_basic_auth(username, password));
         }
+
+        if let Some(token) = value.token {
+            return Ok(data.with_bearer_auth(token));
+        }
+
+        Ok(data)
     }
 }
 
 impl ArtifactoryData {
-    /// Create a new instance of `ArtifactoryData`
-    pub fn new(url: Url, channels: String, token: Option<String>) -> Self {
+    /// Create a new and unauthenticated instance of `ArtifactoryData`
+    pub fn new(url: Url, channels: String) -> Self {
         Self {
             url: url.into(),
             channels,
-            authentication: token.map(ArtifactoryAuthentication::Token),
+            authentication: None,
         }
+    }
+
+    /// Use HTTP bearer authentication with the given token.
+    pub fn with_bearer_auth(mut self, token: String) -> Self {
+        self.authentication = Some(ArtifactoryAuthentication::Token(token));
+        self
     }
 
     /// Use HTTP basic authentication with the given username and password.

--- a/crates/rattler_upload/src/upload/opt.rs
+++ b/crates/rattler_upload/src/upload/opt.rs
@@ -185,11 +185,11 @@ pub struct ArtifactoryOpts {
     #[arg(short, long = "channel", env = "ARTIFACTORY_CHANNEL")]
     pub channels: String,
 
-    /// Your Artifactory username for HTTP Basic authentication. Requires a password.
+    /// Your Artifactory username for HTTP basic authentication. Requires a password.
     #[arg(long, env = "ARTIFACTORY_USERNAME")]
     pub username: Option<String>,
 
-    /// Your Artifactory password for HTTP Basic authentication. Requires a username.
+    /// Your Artifactory password for HTTP basic authentication. Requires a username.
     #[arg(long, env = "ARTIFACTORY_PASSWORD")]
     pub password: Option<String>,
 
@@ -203,7 +203,7 @@ pub struct ArtifactoryOpts {
 pub enum ArtifactoryAuthentication {
     /// Authenticate with a bearer token.
     Token(String),
-    /// Authenticate with HTTP Basic authentication.
+    /// Authenticate with HTTP basic authentication.
     Basic {
         /// The username to use for basic authentication.
         username: String,
@@ -258,7 +258,7 @@ impl ArtifactoryData {
         }
     }
 
-    /// Use HTTP Basic authentication with the given username and password.
+    /// Use HTTP basic authentication with the given username and password.
     pub fn with_basic_auth(mut self, username: String, password: String) -> Self {
         self.authentication = Some(ArtifactoryAuthentication::Basic { username, password });
         self

--- a/crates/rattler_upload/src/upload/opt.rs
+++ b/crates/rattler_upload/src/upload/opt.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use clap::Parser;
 use rattler_conda_types::utils::url_with_trailing_slash::UrlWithTrailingSlash;
 use rattler_networking::AuthenticationStorage;
-use tracing::warn;
 use url::Url;
 
 /// Newtype wrapper for the force overwrite flag.
@@ -184,11 +183,11 @@ pub struct ArtifactoryOpts {
     pub channels: String,
 
     /// Your Artifactory username
-    #[arg(long, env = "ARTIFACTORY_USERNAME", hide = true)]
+    #[arg(long, env = "ARTIFACTORY_USERNAME")]
     pub username: Option<String>,
 
     /// Your Artifactory password
-    #[arg(long, env = "ARTIFACTORY_PASSWORD", hide = true)]
+    #[arg(long, env = "ARTIFACTORY_PASSWORD")]
     pub password: Option<String>,
 
     /// Your Artifactory token
@@ -196,39 +195,53 @@ pub struct ArtifactoryOpts {
     pub token: Option<String>,
 }
 
+/// Authentication provided directly for an Artifactory upload.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ArtifactoryAuthentication {
+    /// Authenticate with a bearer token.
+    Token(String),
+    /// Authenticate with HTTP Basic authentication.
+    Basic {
+        /// The username to use for basic authentication.
+        username: String,
+        /// The password to use for basic authentication.
+        password: String,
+    },
+}
+
 #[derive(Debug)]
 #[allow(missing_docs)]
 pub struct ArtifactoryData {
     pub url: UrlWithTrailingSlash,
     pub channels: String,
-    pub token: Option<String>,
+    pub authentication: Option<ArtifactoryAuthentication>,
 }
 
 impl TryFrom<ArtifactoryOpts> for ArtifactoryData {
     type Error = miette::Error;
 
     fn try_from(value: ArtifactoryOpts) -> Result<Self, Self::Error> {
-        let token = match (value.username, value.password, value.token) {
-            (_, _, Some(token)) => Some(token),
-            (Some(_), Some(password), _) => {
-                warn!(
-                    "Using username and password for Artifactory authentication is deprecated, using password as token. Please use an API token instead."
-                );
-                Some(password)
+        let ArtifactoryOpts {
+            url,
+            channels,
+            username,
+            password,
+            token,
+        } = value;
+
+        match (username, password, token) {
+            (_, _, Some(token)) => Ok(Self::new(url, channels, Some(token))),
+            (Some(username), Some(password), None) => {
+                Ok(Self::new(url, channels, None).with_basic_auth(username, password))
             }
-            (Some(_), None, _) => {
-                return Err(miette::miette!(
-                    "Artifactory username provided without a password"
-                ));
-            }
-            (None, Some(_), _) => {
-                return Err(miette::miette!(
-                    "Artifactory password provided without a username"
-                ));
-            }
-            _ => None,
-        };
-        Ok(Self::new(value.url, value.channels, token))
+            (Some(_), None, None) => Err(miette::miette!(
+                "Artifactory username provided without a password"
+            )),
+            (None, Some(_), None) => Err(miette::miette!(
+                "Artifactory password provided without a username"
+            )),
+            (None, None, None) => Ok(Self::new(url, channels, None)),
+        }
     }
 }
 
@@ -238,8 +251,40 @@ impl ArtifactoryData {
         Self {
             url: url.into(),
             channels,
-            token,
+            authentication: token.map(ArtifactoryAuthentication::Token),
         }
+    }
+
+    /// Use HTTP Basic authentication with the given username and password.
+    pub fn with_basic_auth(mut self, username: String, password: String) -> Self {
+        self.authentication = Some(ArtifactoryAuthentication::Basic { username, password });
+        self
+    }
+}
+
+#[cfg(test)]
+mod artifactory_tests {
+    use super::{ArtifactoryAuthentication, ArtifactoryData, ArtifactoryOpts};
+
+    #[test]
+    fn username_and_password_are_kept_as_basic_auth() {
+        let options = ArtifactoryOpts {
+            url: "https://example.com/artifactory".parse().unwrap(),
+            channels: "test-channel".to_string(),
+            username: Some("test-user".to_string()),
+            password: Some("test-password".to_string()),
+            token: None,
+        };
+
+        let data = ArtifactoryData::try_from(options).unwrap();
+
+        assert_eq!(
+            data.authentication,
+            Some(ArtifactoryAuthentication::Basic {
+                username: "test-user".to_string(),
+                password: "test-password".to_string(),
+            })
+        );
     }
 }
 

--- a/crates/rattler_upload/src/upload/opt.rs
+++ b/crates/rattler_upload/src/upload/opt.rs
@@ -174,8 +174,7 @@ impl QuetzData {
 /// Options for uploading to an Artifactory channel.
 ///
 /// Authentication can be supplied directly with a bearer token or with an Artifactory username
-/// and password. If no credentials are supplied, they are read from the keychain / auth-file. A
-/// token takes precedence when both authentication methods are supplied.
+/// and password. If no credentials are supplied, they are read from the keychain / auth-file.
 pub struct ArtifactoryOpts {
     /// The URL to your Artifactory server
     #[arg(short, long, env = "ARTIFACTORY_SERVER_URL")]

--- a/crates/rattler_upload/src/upload/opt.rs
+++ b/crates/rattler_upload/src/upload/opt.rs
@@ -171,8 +171,11 @@ impl QuetzData {
 }
 
 #[derive(Clone, Debug, PartialEq, Parser)]
-/// Options for uploading to a Artifactory channel.
-/// Authentication is used from the keychain / auth-file.
+/// Options for uploading to an Artifactory channel.
+///
+/// Authentication can be supplied directly with a bearer token or with an Artifactory username
+/// and password. If no credentials are supplied, they are read from the keychain / auth-file. A
+/// token takes precedence when both authentication methods are supplied.
 pub struct ArtifactoryOpts {
     /// The URL to your Artifactory server
     #[arg(short, long, env = "ARTIFACTORY_SERVER_URL")]
@@ -182,15 +185,15 @@ pub struct ArtifactoryOpts {
     #[arg(short, long = "channel", env = "ARTIFACTORY_CHANNEL")]
     pub channels: String,
 
-    /// Your Artifactory username
+    /// Your Artifactory username for HTTP Basic authentication. Requires a password.
     #[arg(long, env = "ARTIFACTORY_USERNAME")]
     pub username: Option<String>,
 
-    /// Your Artifactory password
+    /// Your Artifactory password for HTTP Basic authentication. Requires a username.
     #[arg(long, env = "ARTIFACTORY_PASSWORD")]
     pub password: Option<String>,
 
-    /// Your Artifactory token
+    /// Your Artifactory bearer token. Takes precedence over username/password authentication.
     #[arg(short, long, env = "ARTIFACTORY_TOKEN")]
     pub token: Option<String>,
 }

--- a/crates/rattler_upload/src/upload/opt.rs
+++ b/crates/rattler_upload/src/upload/opt.rs
@@ -1,7 +1,7 @@
 //! Command-line options.
 use std::path::PathBuf;
 
-use clap::{ArgGroup, Parser};
+use clap::Parser;
 use rattler_conda_types::utils::url_with_trailing_slash::UrlWithTrailingSlash;
 use rattler_networking::AuthenticationStorage;
 use url::Url;
@@ -175,11 +175,6 @@ impl QuetzData {
 /// Authentication can be supplied directly with a bearer token or with an Artifactory username
 /// and password. If no credentials are supplied, they are read from the keychain / auth-file.
 #[derive(Clone, Debug, PartialEq, Parser)]
-#[command(group(
-    ArgGroup::new("authentication")
-        .multiple(false)
-        .args(["token", "username"])
-))]
 pub struct ArtifactoryOpts {
     /// The URL to your Artifactory server
     #[arg(short, long, env = "ARTIFACTORY_SERVER_URL")]

--- a/crates/rattler_upload/src/upload/opt.rs
+++ b/crates/rattler_upload/src/upload/opt.rs
@@ -1,7 +1,7 @@
 //! Command-line options.
 use std::path::PathBuf;
 
-use clap::Parser;
+use clap::{ArgGroup, Parser};
 use rattler_conda_types::utils::url_with_trailing_slash::UrlWithTrailingSlash;
 use rattler_networking::AuthenticationStorage;
 use url::Url;
@@ -170,11 +170,16 @@ impl QuetzData {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Parser)]
 /// Options for uploading to an Artifactory channel.
 ///
 /// Authentication can be supplied directly with a bearer token or with an Artifactory username
 /// and password. If no credentials are supplied, they are read from the keychain / auth-file.
+#[derive(Clone, Debug, PartialEq, Parser)]
+#[command(group(
+    ArgGroup::new("authentication")
+        .multiple(false)
+        .args(["token", "username"])
+))]
 pub struct ArtifactoryOpts {
     /// The URL to your Artifactory server
     #[arg(short, long, env = "ARTIFACTORY_SERVER_URL")]
@@ -255,32 +260,6 @@ impl ArtifactoryData {
     pub fn with_basic_auth(mut self, username: String, password: String) -> Self {
         self.authentication = Some(ArtifactoryAuthentication::Basic { username, password });
         self
-    }
-}
-
-#[cfg(test)]
-mod artifactory_tests {
-    use super::{ArtifactoryAuthentication, ArtifactoryData, ArtifactoryOpts};
-
-    #[test]
-    fn username_and_password_are_kept_as_basic_auth() {
-        let options = ArtifactoryOpts {
-            url: "https://example.com/artifactory".parse().unwrap(),
-            channels: "test-channel".to_string(),
-            username: Some("test-user".to_string()),
-            password: Some("test-password".to_string()),
-            token: None,
-        };
-
-        let data = ArtifactoryData::try_from(options).unwrap();
-
-        assert_eq!(
-            data.authentication,
-            Some(ArtifactoryAuthentication::Basic {
-                username: "test-user".to_string(),
-                password: "test-password".to_string(),
-            })
-        );
     }
 }
 


### PR DESCRIPTION
### Description

https://github.com/prefix-dev/rattler-build/issues/1254 and https://github.com/prefix-dev/rattler-build/pull/1280 deprecated support for HTTP Basic Auth for uploading to Artifactory, assuming that, in every situation, the HTTP Basic Auth password can just be passed as a Bearer token.

However, there are corporate IT situations where, in CI, only a username and password for a local Artifactory user are available. The password of local Artifactory users cannot be passed as a bearer token to Artifactory (error: `401 Unauthorized, Token failed verification: signature`). This also makes sense conceptually, since, unlike tokens, two users can have the same password.

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce while reviewing your changes. -->

I tested this change on Windows with the Artifactory instance of a corporate IT network. Since I only have access to a local username and password in a CI system unavailable for testing, I tested HTTP Basic auth not in the situation described above, but with my username and an Artifactory token as password:

1. Navigate to the Artifactory instance
2. Click User Menu -> Edit Profile
3. Generate an Identity Token
4. Run `rattler.exe upload artifactory --url https://artifactory.example.com/artifactory -c my-channel --username USERNAME --password TOKEN ./package.conda`
5. Observe successful upload.

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: ChatGPT Codex

```plaintext
Please find out why upload_package_to_artifactory only works with Bearer tokens. If you don't find any good reason, please make it support basic auth as well.
```
(after this, some minor manual rework followed, I don't share the prompts here for brevity)


### Breaking Change

Marked as breaking because public `ArtifactoryData` changes from

```rust
pub token: Option<String>
```

to 

```rust
pub authentication: Option<ArtifactoryAuthentication>
```

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->

Cc @pavelzw