### PR TITLE
feat: add `lfs` field to git source locations in the lock file

### DIFF
--- a/crates/rattler_lock/src/lib.rs
+++ b/crates/rattler_lock/src/lib.rs
@@ -986,6 +986,7 @@ mod test {
     #[case::v7_conda_source_path("v7/conda-path-lock.yml")]
     #[case::v7_derived_channel("v7/derived-channel-lock.yml")]
     #[case::v7_sources("v7/sources-lock.yml")]
+    #[case::v7_sources_lfs("v7/sources-lfs-lock.yml")]
     #[case::v7_options("v7/options-lock.yml")]
     #[case::v7_pixi_build_pinned_source("v7/pixi-build-pinned-source-lock.yml")]
     #[case::v7_pixi_build_url_source("v7/pixi-build-url-source-lock.yml")]

--- a/crates/rattler_lock/src/parse/models/v6/source_data.rs
+++ b/crates/rattler_lock/src/parse/models/v6/source_data.rs
@@ -171,6 +171,7 @@ impl<'a> TryFrom<SourceLocationData<'a>> for SourceLocation {
                 git,
                 rev,
                 subdirectory: subdirectory.map(Cow::into_owned),
+                lfs: None,
             }))
         } else {
             unreachable!("we already checked that exactly one of url, path or git is set")

--- a/crates/rattler_lock/src/parse/models/v7/source_data.rs
+++ b/crates/rattler_lock/src/parse/models/v7/source_data.rs
@@ -32,6 +32,8 @@ struct SourceLocationData<'a> {
     pub tag: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subdirectory: Option<Cow<'a, str>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lfs: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<Cow<'a, str>>,
@@ -58,6 +60,7 @@ impl<'a> From<&'a UrlSourceLocation> for SourceLocationData<'a> {
             branch: None,
             tag: None,
             subdirectory: value.subdirectory.as_deref().map(Cow::Borrowed),
+            lfs: None,
             path: None,
         }
     }
@@ -86,6 +89,7 @@ impl<'a> From<&'a GitSourceLocation> for SourceLocationData<'a> {
                 None
             },
             subdirectory: value.subdirectory.as_deref().map(Cow::Borrowed),
+            lfs: value.lfs,
             path: None,
         }
     }
@@ -102,6 +106,7 @@ impl<'a> From<&'a PathSourceLocation> for SourceLocationData<'a> {
             branch: None,
             tag: None,
             subdirectory: None,
+            lfs: None,
             path: Some(Cow::Borrowed(value.path.as_str())),
         }
     }
@@ -133,6 +138,7 @@ impl<'a> TryFrom<SourceLocationData<'a>> for SourceLocation {
             branch,
             tag,
             subdirectory,
+            lfs,
         } = value;
 
         let count = [url.is_some(), path.is_some(), git.is_some()]
@@ -172,6 +178,7 @@ impl<'a> TryFrom<SourceLocationData<'a>> for SourceLocation {
                 git,
                 rev,
                 subdirectory: subdirectory.map(Cow::into_owned),
+                lfs,
             }))
         } else {
             unreachable!("we already checked that exactly one of url, path or git is set")

--- a/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__sources-lfs-lock.yml.snap
+++ b/crates/rattler_lock/src/snapshots/rattler_lock__test__v7__sources-lfs-lock.yml.snap
@@ -1,0 +1,35 @@
+---
+source: crates/rattler_lock/src/lib.rs
+expression: conda_lock
+---
+version: 7
+platforms:
+  - name: win-64
+environments:
+  default:
+    channels:
+      - url: "https://conda.anaconda.org/conda-forge/"
+    packages:
+      win-64:
+        - conda_source: "child-package[87dc0b8a] @ child-package"
+packages:
+  - conda_source: "child-package[87dc0b8a] @ child-package"
+    version: 0.1.0
+    build: pyhbf21a9e_0
+    subdir: noarch
+    depends:
+      - git_lfs
+      - git_no_lfs
+      - git_plain
+    source_depends:
+      git_lfs:
+        git: "https://github.com/example/baz.git"
+        branch: foobar
+        lfs: true
+      git_no_lfs:
+        git: "https://github.com/example/baz.git"
+        tag: v0.1.0
+        lfs: false
+      git_plain:
+        git: "https://github.com/example/baz.git"
+        rev: deadbeaf

--- a/crates/rattler_lock/src/source.rs
+++ b/crates/rattler_lock/src/source.rs
@@ -1,6 +1,8 @@
 //! Provides data types that are used to describe the location of a source
 //! package.
 
+use std::hash::{Hash, Hasher};
+
 use rattler_digest::{Md5Hash, Sha256Hash};
 use typed_path::Utf8TypedPathBuf;
 use url::Url;
@@ -35,7 +37,7 @@ pub struct UrlSourceLocation {
 }
 
 /// A specification of source from a git repository.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GitSourceLocation {
     /// The git url of the package which can contain git+ prefixes.
     pub git: Url,
@@ -45,6 +47,28 @@ pub struct GitSourceLocation {
 
     /// The git subdirectory of the package
     pub subdirectory: Option<String>,
+
+    /// Whether git LFS files should be fetched
+    pub lfs: Option<bool>,
+}
+
+impl Hash for GitSourceLocation {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let GitSourceLocation {
+            git,
+            rev,
+            subdirectory,
+            lfs,
+        } = self;
+        git.hash(state);
+        rev.hash(state);
+        subdirectory.hash(state);
+        // An absent `lfs` field is skipped entirely so that source identifier
+        // hashes of lock files written before the field existed stay stable.
+        if let Some(lfs) = lfs {
+            lfs.hash(state);
+        }
+    }
 }
 
 /// A reference to a specific commit in a git repository.

