### PR TITLE
fix: keep trailing underscores in matchspec versions

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -1199,6 +1199,19 @@ mod tests {
         );
 
         assert_matches!(
+            split_version_and_build("=3.7b_", Lenient),
+            Ok(("=3.7b_", None))
+        );
+        assert_matches!(
+            split_version_and_build("==3.7b_", Strict),
+            Ok(("==3.7b_", None))
+        );
+        assert_matches!(
+            split_version_and_build("=1.0_=py27_0", Lenient),
+            Ok(("=1.0_", Some("py27_0")))
+        );
+
+        assert_matches!(
             split_version_and_build("3.8.* *_cpython", Lenient),
             Ok(("3.8.*", Some("*_cpython")))
         );
@@ -1878,6 +1891,32 @@ mod tests {
         let version_spec = match_spec.version.unwrap();
         let version = Version::from_str("0.4.1").unwrap();
         assert!(version_spec.matches(&version));
+    }
+
+    #[test]
+    fn test_pixi_issue_6618() {
+        // A trailing underscore belongs to the version, not the build string
+        for strictness in [ParseStrictness::Lenient, ParseStrictness::Strict] {
+            let match_spec = MatchSpec::from_str("tmux=3.7b_", strictness).unwrap();
+            assert_eq!(
+                match_spec.version,
+                Some(VersionSpec::from_str("3.7b_.*", strictness).unwrap())
+            );
+            assert_eq!(match_spec.build, None);
+            assert!(
+                match_spec
+                    .version
+                    .unwrap()
+                    .matches(&Version::from_str("3.7b_").unwrap())
+            );
+
+            let match_spec = MatchSpec::from_str("tmux==3.7b_", strictness).unwrap();
+            assert_eq!(
+                match_spec.version,
+                Some(VersionSpec::from_str("==3.7b_", strictness).unwrap())
+            );
+            assert_eq!(match_spec.build, None);
+        }
     }
 
     #[test]

--- a/crates/rattler_conda_types/src/version_spec/version_tree.rs
+++ b/crates/rattler_conda_types/src/version_spec/version_tree.rs
@@ -1,7 +1,7 @@
 use nom::{
     IResult, Parser,
     branch::alt,
-    bytes::complete::{tag, take_while},
+    bytes::complete::{tag, take_while, take_while1},
     character::complete::{alpha1, digit1, multispace0, u32},
     combinator::{cut, not, opt, recognize, value},
     error::{ContextError, ParseError, context},
@@ -97,6 +97,12 @@ pub(crate) fn recognize_version<'a, E: ParseError<&'a str> + ContextError<&'a st
                     Ok((r, _)) => rest = r,
                     Err(_) => break,
                 }
+            }
+            // Versions can end in one or more underscores or dashes (e.g.
+            // `3.7b_`), those are part of the version. A trailing `.` stays
+            // unconsumed so globs like `3.*` keep working.
+            if let Ok((r, _)) = take_while1::<_, _, E>(|c: char| c == '_' || c == '-').parse(rest) {
+                rest = r;
             }
             let matched = &input[..input.len() - rest.len()];
             Ok((rest, matched))
@@ -234,6 +240,20 @@ mod tests {
         );
         assert_eq!(recognize_version::<Err<'_>>(false)("3."), Ok((".", "3")));
         assert_eq!(recognize_version::<Err<'_>>(false)("3.*"), Ok((".*", "3")));
+
+        // Trailing underscores and dashes are part of the version
+        assert_eq!(
+            recognize_version::<Err<'_>>(false)("3.7b_"),
+            Ok(("", "3.7b_"))
+        );
+        assert_eq!(
+            recognize_version::<Err<'_>>(false)("1.0__"),
+            Ok(("", "1.0__"))
+        );
+        assert_eq!(
+            recognize_version::<Err<'_>>(false)("1.0-"),
+            Ok(("", "1.0-"))
+        );
 
         let versions = [
             // Implicit epoch of 0


### PR DESCRIPTION
### Description

`MatchSpec` parsing stopped the version at a trailing underscore and treated the rest as a build string, so `tmux=3.7b_` turned into version `3.7b` with build `_`. CEP 33 allows trailing underscores and dashes in version literals, so recognize them as part of the version.

Fixes prefix-dev/pixi#6618

### How Has This Been Tested?

`pixi run test`

### AI Disclosure
<!--- Uncomment the following if your PR does not contain AI-generated content. --->
<!--- This PR doesn't contain AI-generated content. --->
<!--- Remove this section if your PR does not contain AI-generated content. --->
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
<!--- If you used AI to generate code, please specify the tool used and the prompt below. --->
Tools: Claude

<!-- Add your prompt here, this helps us understand your results.
```plaintext
TODO
```
-->

### Checklist:
<!--- Remove the non relevant items. --->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.

<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
