### PR TITLE
fix(rattler_index): re-index packages whose file size changed under the same name

### DIFF
--- a/crates/rattler_index/src/lib.rs
+++ b/crates/rattler_index/src/lib.rs
@@ -767,21 +767,26 @@ async fn index_subdir_inner(
             }
         };
 
-    // List all the packages in the subdirectory.
-    let uploaded_packages: HashSet<DistArchiveIdentifier> = op
+    // List all the packages in the subdirectory, keeping each file's size. The
+    // listers populate content_length as part of the listing, so this needs no
+    // extra stat round-trips.
+    let uploaded_sizes: HashMap<DistArchiveIdentifier, u64> = op
         .list_with(&format!("{}/", subdir.as_str()))
         .await?
         .iter()
         .filter_map(|entry| {
-            if entry.metadata().mode().is_file() {
-                let filename = entry.name().to_string();
+            let meta = entry.metadata();
+            if meta.mode().is_file() {
                 // Check if the file is an archive package file.
-                DistArchiveIdentifier::try_from_filename(&filename)
+                DistArchiveIdentifier::try_from_filename(entry.name())
+                    .map(|id| (id, meta.content_length()))
             } else {
                 None
             }
         })
         .collect();
+    let uploaded_packages: HashSet<DistArchiveIdentifier> =
+        uploaded_sizes.keys().cloned().collect();
 
     tracing::debug!(
         "Found {} already uploaded packages in subdir {}.",
@@ -806,6 +811,37 @@ async fn index_subdir_inner(
     );
 
     for filename in &packages_to_delete {
+        registered_packages.remove(filename);
+    }
+
+    // Re-index packages whose file no longer matches the size recorded in the
+    // previous repodata. `.conda`/`.tar.bz2` archives aren't reproducible, so a
+    // package rebuilt and republished under the same filename has different
+    // bytes; without this the stale record's sha256/size are kept and clients
+    // hit a hash mismatch on download. Dropping the mismatched entry here moves
+    // it into `packages_to_add` below, which re-reads and re-hashes it.
+    //
+    // Size is the only signal available without re-reading every package: a
+    // rebuild that lands on the exact same byte count still slips through, and
+    // `--force` remains the way to rebuild repodata unconditionally.
+    let stale = registered_packages
+        .iter()
+        .filter(|(id, pkg)| match (uploaded_sizes.get(id), pkg.record.size) {
+            (Some(current), Some(recorded)) => *current != recorded,
+            (Some(_), None) => true, // no recorded size to trust
+            (None, _) => false,      // absent from the channel: handled above
+        })
+        .map(|(id, _)| id.clone())
+        .collect::<Vec<_>>();
+
+    if !stale.is_empty() {
+        tracing::info!(
+            "Re-indexing {} packages in subdir {} whose blob size changed since the last index.",
+            stale.len(),
+            subdir
+        );
+    }
+    for filename in &stale {
         registered_packages.remove(filename);
     }
 

--- a/crates/rattler_index/tests/integration/basic_indexing.rs
+++ b/crates/rattler_index/tests/integration/basic_indexing.rs
@@ -378,6 +378,95 @@ async fn test_index_repodata_revision_from_index_json() {
     assert_eq!(revision["newest"], 1710000000000i64);
 }
 
+/// Regression: a package rebuilt and republished under the same filename (new
+/// bytes) must be re-hashed on an incremental index. Keying only on filename
+/// left the previous build's sha256/size in repodata, so clients downloading the
+/// current blob hit a hash mismatch.
+#[tokio::test]
+async fn test_incremental_reindexes_replaced_package() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let subdir_path = temp_dir.path().join("noarch");
+    fs::create_dir(&subdir_path).unwrap();
+    let package_name = "stale-demo-1.0.0-h123_0.tar.bz2";
+
+    // Build a tar.bz2 package with a payload of the given size and write it into
+    // the channel under a fixed filename, overwriting any previous build.
+    let build = |payload_len: usize| {
+        let build_dir = temp_dir.path().join(format!("build-{payload_len}"));
+        let info_dir = build_dir.join("info");
+        fs::create_dir_all(&info_dir).unwrap();
+        fs::write(
+            info_dir.join("index.json"),
+            r#"{"build":"h123_0","build_number":0,"name":"stale-demo","noarch":"generic","subdir":"noarch","timestamp":1710000000000,"version":"1.0.0"}"#,
+        )
+        .unwrap();
+        fs::write(build_dir.join("payload.txt"), "x".repeat(payload_len)).unwrap();
+        let writer = File::create(subdir_path.join(package_name)).unwrap();
+        write_tar_bz2_package(
+            writer,
+            &build_dir,
+            &[info_dir.join("index.json"), build_dir.join("payload.txt")],
+            CompressionLevel::Default,
+            None,
+            None,
+        )
+        .unwrap();
+    };
+
+    // Incremental index (force: false) — the path that carried the bug.
+    async fn index(channel: &Path) {
+        index_fs(IndexFsConfig {
+            channel: channel.into(),
+            target_platform: Some(Platform::NoArch),
+            repodata_patch: None,
+            write_zst: false,
+            write_shards: false,
+            repodata_revisions: Vec::new(),
+            package_revision_assignment: PackageRevisionAssignment::default(),
+            force: false,
+            max_parallel: 1,
+            multi_progress: None,
+        })
+        .await
+        .unwrap();
+    }
+
+    let recorded = |field: &str| -> Value {
+        let repodata: Value =
+            serde_json::from_reader(File::open(subdir_path.join("repodata.json")).unwrap())
+                .unwrap();
+        repodata
+            .pointer(&format!("/packages/{package_name}/{field}"))
+            .expect("package present in repodata")
+            .clone()
+    };
+
+    // Baseline: first build, indexed.
+    build(64);
+    index(temp_dir.path()).await;
+    let disk1 = fs::metadata(subdir_path.join(package_name)).unwrap().len();
+    assert_eq!(recorded("size").as_u64(), Some(disk1));
+    let sha1 = recorded("sha256");
+
+    // Rebuild under the same filename with very different bytes, then reindex
+    // incrementally.
+    build(65536);
+    index(temp_dir.path()).await;
+    let disk2 = fs::metadata(subdir_path.join(package_name)).unwrap().len();
+
+    assert_ne!(disk1, disk2, "test setup: rebuild must change the file size");
+    assert_eq!(
+        recorded("size").as_u64(),
+        Some(disk2),
+        "repodata size must match the rebuilt file"
+    );
+    assert_ne!(
+        recorded("sha256"),
+        sha1,
+        "repodata sha256 must reflect the rebuilt bytes"
+    );
+}
+
 #[tokio::test]
 async fn test_index_writes_channel_metadata() {
     let temp_dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
### Problem

Incremental indexing (`index` without `--force`) decides what to hash purely by **filename**: it reuses every record already present in the previous `repodata.json` and only reads packages whose filename is new (`packages_to_add = uploaded − registered`). If a package is rebuilt and re-uploaded under the **same** filename, its bytes change but the old `sha256`/`size` are kept in `repodata.json`.

Clients then download the new bytes, hash them, and abort with a hash mismatch, e.g.:

```
hash mismatch when extracting <channel>/noarch/<pkg>.conda:
expected 519001f5…, got a434986e…
```

This assumes `name-version-build.<ext>` is immutable, which holds for well-behaved channels but breaks silently for any pipeline that republishes a rebuilt artifact under the same name (`.conda`/`.tar.bz2` archives aren't reproducible). Only a full `--force` reindex recovers.

### Fix

When reusing records from the previous `repodata.json`, also drop any package whose **current file size differs from the recorded size**, so it falls into `packages_to_add` and gets re-read and re-hashed. The listing already populates `content_length` for every entry, so this adds no extra stat/round-trips.

Size is the only signal available without re-reading every package; a rebuild that happens to produce the exact same byte count still requires `--force`. This is a strict improvement over the current filename-only behaviour and preserves incremental performance (unchanged packages are still reused).

### Test

`test_incremental_reindexes_replaced_package` indexes a package, replaces it in place with different bytes under the same filename, reindexes incrementally, and asserts `repodata.json`'s `size`/`sha256` now reflect the new bytes. It fails on `main` and passes with this change.