--- a/crates/rattler_lock/src/source_identifier.rs
+++ b/crates/rattler_lock/src/source_identifier.rs
@@ -692,6 +692,71 @@ mod tests {
         insta::assert_yaml_snapshot!(hashes);
     }
 
+    /// The identifier hash of a package with git sources must not depend on
+    /// an absent `lfs` field: lock files written before the field existed
+    /// carry the same hash. The pinned literal below is that pre-`lfs` hash;
+    /// if this test fails, the hash algorithm changed in a way that would
+    /// alter existing lock files (see also [`compute_test_data_hashes`]).
+    #[test]
+    fn test_git_source_identifier_hash_ignores_absent_lfs() {
+        use std::collections::BTreeMap;
+
+        use rattler_conda_types::{PackageRecord, VersionWithSource};
+        use url::Url;
+
+        use crate::CondaSourceData;
+        use crate::source::{GitSourceLocation, SourceLocation};
+
+        fn git_source_identifier(lfs: Option<bool>) -> String {
+            let name = PackageName::from_str("git-package").unwrap();
+            let mut package_record = PackageRecord::new(
+                name,
+                VersionWithSource::from_str("1.0.0").unwrap(),
+                "pyhbf21a9e_0".to_string(),
+            );
+            package_record.subdir = "noarch".to_string();
+
+            let sources = BTreeMap::from([(
+                "dependency".to_string(),
+                SourceLocation::Git(GitSourceLocation {
+                    git: Url::parse("https://github.com/example/dependency.git").unwrap(),
+                    rev: None,
+                    subdirectory: None,
+                    lfs,
+                }),
+            )]);
+
+            let source_data = CondaSourceData::full(
+                UrlOrPath::from_str("git-package").unwrap(),
+                None,
+                BTreeMap::new(),
+                None,
+                package_record,
+                sources,
+            );
+
+            SourceIdentifier::from_source_data(&source_data)
+                .hash()
+                .to_string()
+        }
+
+        assert_eq!(git_source_identifier(None), "9f510e4a");
+
+        // The three states must stay distinguishable from each other.
+        assert_ne!(
+            git_source_identifier(Some(true)),
+            git_source_identifier(None)
+        );
+        assert_ne!(
+            git_source_identifier(Some(false)),
+            git_source_identifier(None)
+        );
+        assert_ne!(
+            git_source_identifier(Some(true)),
+            git_source_identifier(Some(false))
+        );
+    }
+
     #[test]
     fn test_into_full_returns_none_for_partial() {
         use std::collections::BTreeMap;

--- a/test-data/conda-lock/v7/sources-lfs-lock.yml
+++ b/test-data/conda-lock/v7/sources-lfs-lock.yml
@@ -1,0 +1,31 @@
+version: 7
+platforms:
+  - name: win-64
+environments:
+  default:
+    channels:
+      - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      win-64:
+        - conda_source: child-package[87dc0b8a] @ child-package
+packages:
+  - conda_source: child-package[87dc0b8a] @ child-package
+    version: 0.1.0
+    build: pyhbf21a9e_0
+    subdir: noarch
+    depends:
+      - git_lfs
+      - git_no_lfs
+      - git_plain
+    source_depends:
+      git_lfs:
+        git: https://github.com/example/baz.git
+        branch: foobar
+        lfs: true
+      git_no_lfs:
+        git: https://github.com/example/baz.git
+        tag: v0.1.0
+        lfs: false
+      git_plain:
+        git: https://github.com/example/baz.git
+        rev: deadbeaf


### PR DESCRIPTION
### Description

This allows pixi to record whether a git dependency needs git LFS files directly in the lock file instead of encoding it in the stored git URL.

- Add `lfs: Option<bool>` to `GitSourceLocation`, serialized on v7 git source locations and omitted when absent, so existing lock files render byte-identically
- Skip an absent `lfs` in the `Hash` impl so source identifier hashes of existing lock files stay stable
- The v6 parser always leaves it `None` since the format predates the field

### How Has This Been Tested?

- Added tests
- Use in https://github.com/prefix-dev/pixi/pull/6722

### AI Disclosure
- [x] This PR contains AI-generated content.
  - [x] I have tested any AI-generated content in my PR.
  - [x] I take responsibility for any AI-generated content in my PR.

Tools: Claude

<!-- Add your prompt here, this helps us understand your results. -->
```plaintext
[About pixi round-tripping the LFS flag through a query pair on the locked git
URL:] this looks odd. I think we should upstream to rattler-lock instead
```

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have added sufficient tests to cover my changes.
