### PR TITLE
ci: update bindings lockfiles in release PRs

### DIFF
--- a/.github/workflows/release-rust.yaml
+++ b/.github/workflows/release-rust.yaml
@@ -105,3 +105,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.octo-sts.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Update bindings lockfiles
+        if: steps.release-plz.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          PR: ${{ steps.release-plz.outputs.pr }}
+        run: |
+          gh pr checkout "$(jq -r .number <<<"$PR")"
+          cargo update --manifest-path py-rattler/Cargo.toml --workspace
+          cargo update --manifest-path js-rattler/Cargo.toml --workspace
+          git add py-rattler/Cargo.lock js-rattler/Cargo.lock
+          git diff --cached --quiet || git commit -m "chore: update bindings lockfiles"
+          git push


### PR DESCRIPTION
### Description

Update the standalone Python and JavaScript bindings lockfiles after release-plz creates or updates a release PR. Release-plz only updates the root Cargo workspace lockfile, leaving `py-rattler/Cargo.lock` and `js-rattler/Cargo.lock` stale after crate version bumps.

### How Has This Been Tested?

- `actionlint .github/workflows/release-rust.yaml`
- `cargo update --manifest-path py-rattler/Cargo.toml --workspace`
- `cargo update --manifest-path js-rattler/Cargo.toml --workspace`

### AI Disclosure

- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: OpenAI Codex

```plaintext
Can you make another PR doing that? for JS and Py bindings
```

### Checklist

- [x] I have performed a self-review of my own code
