### PR TITLE
fix(ci): bound semver check disk usage

### DIFF
--- a/scripts/check-breaking-changes.nu
+++ b/scripts/check-breaking-changes.nu
@@ -12,7 +12,9 @@
 
 const repo_root = path self ..
 const public_target_kinds = ["lib", "rlib", "dylib", "cdylib", "staticlib", "proc-macro"]
-const workspace_files = ["Cargo.toml", "Cargo.lock", "rust-toolchain", "rust-toolchain.toml"]
+# cargo-semver-checks builds each side through an isolated placeholder project and
+# runs `cargo update`, so the workspace lockfile is not an input to its API comparison.
+const workspace_files = ["rust-toolchain", "rust-toolchain.toml"]
 const comment_marker = "<!-- cargo-semver-checks-comment -->"
 const breaking_summary = "semver requires new major version:"
 
@@ -78,9 +80,11 @@ export def select-changed-crates [
     current_metadata: record
     baseline_metadata: record
     changed_files: list<string>
+    changed_workspace_dependencies: list<string> = []
+    force_all: bool = false
 ] {
     let baseline_packages = ($baseline_metadata.packages | get name)
-    let check_all = ($changed_files | any {|file|
+    let check_all = $force_all or ($changed_files | any {|file|
         ($file in $workspace_files) or ($file | str starts-with ".cargo/")
     })
 
@@ -100,13 +104,49 @@ export def select-changed-crates [
                 | str replace --all "\\" "/"
         }
         | where {|package|
-            $check_all or ($changed_files | any {|file|
-                $file | str starts-with $"($package.directory)/"
-            })
+            [
+                $check_all
+                ($changed_files | any {|file| $file | str starts-with $"($package.directory)/" })
+                ($package.dependencies? | default [] | any {|dependency|
+                    $dependency.name in $changed_workspace_dependencies
+                })
+            ] | any {|should_check| $should_check}
         }
         | get name
         | sort
         | uniq
+}
+
+# A root Cargo.toml change that only touches workspace dependencies can affect
+# only packages using those dependencies. Conservatively check every crate for
+# any other root-manifest change.
+export def workspace-dependency-impact [
+    current_manifest: record
+    baseline_manifest: record
+] {
+    let current_without_dependencies = ($current_manifest | reject workspace.dependencies)
+    let baseline_without_dependencies = ($baseline_manifest | reject workspace.dependencies)
+
+    if (($current_without_dependencies | to json) != ($baseline_without_dependencies | to json)) {
+        return {force_all: true, dependencies: []}
+    }
+
+    let current_dependencies = ($current_manifest.workspace.dependencies? | default {})
+    let baseline_dependencies = ($baseline_manifest.workspace.dependencies? | default {})
+    let dependency_names = (($current_dependencies | columns)
+        | append ($baseline_dependencies | columns)
+        | sort
+        | uniq)
+    {
+        force_all: false
+        dependencies: ($dependency_names | where {|name|
+            ($current_dependencies | get -o $name) != ($baseline_dependencies | get -o $name)
+        })
+    }
+}
+
+def workspace-dependency-impact-from-root [baseline_root: string] {
+    workspace-dependency-impact (open ($repo_root | path join "Cargo.toml")) (open ($baseline_root | path join "Cargo.toml"))
 }
 
 # Render the exact Markdown body used by the privileged comment workflow.
@@ -176,31 +216,67 @@ def changed-files [base_ref: string] {
     $committed | append $working | append $untracked | where {|path| not ($path | is-empty) } | uniq
 }
 
+# cargo-semver-checks stores a separate compilation target for each checked
+# local crate. It does not reuse those targets, so remove them after each crate
+# to bound peak disk use to one baseline/current pair.
+export def clean-semver-target [target_directory: string] {
+    let semver_target = ($target_directory | path join "semver-checks")
+    if ($semver_target | path exists) {
+        rm --recursive --force $semver_target
+    }
+}
+
 # Run cargo-semver-checks while streaming its output and retaining both streams
 # for the PR comment.
-def semver-check [packages: list<string>, baseline_root: string] {
-    let package_args = ($packages | each {|package| ["--package", $package] } | flatten)
-    let args = [
-        "semver-checks"
-        "check-release"
-        "--manifest-path"
-        ($repo_root | path join "Cargo.toml")
-        "--baseline-root"
-        $baseline_root
-        "--release-type"
-        "minor"
-    ] | append $package_args
+def semver-check [
+    packages: list<string>
+    baseline_root: string
+    current_target_directory: string
+    baseline_target_directory: string
+] {
+    clean-semver-target $current_target_directory
+    clean-semver-target $baseline_target_directory
 
-    print $"Checking API compatibility for: ($packages | str join ', ')"
-    let command_result = (with-env {NO_COLOR: "1", CARGO_TERM_COLOR: "never"} {
-        ^cargo ...$args | complete
-    })
-    print --no-newline $command_result.stdout
-    print --stderr --no-newline $command_result.stderr
+    mut result = "success"
+    mut logs = []
+    mut exit_code = 0
+    for package in $packages {
+        let args = [
+            "semver-checks"
+            "check-release"
+            "--manifest-path"
+            ($repo_root | path join "Cargo.toml")
+            "--baseline-root"
+            $baseline_root
+            "--release-type"
+            "minor"
+            "--package"
+            $package
+        ]
+
+        print $"Checking API compatibility for: ($package)"
+        let command_result = (with-env {NO_COLOR: "1", CARGO_TERM_COLOR: "never"} {
+            ^cargo ...$args | complete
+        })
+        print --no-newline $command_result.stdout
+        print --stderr --no-newline $command_result.stderr
+        let package_result = (classify-result $command_result.exit_code $command_result.stderr)
+        if $package_result == "error" {
+            $result = "error"
+            $exit_code = $command_result.exit_code
+        } else if $package_result == "failure" and $result == "success" {
+            $result = "failure"
+            $exit_code = $command_result.exit_code
+        }
+        $logs = ($logs | append (clean-log $"($command_result.stdout)($command_result.stderr)"))
+
+        clean-semver-target $current_target_directory
+        clean-semver-target $baseline_target_directory
+    }
     {
-        result: (classify-result $command_result.exit_code $command_result.stderr)
-        logs: (clean-log $"($command_result.stdout)($command_result.stderr)")
-        exit_code: $command_result.exit_code
+        result: $result
+        logs: (clean-log ($logs | str join "\n"))
+        exit_code: $exit_code
     }
 }
 
@@ -225,12 +301,27 @@ def check-ref [base_ref: string] {
         let baseline_metadata = (run-command "reading baseline cargo metadata" {
             ^cargo metadata --manifest-path ($baseline_root | path join "Cargo.toml") --no-deps --format-version 1
         } | from json)
-        let packages = (select-changed-crates $current_metadata $baseline_metadata (changed-files $base_ref))
+        let changed_files = (changed-files $base_ref)
+        let workspace_dependency_impact = (if "Cargo.toml" in $changed_files {
+            workspace-dependency-impact-from-root $baseline_root
+        } else {
+            {force_all: false, dependencies: []}
+        })
+        let packages = (select-changed-crates
+            $current_metadata
+            $baseline_metadata
+            $changed_files
+            $workspace_dependency_impact.dependencies
+            $workspace_dependency_impact.force_all)
 
         let outcome = (if ($packages | is-empty) {
             {result: "success", logs: "", exit_code: 0, packages: []}
         } else {
-            let check = (semver-check $packages $baseline_root)
+            let check = (semver-check
+                $packages
+                $baseline_root
+                $current_metadata.target_directory
+                $baseline_metadata.target_directory)
             $check | insert packages $packages
         })
         {ok: true, outcome: $outcome}

--- a/scripts/test-breaking-changes.nu
+++ b/scripts/test-breaking-changes.nu
@@ -1,7 +1,7 @@
 #!/usr/bin/env nu
 
 use std/assert
-use check-breaking-changes.nu [classify-result clean-log render-comment select-changed-crates]
+use check-breaking-changes.nu [classify-result clean-log clean-semver-target render-comment select-changed-crates workspace-dependency-impact]
 
 let summary = "Summary semver requires new major version: 1 major and 0 minor checks failed"
 assert equal (classify-result 0 "") "success"
@@ -44,6 +44,7 @@ let current_metadata = {
             publish: null
             manifest_path: ($root | path join "crates" "a" "Cargo.toml")
             targets: [{kind: ["lib"]}]
+            dependencies: [{name: "shared"}]
         }
         {
             id: "private"
@@ -72,6 +73,7 @@ let current_metadata = {
             publish: ["crates-io"]
             manifest_path: ($root | path join "crates" "proc" "Cargo.toml")
             targets: [{kind: ["proc-macro"]}]
+            dependencies: [{name: "other"}]
         }
     ]
 }
@@ -89,9 +91,53 @@ assert equal (
 ) ["a"]
 assert equal (
     select-changed-crates $current_metadata $baseline_metadata ["Cargo.lock"]
+) []
+assert equal (
+    select-changed-crates $current_metadata $baseline_metadata ["Cargo.toml"] ["shared"]
+) ["a"]
+assert equal (
+    select-changed-crates $current_metadata $baseline_metadata ["Cargo.toml"] [] true
 ) ["a", "proc"]
 assert equal (
     select-changed-crates $current_metadata $baseline_metadata ["README.md"]
 ) []
+
+let baseline_manifest = {
+    workspace: {
+        members: ["crates/*"]
+        dependencies: {
+            shared: {version: "1"}
+            unchanged: "1"
+        }
+    }
+}
+let current_manifest = {
+    workspace: {
+        members: ["crates/*"]
+        dependencies: {
+            shared: {version: "2"}
+            added: "1"
+            unchanged: "1"
+        }
+    }
+}
+assert equal (
+    workspace-dependency-impact $current_manifest $baseline_manifest
+) {force_all: false, dependencies: ["added", "shared"]}
+assert equal (
+    workspace-dependency-impact ($current_manifest | upsert workspace.members ["crates/*", "tools/*"])
+        $baseline_manifest
+) {force_all: true, dependencies: []}
+
+let target = (mktemp --directory)
+let semver_target = ($target | path join "semver-checks")
+let retained_file = ($target | path join "retained")
+mkdir $semver_target
+"temporary" | save ($semver_target | path join "artifact")
+"retained" | save $retained_file
+clean-semver-target $target
+assert (not ($semver_target | path exists))
+assert ($retained_file | path exists)
+rm --recursive --force $target
 
 print "breaking change script tests passed"


### PR DESCRIPTION
### Description

A root workspace dependency change could expand the semver check to every public crate. `cargo-semver-checks` keeps a separate target directory for each checked crate, so this eventually ran out of disk space.

This selects only crates using changed workspace dependencies, skips lockfile-only changes, and removes the semver targets between individual checks. Other root manifest changes still check every crate.

### How Has This Been Tested?

- `pixi run -e semver-check test-breaking-changes`
- `pixi run -e lint actionlint .github/workflows/breaking-changes.yml .github/workflows/breaking-changes-comment.yml`
- Verified the files from #2594 now select only `rattler_cache`.

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.
Tools: pi

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added sufficient tests to cover my changes.