### PR TITLE
fix: render build only match specs with a version placeholder

### DIFF
--- a/crates/rattler_conda_types/src/match_spec/mod.rs
+++ b/crates/rattler_conda_types/src/match_spec/mod.rs
@@ -197,6 +197,8 @@ impl Display for MatchSpec {
 
         if let Some(version) = &self.version {
             write!(f, " {version}")?;
+        } else if self.build.is_some() {
+            write!(f, " *")?;
         }
 
         if let Some(build) = &self.build {

--- a/crates/rattler_conda_types/src/match_spec/parse.rs
+++ b/crates/rattler_conda_types/src/match_spec/parse.rs
@@ -1882,6 +1882,22 @@ mod tests {
     }
 
     #[test]
+    fn test_build_only_matchspec_roundtrips() {
+        // Without a `*` placeholder the build slides into the version slot and misparses.
+        let spec = MatchSpec::from_str("foo[build=py39h123_0]", Strict).unwrap();
+        assert_eq!(spec.version, None);
+        assert!(spec.build.is_some());
+
+        let rendered = spec.to_string();
+        assert_eq!(rendered, "foo * py39h123_0");
+
+        for strictness in [ParseStrictness::Lenient, Strict] {
+            let reparsed = MatchSpec::from_str(&rendered, strictness).unwrap();
+            assert_eq!(reparsed.build, spec.build);
+        }
+    }
+
+    #[test]
     fn test_pixi_issue_3922() {
         let match_spec = MatchSpec::from_str(
             "bird_tool_utils_python =0.*,>=0.4.1",


### PR DESCRIPTION
### Description

`MatchSpec::Display` skipped the version entirely when a spec had a **build but no version** (e.g. `foo[build=py39h123_0]`), rendering it as `foo py39h123_0`. A build token is only grammatically valid *after* a version, so on re-parse the build slides into the version slot:

  - **strict** parsing fails with `AmbiguousVersion`
  - **lenient** parsing silently reinterprets the build string as a version

  So a build-only `MatchSpec` fails to round-trip through its own `Display`.

  The fix emits a `*` version placeholder when a build is present but the version is absent, matching what `NamelessMatchSpec::Display` already does, so that the rendered spec stays parseable and preserves the build.

  **Before → after:**

  ```rust
  let spec = MatchSpec::from_str("foo[build=py39h123_0]", Strict).unwrap();
  // before: spec.to_string() == "foo py39h123_0"      → strict re-parse: Err(AmbiguousVersion)
  // after:  spec.to_string() == "foo * py39h123_0"    → re-parses, build preserved
  ```

  **Why the `*` form and not the docstring's bracket form (discrepancy noted here):**
  The `MatchSpec` docstring rule 3 states build goes *inside* brackets unless the version is an *exact* value. The actual `Display` code does **not** follow this. Itt renders build positionally even for fuzzy versions. This is already visible in the existing `matchspec_to_string` snapshot, where a fuzzy version `1.0.*` with build `py27_0*` renders  positionally:

  ```
  "conda-forge/linux-64:foospace:foo 1.0.* py27_0*[md5=..., build_number=\">=6\", ...]"
  ```

I matched the code's most followed convention (positional build + `*` placeholder, consistent with `NamelessMatchSpec::Display`) rather than the docstring prose. The docstring's rule 3 is inaccurate relative to the code, I left it untouched, but it's worth a follow-up (do let me know your thoughts).

  Fixes: N/A 
  
  ### How Has This Been Tested?
 **New regression test** `test_build_only_matchspec_roundtrips` (`crates/rattler_conda_types/src/match_spec/parse.rs`) asserts `foo[build=py39h123_0]` renders to `foo * py39h123_0` and re-parses under both `Strict` and `Lenient` with the build preserved.

  Reproduce:

  ```sh
  pixi run -- cargo nextest run -p rattler_conda_types match_spec
  ```

  Results observed (run via `cargo test -p rattler_conda_types match_spec`):

  ```
  test result: ok. 111 passed; 0 failed; 0 ignored; 0 measured; 353 filtered out
  ```

  ### AI Disclosure
  - [x] This PR contains AI-generated content.
    - [x] I have tested any AI-generated content in my PR.
    - [x] I take responsibility for any AI-generated content in my PR.

  Tools: Claude

  ### Checklist:
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have added sufficient tests to cover my changes.
