### PR TITLE
fix: Allow build on illumos for rattler_pty

### DIFF
--- a/crates/rattler_pty/src/unix/pty_process.rs
+++ b/crates/rattler_pty/src/unix/pty_process.rs
@@ -27,9 +27,10 @@ use tokio::{
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use nix::pty::ptsname_r;
 
-#[cfg(target_os = "netbsd")]
+#[cfg(any(target_os = "netbsd", target_os = "illumos"))]
 /// NetBSD has `ptsname_r` in libc but apparently the `nix` crate does not expose it for NetBSD.
 /// Call `libc::ptsname_r` directly.
+/// The same is applicable for illumos
 fn ptsname_r(fd: &PtyMaster) -> nix::Result<String> {
     use std::ffi::CStr;
 


### PR DESCRIPTION
### Description

Fixes #2631 

Allows `rattler_pty` crate to be built on illumos platform

### How Has This Been Tested?

Run `cargo build` in the source directory of the crate

### AI Disclosure

This PR doesn't contain AI-generated content.

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added sufficient tests to cover my changes.
